### PR TITLE
feat(mobile-app): auto-complete pools + live status strip

### DIFF
--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -4,6 +4,42 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
+// MaybeAutoCompletePools transitions a pools-format competition from
+// CompStatusPools to CompStatusComplete when every pool match has been
+// recorded as completed. It is a no-op for any other format or status,
+// or when at least one pool match is still scheduled/running.
+//
+// Returns true if the transition was performed. Callers should broadcast
+// EventCompetitionCompleted when true.
+func (e *Engine) MaybeAutoCompletePools(compId string) (bool, error) {
+	comp, err := e.store.LoadCompetition(compId)
+	if err != nil {
+		return false, err
+	}
+	if comp == nil || comp.Format != "pools" || comp.Status != state.CompStatusPools {
+		return false, nil
+	}
+
+	matches, err := e.store.LoadPoolMatches(compId)
+	if err != nil {
+		return false, err
+	}
+	if len(matches) == 0 {
+		return false, nil
+	}
+	for _, m := range matches {
+		if m.Status != state.MatchStatusCompleted {
+			return false, nil
+		}
+	}
+
+	comp.Status = state.CompStatusComplete
+	if err := e.store.SaveCompetition(comp); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (e *Engine) StartCompetition(id string) error {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -24,9 +24,10 @@ func (e *Engine) MaybeAutoCompletePools(compId string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if len(matches) == 0 {
-		return false, nil
-	}
+	// A pools competition with zero matches has nothing left to score, so we
+	// treat it as complete rather than leaving it stuck in CompStatusPools.
+	// This is a corner case (single-participant pool, or any started pools
+	// comp that legitimately generated zero matches), not the hot path.
 	for _, m := range matches {
 		if m.Status != state.MatchStatusCompleted {
 			return false, nil

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -34,10 +34,14 @@ func (e *Engine) MaybeAutoCompletePools(compId string) (bool, error) {
 	}
 
 	comp.Status = state.CompStatusComplete
-	if err := e.store.SaveCompetition(comp); err != nil {
+	// Use SaveCompetitionChanged so that concurrent score submissions that both
+	// see all matches completed only broadcast once: the second writer finds the
+	// file bytes unchanged and gets changed=false, returning false to its caller.
+	changed, err := e.store.SaveCompetitionChanged(comp)
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return changed, nil
 }
 
 func (e *Engine) StartCompetition(id string) error {

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -11,8 +11,8 @@ import (
 //
 // Returns true if the transition was performed. Callers should broadcast
 // EventCompetitionCompleted when true.
-func (e *Engine) MaybeAutoCompletePools(compId string) (bool, error) {
-	comp, err := e.store.LoadCompetition(compId)
+func (e *Engine) MaybeAutoCompletePools(compID string) (bool, error) {
+	comp, err := e.store.LoadCompetition(compID)
 	if err != nil {
 		return false, err
 	}
@@ -20,7 +20,7 @@ func (e *Engine) MaybeAutoCompletePools(compId string) (bool, error) {
 		return false, nil
 	}
 
-	matches, err := e.store.LoadPoolMatches(compId)
+	matches, err := e.store.LoadPoolMatches(compID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -16,7 +16,7 @@ func (e *Engine) MaybeAutoCompletePools(compId string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if comp == nil || comp.Format != "pools" || comp.Status != state.CompStatusPools {
+	if comp == nil || comp.Format != state.CompFormatPools || comp.Status != state.CompStatusPools {
 		return false, nil
 	}
 
@@ -92,7 +92,7 @@ func (e *Engine) StartCompetition(id string) error {
 	}
 
 	// Generate Pools or Bracket
-	if comp.Format == "pools" {
+	if comp.Format == state.CompFormatPools {
 		if err := e.generatePools(comp, players, seeds); err != nil {
 			return err
 		}

--- a/internal/engine/ranking.go
+++ b/internal/engine/ranking.go
@@ -136,7 +136,7 @@ func (e *Engine) resolveReservedSlots(compID string, players []helper.Player) ([
 		}
 
 		var real *helper.Player
-		if srcComp.Format == "pools" {
+		if srcComp.Format == state.CompFormatPools {
 			if srcComp.Status != state.CompStatusComplete && srcComp.Status != state.CompStatusPlayoffs {
 				return nil, validationErrorf("reserved slot source %q pool results are not final yet (status: %s)", srcComp.Name, srcComp.Status)
 			}

--- a/internal/engine/schedule.go
+++ b/internal/engine/schedule.go
@@ -17,7 +17,7 @@ func (e *Engine) GenerateSchedule(compID string) error {
 
 	var entries []state.ScheduleEntry
 
-	if comp.Format == "pools" {
+	if comp.Format == state.CompFormatPools {
 		matches, err := e.store.LoadPoolMatches(compID)
 		if err != nil {
 			return err

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -224,7 +224,7 @@ func TestMaybeAutoCompletePools(t *testing.T) {
 
 	compID := "auto-complete"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: compID, Name: "Auto", Format: "pools", Status: state.CompStatusPools,
+		ID: compID, Name: "Auto", Format: state.CompFormatPools, Status: state.CompStatusPools,
 	}))
 
 	t.Run("no transition while a pool match is still scheduled", func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestMaybeAutoCompletePools(t *testing.T) {
 	t.Run("ignored for playoffs-format competitions", func(t *testing.T) {
 		koID := "auto-complete-ko"
 		require.NoError(t, store.SaveCompetition(&state.Competition{
-			ID: koID, Name: "KO", Format: "playoffs", Status: state.CompStatusPlayoffs,
+			ID: koID, Name: "KO", Format: state.CompFormatPlayoffs, Status: state.CompStatusPlayoffs,
 		}))
 		require.NoError(t, store.SavePoolMatches(koID, []state.MatchResult{
 			{ID: "M1", Status: state.MatchStatusCompleted, Winner: "X", SideA: "X", SideB: "Y"},
@@ -277,7 +277,7 @@ func TestMaybeAutoCompletePools(t *testing.T) {
 		// Without this branch the competition would be stuck in `pools` forever.
 		emptyID := "auto-complete-empty"
 		require.NoError(t, store.SaveCompetition(&state.Competition{
-			ID: emptyID, Name: "Empty", Format: "pools", Status: state.CompStatusPools,
+			ID: emptyID, Name: "Empty", Format: state.CompFormatPools, Status: state.CompStatusPools,
 		}))
 		require.NoError(t, store.SavePoolMatches(emptyID, []state.MatchResult{}))
 		done, err := eng.MaybeAutoCompletePools(emptyID)

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -271,6 +271,21 @@ func TestMaybeAutoCompletePools(t *testing.T) {
 		comp, _ := store.LoadCompetition(koID)
 		assert.Equal(t, state.CompStatusPlayoffs, comp.Status)
 	})
+
+	t.Run("transitions when there are zero pool matches", func(t *testing.T) {
+		// e.g. a single-participant pools comp where no match was generated.
+		// Without this branch the competition would be stuck in `pools` forever.
+		emptyID := "auto-complete-empty"
+		require.NoError(t, store.SaveCompetition(&state.Competition{
+			ID: emptyID, Name: "Empty", Format: "pools", Status: state.CompStatusPools,
+		}))
+		require.NoError(t, store.SavePoolMatches(emptyID, []state.MatchResult{}))
+		done, err := eng.MaybeAutoCompletePools(emptyID)
+		require.NoError(t, err)
+		assert.True(t, done)
+		comp, _ := store.LoadCompetition(emptyID)
+		assert.Equal(t, state.CompStatusComplete, comp.Status)
+	})
 }
 
 // Regression test for the bug where scoring a match cleared its court and

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -212,3 +212,63 @@ func TestScoreSummary_Team(t *testing.T) {
 	assert.Equal(t, "TeamB", teamB.Player.Name)
 	assert.Equal(t, "W:0 L:1 D:0 | IV:1 IL:2 IT:0 | PW:0 PL:0", teamB.ScoreSummary)
 }
+
+func TestMaybeAutoCompletePools(t *testing.T) {
+	dir, err := os.MkdirTemp("", "engine-autocomplete-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	eng := New(store)
+
+	compID := "auto-complete"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: compID, Name: "Auto", Format: "pools", Status: state.CompStatusPools,
+	}))
+
+	t.Run("no transition while a pool match is still scheduled", func(t *testing.T) {
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "P1-1", Status: state.MatchStatusCompleted, Winner: "Alice", SideA: "Alice", SideB: "Bob"},
+			{ID: "P1-2", Status: state.MatchStatusScheduled, SideA: "Alice", SideB: "Charlie"},
+		}))
+		done, err := eng.MaybeAutoCompletePools(compID)
+		require.NoError(t, err)
+		assert.False(t, done)
+		comp, _ := store.LoadCompetition(compID)
+		assert.Equal(t, state.CompStatusPools, comp.Status)
+	})
+
+	t.Run("transitions to complete when all pool matches are completed", func(t *testing.T) {
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "P1-1", Status: state.MatchStatusCompleted, Winner: "Alice", SideA: "Alice", SideB: "Bob"},
+			{ID: "P1-2", Status: state.MatchStatusCompleted, Winner: "Alice", SideA: "Alice", SideB: "Charlie"},
+		}))
+		done, err := eng.MaybeAutoCompletePools(compID)
+		require.NoError(t, err)
+		assert.True(t, done)
+		comp, _ := store.LoadCompetition(compID)
+		assert.Equal(t, state.CompStatusComplete, comp.Status)
+	})
+
+	t.Run("is a no-op once already complete (idempotent)", func(t *testing.T) {
+		done, err := eng.MaybeAutoCompletePools(compID)
+		require.NoError(t, err)
+		assert.False(t, done)
+	})
+
+	t.Run("ignored for playoffs-format competitions", func(t *testing.T) {
+		koID := "auto-complete-ko"
+		require.NoError(t, store.SaveCompetition(&state.Competition{
+			ID: koID, Name: "KO", Format: "playoffs", Status: state.CompStatusPlayoffs,
+		}))
+		require.NoError(t, store.SavePoolMatches(koID, []state.MatchResult{
+			{ID: "M1", Status: state.MatchStatusCompleted, Winner: "X", SideA: "X", SideB: "Y"},
+		}))
+		done, err := eng.MaybeAutoCompletePools(koID)
+		require.NoError(t, err)
+		assert.False(t, done)
+		comp, _ := store.LoadCompetition(koID)
+		assert.Equal(t, state.CompStatusPlayoffs, comp.Status)
+	})
+}

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -307,12 +307,11 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// A pools competition that generated zero matches (e.g. single
 		// participant) has nothing to score, so trip the auto-complete check
 		// at start time. The non-zero case will trip via score handlers.
-		// Errors are logged with full details server-side; we only surface a
-		// generic signal in the response header so we don't leak internal
-		// paths or store details to clients.
+		// Same sanitized-header contract as tryAutoCompletePools — see
+		// AutoCompleteErrorHeader/Value in hub.go.
 		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
 			log.Printf("MaybeAutoCompletePools(%s) after start: %v", id, err)
-			c.Header("X-Auto-Complete-Error", "failed")
+			c.Header(AutoCompleteErrorHeader, AutoCompleteErrorValue)
 		} else if autoCompleted {
 			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 			// Reflect the auto-complete in the response body so the caller doesn't

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -3,6 +3,7 @@ package mobileapp
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -302,6 +303,16 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		}
 
 		hub.Broadcast(EventCompetitionStarted, gin.H{"competitionId": id})
+
+		// A pools competition that generated zero matches (e.g. single
+		// participant) has nothing to score, so trip the auto-complete check
+		// at start time. The non-zero case will trip via score handlers.
+		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
+			log.Printf("MaybeAutoCompletePools(%s) after start: %v", id, err)
+		} else if autoCompleted {
+			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
+		}
+
 		c.JSON(http.StatusOK, comp)
 	})
 

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -307,11 +307,12 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// A pools competition that generated zero matches (e.g. single
 		// participant) has nothing to score, so trip the auto-complete check
 		// at start time. The non-zero case will trip via score handlers.
-		// Errors are surfaced via response header so disk/store failures
-		// aren't only visible in server logs.
+		// Errors are logged with full details server-side; we only surface a
+		// generic signal in the response header so we don't leak internal
+		// paths or store details to clients.
 		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
 			log.Printf("MaybeAutoCompletePools(%s) after start: %v", id, err)
-			c.Header("X-Auto-Complete-Error", err.Error())
+			c.Header("X-Auto-Complete-Error", "failed")
 		} else if autoCompleted {
 			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 			// Reflect the auto-complete in the response body so the caller doesn't

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -311,6 +311,9 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			log.Printf("MaybeAutoCompletePools(%s) after start: %v", id, err)
 		} else if autoCompleted {
 			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
+			// Reflect the auto-complete in the response body so the caller doesn't
+			// see a stale "pools" status. The persisted file is already updated.
+			comp.Status = state.CompStatusComplete
 		}
 
 		c.JSON(http.StatusOK, comp)

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -427,7 +427,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 
 		playoff := state.Competition{
 			Name:           src.Name + " - Playoffs",
-			Format:         "playoffs",
+			Format:         state.CompFormatPlayoffs,
 			Courts:         src.Courts,
 			WithZekkenName: src.WithZekkenName,
 			NumberPrefix:   src.NumberPrefix,

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -404,7 +404,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 
-		if src.Format != "pools" {
+		if src.Format != state.CompFormatPools {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "source competition must use pools format"})
 			return
 		}

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -307,8 +307,11 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// A pools competition that generated zero matches (e.g. single
 		// participant) has nothing to score, so trip the auto-complete check
 		// at start time. The non-zero case will trip via score handlers.
+		// Errors are surfaced via response header so disk/store failures
+		// aren't only visible in server logs.
 		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
 			log.Printf("MaybeAutoCompletePools(%s) after start: %v", id, err)
+			c.Header("X-Auto-Complete-Error", err.Error())
 		} else if autoCompleted {
 			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 			// Reflect the auto-complete in the response body so the caller doesn't

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -23,19 +23,21 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 			Error   string `json:"error"`
 		}
 		var errs []scoreError
-		succeeded := 0
+		// Only successfully-recorded results go into the SSE broadcast so
+		// clients never patch with values the engine rejected.
+		var successful []state.MatchResult
 		for i := range results {
 			if err := eng.RecordMatchResult(id, results[i].ID, &results[i]); err != nil {
 				errs = append(errs, scoreError{MatchID: results[i].ID, Error: err.Error()})
 			} else {
-				succeeded++
+				successful = append(successful, results[i])
 			}
 		}
 
-		if succeeded > 0 {
+		if len(successful) > 0 {
 			hub.Broadcast(EventMatchUpdated, gin.H{
 				"competitionId": id,
-				"results":       results,
+				"results":       successful,
 			})
 			if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
 				log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
@@ -43,7 +45,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 				hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 			}
 		}
-		c.JSON(http.StatusOK, gin.H{"succeeded": succeeded, "errors": errs})
+		c.JSON(http.StatusOK, gin.H{"succeeded": len(successful), "errors": errs})
 	})
 
 	r.PUT("/competitions/:id/matches/:mid/quick-score", func(c *gin.Context) {

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -11,15 +11,16 @@ import (
 
 // tryAutoCompletePools runs the auto-complete check after a successful score
 // write. The score itself has already been recorded, so we don't fail the
-// request when the auto-complete check errors; instead we log and surface
-// the failure via the X-Auto-Complete-Error response header so that bad
-// disks / store errors aren't visible only in server logs. Broadcasts
-// EventCompetitionCompleted when the transition actually happens.
+// request when the auto-complete check errors; instead we log full details
+// server-side and surface a generic signal via the X-Auto-Complete-Error
+// response header so clients can detect the failure (and refresh) without
+// us leaking filesystem paths or other internal details from raw errors.
+// Broadcasts EventCompetitionCompleted when the transition actually happens.
 func tryAutoCompletePools(c *gin.Context, eng *engine.Engine, hub *Hub, compID string) {
 	autoCompleted, err := eng.MaybeAutoCompletePools(compID)
 	if err != nil {
 		log.Printf("MaybeAutoCompletePools(%s): %v", compID, err)
-		c.Header("X-Auto-Complete-Error", err.Error())
+		c.Header("X-Auto-Complete-Error", "failed")
 		return
 	}
 	if autoCompleted {

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -9,6 +9,24 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
+// tryAutoCompletePools runs the auto-complete check after a successful score
+// write. The score itself has already been recorded, so we don't fail the
+// request when the auto-complete check errors; instead we log and surface
+// the failure via the X-Auto-Complete-Error response header so that bad
+// disks / store errors aren't visible only in server logs. Broadcasts
+// EventCompetitionCompleted when the transition actually happens.
+func tryAutoCompletePools(c *gin.Context, eng *engine.Engine, hub *Hub, compID string) {
+	autoCompleted, err := eng.MaybeAutoCompletePools(compID)
+	if err != nil {
+		log.Printf("MaybeAutoCompletePools(%s): %v", compID, err)
+		c.Header("X-Auto-Complete-Error", err.Error())
+		return
+	}
+	if autoCompleted {
+		hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": compID})
+	}
+}
+
 func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.Engine, hub *Hub) {
 	r.POST("/competitions/:id/matches/bulk-score", func(c *gin.Context) {
 		id := c.Param("id")
@@ -39,11 +57,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 				"competitionId": id,
 				"results":       successful,
 			})
-			if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
-				log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
-			} else if autoCompleted {
-				hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
-			}
+			tryAutoCompletePools(c, eng, hub, id)
 		}
 		c.JSON(http.StatusOK, gin.H{"succeeded": len(successful), "errors": errs})
 	})
@@ -108,11 +122,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 		}
 
 		hub.Broadcast(EventMatchUpdated, gin.H{"competitionId": id, "matchId": mid})
-		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
-			log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
-		} else if autoCompleted {
-			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
-		}
+		tryAutoCompletePools(c, eng, hub, id)
 		c.JSON(http.StatusOK, result)
 	})
 
@@ -136,11 +146,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 			"matchId":       mid,
 			"result":        result,
 		})
-		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
-			log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
-		} else if autoCompleted {
-			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
-		}
+		tryAutoCompletePools(c, eng, hub, id)
 
 		c.JSON(http.StatusOK, result)
 	})

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -12,15 +12,15 @@ import (
 // tryAutoCompletePools runs the auto-complete check after a successful score
 // write. The score itself has already been recorded, so we don't fail the
 // request when the auto-complete check errors; instead we log full details
-// server-side and surface a generic signal via the X-Auto-Complete-Error
-// response header so clients can detect the failure (and refresh) without
-// us leaking filesystem paths or other internal details from raw errors.
-// Broadcasts EventCompetitionCompleted when the transition actually happens.
+// server-side and set AutoCompleteErrorHeader to a generic sentinel so
+// clients can detect the failure (and refresh) without us leaking
+// internal store details. Broadcasts EventCompetitionCompleted when the
+// transition actually happens.
 func tryAutoCompletePools(c *gin.Context, eng *engine.Engine, hub *Hub, compID string) {
 	autoCompleted, err := eng.MaybeAutoCompletePools(compID)
 	if err != nil {
 		log.Printf("MaybeAutoCompletePools(%s): %v", compID, err)
-		c.Header("X-Auto-Complete-Error", "failed")
+		c.Header(AutoCompleteErrorHeader, AutoCompleteErrorValue)
 		return
 	}
 	if autoCompleted {

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -36,6 +36,9 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 				"competitionId": id,
 				"results":       results,
 			})
+			if autoCompleted, _ := eng.MaybeAutoCompletePools(id); autoCompleted {
+				hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
+			}
 		}
 		c.JSON(http.StatusOK, gin.H{"succeeded": succeeded, "errors": errs})
 	})
