### PR TITLE
fix(mobile-app): standardize Shiro/Aka and tighten scoring modal UX

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2241,6 +2241,28 @@ a:hover {
   text-align: center;
 }
 
+/* Small icon-only button used for stacked arrow controls (e.g., seed-row ↑/↓).
+   Sized to meet a comfortable touch target on desktop; bumps to 44px on touch
+   devices so phones/tablets remain usable. */
+.btn--icon-sm {
+  min-width: 32px;
+  min-height: 32px;
+  padding: 4px 8px;
+  font-size: 13px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (pointer: coarse) {
+  .btn--icon-sm {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 10px;
+  }
+}
+
 .seed-row__input:focus {
   outline: none;
   border-color: var(--accent);

--- a/web-mobile/js/__tests__/admin_ui_fixes.test.jsx
+++ b/web-mobile/js/__tests__/admin_ui_fixes.test.jsx
@@ -44,7 +44,7 @@ describe('Scoring Modal Feedback', () => {
     let submitting = false;
     const setSubmitting = (val) => { submitting = val; };
     const onSubmit = vi.fn().mockResolvedValue({});
-    
+
     const submit = async () => {
       setSubmitting(true);
       try {
@@ -53,11 +53,123 @@ describe('Scoring Modal Feedback', () => {
         setSubmitting(false);
       }
     };
-    
+
     const promise = submit();
     expect(submitting).toBe(true);
     await promise;
     expect(submitting).toBe(false);
     expect(onSubmit).toHaveBeenCalled();
+  });
+});
+
+// --- Draw toggle logic ---
+// Mirrors the toggle handler in ScoreEditorModal
+function makeDrawToggleHandler(state, setState) {
+  return () => {
+    if (state.isDrawToggled) {
+      setState({ ...state, isDrawToggled: false });
+    } else {
+      setState({ ...state, isDrawToggled: true, aPts: [], bPts: [] });
+    }
+  };
+}
+
+describe('ScoreEditorModal draw toggle', () => {
+  it('sets draw mode and clears scores when toggled on with partial score', () => {
+    const state = { isDrawToggled: false, aPts: ['M'], bPts: [] };
+    let next;
+    makeDrawToggleHandler(state, s => { next = s; })();
+    expect(next.isDrawToggled).toBe(true);
+    expect(next.aPts).toEqual([]);
+    expect(next.bPts).toEqual([]);
+  });
+
+  it('clears draw mode when toggled off', () => {
+    const state = { isDrawToggled: true, aPts: [], bPts: [] };
+    let next;
+    makeDrawToggleHandler(state, s => { next = s; })();
+    expect(next.isDrawToggled).toBe(false);
+  });
+
+  it('sets draw mode and clears scores when toggled on at 0-0', () => {
+    const state = { isDrawToggled: false, aPts: [], bPts: [] };
+    let next;
+    makeDrawToggleHandler(state, s => { next = s; })();
+    expect(next.isDrawToggled).toBe(true);
+    expect(next.aPts).toEqual([]);
+    expect(next.bPts).toEqual([]);
+  });
+});
+
+// --- Dirty-state and handleDismiss logic ---
+function arraysEqual(a, b) {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+function isDirty(state, initial) {
+  return (
+    !arraysEqual(state.aPts, initial.aPts) ||
+    !arraysEqual(state.bPts, initial.bPts) ||
+    state.aFouls !== initial.aFouls ||
+    state.bFouls !== initial.bFouls ||
+    state.isDrawToggled !== initial.isDrawToggled
+  );
+}
+
+function makeHandleDismiss({ submitting, dirty, confirmResult, onClose }) {
+  const confirm = vi.fn().mockReturnValue(confirmResult);
+  const dismiss = () => {
+    if (submitting) return;
+    if (dirty && !confirm('Discard unsaved scoring changes?')) return;
+    onClose();
+  };
+  return { dismiss, confirm };
+}
+
+describe('ScoreEditorModal dirty-state and dismiss guard', () => {
+  it('is not dirty when nothing has changed', () => {
+    const initial = { aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0, isDrawToggled: false };
+    expect(isDirty({ ...initial }, initial)).toBe(false);
+  });
+
+  it('is dirty when a point is added', () => {
+    const initial = { aPts: [], bPts: [], aFouls: 0, bFouls: 0, isDrawToggled: false };
+    expect(isDirty({ ...initial, aPts: ['M'] }, initial)).toBe(true);
+  });
+
+  it('is dirty when draw is toggled on', () => {
+    const initial = { aPts: [], bPts: [], aFouls: 0, bFouls: 0, isDrawToggled: false };
+    expect(isDirty({ ...initial, isDrawToggled: true }, initial)).toBe(true);
+  });
+
+  it('calls onClose immediately when not dirty', () => {
+    const onClose = vi.fn();
+    const { dismiss } = makeHandleDismiss({ submitting: false, dirty: false, confirmResult: true, onClose });
+    dismiss();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('prompts and closes when dirty and user confirms', () => {
+    const onClose = vi.fn();
+    const { dismiss, confirm } = makeHandleDismiss({ submitting: false, dirty: true, confirmResult: true, onClose });
+    dismiss();
+    expect(confirm).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('prompts but does not close when dirty and user cancels', () => {
+    const onClose = vi.fn();
+    const { dismiss, confirm } = makeHandleDismiss({ submitting: false, dirty: true, confirmResult: false, onClose });
+    dismiss();
+    expect(confirm).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close or prompt while submitting', () => {
+    const onClose = vi.fn();
+    const { dismiss, confirm } = makeHandleDismiss({ submitting: true, dirty: true, confirmResult: true, onClose });
+    dismiss();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/web-mobile/js/__tests__/admin_ui_fixes.test.jsx
+++ b/web-mobile/js/__tests__/admin_ui_fixes.test.jsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { arraysEqual } from '../data.jsx';
 
 // We re-implement pluralize here to verify the logic we added to admin.jsx
 function pluralize(count, singular, plural) {
@@ -102,10 +103,8 @@ describe('ScoreEditorModal draw toggle', () => {
 });
 
 // --- Dirty-state and handleDismiss logic ---
-function arraysEqual(a, b) {
-  return a.length === b.length && a.every((v, i) => v === b[i]);
-}
-
+// isDirty uses the real arraysEqual from data.jsx (imported above), so the
+// test fails if the production implementation changes.
 function isDirty(state, initial) {
   return (
     !arraysEqual(state.aPts, initial.aPts) ||

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -2805,7 +2805,6 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
   const [bPts, setBPts] = useStateA(initialBPts);
   const [aFouls, setAFouls] = useStateA(m.hansokuA || m.score?.fouls?.a || 0);
   const [bFouls, setBFouls] = useStateA(m.hansokuB || m.score?.fouls?.b || 0);
-  const [note, setNote] = useStateA("");
   const [submitting, setSubmitting] = useStateA(false);
 
   // Hansoku → ippon awarded to opponent on every 2nd foul
@@ -2830,19 +2829,19 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
       status: "running", winner: null,
       ipponsA: aPts.filter(x => x !== "•"), ipponsB: bPts.filter(x => x !== "•"),
       hansokuA: aFouls, hansokuB: bFouls,
-      score: { type: "ippon", winnerPts: aTotal, loserPts: bTotal, ippons: aPts, fouls, live: true, corrected: isComplete, note },
+      score: { type: "ippon", winnerPts: aTotal, loserPts: bTotal, ippons: aPts, fouls, live: true, corrected: isComplete },
     };
-    if (isDrawToggled) return { winner: null, ipponsA: [], ipponsB: [], hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete, note } };
+    if (isDrawToggled) return { winner: null, ipponsA: [], ipponsB: [], hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete } };
     // ippon
     const aLetters = aPts.filter(x => x !== "•");
     const bLetters = bPts.filter(x => x !== "•");
     const aFinal = [...aLetters, ...Array(aHansokuPts).fill("H")].slice(0, 2);
     const bFinal = [...bLetters, ...Array(bHansokuPts).fill("H")].slice(0, 2);
     const winnerSide = aFinal.length > bFinal.length ? "a" : bFinal.length > aFinal.length ? "b" : null;
-    if (!winnerSide) return { winner: null, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete, note } };
+    if (!winnerSide) return { winner: null, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete } };
     const winner = winnerSide === "a" ? m.sideA : m.sideB;
     const ippons = winnerSide === "a" ? aFinal : bFinal;
-    return { winner, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "ippon", winnerPts: ippons.length, loserPts: (winnerSide === "a" ? bFinal : aFinal).length, ippons, fouls, corrected: isComplete, note } };
+    return { winner, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "ippon", winnerPts: ippons.length, loserPts: (winnerSide === "a" ? bFinal : aFinal).length, ippons, fouls, corrected: isComplete } };
   };
 
   const doSubmit = async (fn) => {
@@ -2869,8 +2868,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
     !arraysEqual(bPts, initialBPts) ||
     aFouls !== initialAFouls ||
     bFouls !== initialBFouls ||
-    isDrawToggled !== initialIsDrawToggled ||
-    note !== "";
+    isDrawToggled !== initialIsDrawToggled;
   const handleDismiss = () => {
     if (isDirty && !confirm("Discard unsaved scoring changes?")) return;
     onClose();
@@ -2921,7 +2919,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
                     {idx === 0 && (
                       <div className="sb-center">
                         {isDrawToggled ? (
-                          <button className="sb-draw-toggle sb-draw-toggle--active" onClick={() => { setIsDrawToggled(false); }} title="Cancel draw">X</button>
+                          <button className="sb-draw-toggle sb-draw-toggle--active" onClick={() => { setIsDrawToggled(false); }} title="Cancel draw" aria-label="Cancel draw (hikiwake)">X</button>
                         ) : (
                           <>
                             {(aTotal > 0 || bTotal > 0) && <div className="sb-vs">{`${bTotal}–${aTotal}`}</div>}
@@ -2929,6 +2927,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
                               className="sb-draw-toggle"
                               onClick={() => { setIsDrawToggled(true); setAPts([]); setBPts([]); }}
                               title="Mark as draw (hikiwake)"
+                              aria-label="Mark as draw (hikiwake)"
                             >{aTotal === 0 && bTotal === 0 ? "vs" : "X"}</button>
                           </>
                         )}
@@ -2953,13 +2952,6 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
               </div>
           </div>
 
-          {isComplete && (
-            <div className="field">
-              <label className="field__label">Correction note (optional)</label>
-              <input className="input" placeholder="e.g. Reviewed video, ippon awarded to White" value={note} onChange={(e) => setNote(e.target.value)} />
-              <div className="field__hint">Recorded as audit trail. Subsequent rounds will be re-propagated automatically.</div>
-            </div>
-          )}
         </div>
 
         {/* Sticky navigation + action footer */}
@@ -3003,7 +2995,6 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
   const m = match;
   const isComplete = m.status === "completed";
   const positions = TEAM_POSITIONS.slice(0, teamSize);
-  const [note, setNote] = useStateA("");
   const [submitting, setSubmitting] = useStateA(false);
 
   const existingSub = m.subResults || [];
@@ -3060,7 +3051,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
       status: targetStatus === "running" ? "running" : "completed",
       ipponsA: [],
       ipponsB: [],
-      score: { type: teamWinner ? "ippon" : "hikiwake", winnerPts: teamWinner === "a" ? ivA : ivB, loserPts: teamWinner === "a" ? ivB : ivA, fouls: { a: 0, b: 0 }, corrected: isComplete, note },
+      score: { type: teamWinner ? "ippon" : "hikiwake", winnerPts: teamWinner === "a" ? ivA : ivB, loserPts: teamWinner === "a" ? ivB : ivA, fouls: { a: 0, b: 0 }, corrected: isComplete },
       subResults,
     };
   };
@@ -3203,12 +3194,6 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
             ))}
           </div>
 
-          {isComplete && (
-            <div className="field">
-              <label className="field__label">Correction note (optional)</label>
-              <input className="input" placeholder="e.g. Reviewed video" value={note} onChange={(e) => setNote(e.target.value)} />
-            </div>
-          )}
         </div>
 
         <div className="editor-modal__foot editor-modal__foot--nav">

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -2870,6 +2870,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
     bFouls !== initialBFouls ||
     isDrawToggled !== initialIsDrawToggled;
   const handleDismiss = () => {
+    if (submitting) return; // don't close while save is in-flight
     if (isDirty && !confirm("Discard unsaved scoring changes?")) return;
     onClose();
   };

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -1521,9 +1521,9 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                       <div className="seed-row__name" title={p.name}>{p.name}{p.tag && <span className="tag-badge">{p.tag}</span>}</div>
                       <div className="seed-row__dojo">{p.dojo}</div>
                     </div>
-                    <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                      <button className="btn btn--sm" style={{ padding: "1px 6px", fontSize: 11 }} onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0}>↑</button>
-                      <button className="btn btn--sm" style={{ padding: "1px 6px", fontSize: 11 }} onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1}>↓</button>
+                    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                      <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0} aria-label="Move up">↑</button>
+                      <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1} aria-label="Move down">↓</button>
                     </div>
                      <window.StableInput
                         className="seed-row__input"
@@ -2042,45 +2042,46 @@ const LiveMatchPanel = React.memo(({ match, compId, courts, onMoveCourt, onRecor
         <button className={mode === "scoreboard" ? "is-active" : ""} onClick={() => setMode("scoreboard")}>Scoreboard</button>
       </div>
       {mode === "tap" && (<>
+        {/* Layout convention: SHIRO (White, sideB) on the LEFT, AKA (Red, sideA) on the RIGHT. */}
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 10 }}>
-          <button className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === a.id ? "var(--red)" : "var(--line)", background: match.winner?.id === a.id ? "var(--red)" : "var(--surface)", color: match.winner?.id === a.id ? "white" : "inherit" }} onClick={() => onRecord("a", "ippon")}>
-            <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em", color: "var(--red)" }}>AKA (RED)</div>
-            <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{a.name}</div>
-            <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{a.dojo}</div>
-          </button>
           <button className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === b.id ? "var(--accent)" : "var(--line)", background: match.winner?.id === b.id ? "var(--accent)" : "var(--surface)", color: match.winner?.id === b.id ? "white" : "inherit" }} onClick={() => onRecord("b", "ippon")}>
             <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em" }}>SHIRO (WHITE)</div>
             <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{b.name}</div>
             <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{b.dojo}</div>
