### PR TITLE
fix(mobile-app): restore data integrity in admin views

### DIFF
--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -56,12 +56,20 @@ func (e *Engine) withBracketMatch(compId, matchId string, mutate func(*state.Bra
 func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.MatchResult) error {
 	result.ID = matchId // normalize ID-less payloads before overwriting
 	err := e.withPoolMatch(compId, matchId, func(r *state.MatchResult) {
-		// Preserve SideA and SideB if missing in update payload
+		// Preserve scheduling and side fields if missing in the update payload.
+		// The scoring UI only sends scoring-related fields; without this guard,
+		// `*r = *result` would zero Court/ScheduledAt/SideA/SideB.
 		if result.SideA == "" {
 			result.SideA = r.SideA
 		}
 		if result.SideB == "" {
 			result.SideB = r.SideB
+		}
+		if result.Court == "" {
+			result.Court = r.Court
+		}
+		if result.ScheduledAt == "" {
+			result.ScheduledAt = r.ScheduledAt
 		}
 		*r = *result
 	})
@@ -279,6 +287,15 @@ func (e *Engine) recordBracketMatchResult(compId string, matchId string, result 
 				bracket.Rounds[rIdx][mIdx].Status = state.MatchStatusCompleted
 				bracket.Rounds[rIdx][mIdx].ScoreA = formatScore(result.IpponsA, result.HansokuA)
 				bracket.Rounds[rIdx][mIdx].ScoreB = formatScore(result.IpponsB, result.HansokuB)
+				// Echo the persisted scheduling fields back into the result so the
+				// caller (and SSE broadcast) sees the full, correct match state
+				// rather than the empty Court/ScheduledAt the scoring UI sends.
+				if result.Court == "" {
+					result.Court = m.Court
+				}
+				if result.ScheduledAt == "" {
+					result.ScheduledAt = m.ScheduledAt
+				}
 				found = true
 
 				e.propagateBracketWinner(bracket, rIdx, mIdx)

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -212,3 +212,73 @@ func TestScoreSummary_Team(t *testing.T) {
 	assert.Equal(t, "TeamB", teamB.Player.Name)
 	assert.Equal(t, "W:0 L:1 D:0 | IV:1 IL:2 IT:0 | PW:0 PL:0", teamB.ScoreSummary)
 }
+
+// Regression test for the bug where scoring a match cleared its court and
+// scheduledAt because the UI payload omits those fields. RecordMatchResult
+// must preserve them when the incoming MatchResult has empty values.
+func TestRecordMatchResult_PreservesCourtAndScheduledAt(t *testing.T) {
+	dir, err := os.MkdirTemp("", "engine-preserve-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	eng := New(store)
+
+	compID := "preserve-test"
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, Name: "Preserve"}))
+
+	t.Run("pool match preserves Court and ScheduledAt", func(t *testing.T) {
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{
+				ID: "P1-1", SideA: "Alice", SideB: "Bob",
+				Status: state.MatchStatusScheduled,
+				Court:  "A", ScheduledAt: "09:30",
+			},
+		}))
+
+		// Scoring UI sends a patch with no Court / ScheduledAt.
+		patch := &state.MatchResult{
+			Winner:  "Alice",
+			IpponsA: []string{"M"},
+			IpponsB: []string{},
+			Status:  state.MatchStatusCompleted,
+		}
+		require.NoError(t, eng.RecordMatchResult(compID, "P1-1", patch))
+
+		// Persisted match keeps the original scheduling fields.
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		assert.Equal(t, "A", stored[0].Court)
+		assert.Equal(t, "09:30", stored[0].ScheduledAt)
+		// Patch is also mutated in place so the broadcast carries the merged value.
+		assert.Equal(t, "A", patch.Court)
+		assert.Equal(t, "09:30", patch.ScheduledAt)
+	})
+
+	t.Run("bracket match preserves Court and ScheduledAt", func(t *testing.T) {
+		bracket := &state.Bracket{
+			Rounds: [][]state.BracketMatch{
+				{{ID: "B1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled, Court: "B", ScheduledAt: "10:15"}},
+			},
+		}
+		require.NoError(t, store.SaveBracket(compID, bracket))
+
+		patch := &state.MatchResult{
+			Winner:  "Bob",
+			IpponsB: []string{"K"},
+			Status:  state.MatchStatusCompleted,
+		}
+		require.NoError(t, eng.RecordMatchResult(compID, "B1", patch))
+
+		stored, err := store.LoadBracket(compID)
+		require.NoError(t, err)
+		assert.Equal(t, "B", stored.Rounds[0][0].Court)
+		assert.Equal(t, "10:15", stored.Rounds[0][0].ScheduledAt)
+		// Patch is mutated in place so the SSE broadcast can echo the
+		// scheduling fields the scoring UI never sent.
+		assert.Equal(t, "B", patch.Court)
+		assert.Equal(t, "10:15", patch.ScheduledAt)
+	})
+}

--- a/web-mobile/js/__tests__/mergeMatchPatch.test.jsx
+++ b/web-mobile/js/__tests__/mergeMatchPatch.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { mergeMatchPatch } from '../data.jsx';
+
+describe('mergeMatchPatch', () => {
+  it('preserves existing court when patch.court is empty string', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30", status: "scheduled" };
+    const patch = { winner: "P1", court: "", status: "completed" };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.court).toBe("A");
+    expect(merged.status).toBe("completed");
+    expect(merged.winner).toBe("P1");
+  });
+
+  it('preserves existing scheduledAt when patch.scheduledAt is empty string', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30" };
+    const patch = { winner: "P1", scheduledAt: "" };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.scheduledAt).toBe("09:30");
+  });
+
+  it('preserves existing court when patch.court is null', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30" };
+    const patch = { winner: "P1", court: null };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.court).toBe("A");
+  });
+
+  it('preserves existing scheduledAt when patch.scheduledAt is undefined', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30" };
+    const patch = { winner: "P1" };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.scheduledAt).toBe("09:30");
+  });
+
+  it('lets non-empty patch.court override existing court', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30" };
+    const patch = { court: "B" };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.court).toBe("B");
+  });
+
+  it('lets non-empty patch.scheduledAt override existing scheduledAt', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30" };
+    const patch = { scheduledAt: "10:00" };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.scheduledAt).toBe("10:00");
+  });
+
+  it('only guards court and scheduledAt — other fields follow normal spread semantics', () => {
+    const existing = { id: "m1", winner: "P1", status: "completed", court: "A" };
+    // status: "" is a normal empty string and *should* overwrite (we only special-case scheduling fields)
+    const patch = { status: "" };
+    const merged = mergeMatchPatch(existing, patch);
+    expect(merged.status).toBe("");
+    expect(merged.court).toBe("A"); // still preserved
+  });
+
+  it('does not mutate the existing match object', () => {
+    const existing = { id: "m1", court: "A", scheduledAt: "09:30" };
+    const patch = { court: "B" };
+    mergeMatchPatch(existing, patch);
+    expect(existing.court).toBe("A");
+    expect(existing.scheduledAt).toBe("09:30");
+  });
+});

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -980,8 +980,13 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
 }
 
 function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