@@ -100,6 +103,9 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 		}
 
 		hub.Broadcast(EventMatchUpdated, gin.H{"competitionId": id, "matchId": mid})
+		if autoCompleted, _ := eng.MaybeAutoCompletePools(id); autoCompleted {
+			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
+		}
 		c.JSON(http.StatusOK, result)
 	})
 
@@ -123,6 +129,9 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 			"matchId":       mid,
 			"result":        result,
 		})
+		if autoCompleted, _ := eng.MaybeAutoCompletePools(id); autoCompleted {
+			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
+		}
 
 		c.JSON(http.StatusOK, result)
 	})

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -1,6 +1,7 @@
 package mobileapp
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -36,7 +37,9 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 				"competitionId": id,
 				"results":       results,
 			})
-			if autoCompleted, _ := eng.MaybeAutoCompletePools(id); autoCompleted {
+			if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
+				log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
+			} else if autoCompleted {
 				hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 			}
 		}
@@ -103,7 +106,9 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 		}
 
 		hub.Broadcast(EventMatchUpdated, gin.H{"competitionId": id, "matchId": mid})
-		if autoCompleted, _ := eng.MaybeAutoCompletePools(id); autoCompleted {
+		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
+			log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
+		} else if autoCompleted {
 			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 		}
 		c.JSON(http.StatusOK, result)
@@ -129,7 +134,9 @@ func RegisterMatchHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.E
 			"matchId":       mid,
 			"result":        result,
 		})