+          </button>
+          <button className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === a.id ? "var(--red)" : "var(--line)", background: match.winner?.id === a.id ? "var(--red)" : "var(--surface)", color: match.winner?.id === a.id ? "white" : "inherit" }} onClick={() => onRecord("a", "ippon")}>
+            <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em", color: "var(--red)" }}>AKA (RED)</div>
+            <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{a.name}</div>
+            <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{a.dojo}</div>
           </button>
         </div>
         <div className="field__hint" style={{ textAlign: "center" }}>Tap the winner. Use Match card or Scoreboard for detail.</div>
       </>)}
       {mode === "card" && (
         <div className="score-card">
-          <div className="score-side score-side--red">
-            <div><div className="score-side__lbl">Aka (Red)</div><div className="score-side__name">{a.name}</div><div className="score-side__dojo">{a.dojo}</div></div>
-            <div className="score-side__buttons"><button className="btn btn--sm btn--danger" onClick={() => onRecord("a", "ippon", "M")}>Win (Ippon)</button><button className="btn btn--sm" onClick={() => onRecord("a", "hantei")}>Hantei</button></div>
-          </div>
-          <div className="score-vs">VS</div>
           <div className="score-side score-side--white">
             <div><div className="score-side__lbl">Shiro (White)</div><div className="score-side__name">{b.name}</div><div className="score-side__dojo">{b.dojo}</div></div>
             <div className="score-side__buttons"><button className="btn btn--sm btn--primary" onClick={() => onRecord("b", "ippon", "M")}>Win (Ippon)</button><button className="btn btn--sm" onClick={() => onRecord("b", "hantei")}>Hantei</button></div>
+          </div>
+          <div className="score-vs">VS</div>
+          <div className="score-side score-side--red">
+            <div><div className="score-side__lbl">Aka (Red)</div><div className="score-side__name">{a.name}</div><div className="score-side__dojo">{a.dojo}</div></div>
+            <div className="score-side__buttons"><button className="btn btn--sm btn--danger" onClick={() => onRecord("a", "ippon", "M")}>Win (Ippon)</button><button className="btn btn--sm" onClick={() => onRecord("a", "hantei")}>Hantei</button></div>
           </div>
         </div>
       )}
       {mode === "scoreboard" && (
         <div className="score-card">
-          <div className="score-side score-side--red">
-            <div><div className="score-side__lbl">Aka (Red)</div><div className="score-side__name">{a.name}</div></div>
-            <div className="score-side__points">{[0, 1].map((i) => (<span key={i} className={`score-pt score-pt--aka ${aPoints[i] ? "score-pt--filled" : "score-pt--empty"}`}>{aPoints[i] || "·"}</span>))}</div>
-            <div className="score-side__buttons">{["M", "K", "D", "T"].map((cc) => (<button key={cc} className="ipt-btn ipt-btn--aka" onClick={() => setAPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}<button className="ipt-btn" onClick={() => setAPoints([])}>↺</button></div>
-          </div>
-          <div className="score-vs">VS</div>
           <div className="score-side score-side--white">
             <div><div className="score-side__lbl">Shiro (White)</div><div className="score-side__name">{b.name}</div></div>
             <div className="score-side__points">{[0, 1].map((i) => (<span key={i} className={`score-pt score-pt--shiro ${bPoints[i] ? "score-pt--filled" : "score-pt--empty"}`}>{bPoints[i] || "·"}</span>))}</div>
             <div className="score-side__buttons">{["M", "K", "D", "T"].map((cc) => (<button key={cc} className="ipt-btn" onClick={() => setBPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}<button className="ipt-btn" onClick={() => setBPoints([])}>↺</button></div>
+          </div>
+          <div className="score-vs">VS</div>
+          <div className="score-side score-side--red">
+            <div><div className="score-side__lbl">Aka (Red)</div><div className="score-side__name">{a.name}</div></div>
+            <div className="score-side__points">{[0, 1].map((i) => (<span key={i} className={`score-pt score-pt--aka ${aPoints[i] ? "score-pt--filled" : "score-pt--empty"}`}>{aPoints[i] || "·"}</span>))}</div>
+            <div className="score-side__buttons">{["M", "K", "D", "T"].map((cc) => (<button key={cc} className="ipt-btn ipt-btn--aka" onClick={() => setAPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}<button className="ipt-btn" onClick={() => setAPoints([])}>↺</button></div>
           </div>
         </div>
       )}
@@ -2849,7 +2850,8 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
     try { await fn(); } finally { setSubmitting(false); }
   };
 
-  const [isDrawToggled, setIsDrawToggled] = useStateA(m.score?.type === "hikiwake" || m.decision === "hikewake");
+  const initialIsDrawToggled = m.score?.type === "hikiwake" || m.decision === "hikewake";
+  const [isDrawToggled, setIsDrawToggled] = useStateA(initialIsDrawToggled);
 
   // Arranged as [left, right] — left is always SHIRO (White), right is always AKA (Red)
   const sides = [
@@ -2859,8 +2861,23 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
 
   const canFinish = isDrawToggled || aTotal > 0 || bTotal > 0;
 
+  const initialAFouls = m.hansokuA || m.score?.fouls?.a || 0;
+  const initialBFouls = m.hansokuB || m.score?.fouls?.b || 0;
+  const arraysEqual = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+  const isDirty =
+    !arraysEqual(aPts, initialAPts) ||
+    !arraysEqual(bPts, initialBPts) ||
+    aFouls !== initialAFouls ||
+    bFouls !== initialBFouls ||
+    isDrawToggled !== initialIsDrawToggled ||
+    note !== "";
+  const handleDismiss = () => {
+    if (isDirty && !confirm("Discard unsaved scoring changes?")) return;
+    onClose();
+  };
+
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <div className="modal-backdrop" onClick={handleDismiss}>
       <div className="editor-modal editor-modal--lg" onClick={(e) => e.stopPropagation()}>
         <div className="editor-modal__head">
           <div style={{ flex: 1 }}>
@@ -2875,7 +2892,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
             <div className={`viewer__admin-pill ${m.status === "running" ? "sched-row--live" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
               {isComplete ? "CORRECTION" : m.status === "running" ? "● LIVE" : "PRE-MATCH"}
             </div>
-            <button className="btn btn--ghost btn--sm" onClick={onClose} style={{ padding: "2px 8px" }}>✕ Close</button>
+            <button className="btn btn--ghost btn--sm" onClick={handleDismiss} style={{ padding: "2px 8px" }}>✕ Close</button>
           </div>
         </div>
 
@@ -2905,10 +2922,15 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
                       <div className="sb-center">
                         {isDrawToggled ? (
                           <button className="sb-draw-toggle sb-draw-toggle--active" onClick={() => { setIsDrawToggled(false); }} title="Cancel draw">X</button>
-                        ) : aTotal === 0 && bTotal === 0 ? (
-                          <button className="sb-draw-toggle" onClick={() => { setIsDrawToggled(true); setAPts([]); setBPts([]); }} title="Mark as draw (hikiwake)">vs</button>
                         ) : (
-                          <div className="sb-vs">{`${bTotal}–${aTotal}`}</div>
+                          <>
+                            {(aTotal > 0 || bTotal > 0) && <div className="sb-vs">{`${bTotal}–${aTotal}`}</div>}
+                            <button
+                              className="sb-draw-toggle"
+                              onClick={() => { setIsDrawToggled(true); setAPts([]); setBPts([]); }}
+                              title="Mark as draw (hikiwake)"
+                            >{aTotal === 0 && bTotal === 0 ? "vs" : "X"}</button>
+                          </>
                         )}
                       </div>
                     )}
@@ -2953,7 +2975,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
                   ▶ Start Match
                 </button>
               )}
-              <button className="btn" onClick={onClose} disabled={submitting}>Cancel</button>
+              <button className="btn" onClick={handleDismiss} disabled={submitting}>Cancel</button>
               {onSubmitAndNext ? (
                 <button className="btn btn--primary" onClick={() => doSubmit(() => onSubmitAndNext(buildPatch("completed")))} disabled={submitting || !canFinish}>
                   {submitting ? "Saving…" : "Finish + Start Next →"}

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -2801,10 +2801,12 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
   const initialAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
   const initialBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
 
+  const initialAFouls = m.hansokuA || m.score?.fouls?.a || 0;
+  const initialBFouls = m.hansokuB || m.score?.fouls?.b || 0;
   const [aPts, setAPts] = useStateA(initialAPts);
   const [bPts, setBPts] = useStateA(initialBPts);
-  const [aFouls, setAFouls] = useStateA(m.hansokuA || m.score?.fouls?.a || 0);
-  const [bFouls, setBFouls] = useStateA(m.hansokuB || m.score?.fouls?.b || 0);
+  const [aFouls, setAFouls] = useStateA(initialAFouls);
+  const [bFouls, setBFouls] = useStateA(initialBFouls);
   const [submitting, setSubmitting] = useStateA(false);
 
   // Hansoku → ippon awarded to opponent on every 2nd foul
@@ -2860,12 +2862,9 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
 
   const canFinish = isDrawToggled || aTotal > 0 || bTotal > 0;
 
-  const initialAFouls = m.hansokuA || m.score?.fouls?.a || 0;
-  const initialBFouls = m.hansokuB || m.score?.fouls?.b || 0;
-  const arraysEqual = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
   const isDirty =
-    !arraysEqual(aPts, initialAPts) ||
-    !arraysEqual(bPts, initialBPts) ||
+    !window.arraysEqual(aPts, initialAPts) ||
+    !window.arraysEqual(bPts, initialBPts) ||
     aFouls !== initialAFouls ||
     bFouls !== initialBFouls ||
     isDrawToggled !== initialIsDrawToggled;
@@ -2891,7 +2890,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
             <div className={`viewer__admin-pill ${m.status === "running" ? "sched-row--live" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
               {isComplete ? "CORRECTION" : m.status === "running" ? "● LIVE" : "PRE-MATCH"}
             </div>
-            <button className="btn btn--ghost btn--sm" onClick={handleDismiss} style={{ padding: "2px 8px" }}>✕ Close</button>
+            <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>
           </div>
         </div>
 

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -2851,6 +2851,10 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
     try { await fn(); } finally { setSubmitting(false); }
   };
 
+  // Both spellings are intentional: `score.type` uses the correct "hikiwake"
+  // while the `decision` protocol string is the long-standing "hikewake"
+  // (without the i) — see api.jsx and scoring.go. Don't "fix" without a repo-
+  // wide migration.
   const initialIsDrawToggled = m.score?.type === "hikiwake" || m.decision === "hikewake";
   const [isDrawToggled, setIsDrawToggled] = useStateA(initialIsDrawToggled);
 

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -2050,7 +2050,8 @@ const LiveMatchPanel = React.memo(({ match, compId, courts, onMoveCourt, onRecor
             <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{b.dojo}</div>
           </button>
           <button className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === a.id ? "var(--red)" : "var(--line)", background: match.winner?.id === a.id ? "var(--red)" : "var(--surface)", color: match.winner?.id === a.id ? "white" : "inherit" }} onClick={() => onRecord("a", "ippon")}>
-            <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em", color: "var(--red)" }}>AKA (RED)</div>
+            {/* Label tinted red when unselected (button is on white), inherits white when selected (button background is red) */}
+            <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em", color: match.winner?.id === a.id ? "inherit" : "var(--red)" }}>AKA (RED)</div>
             <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{a.name}</div>
             <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{a.dojo}</div>
           </button>
@@ -2801,8 +2802,9 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
   const initialAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
   const initialBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
 
-  const initialAFouls = m.hansokuA || m.score?.fouls?.a || 0;
-  const initialBFouls = m.hansokuB || m.score?.fouls?.b || 0;
+  // Use ?? not || so an explicit 0 isn't treated as "unset"
+  const initialAFouls = m.hansokuA ?? m.score?.fouls?.a ?? 0;
+  const initialBFouls = m.hansokuB ?? m.score?.fouls?.b ?? 0;
   const [aPts, setAPts] = useStateA(initialAPts);
   const [bPts, setBPts] = useStateA(initialBPts);
   const [aFouls, setAFouls] = useStateA(initialAFouls);

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -316,13 +316,19 @@ function parseParticipantLines(lines, withZekken) {
   });
 }
 
+// Pure utility — used by ScoreEditorModal for isDirty checks; exported so tests
+// can import the real implementation rather than re-implementing it.
+function arraysEqual(a, b) {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
 export {
   makePlayer, makeTeam, makeCompetitors, standardSeedOrder, nextPow2, newMatchId,
   buildBracket, advanceByes, pickIppons, simulateRounds, scheduleRound, addMinutes,
   buildPools, simulatePools, computeStandings, poolWinners,
   buildEmptyCompetition, applyFormat, buildCompetition,
   buildTournament, competitionStatus, SAMPLE_TOURNAMENTS, parseParticipantLines,
-  assignCourt
+  assignCourt, arraysEqual
 };
 
 if (typeof window !== 'undefined') {
@@ -338,4 +344,5 @@ if (typeof window !== 'undefined') {
   window.poolWinners = poolWinners;
   window.parseParticipantLines = parseParticipantLines;
   window.addMinutes = addMinutes;
+  window.arraysEqual = arraysEqual;
 }


### PR DESCRIPTION
## Summary

Phase 2 of the mobile-app improvement plan — four scoring/match-rendering UX issues from [webui_recommendations.md](../blob/main/webui_recommendations.md):

- **Issue #7 — Tie toggle**: The central 'vs' toggle only rendered at 0-0; with any partial score, it was impossible to mark a draw without clearing scores first. Now it's always present (shows 'X' next to the running score). Cancellation still uses the same button. Both states carry an `aria-label` for accessibility.
- **Issue #9 — Shiro/Aka convention**: Per CLAUDE.md, **White (Shiro) is always the left column, Red (Aka) is always the right column**. The `ScoreEditorModal` already obeyed this; `LiveMatchPanel`'s tap/card/scoreboard modes had AKA on the left. Brought them in line.
- **Touch targets**: Seed-row up/down arrows were 1px-padded 11px-font controls — far below any reasonable touch target. Introduced `.btn--icon-sm` (32px min, 44px on `pointer:coarse`) and applied to the arrows.
- **Dirty-state guard**: Backdrop click and Cancel on `ScoreEditorModal` warn before discarding entered scores. Dirty state compares aPts/bPts/aFouls/bFouls/draw-toggle against initial values. Dismiss is blocked entirely while a save is in-flight to prevent closing mid-request.
- **Note field removed**: The "Correction note" input was removed from both `ScoreEditorModal` and `TeamScoreEditorModal`. `toBackendMatchResult` in `api.jsx` never included `score.note` in the backend payload, so the field was cosmetic and produced a misleading "Discard unsaved changes?" prompt. It can be reintroduced once the backend schema supports it.

## Test plan

- [x] `make go/test` — full suite passes (61 JS tests, all Go tests)
- [x] `make examples` — no diff in generated Excel files
- [x] Unit: draw toggle clears scores on activation, toggling off, isDirty logic, handleDismiss submit guard
- [x] Manual: open scoring modal, enter 1-0, tap 'X' — confirm it switches to tie mode and shows 'X' active
- [x] Manual: open scoring modal, enter a score, click backdrop — confirm 'Discard unsaved changes?' prompt
- [x] Manual: open scoring modal, click Save — confirm backdrop clicks are ignored until save completes
- [x] Manual: verify Shiro is on the LEFT in `LiveMatchPanel`'s tap/card/scoreboard modes
- [x] Manual: tap seed-row ↑/↓ arrows on a touchscreen — confirm they're easy to hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)