-  const { total, done, live } = compMatchStats({ ...c, pools, poolMatches, bracket });
+  // Prefer the props passed from the detail fetch, but fall back to whatever
+  // is already on `c` when the detail hasn't loaded yet (or errored). Using ??
+  // avoids overwriting non-null fields on `c` with undefined prop values.
+  const statsSource = { ...c, pools: pools ?? c.pools, poolMatches: poolMatches ?? c.poolMatches, bracket: bracket ?? c.bracket };
+  const { total, done, live } = compMatchStats(statsSource);
   const pct = total ? Math.round((done / total) * 100) : 0;
+  const effectiveBracket = bracket ?? c.bracket;
   return (
     <div>
       <div className="stats-strip">
@@ -1001,7 +1006,7 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
           <div className="card__title" style={{ marginBottom: 6 }}>Scores →</div>
           <div className="card__sub">Update or correct match results</div>
         </button>
-        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(bracket ? "bracket" : "pools")}>
+        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}>
           <div className="card__title" style={{ marginBottom: 6 }}>Live results →</div>
           <div className="card__sub">Visual bracket / pool standings</div>
         </button>

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -263,23 +263,23 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   };
 
   useEffectA(() => {
-    if (view.kind === "competition") {
-      // Clear stale data from the previously-viewed competition so the
-      // header/modal don't briefly render with another comp's identity.
-      setAdminCompData(prev => (prev && prev.config && prev.config.id === view.id) ? prev : null);
-      setAdminLoading(true);
-      window.API.fetchCompetitionDetails(view.id)
-        .then(data => {
-          setAdminCompData(data);
-          setAdminLoading(false);
-        })
-        .catch(err => {
-          console.error(err);
-          setAdminLoading(false);
-        });
-    } else {
+    if (view.kind !== "competition") {
       setAdminCompData(null);
+      return;
     }
+    let cancelled = false;
+    // Clear stale data from the previously-viewed competition so the
+    // header/modal don't briefly render with another comp's identity.
+    setAdminCompData(prev => (prev && prev.config && prev.config.id === view.id) ? prev : null);
+    setAdminLoading(true);
+    window.API.fetchCompetitionDetails(view.id)
+      .then(data => {
+        if (!cancelled) { setAdminCompData(data); setAdminLoading(false); }
+      })
+      .catch(err => {
+        if (!cancelled) { console.error(err); setAdminLoading(false); }
+      });
+    return () => { cancelled = true; };
   }, [view.id, view.kind]);
 
   useEffectA(() => {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -4,8 +4,11 @@
 const { useState: useStateA, useMemo: useMemoA, useEffect: useEffectA, useRef: useRefA } = React;
 
 // Returns { total, done, live } match counts for a single competition object.
-// Accepts either the structured `pools[].matches` shape (from /competitions/:id)
-// or the flat `poolMatches` shape (from /viewer/competitions list endpoint).
+// Accepts either:
+//   - flat `poolMatches` array from GET /api/viewer/competitions (list endpoint)
+//   - structured `pools[].matches` from GET /api/viewer/competitions/:id (detail endpoint)
+// The admin-side GET /api/competitions/:id returns only config; use the viewer
+// endpoints when match counts are needed.
 function compMatchStats(c) {
   let total = 0, done = 0, live = 0;
   const count = (m) => {
@@ -61,14 +64,7 @@ function normalizeDate(d) {
 
 const pluralize = window.pluralize;
 
-// mergeMatchPatch applies a server-side patch onto an existing match, ignoring
-// empty scheduling fields so a partial broadcast can't blank court/scheduledAt.
-function mergeMatchPatch(existing, patch) {
-  const merged = { ...existing, ...patch };
-  if (patch.court === "" || patch.court == null) merged.court = existing.court;
-  if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
-  return merged;
-}
+const mergeMatchPatch = window.mergeMatchPatch;
 
 function patchCompetitionData(prev, event) {
   if (!prev || !event.data) return prev;

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -63,7 +63,6 @@ function normalizeDate(d) {
 }
 
 const pluralize = window.pluralize;
-
 const mergeMatchPatch = window.mergeMatchPatch;
 
 function patchCompetitionData(prev, event) {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -4,23 +4,23 @@
 const { useState: useStateA, useMemo: useMemoA, useEffect: useEffectA, useRef: useRefA } = React;
 
 // Returns { total, done, live } match counts for a single competition object.
+// Accepts either the structured `pools[].matches` shape (from /competitions/:id)
+// or the flat `poolMatches` shape (from /viewer/competitions list endpoint).
 function compMatchStats(c) {
   let total = 0, done = 0, live = 0;
-  if (c.pools) {
-    c.pools.forEach((p) => (p.matches || []).forEach((m) => {
-      if (!m.sideA || !m.sideB) return;
-      total++;
-      if (m.status === "completed") done++;
-      if (m.status === "running") live++;
-    }));
+  const count = (m) => {
+    if (!m || !m.sideA || !m.sideB) return;
+    total++;
+    if (m.status === "completed") done++;
+    if (m.status === "running") live++;
+  };
+  if (Array.isArray(c.poolMatches)) {
+    c.poolMatches.forEach(count);
+  } else if (c.pools) {
+    c.pools.forEach((p) => (p.matches || []).forEach(count));
   }
   if (c.bracket && c.bracket.rounds) {
-    c.bracket.rounds.forEach((r) => (r || []).forEach((m) => {
-      if (!m.sideA || !m.sideB) return;
-      total++;
-      if (m.status === "completed") done++;
-      if (m.status === "running") live++;
-    }));
+    c.bracket.rounds.forEach((r) => (r || []).forEach(count));
   }
   return { total, done, live };
 }
@@ -61,6 +61,15 @@ function normalizeDate(d) {
 
 const pluralize = window.pluralize;
 
+// mergeMatchPatch applies a server-side patch onto an existing match, ignoring
+// empty scheduling fields so a partial broadcast can't blank court/scheduledAt.
+function mergeMatchPatch(existing, patch) {
+  const merged = { ...existing, ...patch };
+  if (patch.court === "" || patch.court == null) merged.court = existing.court;
+  if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
+  return merged;
+}
+
 function patchCompetitionData(prev, event) {
   if (!prev || !event.data) return prev;
   const { result, results } = event.data;
@@ -74,7 +83,7 @@ function patchCompetitionData(prev, event) {
   if (next.poolMatches) {
     next.poolMatches = next.poolMatches.map(m => {
       const update = resultMap.get(m.id);
-      if (update) { changed = true; return { ...m, ...update }; }
+      if (update) { changed = true; return mergeMatchPatch(m, update); }
       return m;
     });
   }
@@ -90,7 +99,7 @@ function patchCompetitionData(prev, event) {
           const patch = { ...update };
           if (patch.ipponsA) patch.scoreA = patch.ipponsA.join("");
           if (patch.ipponsB) patch.scoreB = patch.ipponsB.join("");
-          return { ...m, ...patch };
+          return mergeMatchPatch(m, patch);
         }
         return m;
       })
@@ -255,6 +264,9 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
 
   useEffectA(() => {
     if (view.kind === "competition") {
+      // Clear stale data from the previously-viewed competition so the
+      // header/modal don't briefly render with another comp's identity.
+      setAdminCompData(prev => (prev && prev.config && prev.config.id === view.id) ? prev : null);
       setAdminLoading(true);
       window.API.fetchCompetitionDetails(view.id)
         .then(data => {
@@ -382,16 +394,18 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   if (view.kind === "competition") {
     const c = t.competitions.find((cc) => cc.id === view.id);
     if (!c) return <div className="page"><div className="empty"><h3>Competition not found</h3></div></div>;
-    if (adminLoading && !adminCompData) return <div className="page"><div className="loading">Loading details...</div></div>;
+    // Only use adminCompData when it matches the current view; otherwise it's stale.
+    const detail = adminCompData && adminCompData.config && adminCompData.config.id === view.id ? adminCompData : null;
+    if (adminLoading && !detail) return <div className="page"><div className="loading">Loading details...</div></div>;
 
     return <AdminCompetition
       tournament={t}
-      competition={adminCompData?.config || c}
-      pools={adminCompData?.pools}
-      poolMatches={adminCompData?.poolMatches}
-      standings={adminCompData?.standings}
-      bracket={adminCompData?.bracket}
-      reservedSlots={adminCompData?.reservedSlots || []}
+      competition={detail?.config || c}
+      pools={detail?.pools}
+      poolMatches={detail?.poolMatches}
+      standings={detail?.standings}
+      bracket={detail?.bracket}
+      reservedSlots={detail?.reservedSlots || []}
       section={view.section}
       onSection={(section) => setView({ ...view, section })}
       onBack={() => setView({ kind: "dashboard" })}
@@ -539,9 +553,7 @@ function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, on
 }
 
 function CompCard({ c, onOpen, onStart }) {
-  let liveCount = 0;
-  if (c.pools) c.pools.forEach((p) => (p.matches || []).forEach((m) => m.status === "running" && liveCount++));
-  if (c.bracket && c.bracket.rounds) c.bracket.rounds.forEach((r) => (r || []).forEach((m) => m.status === "running" && liveCount++));
+  const { live: liveCount } = compMatchStats(c);
   const playerCount = (c.players || []).length;
 
   return (
@@ -839,7 +851,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   );
 }
 
-function AdminCompetition({ tournament, competition, pools, _poolMatches, standings, bracket, reservedSlots, section, onSection, onBack, onOpenCompetition, onUpdate, onCreatePlayoff, onMoveCourt, onEditScore, onLogout, onViewerMode, tweaks, password, showToast }) {
+function AdminCompetition({ tournament, competition, pools, poolMatches, standings, bracket, reservedSlots, section, onSection, onBack, onOpenCompetition, onUpdate, onCreatePlayoff, onMoveCourt, onEditScore, onLogout, onViewerMode, tweaks, password, showToast }) {
   const c = competition;
   const t = tournament;
   const [starting, setStarting] = useStateA(false);
@@ -958,7 +970,7 @@ function AdminCompetition({ tournament, competition, pools, _poolMatches, standi
             </div>
           </div>
           <div>
-            {section === "overview" && <AdminCompOverview c={c} onSection={onSection} />}
+            {section === "overview" && <AdminCompOverview c={c} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} />}
             {section === "participants" && <AdminParticipants c={c} tournament={t} reservedSlots={reservedSlots || []} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} />}
             {section === "settings" && <AdminSettings c={c} tournament={t} onUpdate={onUpdate} onBack={onBack} password={password} showToast={showToast} />}
             {section === "pools" && <AdminPools c={c} pools={pools} standings={standings} tweaks={tweaks} onEditScore={onEditScore} password={password} />}
@@ -972,8 +984,8 @@ function AdminCompetition({ tournament, competition, pools, _poolMatches, standi
   );
 }
 
-function AdminCompOverview({ c, onSection }) {
-  const { total, done, live } = compMatchStats(c);
+function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
+  const { total, done, live } = compMatchStats({ ...c, pools, poolMatches, bracket });
   const pct = total ? Math.round((done / total) * 100) : 0;
   return (
     <div>
@@ -994,7 +1006,7 @@ function AdminCompOverview({ c, onSection }) {
           <div className="card__title" style={{ marginBottom: 6 }}>Scores →</div>
           <div className="card__sub">Update or correct match results</div>
         </button>
-        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(c.bracket ? "bracket" : "pools")}>
+        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(bracket ? "bracket" : "pools")}>
           <div className="card__title" style={{ marginBottom: 6 }}>Live results →</div>
           <div className="card__sub">Visual bracket / pool standings</div>
         </button>

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -11,8 +11,18 @@ const { useState: useStateA, useMemo: useMemoA, useEffect: useEffectA, useRef: u
 // endpoints when match counts are needed.
 function compMatchStats(c) {
   let total = 0, done = 0, live = 0;
+  // sideA/sideB can be: a string (raw backend shape), an object {id,name}
+  // (normalizeMatch shape, which substitutes {id:"",name:""} for missing
+  // sides), or null. Truthy-checking the side itself is not enough — we have
+  // to look at the actual participant name so byes and unresolved bracket
+  // slots don't get counted toward total/done/live.
+  const hasName = (side) => {
+    if (!side) return false;
+    if (typeof side === "string") return side.length > 0;
+    return !!(side.name && side.name.length > 0);
+  };
   const count = (m) => {
-    if (!m || !m.sideA || !m.sideB) return;
+    if (!m || !hasName(m.sideA) || !hasName(m.sideB)) return;
     total++;
     if (m.status === "completed") done++;
     if (m.status === "running") live++;

--- a/web-mobile/js/api.jsx
+++ b/web-mobile/js/api.jsx
@@ -1,16 +1,6 @@
 // Status enum mapping: backend uses "completed"/"running"/"scheduled"
 const STATUS_MAP = { "complete": "completed", "in_progress": "running" };
 
-// Merge an SSE match patch onto an existing match object.
-// Preserves court and scheduledAt when the patch omits them (empty/null) so a
-// partial broadcast can never blank scheduling context already on the match.
-function mergeMatchPatch(existing, patch) {
-    const merged = { ...existing, ...patch };
-    if (patch.court === "" || patch.court == null) merged.court = existing.court;
-    if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
-    return merged;
-}
-
 function toBackendStatus(s) { return STATUS_MAP[s] || s; }
 
 // Translate UI score patch into backend MatchResult shape.
@@ -466,7 +456,7 @@ const API = {
     }
 };
 
-export { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, normalizeCompetitionDetail, mergeMatchPatch, API };
+export { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, normalizeCompetitionDetail, API };
 
 if (typeof window !== 'undefined') {
     window.API = API;
@@ -474,5 +464,4 @@ if (typeof window !== 'undefined') {
     window.normalizeCompetitionDetail = normalizeCompetitionDetail;
     window.buildPlayerMap = buildPlayerMap;
     window.toBackendStatus = toBackendStatus;
-    window.mergeMatchPatch = mergeMatchPatch;
 }

--- a/web-mobile/js/api.jsx
+++ b/web-mobile/js/api.jsx
@@ -1,6 +1,16 @@
 // Status enum mapping: backend uses "completed"/"running"/"scheduled"
 const STATUS_MAP = { "complete": "completed", "in_progress": "running" };
 
+// Merge an SSE match patch onto an existing match object.
+// Preserves court and scheduledAt when the patch omits them (empty/null) so a
+// partial broadcast can never blank scheduling context already on the match.
+function mergeMatchPatch(existing, patch) {
+    const merged = { ...existing, ...patch };
+    if (patch.court === "" || patch.court == null) merged.court = existing.court;
+    if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
+    return merged;
+}
+
 function toBackendStatus(s) { return STATUS_MAP[s] || s; }
 
 // Translate UI score patch into backend MatchResult shape.
@@ -456,7 +466,7 @@ const API = {
     }
 };
 
-export { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, normalizeCompetitionDetail, API };
+export { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, normalizeCompetitionDetail, mergeMatchPatch, API };
 
 if (typeof window !== 'undefined') {
     window.API = API;
@@ -464,4 +474,5 @@ if (typeof window !== 'undefined') {
     window.normalizeCompetitionDetail = normalizeCompetitionDetail;
     window.buildPlayerMap = buildPlayerMap;
     window.toBackendStatus = toBackendStatus;
+    window.mergeMatchPatch = mergeMatchPatch;
 }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -2,7 +2,6 @@
 // (Men's Individual, Women's Individual, Teams, etc.). Auth gates admin mode.
 
 const { useState: useS, useEffect: useE } = React;
-
 const mergeMatchPatch = window.mergeMatchPatch;
 
 const patchCompetitionData = (prev, event) => {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -3,6 +3,13 @@
 
 const { useState: useS, useEffect: useE } = React;
 
+const mergeMatchPatch = (existing, patch) => {
+  const merged = { ...existing, ...patch };
+  if (patch.court === "" || patch.court == null) merged.court = existing.court;
+  if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
+  return merged;
+};
+
 const patchCompetitionData = (prev, event) => {
   if (!prev || !event.data) return prev;
   const { result, results } = event.data;
@@ -16,7 +23,7 @@ const patchCompetitionData = (prev, event) => {
   if (next.poolMatches) {
     next.poolMatches = next.poolMatches.map(m => {
       const update = resultMap.get(m.id);
-      if (update) { changed = true; return { ...m, ...update }; }
+      if (update) { changed = true; return mergeMatchPatch(m, update); }
       return m;
     });
   }
@@ -31,7 +38,7 @@ const patchCompetitionData = (prev, event) => {
           const patch = { ...update };
           if (patch.ipponsA) patch.scoreA = patch.ipponsA.join("");
           if (patch.ipponsB) patch.scoreB = patch.ipponsB.join("");
-          return { ...m, ...patch };
+          return mergeMatchPatch(m, patch);
         }
         return m;
       })

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -3,12 +3,7 @@
 
 const { useState: useS, useEffect: useE } = React;
 
-const mergeMatchPatch = (existing, patch) => {
-  const merged = { ...existing, ...patch };
-  if (patch.court === "" || patch.court == null) merged.court = existing.court;
-  if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
-  return merged;
-};
+const mergeMatchPatch = window.mergeMatchPatch;
 
 const patchCompetitionData = (prev, event) => {
   if (!prev || !event.data) return prev;

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -25,6 +25,13 @@ function assignCourt(matchIdx, courts) {
   return courts[matchIdx % courts.length];
 }
 
+function mergeMatchPatch(existing, patch) {
+  const merged = { ...existing, ...patch };
+  if (patch.court === "" || patch.court == null) merged.court = existing.court;
+  if (patch.scheduledAt === "" || patch.scheduledAt == null) merged.scheduledAt = existing.scheduledAt;
+  return merged;
+}
+
 function makePlayer(i, gender, prefix, seed) {
   const first = (gender === "F" ? FIRST_F : FIRST_M);
   const fn = first[i % first.length];
@@ -337,5 +344,6 @@ if (typeof window !== 'undefined') {
   window.standardSeedOrder = standardSeedOrder; window.nextPow2 = nextPow2;
   window.poolWinners = poolWinners;
   window.parseParticipantLines = parseParticipantLines;
+  window.mergeMatchPatch = mergeMatchPatch;
   window.addMinutes = addMinutes;
 }

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -329,7 +329,7 @@ export {
   buildPools, simulatePools, computeStandings, poolWinners,
   buildEmptyCompetition, applyFormat, buildCompetition,
   buildTournament, competitionStatus, SAMPLE_TOURNAMENTS, parseParticipantLines,
-  assignCourt
+  assignCourt, mergeMatchPatch
 };
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary

Phase 1 of the [mobile-app improvement plan](https://github.com/gitrgoliveira/bracket-creator/blob/main/.. ) — addresses four bugs from [webui_recommendations.md](../blob/main/webui_recommendations.md) that actively corrupt the operator experience during live tournaments:

- **Bug 2 — 0/0 matches done counter.** `compMatchStats` only read the structured `c.pools[].matches` shape, but the viewer list endpoint returns the flat `c.poolMatches` shape. Helper now accepts both; `CompCard`'s duplicated logic replaced with a call to it.
- **Bug 1 / Bug 4 — wrong competition identity in header / scoring modal.** When navigating between competitions, `adminCompData` retained the previously-viewed comp's data until the new fetch resolved, so the page header and scoring modal could flash the wrong name/kind. `adminCompData` is now treated as stale unless `config.id` matches the current view id, and cleared eagerly on navigation.
- **Bug 5 — court letter & start time disappeared after scoring.** Two-layer fix:
  - Backend `RecordMatchResult` previously did `*r = *result`, overwriting the persisted pool match with the scoring UI's patch payload (which has empty `Court` / `ScheduledAt`). Now preserves both when empty in the patch.
  - `recordBracketMatchResult` echoes the persisted scheduling fields back into the `MatchResult` so the SSE broadcast carries the full match state instead of the stripped patch.
  - Frontend `patchCompetitionData` (admin and viewer copies) ignores empty `court` / `scheduledAt` in patches as defense-in-depth.

Adds engine regression tests covering both pool and bracket paths.

## Test plan

- [x] `make go/test` — all suites green, new `TestRecordMatchResult_PreservesCourtAndScheduledAt` passes
- [x] `make examples` — no diff in generated Excel files
- [x] `make go/build` — JS bundle rebuilds cleanly
- [x] Manual: create a Pools+KO Team competition; score pool matches; confirm dashboard "Matches done" updates from 0/N → N/N
- [x] Manual: switch between two competitions in admin; header should never flash the previous comp's name/kind
- [x] Manual: score a match; confirm the row still shows the original court and start time afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)