-		if autoCompleted, _ := eng.MaybeAutoCompletePools(id); autoCompleted {
+		if autoCompleted, err := eng.MaybeAutoCompletePools(id); err != nil {
+			log.Printf("MaybeAutoCompletePools(%s): %v", id, err)
+		} else if autoCompleted {
 			hub.Broadcast(EventCompetitionCompleted, gin.H{"competitionId": id})
 		}
 

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBulkScoreHandler(t *testing.T) {
@@ -240,4 +242,79 @@ func TestMatchHandlers_Extended(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
+}
+
+// TestScoreHandler_CompletionBroadcastContract verifies that scoring the final
+// pool match emits EventCompetitionCompleted exactly once, and that scoring a
+// non-final match does not emit it.
+func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
+	r, store, _, hub, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	comp := state.Competition{
+		ID:     "pools1",
+		Format: "pools",
+		Status: state.CompStatusPools,
+	}
+	require.NoError(t, store.SaveCompetition(&comp))
+	require.NoError(t, store.SaveParticipants("pools1", []helper.Player{
+		{Name: "P1"}, {Name: "P2"}, {Name: "P3"},
+	}))
+	require.NoError(t, store.SavePoolMatches("pools1", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "P1", SideB: "P2"},
+		{ID: "PoolA-2", SideA: "P1", SideB: "P3"},
+	}))
+
+	ch := hub.Subscribe()
+	defer hub.Unsubscribe(ch)
+
+	drainFor := func(d time.Duration) []SSEEvent {
+		var events []SSEEvent
+		deadline := time.After(d)
+		for {
+			select {
+			case msg := <-ch:
+				var e SSEEvent
+				require.NoError(t, json.Unmarshal([]byte(msg), &e))
+				events = append(events, e)
+			case <-deadline:
+				return events
+			}
+		}
+	}
+
+	scoreMatch := func(mid, winner string) {
+		body, _ := json.Marshal(state.MatchResult{
+			ID: mid, SideA: "P1", SideB: "P2",
+			Winner: winner, Status: state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/pools1/matches/"+mid+"/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// Partial completion — no EventCompetitionCompleted
+	scoreMatch("PoolA-1", "P1")
+	partialEvents := drainFor(30 * time.Millisecond)
+	for _, e := range partialEvents {
+		assert.NotEqual(t, EventCompetitionCompleted, e.Type,
+			"partial completion must not broadcast competition_completed")
+	}
+
+	// Final match — EventCompetitionCompleted must be emitted exactly once
+	scoreMatch("PoolA-2", "P1")
+	finalEvents := drainFor(100 * time.Millisecond)
+
+	completedCount := 0
+	for _, e := range finalEvents {
+		if e.Type == EventCompetitionCompleted {
+			completedCount++
+			compData, isMap := e.Data.(map[string]any)
+			require.True(t, isMap, "competition_completed data must be a map")
+			assert.Equal(t, "pools1", compData["competitionId"])
+		}
+	}
+	assert.Equal(t, 1, completedCount, "final match must emit competition_completed exactly once")
 }

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -253,7 +253,7 @@ func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
 
 	comp := state.Competition{
 		ID:     "pools1",
-		Format: "pools",
+		Format: state.CompFormatPools,
 		Status: state.CompStatusPools,
 	}
 	require.NoError(t, store.SaveCompetition(&comp))

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -322,3 +322,133 @@ func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
 	}
 	assert.Equal(t, 1, completedCount, "final match must emit competition_completed exactly once")
 }
+
+// drainHubEvents pulls every queued event off the given hub-subscriber
+// channel within d, decoding each into SSEEvent for inspection.
+func drainHubEvents(t *testing.T, ch <-chan string, d time.Duration) []SSEEvent {
+	t.Helper()
+	var events []SSEEvent
+	deadline := time.After(d)
+	for {
+		select {
+		case msg := <-ch:
+			var e SSEEvent
+			require.NoError(t, json.Unmarshal([]byte(msg), &e))
+			events = append(events, e)
+		case <-deadline:
+			return events
+		}
+	}
+}
+
+// countCompletedEvents counts EventCompetitionCompleted events and asserts
+// each carries the expected competitionId.
+func countCompletedEvents(t *testing.T, events []SSEEvent, wantCompID string) int {
+	t.Helper()
+	n := 0
+	for _, e := range events {
+		if e.Type != EventCompetitionCompleted {
+			continue
+		}
+		n++
+		data, isMap := e.Data.(map[string]any)
+		require.True(t, isMap, "competition_completed data must be a map")
+		assert.Equal(t, wantCompID, data["competitionId"])
+	}
+	return n
+}
+
+// TestBulkScoreHandler_CompletionBroadcastContract verifies that bulk-scoring
+// the last remaining pool matches emits EventCompetitionCompleted exactly
+// once (and partial bulk completion does not).
+func TestBulkScoreHandler_CompletionBroadcastContract(t *testing.T) {
+	r, store, _, hub, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "bulk1", Format: state.CompFormatPools, Status: state.CompStatusPools,
+	}))
+	require.NoError(t, store.SaveParticipants("bulk1", []helper.Player{
+		{Name: "P1"}, {Name: "P2"}, {Name: "P3"},
+	}))
+	require.NoError(t, store.SavePoolMatches("bulk1", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "P1", SideB: "P2"},
+		{ID: "PoolA-2", SideA: "P1", SideB: "P3"},
+		{ID: "PoolA-3", SideA: "P2", SideB: "P3"},
+	}))
+
+	ch := hub.Subscribe()
+	defer hub.Unsubscribe(ch)
+
+	bulkScore := func(results []state.MatchResult) {
+		body, _ := json.Marshal(results)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/bulk1/matches/bulk-score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// Partial bulk completion (1 of 3) — no competition_completed
+	bulkScore([]state.MatchResult{
+		{ID: "PoolA-1", Winner: "P1", Status: state.MatchStatusCompleted},
+	})
+	partial := drainHubEvents(t, ch, 30*time.Millisecond)
+	assert.Equal(t, 0, countCompletedEvents(t, partial, "bulk1"),
+		"partial bulk completion must not broadcast competition_completed")
+
+	// Final batch closes out the comp — exactly one competition_completed
+	bulkScore([]state.MatchResult{
+		{ID: "PoolA-2", Winner: "P1", Status: state.MatchStatusCompleted},
+		{ID: "PoolA-3", Winner: "P2", Status: state.MatchStatusCompleted},
+	})
+	final := drainHubEvents(t, ch, 100*time.Millisecond)
+	assert.Equal(t, 1, countCompletedEvents(t, final, "bulk1"),
+		"final bulk-score batch must emit competition_completed exactly once")
+}
+
+// TestQuickScoreHandler_CompletionBroadcastContract verifies that
+// quick-scoring the last remaining pool match emits EventCompetitionCompleted
+// exactly once, and a non-final quick-score does not.
+func TestQuickScoreHandler_CompletionBroadcastContract(t *testing.T) {
+	r, store, _, hub, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "qs1", Format: state.CompFormatPools, Status: state.CompStatusPools, TeamSize: 3,
+	}))
+	require.NoError(t, store.SavePools("qs1", []helper.Pool{
+		{PoolName: "PoolA", Players: []helper.Player{{Name: "TeamA"}, {Name: "TeamB"}, {Name: "TeamC"}}},
+	}))
+	require.NoError(t, store.SavePoolMatches("qs1", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "TeamA", SideB: "TeamB"},
+		{ID: "PoolA-2", SideA: "TeamA", SideB: "TeamC"},
+	}))
+
+	ch := hub.Subscribe()
+	defer hub.Unsubscribe(ch)
+
+	quickScore := func(mid, sideA, sideB string, aWins, bWins, draws int) {
+		body, _ := json.Marshal(map[string]any{
+			"sideA": sideA, "sideB": sideB,
+			"teamAWins": aWins, "teamBWins": bWins, "draws": draws,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/qs1/matches/"+mid+"/quick-score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// First match — no completion
+	quickScore("PoolA-1", "TeamA", "TeamB", 2, 1, 0)
+	partial := drainHubEvents(t, ch, 30*time.Millisecond)
+	assert.Equal(t, 0, countCompletedEvents(t, partial, "qs1"),
+		"partial quick-score must not broadcast competition_completed")
+
+	// Final match — exactly one completion
+	quickScore("PoolA-2", "TeamA", "TeamC", 2, 1, 0)
+	final := drainHubEvents(t, ch, 100*time.Millisecond)
+	assert.Equal(t, 1, countCompletedEvents(t, final, "qs1"),
+		"final quick-score must emit competition_completed exactly once")
+}

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -283,10 +283,14 @@ func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
 		}
 	}
 
+	// Omit sideA/sideB from the patch so the engine preserves the stored
+	// participants. Hardcoding "P1"/"P2" for every match would mutate
+	// PoolA-2 (which has P1 vs P3) and mask side-preservation bugs.
 	scoreMatch := func(mid, winner string) {
 		body, _ := json.Marshal(state.MatchResult{
-			ID: mid, SideA: "P1", SideB: "P2",
-			Winner: winner, Status: state.MatchStatusCompleted,
+			ID:     mid,
+			Winner: winner,
+			Status: state.MatchStatusCompleted,
 		})
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("PUT", "/api/competitions/pools1/matches/"+mid+"/score", bytes.NewBuffer(body))

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 	"github.com/stretchr/testify/assert"
@@ -425,4 +426,29 @@ func TestQuickScoreHandler_CompletionBroadcastContract(t *testing.T) {
 	final := drainHubEvents(t, ch, 100*time.Millisecond)
 	assert.Equal(t, 1, countCompletedEvents(t, final, "qs1"),
 		"final quick-score must emit competition_completed exactly once")
+}
+
+// TestTryAutoCompletePools_SanitizesErrorHeader locks in the contract that
+// when MaybeAutoCompletePools fails, the response carries the generic
+// AutoCompleteErrorValue sentinel — never the raw error string, which can
+// contain filesystem paths or other internal store details.
+func TestTryAutoCompletePools_SanitizesErrorHeader(t *testing.T) {
+	_, _, eng, hub, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	// An ID containing "/" trips ValidateCompetitionID inside
+	// LoadCompetition, exercising the error path with a deterministic
+	// non-I/O failure (no need to fault-inject the filesystem).
+	tryAutoCompletePools(c, eng, hub, "../bad")
+
+	got := w.Header().Get(AutoCompleteErrorHeader)
+	assert.Equal(t, AutoCompleteErrorValue, got,
+		"header must be the generic sentinel, not the raw error")
+	assert.NotContains(t, got, "competition ID",
+		"raw validation error text must not leak into the response header")
+	assert.NotContains(t, got, "invalid",
+		"raw validation error text must not leak into the response header")
 }

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -268,21 +268,6 @@ func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
 	ch := hub.Subscribe()
 	defer hub.Unsubscribe(ch)
 
-	drainFor := func(d time.Duration) []SSEEvent {
-		var events []SSEEvent
-		deadline := time.After(d)
-		for {
-			select {
-			case msg := <-ch:
-				var e SSEEvent
-				require.NoError(t, json.Unmarshal([]byte(msg), &e))
-				events = append(events, e)
-			case <-deadline:
-				return events
-			}
-		}
-	}
-
 	// Omit sideA/sideB from the patch so the engine preserves the stored
 	// participants. Hardcoding "P1"/"P2" for every match would mutate
 	// PoolA-2 (which has P1 vs P3) and mask side-preservation bugs.
@@ -301,26 +286,15 @@ func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
 
 	// Partial completion — no EventCompetitionCompleted
 	scoreMatch("PoolA-1", "P1")
-	partialEvents := drainFor(30 * time.Millisecond)
-	for _, e := range partialEvents {
-		assert.NotEqual(t, EventCompetitionCompleted, e.Type,
-			"partial completion must not broadcast competition_completed")
-	}
+	partial := drainHubEvents(t, ch, 30*time.Millisecond)
+	assert.Equal(t, 0, countCompletedEvents(t, partial, "pools1"),
+		"partial completion must not broadcast competition_completed")
 
 	// Final match — EventCompetitionCompleted must be emitted exactly once
 	scoreMatch("PoolA-2", "P1")
-	finalEvents := drainFor(100 * time.Millisecond)
-
-	completedCount := 0
-	for _, e := range finalEvents {
-		if e.Type == EventCompetitionCompleted {
-			completedCount++
-			compData, isMap := e.Data.(map[string]any)
-			require.True(t, isMap, "competition_completed data must be a map")
-			assert.Equal(t, "pools1", compData["competitionId"])
-		}
-	}
-	assert.Equal(t, 1, completedCount, "final match must emit competition_completed exactly once")
+	final := drainHubEvents(t, ch, 100*time.Millisecond)
+	assert.Equal(t, 1, countCompletedEvents(t, final, "pools1"),
+		"final match must emit competition_completed exactly once")
 }
 
 // drainHubEvents pulls every queued event off the given hub-subscriber

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -539,13 +539,21 @@ func TestViewerHandlers(t *testing.T) {
 }
 
 // TestStartCompetition_BroadcastContract verifies the exact events emitted by
-// POST /competitions/:id/start. Only EventCompetitionStarted is sent; the
-// competition_started handler in app.js already calls load() so a separate
+// POST /competitions/:id/start in the common case (playoffs format, or pools
+// with at least one un-completed match): only EventCompetitionStarted is sent.
+// The competition_started handler in app.js already calls load() so a separate
 // EventTournamentUpdated would cause a redundant second reload per viewer.
+//
+// The start handler ALSO invokes MaybeAutoCompletePools, which for a pools
+// competition that finishes generation with every match already completed (a
+// theoretical zero-match edge case) would additionally emit
+// EventCompetitionCompleted. That branch is covered at the engine layer by
+// TestMaybeAutoCompletePools/transitions_when_there_are_zero_pool_matches.
 func TestStartCompetition_BroadcastContract(t *testing.T) {
 	r, store, _, hub, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
+	// Format omitted → playoffs path; MaybeAutoCompletePools is a no-op.
 	comp := state.Competition{ID: "c1", Status: "setup", Courts: []string{"A"}}
 	require.NoError(t, store.SaveCompetition(&comp))
 	require.NoError(t, store.SaveParticipants("c1", []helper.Player{{Name: "P1"}, {Name: "P2"}}))
@@ -578,5 +586,5 @@ func TestStartCompetition_BroadcastContract(t *testing.T) {
 	assert.Equal(t, "c1", compData["competitionId"])
 
 	_, extra := receiveEvent(10 * time.Millisecond)
-	assert.False(t, extra, "start must emit exactly 1 broadcast")
+	assert.False(t, extra, "start must emit exactly 1 broadcast for the common case")
 }

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -22,6 +22,16 @@ const (
 	EventScheduleUpdated      EventType = "schedule_updated"
 )
 
+// AutoCompleteErrorHeader is set on score/start responses when the
+// post-write MaybeAutoCompletePools check itself errored. The value is a
+// deliberately generic sentinel (AutoCompleteErrorValue) so we don't leak
+// filesystem paths or other internal store details to clients — full error
+// detail is logged server-side.
+const (
+	AutoCompleteErrorHeader = "X-Auto-Complete-Error"
+	AutoCompleteErrorValue  = "failed"
+)
+
 // SSEEvent represents the payload sent to clients
 type SSEEvent struct {
 	Type EventType `json:"type"`

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -15,10 +15,11 @@ import (
 type EventType string
 
 const (
-	EventMatchUpdated       EventType = "match_updated"
-	EventCompetitionStarted EventType = "competition_started"
-	EventTournamentUpdated  EventType = "tournament_updated"
-	EventScheduleUpdated    EventType = "schedule_updated"
+	EventMatchUpdated         EventType = "match_updated"
+	EventCompetitionStarted   EventType = "competition_started"
+	EventCompetitionCompleted EventType = "competition_completed"
+	EventTournamentUpdated    EventType = "tournament_updated"
+	EventScheduleUpdated      EventType = "schedule_updated"
 )
 
 // SSEEvent represents the payload sent to clients

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -52,6 +52,14 @@ const (
 	MatchStatusCompleted MatchStatus = "completed"
 )
 
+// Competition.Format values. Kept as untyped string constants because the
+// Competition.Format field is a plain `string` for backward compatibility
+// with existing YAML/JSON state files.
+const (
+	CompFormatPools    = "pools"
+	CompFormatPlayoffs = "playoffs"
+)
+
 // DecisionDraw is the canonical value for a tied (hikiwake) match. The
 // legacy spelling "hikewake" (missing the 'i') was used historically and is
 // still accepted by IsDraw() for backward compatibility on existing data,

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -345,6 +345,7 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
     """
     deadline = time.time() + timeout_s
     last_status = None
+    resp = None  # guard against UnboundLocalError if every attempt raises ConnectionError
     while time.time() < deadline:
         try:
             resp = requests.get(f"{BASE_URL}/api/competitions/{comp_id}", headers=HEADERS)
@@ -363,9 +364,10 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
             if last_status == expected:
                 return last_status
         time.sleep(interval_s)
+    http_info = f" (HTTP {resp.status_code})" if resp is not None else " (no successful response)"
     raise RuntimeError(
         f"[FAIL] {comp_id}: expected status {expected!r} within {timeout_s}s, "
-        f"last seen {last_status!r} (HTTP {resp.status_code}). "
+        f"last seen {last_status!r}{http_info}. "
         f"Backend auto-completion may have regressed."
     )
 

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -348,10 +348,17 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
     resp = None  # guard against UnboundLocalError if every attempt raises ConnectionError
     while time.time() < deadline:
         try:
-            resp = requests.get(f"{BASE_URL}/api/competitions/{comp_id}", headers=HEADERS)
-        except requests.exceptions.ConnectionError as e:
+            # Bound the per-call wait to interval_s so a hung server can't
+            # block past `timeout_s`. The loop's own deadline still bounds
+            # total wait time.
+            resp = requests.get(
+                f"{BASE_URL}/api/competitions/{comp_id}",
+                headers=HEADERS,
+                timeout=interval_s,
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             # Transient — retry until deadline
-            print(f"  [WARN] Connection error polling {comp_id}: {e}")
+            print(f"  [WARN] Connection/timeout error polling {comp_id}: {e}")
             time.sleep(interval_s)
             continue
         if 400 <= resp.status_code < 500:

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -368,7 +368,15 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
                 f"Check auth/config. Response: {resp.text[:200]}"
             )
         if resp.status_code == 200:
-            last_status = resp.json().get("status")
+            try:
+                body = resp.json()
+            except ValueError as e:
+                # 200 with non-JSON body (HTML error page from a proxy, etc.) —
+                # treat as a transient poll failure rather than crashing.
+                print(f"  [WARN] Non-JSON 200 response polling {comp_id}: {e}. Body: {resp.text[:200]}")
+                time.sleep(interval_s)
+                continue
+            last_status = body.get("status") if isinstance(body, dict) else None
             if last_status == expected:
                 return last_status
         time.sleep(interval_s)

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -341,11 +341,23 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
 
     Used after scoring all pool matches to assert the backend's auto-completion
     has fired. If this times out, the auto-completion logic has regressed.
+    Fails immediately on 4xx responses (auth/config problems, not transient).
     """
     deadline = time.time() + timeout_s
     last_status = None
     while time.time() < deadline:
-        resp = requests.get(f"{BASE_URL}/api/competitions/{comp_id}", headers=HEADERS)
+        try:
+            resp = requests.get(f"{BASE_URL}/api/competitions/{comp_id}", headers=HEADERS)
+        except requests.exceptions.ConnectionError as e:
+            # Transient — retry until deadline
+            print(f"  [WARN] Connection error polling {comp_id}: {e}")
+            time.sleep(interval_s)
+            continue
+        if 400 <= resp.status_code < 500:
+            raise RuntimeError(
+                f"[FAIL] {comp_id}: unexpected {resp.status_code} while polling status. "
+                f"Check auth/config. Response: {resp.text[:200]}"
+            )
         if resp.status_code == 200:
             last_status = resp.json().get("status")
             if last_status == expected:
@@ -353,7 +365,8 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
         time.sleep(interval_s)
     raise RuntimeError(
         f"[FAIL] {comp_id}: expected status {expected!r} within {timeout_s}s, "
-        f"last seen {last_status!r}. Backend auto-completion may have regressed."
+        f"last seen {last_status!r} (HTTP {resp.status_code}). "
+        f"Backend auto-completion may have regressed."
     )
 
 

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -346,15 +346,16 @@ def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
     deadline = time.time() + timeout_s
     last_status = None
     resp = None  # guard against UnboundLocalError if every attempt raises ConnectionError
+    # Use a forgiving per-request timeout: at least 1s so slow/busy machines
+    # don't spuriously time out on a healthy backend. The loop's own deadline
+    # still bounds total wait time, so a truly hung server can't block forever.
+    request_timeout = max(1.0, interval_s * 4)
     while time.time() < deadline:
         try:
-            # Bound the per-call wait to interval_s so a hung server can't
-            # block past `timeout_s`. The loop's own deadline still bounds
-            # total wait time.
             resp = requests.get(
                 f"{BASE_URL}/api/competitions/{comp_id}",
                 headers=HEADERS,
-                timeout=interval_s,
+                timeout=request_timeout,
             )
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             # Transient — retry until deadline

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -336,6 +336,27 @@ def create_linked_playoff(pool_comp_id, cat):
     playoff_id = resp.json()['id']
     return playoff_id
 
+def wait_for_status(comp_id, expected, timeout_s=5.0, interval_s=0.2):
+    """Poll the competition until its status matches `expected` or timeout.
+
+    Used after scoring all pool matches to assert the backend's auto-completion
+    has fired. If this times out, the auto-completion logic has regressed.
+    """
+    deadline = time.time() + timeout_s
+    last_status = None
+    while time.time() < deadline:
+        resp = requests.get(f"{BASE_URL}/api/competitions/{comp_id}", headers=HEADERS)
+        if resp.status_code == 200:
+            last_status = resp.json().get("status")
+            if last_status == expected:
+                return last_status
+        time.sleep(interval_s)
+    raise RuntimeError(
+        f"[FAIL] {comp_id}: expected status {expected!r} within {timeout_s}s, "
+        f"last seen {last_status!r}. Backend auto-completion may have regressed."
+    )
+
+
 def main():
     wait_for_server()
     setup_tournament()
@@ -343,23 +364,17 @@ def main():
     for cat in CATEGORIES:
         # 1. Setup Pools
         pool_comp_id = run_competition_setup(cat)
-        
+
         # 2. Setup Linked Playoff
         playoff_id = create_linked_playoff(pool_comp_id, cat)
-        
 
-        # 3. Run Pools
+        # 3. Run Pools — backend auto-transitions status to "completed" when
+        #    the last pool match is recorded, so the explicit PUT we used to
+        #    issue here is intentionally absent. Poll to confirm.
         score_all_matches(pool_comp_id)
-        
-        # 3.5 Mark pools as completed
-        resp = requests.get(f"{BASE_URL}/api/competitions/{pool_comp_id}", headers=HEADERS)
-        if resp.status_code == 200:
-            comp_data = resp.json()
-            comp_data["status"] = "completed"
-            requests.put(f"{BASE_URL}/api/competitions/{pool_comp_id}", json=comp_data, headers=HEADERS).raise_for_status()
-            print(f"Marked {pool_comp_id} as completed.")
+        wait_for_status(pool_comp_id, "completed")
+        print(f"[OK] {pool_comp_id} auto-transitioned to 'completed'.")
 
-        
         # 4. Start and Run Playoffs (Promotion happens automatically!)
         try:
             requests.post(f"{BASE_URL}/api/competitions/{playoff_id}/start", headers=HEADERS).raise_for_status()

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1,6 +1,7 @@
 /* Bracket Creator — clean utilitarian, polished */
 
 :root {
+  --topbar-h: 50px;
   --accent: #1d3557;
   --accent-soft: #e7eaf3;
   --accent-fg: #ffffff;
@@ -87,6 +88,7 @@ a:hover {
   align-items: center;
   gap: 14px;
   padding: 10px 20px;
+  min-height: var(--topbar-h);
   position: sticky;
   top: 0;
   z-index: 30;
@@ -177,7 +179,7 @@ a:hover {
   align-items: center;
   gap: 12px;
   position: sticky;
-  top: 50px;
+  top: var(--topbar-h);
   z-index: 29;
   font-size: 12px;
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -168,6 +168,69 @@ a:hover {
   border-color: var(--ink-4);
 }
 
+/* ---------- Live status strip (under topbar) ---------- */
+.live-strip {
+  background: var(--red-soft);
+  border-bottom: 1px solid var(--line);
+  padding: 6px 20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: sticky;
+  top: 50px;
+  z-index: 29;
+  font-size: 12px;
+}
+
+.live-strip__lbl {
+  font-weight: 700;
+  color: var(--red);
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.live-strip__chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.live-strip__chip {
+  background: var(--surface);
+  border: 1px solid var(--red);
+  border-radius: 999px;
+  padding: 3px 10px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--ink);
+  cursor: pointer;
+  transition: background 120ms;
+}
+
+.live-strip__chip:hover {
+  background: var(--red);
+  color: white;
+}
+
+.live-strip__court {
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.live-strip__names {
+  font-size: 12px;
+}
+
+.live-strip__more {
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
 /* ---------- Page container ---------- */
 .page {
   padding: 24px 32px;
@@ -178,6 +241,15 @@ a:hover {
 
 .page--wide {
   max-width: none;
+}
+
+.page-head__eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  font-weight: 600;
+  margin-bottom: 4px;
 }
 
 .page-head {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1,10 +1,6 @@
 /* Bracket Creator — clean utilitarian, polished */
 
 :root {
-  /* Topbar uses fixed `height` (not min-height) so the live-strip's
-     `top: var(--topbar-h)` aligns perfectly. Value must accommodate the
-     brand title (15px/1.4) + sub (12px/1.4) ≈ 38px + 10px×2 padding = 58px. */
-  --topbar-h: 60px;
   --accent: #1d3557;
   --accent-soft: #e7eaf3;
   --accent-fg: #ffffff;
@@ -84,6 +80,16 @@ a:hover {
 }
 
 /* ---------- Top bar (admin) ---------- */
+/* The .topbar-stack wrapper is sticky; topbar + live-strip sit inside as
+   normal flow, so the topbar can size to its content (font scaling / zoom
+   never clip the brand block, and the live-strip stays glued underneath
+   without a hardcoded offset). */
+.topbar-stack {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+}
+
 .topbar {
   background: var(--surface);
   border-bottom: 1px solid var(--line);
@@ -91,11 +97,6 @@ a:hover {
   align-items: center;
   gap: 14px;
   padding: 10px 20px;
-  height: var(--topbar-h);
-  box-sizing: border-box;
-  position: sticky;
-  top: 0;
-  z-index: 30;
 }
 
 .topbar__brand {
@@ -184,6 +185,8 @@ a:hover {
 }
 
 /* ---------- Live status strip (under topbar) ---------- */
+/* Stickiness is provided by the parent .topbar-stack so the strip never
+   needs to know the topbar's height — it sits naturally below in flow. */
 .live-strip {
   background: var(--red-soft);
   border-bottom: 1px solid var(--line);
@@ -191,9 +194,6 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 12px;
-  position: sticky;
-  top: var(--topbar-h);
-  z-index: 29;
   font-size: 12px;
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1,7 +1,10 @@
 /* Bracket Creator — clean utilitarian, polished */
 
 :root {
-  --topbar-h: 50px;
+  /* Topbar uses fixed `height` (not min-height) so the live-strip's
+     `top: var(--topbar-h)` aligns perfectly. Value must accommodate the
+     brand title (15px/1.4) + sub (12px/1.4) ≈ 38px + 10px×2 padding = 58px. */
+  --topbar-h: 60px;
   --accent: #1d3557;
   --accent-soft: #e7eaf3;
   --accent-fg: #ffffff;
@@ -99,6 +102,15 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-width: 0; /* allow truncation when the title block sits next to a wide spacer */
+  overflow: hidden;
+}
+
+.topbar__title,
+.topbar__sub {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .topbar__logo {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -88,7 +88,8 @@ a:hover {
   align-items: center;
   gap: 14px;
   padding: 10px 20px;
-  min-height: var(--topbar-h);
+  height: var(--topbar-h);
+  box-sizing: border-box;
   position: sticky;
   top: 0;
   z-index: 30;

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -457,11 +457,19 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
   // know what's live, regardless of which screen they're on. Clicking
   // a chip jumps to that competition's score editor via the global
   // navigator helper set up by AdminApp.
+  // sideA/sideB may be a string (raw backend), an object with .name
+  // (normalised), or an empty {id:"",name:""} placeholder. Extract names
+  // defensively and skip chips where either side has no real name.
+  const sideName = (side) => {
+    if (!side) return "";
+    if (typeof side === "string") return side;
+    return side.name || "";
+  };
   const liveMatches = useMemoA(() => {
     if (!tournament || !window.compMatches) return [];
     return (tournament.competitions || [])
       .flatMap(cc => window.compMatches(cc))
-      .filter(m => m.status === "running" && m.sideA && m.sideB);
+      .filter(m => m.status === "running" && sideName(m.sideA) && sideName(m.sideB));
   }, [tournament]);
   const onOpenScore = (m) => {
     if (typeof window.__adminNavigateToScore === "function") {
@@ -487,17 +495,21 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
         <div className="live-strip" role="status" aria-label={`${liveMatches.length} matches live`}>
           <span className="live-strip__lbl"><span className="dot dot--live"></span> {pluralize(liveMatches.length, "match", "matches")} live</span>
           <div className="live-strip__chips">
-            {liveMatches.slice(0, 6).map(m => (
-              <button
-                key={`${m.compId}:${m.id}`}
-                className="live-strip__chip"
-                onClick={() => onOpenScore && onOpenScore(m)}
-                title={`${m.sideB.name} – ${m.sideA.name}`}
-              >
-                <span className="live-strip__court">Shiaijo {m.court}</span>
-                <span className="live-strip__names">{m.sideB.name} – {m.sideA.name}</span>
-              </button>
-            ))}
+            {liveMatches.slice(0, 6).map(m => {
+              const a = sideName(m.sideA);
+              const b = sideName(m.sideB);
+              return (
+                <button
+                  key={`${m.compId}:${m.id}`}
+                  className="live-strip__chip"
+                  onClick={() => onOpenScore && onOpenScore(m)}
+                  title={`${b} – ${a}`}
+                >
+                  <span className="live-strip__court">Shiaijo {m.court}</span>
+                  <span className="live-strip__names">{b} – {a}</span>
+                </button>
+              );
+            })}
             {liveMatches.length > 6 && <span className="live-strip__more">+{liveMatches.length - 6} more</span>}
           </div>
         </div>

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -586,6 +586,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
                   className="live-strip__chip"
                   onClick={() => onOpenScore && onOpenScore(m)}
                   title={`${b} – ${a}`}
+                  aria-label={`Open score editor: ${court}, ${b} versus ${a}`}
                 >
                   <span className="live-strip__court">{court}</span>
                   <span className="live-strip__names">{b} – {a}</span>

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -470,7 +470,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
           <div className="live-strip__chips">
             {liveMatches.slice(0, 6).map(m => (
               <button
-                key={m.compId + m.id}
+                key={`${m.compId}:${m.id}`}
                 className="live-strip__chip"
                 onClick={() => onOpenScore && onOpenScore(m)}
                 title={`${m.sideB.name} – ${m.sideA.name}`}
@@ -2581,7 +2581,7 @@ function AdminSchedulePage({ tournament, onBack, onMoveCourt, _onEditScore, onLo
                       <div style={{ fontSize: 12, color: "var(--ink-3)", padding: "20px 8px", textAlign: "center" }}>No matches assigned to this shiaijo</div>
                     ) : list.map((m) => (
                       <AdminTWMatch
-                        key={m.compId + m.id}
+                        key={`${m.compId}:${m.id}`}
                         m={m}
                         highlight={matchHasFilter(m)}
                         courts={courts}
@@ -2776,7 +2776,7 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, _e
           const bWin = m.winner && m.sideB && m.winner.id === m.sideB.id;
           const isCorrection = m.status === "completed" && m.score?.corrected;
           return (
-            <div key={m.compId + m.id} className={`score-edit-row ${m.status === "running" ? "score-edit-row--live" : ""} ${m.status === "completed" ? "score-edit-row--complete" : ""}`}>
+            <div key={`${m.compId}:${m.id}`} className={`score-edit-row ${m.status === "running" ? "score-edit-row--live" : ""} ${m.status === "completed" ? "score-edit-row--complete" : ""}`}>
               <div>
                 <div className="score-edit-row__time">{m.scheduledAt || "—"}</div>
                 <div style={{ fontSize: 10, color: "var(--ink-3)", marginTop: 2 }}>{m.compName}</div>
@@ -2812,7 +2812,7 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, _e
       </div>
 
       {openMatch && (() => {
-        const openIdx = filtered.findIndex(m => m.compId + m.id === openMatch.compId + openMatch.id);
+        const openIdx = filtered.findIndex(m => `${m.compId}:${m.id}` === `${openMatch.compId}:${openMatch.id}`);
         const prevMatch = openIdx > 0 ? filtered[openIdx - 1] : null;
         const nextMatch = openIdx < filtered.length - 1 ? filtered[openIdx + 1] : null;
         return (

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -548,12 +548,13 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
         <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
       </div>
       {liveMatches.length > 0 && (
-        <div className="live-strip" role="region" aria-label={`${liveMatches.length} matches live`}>
+        <div className="live-strip" role="region" aria-label={`${pluralize(liveMatches.length, "match", "matches")} live`}>
           <span className="live-strip__lbl"><span className="dot dot--live"></span> {pluralize(liveMatches.length, "match", "matches")} live</span>
           <div className="live-strip__chips">
             {liveMatches.slice(0, LIVE_STRIP_MAX_CHIPS).map(m => {
               const a = sideName(m.sideA);
               const b = sideName(m.sideB);
+              const court = m.court ? `Shiaijo ${m.court}` : "Unassigned";
               return (
                 <button
                   key={`${m.compId}:${m.id}`}
@@ -561,7 +562,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
                   onClick={() => onOpenScore && onOpenScore(m)}
                   title={`${b} – ${a}`}
                 >
-                  <span className="live-strip__court">Shiaijo {m.court}</span>
+                  <span className="live-strip__court">{court}</span>
                   <span className="live-strip__names">{b} – {a}</span>
                 </button>
               );

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -308,35 +308,60 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
 
   useEffectA(() => {
     if (view.kind === "competition") {
+      // Track pending refresh timers + a viewId snapshot so a late-arriving
+      // SSE refresh can't overwrite the current competition with stale data.
+      const compId = view.id;
+      const timers = new Set();
+      const schedule = (fn) => {
+        const id = setTimeout(() => {
+          timers.delete(id);
+          // Re-check the captured compId before applying; if the user has
+          // already navigated away, the new effect run will fetch fresh data.
+          fn(compId);
+        }, Math.random() * 500);
+        timers.add(id);
+      };
       const unsub = window.API.subscribeToEvents((event) => {
-        const jitter = Math.random() * 500;
         if (REFRESHABLE_EVENTS.has(event.type)) {
           // tournament_updated carries null data (tournament-wide change) — always
           // relevant.  match_updated / competition_started / competition_completed
           // carry competitionId — skip if they belong to a different competition.
           const relevant = event.type === "tournament_updated"
             || !event.data?.competitionId
-            || event.data.competitionId === view.id;
+            || event.data.competitionId === compId;
           if (relevant) {
             // Apply partial update immediately for responsive UI
             if (event.type === "match_updated") {
               setAdminCompData(prev => patchCompetitionData(prev, event));
             }
             // Still trigger full refresh (jittered) to reconcile standings/propagation
-            setTimeout(() => window.API.fetchCompetitionDetails(view.id)
-              .then(setAdminCompData)
-              .catch(err => console.error("Failed to refresh competition details", err)), jitter);
+            schedule((targetId) => {
+              window.API.fetchCompetitionDetails(targetId)
+                .then(data => setAdminCompData(prev => {
+                  // Drop stale data if the user navigated to a different comp
+                  // (or away entirely) while the fetch was in flight.
+                  if (data?.config?.id !== targetId) return prev;
+                  return data;
+                }))
+                .catch(err => console.error("Failed to refresh competition details", err));
+            });
           }
           // competition_completed on any comp may unblock a dependent playoff
           // we're currently viewing, so always trigger a tournament-wide refresh.
           if (event.type === "competition_completed") {
-            setTimeout(() => window.API.fetchCompetitions()
-              .then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps }))
-              .catch(err => console.error("Failed to refresh competitions after completion", err)), jitter);
+            schedule(() => {
+              window.API.fetchCompetitions()
+                .then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps }))
+                .catch(err => console.error("Failed to refresh competitions after completion", err));
+            });
           }
         }
       });
-      return unsub;
+      return () => {
+        timers.forEach(clearTimeout);
+        timers.clear();
+        unsub();
+      };
     }
   }, [view.id, view.kind]); // t and onUpdate accessed via refs to avoid churn
 

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -15,9 +15,10 @@ const REFRESHABLE_EVENTS = new Set([
 const LIVE_STRIP_MAX_CHIPS = 6;
 
 // sideA/sideB can be a string (raw backend shape), an object with .name
-// (normaliseMatch output, which substitutes {id:"",name:""} for missing sides),
+// (normalizeMatch output, which substitutes {id:"",name:""} for missing sides),
 // or null. Return the participant's display name, or "" when no real side is
-// present. Used by compMatchStats and AdminTopbar's live-strip filter.
+// present. Used by compMatchStats and AdminTopbar's live-strip filter, so the
+// two stay in lockstep about what "has a real side" means.
 function sideName(side) {
   if (!side) return "";
   if (typeof side === "string") return side;
@@ -32,18 +33,11 @@ function sideName(side) {
 // endpoints when match counts are needed.
 function compMatchStats(c) {
   let total = 0, done = 0, live = 0;
-  // sideA/sideB can be: a string (raw backend shape), an object {id,name}
-  // (normalizeMatch shape, which substitutes {id:"",name:""} for missing
-  // sides), or null. Truthy-checking the side itself is not enough — we have
-  // to look at the actual participant name so byes and unresolved bracket
-  // slots don't get counted toward total/done/live.
-  const hasName = (side) => {
-    if (!side) return false;
-    if (typeof side === "string") return side.length > 0;
-    return !!(side.name && side.name.length > 0);
-  };
+  // Truthy-checking the side itself isn't enough — normalizeMatch substitutes
+  // {id:"",name:""} for missing sides, which is truthy. sideName() returns
+  // "" for those, so byes and unresolved bracket slots stay uncounted.
   const count = (m) => {
-    if (!m || !hasName(m.sideA) || !hasName(m.sideB)) return;
+    if (!m || !sideName(m.sideA) || !sideName(m.sideB)) return;
     total++;
     if (m.status === "completed") done++;
     if (m.status === "running") live++;

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -3,6 +3,13 @@
 
 const { useState: useStateA, useMemo: useMemoA, useEffect: useEffectA, useRef: useRefA } = React;
 
+const REFRESHABLE_EVENTS = new Set([
+  "competition_started",
+  "competition_completed",
+  "match_updated",
+  "tournament_updated",
+]);
+
 // Returns { total, done, live } match counts for a single competition object.
 function compMatchStats(c) {
   let total = 0, done = 0, live = 0;
@@ -137,6 +144,11 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   }, [setView]);
 
   const t = tournament;
+  // Refs so the SSE subscription can read the latest tournament/onUpdate
+  // without being torn down every time the tournament object is replaced.
+  const tRef = useRefA(t);
+  const onUpdateRef = useRefA(onUpdate);
+  useEffectA(() => { tRef.current = t; onUpdateRef.current = onUpdate; });
 
   const updateCompetition = async (cid, next) => {
     try {
@@ -281,13 +293,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     if (view.kind === "competition") {
       const unsub = window.API.subscribeToEvents((event) => {
         const jitter = Math.random() * 500;
-        const refreshableEvents = new Set([
-          "competition_started",
-          "competition_completed",
-          "match_updated",
-          "tournament_updated",
-        ]);
-        if (refreshableEvents.has(event.type)) {
+        if (REFRESHABLE_EVENTS.has(event.type)) {
           // tournament_updated carries null data (tournament-wide change) — always
           // relevant.  match_updated / competition_started / competition_completed
           // carry competitionId — skip if they belong to a different competition.
@@ -305,13 +311,13 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
           // competition_completed on any comp may unblock a dependent playoff
           // we're currently viewing, so always trigger a tournament-wide refresh.
           if (event.type === "competition_completed") {
-            setTimeout(() => window.API.fetchCompetitions().then(comps => onUpdate({ ...t, competitions: comps })), jitter);
+            setTimeout(() => window.API.fetchCompetitions().then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps })), jitter);
           }
         }
       });
       return unsub;
     }
-  }, [view.id, view.kind, t, onUpdate]);
+  }, [view.id, view.kind]); // t and onUpdate accessed via refs to avoid churn
 
   if (view.kind === "dashboard") {
     return <AdminDashboard
@@ -467,7 +473,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
                 key={m.compId + m.id}
                 className="live-strip__chip"
                 onClick={() => onOpenScore && onOpenScore(m)}
-                title={`${m.sideA.name} vs ${m.sideB.name}`}
+                title={`${m.sideB.name} – ${m.sideA.name}`}
               >
                 <span className="live-strip__court">Shiaijo {m.court}</span>
                 <span className="live-strip__names">{m.sideB.name} – {m.sideA.name}</span>

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -337,7 +337,12 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       // match update.
       let pendingTournament = null;
       let tournamentFetching = false;
-      const scheduleTournamentRefresh = () => {
+      // Tracks whether any event in the coalesced burst needs the tournament
+      // config refetched (name/date/venue/courts). Match-level events only
+      // need the competitions list; tournament_updated needs both.
+      let pendingNeedsTournamentFetch = false;
+      const scheduleTournamentRefresh = (needsTournament) => {
+        if (needsTournament) pendingNeedsTournamentFetch = true;
         if (pendingTournament || tournamentFetching) return;
         const jitter = 500 + Math.random() * 1000;
         pendingTournament = setTimeout(() => {
@@ -348,12 +353,19 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
           // can't kick off a second concurrent fetch that might resolve
           // out-of-order and clobber fresher data.
           tournamentFetching = true;
-          window.API.fetchCompetitions()
-            .then(comps => {
+          const fetchTournament = pendingNeedsTournamentFetch;
+          pendingNeedsTournamentFetch = false;
+          const work = fetchTournament
+            ? Promise.all([window.API.fetchTournament(), window.API.fetchCompetitions()])
+                .then(([tourney, comps]) => ({ tourney, comps }))
+            : window.API.fetchCompetitions().then(comps => ({ tourney: null, comps }));
+          work
+            .then(({ tourney, comps }) => {
               if (cancelled) return;
-              onUpdateRef.current({ ...tRef.current, competitions: comps });
+              const base = tourney || tRef.current;
+              onUpdateRef.current({ ...base, competitions: comps });
             })
-            .catch(err => console.error("Failed to refresh competitions list", err))
+            .catch(err => console.error("Failed to refresh tournament/competitions", err))
             .finally(() => { tournamentFetching = false; });
         }, jitter);
       };
@@ -387,11 +399,13 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
           // Any of these may change the topbar live-strip (matches becoming
           // live/done in *other* competitions, a comp starting, a dependent
           // playoff unblocking, …). Coalesced so a burst is one fetch.
+          // tournament_updated also needs the tournament config itself.
           if (event.type === "match_updated"
               || event.type === "competition_started"
-              || event.type === "competition_completed"
-              || event.type === "tournament_updated") {
-            scheduleTournamentRefresh();
+              || event.type === "competition_completed") {
+            scheduleTournamentRefresh(false);
+          } else if (event.type === "tournament_updated") {
+            scheduleTournamentRefresh(true);
           }
         }
       });
@@ -541,7 +555,11 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
   };
 
   return (
-    <>
+    // Wrap topbar + live-strip in a single sticky container so they scroll
+    // together. This lets the topbar size naturally (min-height instead of a
+    // fixed height) — robust to font scaling / browser zoom — while still
+    // keeping the live-strip visually anchored beneath it.
+    <div className="topbar-stack">
       <div className="topbar">
         <div className="topbar__brand">
           <div className="topbar__logo">BC</div>
@@ -578,7 +596,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }
 

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -10,6 +10,20 @@ const REFRESHABLE_EVENTS = new Set([
   "tournament_updated",
 ]);
 
+// Maximum live-match chips rendered in the topbar status strip before the
+// "+N more" overflow indicator kicks in.
+const LIVE_STRIP_MAX_CHIPS = 6;
+
+// sideA/sideB can be a string (raw backend shape), an object with .name
+// (normaliseMatch output, which substitutes {id:"",name:""} for missing sides),
+// or null. Return the participant's display name, or "" when no real side is
+// present. Used by compMatchStats and AdminTopbar's live-strip filter.
+function sideName(side) {
+  if (!side) return "";
+  if (typeof side === "string") return side;
+  return side.name || "";
+}
+
 // Returns { total, done, live } match counts for a single competition object.
 // Accepts either:
 //   - flat `poolMatches` array from GET /api/viewer/competitions (list endpoint)
@@ -162,6 +176,8 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   // without being torn down every time the tournament object is replaced.
   const tRef = useRefA(t);
   const onUpdateRef = useRefA(onUpdate);
+  // Intentionally no deps array — this effect runs after every render to keep
+  // the refs in sync with the latest props for the SSE handler to read.
   useEffectA(() => { tRef.current = t; onUpdateRef.current = onUpdate; });
 
   const updateCompetition = async (cid, next) => {
@@ -485,15 +501,9 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
   // Render running matches as chips below the topbar so admins always
   // know what's live, regardless of which screen they're on. Clicking
   // a chip jumps to that competition's score editor via the global
-  // navigator helper set up by AdminApp.
-  // sideA/sideB may be a string (raw backend), an object with .name
-  // (normalised), or an empty {id:"",name:""} placeholder. Extract names
-  // defensively and skip chips where either side has no real name.
-  const sideName = (side) => {
-    if (!side) return "";
-    if (typeof side === "string") return side;
-    return side.name || "";
-  };
+  // navigator helper set up by AdminApp. sideName (hoisted to module
+  // scope) handles the three possible side shapes; chips with no real
+  // name on either side are filtered out.
   const liveMatches = useMemoA(() => {
     if (!tournament || !window.compMatches) return [];
     return (tournament.competitions || [])
@@ -524,7 +534,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
         <div className="live-strip" role="status" aria-label={`${liveMatches.length} matches live`}>
           <span className="live-strip__lbl"><span className="dot dot--live"></span> {pluralize(liveMatches.length, "match", "matches")} live</span>
           <div className="live-strip__chips">
-            {liveMatches.slice(0, 6).map(m => {
+            {liveMatches.slice(0, LIVE_STRIP_MAX_CHIPS).map(m => {
               const a = sideName(m.sideA);
               const b = sideName(m.sideB);
               return (
@@ -539,7 +549,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
                 </button>
               );
             })}
-            {liveMatches.length > 6 && <span className="live-strip__more">+{liveMatches.length - 6} more</span>}
+            {liveMatches.length > LIVE_STRIP_MAX_CHIPS && <span className="live-strip__more">+{liveMatches.length - LIVE_STRIP_MAX_CHIPS} more</span>}
           </div>
         </div>
       )}

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -337,6 +337,20 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
         }, Math.random() * 500);
         timers.add(id);
       };
+      // Coalesce tournament-wide refreshes across all events so the topbar's
+      // live-strip stays current without firing one fetchCompetitions() per
+      // match update.
+      let pendingTournament = null;
+      const scheduleTournamentRefresh = () => {
+        if (pendingTournament) return;
+        const jitter = 500 + Math.random() * 1000;
+        pendingTournament = setTimeout(() => {
+          pendingTournament = null;
+          window.API.fetchCompetitions()
+            .then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps }))
+            .catch(err => console.error("Failed to refresh competitions list", err));
+        }, jitter);
+      };
       const unsub = window.API.subscribeToEvents((event) => {
         if (REFRESHABLE_EVENTS.has(event.type)) {
           // tournament_updated carries null data (tournament-wide change) — always
@@ -362,20 +376,21 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
                 .catch(err => console.error("Failed to refresh competition details", err));
             });
           }
-          // competition_completed on any comp may unblock a dependent playoff
-          // we're currently viewing, so always trigger a tournament-wide refresh.
-          if (event.type === "competition_completed") {
-            schedule(() => {
-              window.API.fetchCompetitions()
-                .then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps }))
-                .catch(err => console.error("Failed to refresh competitions after completion", err));
-            });
+          // Any of these may change the topbar live-strip (matches becoming
+          // live/done in *other* competitions, a comp starting, a dependent
+          // playoff unblocking, …). Coalesced so a burst is one fetch.
+          if (event.type === "match_updated"
+              || event.type === "competition_started"
+              || event.type === "competition_completed"
+              || event.type === "tournament_updated") {
+            scheduleTournamentRefresh();
           }
         }
       });
       return () => {
         timers.forEach(clearTimeout);
         timers.clear();
+        if (pendingTournament) clearTimeout(pendingTournament);
         unsub();
       };
     }
@@ -531,7 +546,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
         <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
       </div>
       {liveMatches.length > 0 && (
-        <div className="live-strip" role="status" aria-label={`${liveMatches.length} matches live`}>
+        <div className="live-strip" role="region" aria-label={`${liveMatches.length} matches live`}>
           <span className="live-strip__lbl"><span className="dot dot--live"></span> {pluralize(liveMatches.length, "match", "matches")} live</span>
           <div className="live-strip__chips">
             {liveMatches.slice(0, LIVE_STRIP_MAX_CHIPS).map(m => {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -336,18 +336,25 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       // live-strip stays current without firing one fetchCompetitions() per
       // match update.
       let pendingTournament = null;
+      let tournamentFetching = false;
       const scheduleTournamentRefresh = () => {
-        if (pendingTournament) return;
+        if (pendingTournament || tournamentFetching) return;
         const jitter = 500 + Math.random() * 1000;
         pendingTournament = setTimeout(() => {
           pendingTournament = null;
           if (cancelled) return;
+          // tournamentFetching keeps the coalescing gate closed until the
+          // fetch settles, so an event arriving during the in-flight window
+          // can't kick off a second concurrent fetch that might resolve
+          // out-of-order and clobber fresher data.
+          tournamentFetching = true;
           window.API.fetchCompetitions()
             .then(comps => {
               if (cancelled) return;
               onUpdateRef.current({ ...tRef.current, competitions: comps });
             })
-            .catch(err => console.error("Failed to refresh competitions list", err));
+            .catch(err => console.error("Failed to refresh competitions list", err))
+            .finally(() => { tournamentFetching = false; });
         }, jitter);
       };
       const unsub = window.API.subscribeToEvents((event) => {
@@ -593,17 +600,23 @@ function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, on
     // event the SSE stream can fire dozens of match_updated per minute, and
     // each one previously triggered a full tournament+competitions fetch.
     let pending = null;
+    let fetching = false;
     const scheduleRefresh = () => {
-      if (pending) return;
+      if (pending || fetching) return;
       const jitter = 500 + Math.random() * 1000; // 500-1500ms window
       pending = setTimeout(() => {
         pending = null;
+        // Keep the gate closed for the duration of the fetch so a second
+        // burst can't fire a concurrent request that might resolve
+        // out-of-order and clobber fresher data.
+        fetching = true;
         Promise.all([
           window.API.fetchTournament(),
           window.API.fetchCompetitions()
         ]).then(([tourney, competitions]) => {
           onUpdate({ ...tourney, competitions });
-        }).catch(err => console.error("Dashboard refresh failed", err));
+        }).catch(err => console.error("Dashboard refresh failed", err))
+          .finally(() => { fetching = false; });
       }, jitter);
     };
     const unsub = window.API.subscribeToEvents((event) => {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -129,6 +129,13 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   const [adminCompData, setAdminCompData] = useStateA(null);
   const [adminLoading, setAdminLoading] = useStateA(false);
 
+  // Expose a navigation helper used by AdminTopbar's live-strip chips,
+  // avoiding prop-drilling through every screen. Set once per mount.
+  useEffectA(() => {
+    window.__adminNavigateToScore = (compId) => setView({ kind: "competition", id: compId, section: "scores" });
+    return () => { delete window.__adminNavigateToScore; };
+  }, [setView]);
+
   const t = tournament;
 
   const updateCompetition = async (cid, next) => {
@@ -274,10 +281,16 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     if (view.kind === "competition") {
       const unsub = window.API.subscribeToEvents((event) => {
         const jitter = Math.random() * 500;
-        if (event.type === "competition_started" || event.type === "match_updated" || event.type === "tournament_updated") {
+        const refreshableEvents = new Set([
+          "competition_started",
+          "competition_completed",
+          "match_updated",
+          "tournament_updated",
+        ]);
+        if (refreshableEvents.has(event.type)) {
           // tournament_updated carries null data (tournament-wide change) — always
-          // relevant.  match_updated / competition_started carry competitionId —
-          // skip if they belong to a different competition.
+          // relevant.  match_updated / competition_started / competition_completed
+          // carry competitionId — skip if they belong to a different competition.
           const relevant = event.type === "tournament_updated"
             || !event.data?.competitionId
             || event.data.competitionId === view.id;
@@ -289,11 +302,16 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
             // Still trigger full refresh (jittered) to reconcile standings/propagation
             setTimeout(() => window.API.fetchCompetitionDetails(view.id).then(setAdminCompData), jitter);
           }
+          // competition_completed on any comp may unblock a dependent playoff
+          // we're currently viewing, so always trigger a tournament-wide refresh.
+          if (event.type === "competition_completed") {
+            setTimeout(() => window.API.fetchCompetitions().then(comps => onUpdate({ ...t, competitions: comps })), jitter);
+          }
         }
       });
       return unsub;
     }
-  }, [view.id, view.kind]);
+  }, [view.id, view.kind, t, onUpdate]);
 
   if (view.kind === "dashboard") {
     return <AdminDashboard
@@ -410,19 +428,56 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
 }
 
 function AdminTopbar({ onLogout, onViewerMode, tournament }) {
+  // Render running matches as chips below the topbar so admins always
+  // know what's live, regardless of which screen they're on. Clicking
+  // a chip jumps to that competition's score editor via the global
+  // navigator helper set up by AdminApp.
+  const liveMatches = useMemoA(() => {
+    if (!tournament || !window.compMatches) return [];
+    return (tournament.competitions || [])
+      .flatMap(cc => window.compMatches(cc))
+      .filter(m => m.status === "running" && m.sideA && m.sideB);
+  }, [tournament]);
+  const onOpenScore = (m) => {
+    if (typeof window.__adminNavigateToScore === "function") {
+      window.__adminNavigateToScore(m.compId);
+    }
+  };
+
   return (
-    <div className="topbar">
-      <div className="topbar__brand">
-        <div className="topbar__logo">BC</div>
-        <div>
-          <div className="topbar__title">{tournament?.name || "Bracket Creator"}</div>
-          <div className="topbar__sub">Admin console</div>
+    <>
+      <div className="topbar">
+        <div className="topbar__brand">
+          <div className="topbar__logo">BC</div>
+          <div>
+            <div className="topbar__title">{tournament?.name || "Bracket Creator"}</div>
+            <div className="topbar__sub">Admin console</div>
+          </div>
         </div>
+        <div className="topbar__spacer"></div>
+        <button className="viewer-toggle" onClick={onViewerMode}>👁 Public viewer</button>
+        <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
       </div>
-      <div className="topbar__spacer"></div>
-      <button className="viewer-toggle" onClick={onViewerMode}>👁 Public viewer</button>
-      <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
-    </div>
+      {liveMatches.length > 0 && (
+        <div className="live-strip" role="status" aria-label={`${liveMatches.length} matches live`}>
+          <span className="live-strip__lbl"><span className="dot dot--live"></span> {pluralize(liveMatches.length, "match", "matches")} live</span>
+          <div className="live-strip__chips">
+            {liveMatches.slice(0, 6).map(m => (
+              <button
+                key={m.compId + m.id}
+                className="live-strip__chip"
+                onClick={() => onOpenScore && onOpenScore(m)}
+                title={`${m.sideA.name} vs ${m.sideB.name}`}
+              >
+                <span className="live-strip__court">Shiaijo {m.court}</span>
+                <span className="live-strip__names">{m.sideB.name} – {m.sideA.name}</span>
+              </button>
+            ))}
+            {liveMatches.length > 6 && <span className="live-strip__more">+{liveMatches.length - 6} more</span>}
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -442,8 +497,9 @@ function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, on
   useEffectA(() => {
     const unsub = window.API.subscribeToEvents((event) => {
       const jitter = Math.random() * 500;
-      if (event.type === "tournament_updated" || event.type === "competition_started" || event.type === "competition_deleted") {
-        // Refresh everything on the dashboard
+      if (event.type === "tournament_updated" || event.type === "competition_started" || event.type === "competition_completed" || event.type === "competition_deleted" || event.type === "match_updated") {
+        // Refresh everything on the dashboard so live-match counts and
+        // status badges stay current as competitions progress.
         setTimeout(() => {
           Promise.all([
             window.API.fetchTournament(),
@@ -907,6 +963,7 @@ function AdminCompetition({ tournament, competition, pools, _poolMatches, standi
         ].filter(Boolean)} />
         <div className="page-head">
           <div>
+            <div className="page-head__eyebrow">{t.name} ›</div>
             <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
               <h1 className="page-head__title">{c.name}</h1>
               <StatusBadge status={c.status} />

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -170,9 +170,9 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   // without being torn down every time the tournament object is replaced.
   const tRef = useRefA(t);
   const onUpdateRef = useRefA(onUpdate);
-  // Intentionally no deps array — this effect runs after every render to keep
-  // the refs in sync with the latest props for the SSE handler to read.
-  useEffectA(() => { tRef.current = t; onUpdateRef.current = onUpdate; });
+  // Refs are read by the SSE subscription (which has narrower deps to avoid
+  // teardown); refresh them only when the underlying props change.
+  useEffectA(() => { tRef.current = t; onUpdateRef.current = onUpdate; }, [t, onUpdate]);
 
   const updateCompetition = async (cid, next) => {
     try {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -323,12 +323,16 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
               setAdminCompData(prev => patchCompetitionData(prev, event));
             }
             // Still trigger full refresh (jittered) to reconcile standings/propagation
-            setTimeout(() => window.API.fetchCompetitionDetails(view.id).then(setAdminCompData), jitter);
+            setTimeout(() => window.API.fetchCompetitionDetails(view.id)
+              .then(setAdminCompData)
+              .catch(err => console.error("Failed to refresh competition details", err)), jitter);
           }
           // competition_completed on any comp may unblock a dependent playoff
           // we're currently viewing, so always trigger a tournament-wide refresh.
           if (event.type === "competition_completed") {
-            setTimeout(() => window.API.fetchCompetitions().then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps })), jitter);
+            setTimeout(() => window.API.fetchCompetitions()
+              .then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps }))
+              .catch(err => console.error("Failed to refresh competitions after completion", err)), jitter);
           }
         }
       });

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -318,15 +318,16 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
 
   useEffectA(() => {
     if (view.kind === "competition") {
-      // Track pending refresh timers + a viewId snapshot so a late-arriving
-      // SSE refresh can't overwrite the current competition with stale data.
+      // `cancelled` is the master gate: cleanup flips it true, and every
+      // async resolution paths through it before calling state setters.
+      // This is what makes navigation-during-in-flight-fetch safe.
+      let cancelled = false;
       const compId = view.id;
       const timers = new Set();
       const schedule = (fn) => {
         const id = setTimeout(() => {
           timers.delete(id);
-          // Re-check the captured compId before applying; if the user has
-          // already navigated away, the new effect run will fetch fresh data.
+          if (cancelled) return;
           fn(compId);
         }, Math.random() * 500);
         timers.add(id);
@@ -340,12 +341,17 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
         const jitter = 500 + Math.random() * 1000;
         pendingTournament = setTimeout(() => {
           pendingTournament = null;
+          if (cancelled) return;
           window.API.fetchCompetitions()
-            .then(comps => onUpdateRef.current({ ...tRef.current, competitions: comps }))
+            .then(comps => {
+              if (cancelled) return;
+              onUpdateRef.current({ ...tRef.current, competitions: comps });
+            })
             .catch(err => console.error("Failed to refresh competitions list", err));
         }, jitter);
       };
       const unsub = window.API.subscribeToEvents((event) => {
+        if (cancelled) return;
         if (REFRESHABLE_EVENTS.has(event.type)) {
           // tournament_updated carries null data (tournament-wide change) — always
           // relevant.  match_updated / competition_started / competition_completed
@@ -361,12 +367,13 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
             // Still trigger full refresh (jittered) to reconcile standings/propagation
             schedule((targetId) => {
               window.API.fetchCompetitionDetails(targetId)
-                .then(data => setAdminCompData(prev => {
-                  // Drop stale data if the user navigated to a different comp
-                  // (or away entirely) while the fetch was in flight.
-                  if (data?.config?.id !== targetId) return prev;
-                  return data;
-                }))
+                .then(data => {
+                  // Cancelled flag is the primary navigation guard. The id
+                  // check is belt-and-braces in case a fetch comes back with
+                  // unexpected data shape.
+                  if (cancelled || data?.config?.id !== targetId) return;
+                  setAdminCompData(data);
+                })
                 .catch(err => console.error("Failed to refresh competition details", err));
             });
           }
@@ -382,6 +389,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
         }
       });
       return () => {
+        cancelled = true;
         timers.forEach(clearTimeout);
         timers.clear();
         if (pendingTournament) clearTimeout(pendingTournament);

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -501,22 +501,32 @@ function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, on
   const comps = t.competitions || [];
 
   useEffectA(() => {
+    // Coalesce bursts of events into a single dashboard refresh. On a busy
+    // event the SSE stream can fire dozens of match_updated per minute, and
+    // each one previously triggered a full tournament+competitions fetch.
+    let pending = null;
+    const scheduleRefresh = () => {
+      if (pending) return;
+      const jitter = 500 + Math.random() * 1000; // 500-1500ms window
+      pending = setTimeout(() => {
+        pending = null;
+        Promise.all([
+          window.API.fetchTournament(),
+          window.API.fetchCompetitions()
+        ]).then(([tourney, competitions]) => {
+          onUpdate({ ...tourney, competitions });
+        }).catch(err => console.error("Dashboard refresh failed", err));
+      }, jitter);
+    };
     const unsub = window.API.subscribeToEvents((event) => {
-      const jitter = Math.random() * 500;
       if (event.type === "tournament_updated" || event.type === "competition_started" || event.type === "competition_completed" || event.type === "competition_deleted" || event.type === "match_updated") {
-        // Refresh everything on the dashboard so live-match counts and
-        // status badges stay current as competitions progress.
-        setTimeout(() => {
-          Promise.all([
-            window.API.fetchTournament(),
-            window.API.fetchCompetitions()
-          ]).then(([tourney, competitions]) => {
-            onUpdate({ ...tourney, competitions });
-          }).catch(err => console.error("Dashboard refresh failed", err));
-        }, jitter);
+        scheduleRefresh();
       }
     });
-    return unsub;
+    return () => {
+      if (pending) clearTimeout(pending);
+      unsub();
+    };
   }, []);
 
   const { totalMatches, doneMatches, liveMatches, totalParticipants } = useMemoA(() => {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -579,16 +579,16 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
             {liveMatches.slice(0, LIVE_STRIP_MAX_CHIPS).map(m => {
               const a = sideName(m.sideA);
               const b = sideName(m.sideB);
-              const court = m.court ? `Shiaijo ${m.court}` : "Unassigned";
+              const courtLabel = m.court ? `Shiaijo ${m.court}` : "Unassigned";
+              const courtPhrase = m.court ? `on Shiaijo ${m.court}` : "with no court assigned";
               return (
                 <button
                   key={`${m.compId}:${m.id}`}
                   className="live-strip__chip"
                   onClick={() => onOpenScore && onOpenScore(m)}
-                  title={`${b} – ${a}`}
-                  aria-label={`Open score editor: ${court}, ${b} versus ${a}`}
+                  aria-label={`Open score editor for ${b} versus ${a} ${courtPhrase}`}
                 >
-                  <span className="live-strip__court">{court}</span>
+                  <span className="live-strip__court">{courtLabel}</span>
                   <span className="live-strip__names">{b} – {a}</span>
                 </button>
               );

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -182,13 +182,16 @@ function App() {
         const jitter = Math.random() * 500;
         if (event.type === "tournament_updated") {
             if (!authPromptRef.current) setTimeout(load, jitter);
-        } else if (event.type === "competition_started" || event.type === "match_updated") {
+        } else if (event.type === "competition_started" || event.type === "match_updated" || event.type === "competition_completed") {
             if (viewerCompId === event.data.competitionId) {
-                // Apply partial update immediately
+                // Apply partial update immediately (match_updated only —
+                // competition_completed has no per-match payload)
                 if (event.type === "match_updated") {
                     setSelectedCompData(prev => patchCompetitionData(prev, event));
                 }
-                // Refresh current competition (jittered)
+                // Refresh current competition (jittered) — the backend has
+                // already persisted the new status before broadcasting, so
+                // this fetch deterministically picks up the transition.
                 setTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData), jitter);
             }
             // Also refresh tournament list for status updates


### PR DESCRIPTION
## Summary

Phase 3 of the mobile-app improvement plan. Closes the pools→playoffs workflow gap (Issue #3 in webui_recommendations.md) and adds a tournament-wide live-match indicator.

### Backend
- New `engine.MaybeAutoCompletePools(compId)` transitions a pool competition from `CompStatusPools` → `CompStatusComplete` when every pool match is marked completed (no-op otherwise). Idempotent.
- All three score handlers (bulk-score, quick-score, score) call it after a successful `RecordMatchResult` and broadcast a new `EventCompetitionCompleted` SSE event when the transition fires.
- The existing `POST /api/competitions/:id/complete` endpoint is unchanged and still works as a manual override.

### Frontend
- `AdminApp` subscribes to `competition_completed` on the competition view and refreshes the tournament list, so a linked playoff's *Start playoff* button (gated by the source pool being in `completed` status) unblocks automatically without operator intervention.
- `AdminDashboard` SSE handler now refreshes on `match_updated` and `competition_completed` too, so the dashboard's match-counter and live count stay current.
- `AdminTopbar` gets a sticky `live-strip` showing running matches as clickable chips (court + names). Clicking jumps to that competition's score editor.
- `AdminCompetition` page-head gets a tournament eyebrow (`London Cup 2026 ›`) so the operator always reads both names.

### Tooling
- `scripts/setup_tournament.py` drops the manual *mark pools complete* `PUT` and instead polls `GET /api/competitions/:id` until `status === \"completed\"` (5s timeout, loud failure). The script now doubles as the canonical regression test for auto-completion.

## Test plan

- [x] `make go/test` — all green; new `TestMaybeAutoCompletePools` covers no-op cases (partial completion, already complete, playoffs format) and the success path
- [x] `make examples` — no diff in generated Excel files
- [x] Manual: start a pools competition, score all matches; verify the status flips to `completed` automatically within ~1s and the linked playoff's *Start playoff* button enables
- [x] Manual: with a match live, navigate around admin screens — the live-strip should follow under the topbar everywhere; clicking a chip lands on the right scores page
- [x] Manual: `scripts/setup_tournament.py` runs end-to-end without errors (and would have failed loudly if auto-completion regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)