### PR TITLE
chore: normalize hikiwake spelling across Go and JS

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -733,10 +733,10 @@ func TestCalculatePoolStandings_AllDraws(t *testing.T) {
 	matches, err := store.LoadPoolMatches(compID)
 	require.NoError(t, err)
 
-	// All matches are draws (hikewake)
+	// All matches are draws (hikiwake)
 	for i := range matches {
 		matches[i].Status = state.MatchStatusCompleted
-		matches[i].Decision = "hikewake"
+		matches[i].Decision = state.DecisionDraw
 		matches[i].Winner = ""
 	}
 	require.NoError(t, store.SavePoolMatches(compID, matches))

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -166,7 +166,7 @@ func (e *Engine) computeStandings(compId string) (map[string][]state.PlayerStand
 			} else if m.Winner == m.SideB {
 				sB.Wins++
 				sA.Losses++
-			} else if m.Decision == "hikewake" || m.Winner == "" {
+			} else if state.IsDraw(m.Decision) || m.Winner == "" {
 				sA.Draws++
 				sB.Draws++
 			}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -52,6 +52,21 @@ const (
 	MatchStatusCompleted MatchStatus = "completed"
 )
 
+// DecisionDraw is the canonical value for a tied (hikiwake) match. The
+// legacy spelling "hikewake" (missing the 'i') was used historically and is
+// still accepted by IsDraw() for backward compatibility on existing data,
+// but all new writes use this canonical spelling.
+const (
+	DecisionDraw       = "hikiwake"
+	decisionDrawLegacy = "hikewake"
+)
+
+// IsDraw reports whether a match decision string represents a draw.
+// Accepts both the canonical "hikiwake" and the legacy "hikewake".
+func IsDraw(decision string) bool {
+	return decision == DecisionDraw || decision == decisionDrawLegacy
+}
+
 type SubMatchResult struct {
 	Position int      `json:"position"`
 	SideA    string   `json:"sideA"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -812,3 +812,11 @@ func TestStore_ConcurrentAccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, loaded)
 }
+
+func TestIsDraw(t *testing.T) {
+	assert.True(t, IsDraw("hikiwake"), "canonical spelling")
+	assert.True(t, IsDraw("hikewake"), "legacy spelling preserved for backward compat")
+	assert.False(t, IsDraw(""))
+	assert.False(t, IsDraw("ippon"))
+	assert.False(t, IsDraw("HIKIWAKE"), "case-sensitive — wire format is lowercase")
+}

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1263,10 +1263,13 @@ components:
           description: >
             Decision code for the match outcome. Valid values:
             `""` — normal victory (winner field determines the result);
-            `"hikewake"` — draw/tie, recorded when the operator enters 'X' in the vs column
+            `"hikiwake"` — draw/tie, recorded when the operator enters 'X' in the vs column
             or when both sides finish with equal scores.
             Note: encho (extended time) is a play mechanism, not a decision value — a match
-            that goes to encho still resolves as a normal victory or hikewake.
+            that goes to encho still resolves as a normal victory or hikiwake.
+            Backward compatibility: the legacy misspelling `"hikewake"` (missing the 'i')
+            is still accepted on read for data persisted by older versions. All new writes
+            use `"hikiwake"`.
             For individual sub-matches within team matches see `SubMatchResult.decision`.
         status:
           type: string
@@ -1308,7 +1311,8 @@ components:
           type: string
           description: >
             Decision code for this individual sub-match. Same values as `MatchResult.decision`:
-            `""` (normal victory) or `"hikewake"` (draw/tie).
+            `""` (normal victory) or `"hikiwake"` (draw/tie). The legacy spelling
+            `"hikewake"` is still accepted on read.
 
     BracketMatch:
       type: object

--- a/web-mobile/js/__tests__/api.test.jsx
+++ b/web-mobile/js/__tests__/api.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, API } from '../api.jsx';
+import { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, isHikiwake, API } from '../api.jsx';
 
 describe('API Utils', () => {
   describe('toBackendMatchResult', () => {
@@ -24,7 +24,28 @@ describe('API Utils', () => {
       const match = { sideA: 'A', sideB: 'B' };
       const patch = { status: 'complete', score: { type: 'hikiwake' } };
       const result = toBackendMatchResult(patch, match);
-      expect(result.decision).toBe('hikewake');
+      expect(result.decision).toBe('hikiwake');
+    });
+
+    it('should still treat legacy hikewake score.type as a draw on write', () => {
+      const match = { sideA: 'A', sideB: 'B' };
+      const patch = { status: 'complete', score: { type: 'hikewake' } };
+      const result = toBackendMatchResult(patch, match);
+      expect(result.decision).toBe('hikiwake'); // normalises to canonical
+    });
+  });
+
+  describe('isHikiwake', () => {
+    it('accepts canonical and legacy spellings', () => {
+      expect(isHikiwake('hikiwake')).toBe(true);
+      expect(isHikiwake('hikewake')).toBe(true);
+    });
+
+    it('rejects other values', () => {
+      expect(isHikiwake('')).toBe(false);
+      expect(isHikiwake('ippon')).toBe(false);
+      expect(isHikiwake(null)).toBe(false);
+      expect(isHikiwake(undefined)).toBe(false);
     });
   });
 

--- a/web-mobile/js/__tests__/score_display.test.jsx
+++ b/web-mobile/js/__tests__/score_display.test.jsx
@@ -48,7 +48,9 @@ describe('formatIpponsScore', () => {
 
     it('returns X for a no-score draw', () => {
       expect(formatIpponsScore([], [], { type: 'hikiwake' }, null)).toBe('X');
+      // Legacy spelling still accepted on read for backward compat
       expect(formatIpponsScore([], [], null, 'hikewake')).toBe('X');
+      expect(formatIpponsScore([], [], null, 'hikiwake')).toBe('X');
     });
 
     it('returns △ for a draw where scores were entered', () => {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -2849,7 +2849,7 @@ function ScoreEditorModal({ match, tournament, onClose, onSubmit, onSubmitAndNex
     try { await fn(); } finally { setSubmitting(false); }
   };
 
-  const [isDrawToggled, setIsDrawToggled] = useStateA(m.score?.type === "hikiwake" || m.decision === "hikewake");
+  const [isDrawToggled, setIsDrawToggled] = useStateA(window.isHikiwake(m.score?.type) || window.isHikiwake(m.decision));
 
   // Arranged as [left, right] — left is always SHIRO (White), right is always AKA (Red)
   const sides = [
@@ -3029,7 +3029,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
         hansokuA: s.aFouls,
         hansokuB: s.bFouls,
         winner: w ? (typeof w === "object" ? w.name : w) : "",
-        decision: t.winner === null ? "hikewake" : "",
+        decision: t.winner === null ? "hikiwake" : "",
       };
     });
     const winner = teamWinner === "a" ? m.sideA : teamWinner === "b" ? m.sideB : null;

--- a/web-mobile/js/api.jsx
+++ b/web-mobile/js/api.jsx
@@ -3,6 +3,11 @@ const STATUS_MAP = { "complete": "completed", "in_progress": "running" };
 
 function toBackendStatus(s) { return STATUS_MAP[s] || s; }
 
+// Canonical draw value is "hikiwake"; "hikewake" (missing 'i') is the legacy
+// spelling and is still accepted on read for backward compatibility. All new
+// writes use "hikiwake". See specs/openapi.yaml for details.
+function isHikiwake(v) { return v === "hikiwake" || v === "hikewake"; }
+
 // Translate UI score patch into backend MatchResult shape.
 // UI sends: { winner: {id,name,...}, status, score: {type,winnerPts,loserPts,ippons,fouls,...} }
 // Backend expects: { winner: string, ipponsA: [], ipponsB: [], hansokuA: int, hansokuB: int, decision: "", status: "completed"|"running"|"scheduled" }
@@ -24,7 +29,7 @@ function toBackendMatchResult(patch, match) {
         ipponsB,
         hansokuA: fouls.a || 0,
         hansokuB: fouls.b || 0,
-        decision: score.type === "hikiwake" || score.type === "hikewake" ? "hikewake" : "",
+        decision: isHikiwake(score.type) ? "hikiwake" : "",
         status: toBackendStatus(patch.status || "scheduled"),
     };
     if (patch.subResults) {
@@ -72,7 +77,7 @@ function normalizeMatch(m, playerMap) {
     if (!norm.score && (norm.ipponsA?.length || norm.ipponsB?.length) && norm.status === "completed") {
         const aWin = norm.winner && norm.sideA && (typeof norm.winner === "object" ? norm.winner.name : norm.winner) === (typeof norm.sideA === "object" ? norm.sideA.name : norm.sideA);
         norm.score = {
-            type: norm.decision === "hikewake" ? "hikiwake" : "ippon",
+            type: isHikiwake(norm.decision) ? "hikiwake" : "ippon",
             winnerPts: aWin ? (norm.ipponsA?.length || 0) : (norm.ipponsB?.length || 0),
             loserPts: aWin ? (norm.ipponsB?.length || 0) : (norm.ipponsA?.length || 0),
             ippons: aWin ? norm.ipponsA : norm.ipponsB,
@@ -456,7 +461,7 @@ const API = {
     }
 };
 
-export { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, normalizeCompetitionDetail, API };
+export { toBackendMatchResult, normalizeMatch, buildPlayerMap, normalizePlayer, normalizeCompetitionDetail, isHikiwake, API };
 
 if (typeof window !== 'undefined') {
     window.API = API;
@@ -464,4 +469,5 @@ if (typeof window !== 'undefined') {
     window.normalizeCompetitionDetail = normalizeCompetitionDetail;
     window.buildPlayerMap = buildPlayerMap;
     window.toBackendStatus = toBackendStatus;
+    window.isHikiwake = isHikiwake;
 }

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -4,6 +4,10 @@
 
 const { useRef, useLayoutEffect: useLayoutEffectBC, useState: useStateBC, useEffect: useEffectBC } = React;
 
+// Local hikiwake check — bracket.jsx is tested in isolation, so we don't rely
+// on window.isHikiwake here. Accepts both spellings; see specs/openapi.yaml.
+function isHikiwakeBC(v) { return v === "hikiwake" || v === "hikewake"; }
+
 function roundLabel(roundIdx, total) {
   const fromEnd = total - 1 - roundIdx;
   if (fromEnd === 0) return "Final";
@@ -26,7 +30,7 @@ function formatIpponsScore(ipponsA, ipponsB, score, decision) {
   if (score?.type === "hantei") return "H";
   const aStr = (ipponsA || []).filter(x => x && x !== "•").join("");
   const bStr = (ipponsB || []).filter(x => x && x !== "•").join("");
-  const isDraw = decision === "hikewake" || score?.type === "hikiwake";
+  const isDraw = isHikiwakeBC(decision) || isHikiwakeBC(score?.type);
   if (isDraw) {
     // No-score draw → X; with scores → △
     return (!aStr && !bStr) ? "X" : "△";

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -375,7 +375,7 @@ function MatchDetailCard({ match, onClose }) {
           </div>
           <div className="match-detail-card__ippons-center">
             {match.score?.type === "hantei" && <span className="match-detail-card__decision">Hantei</span>}
-            {(match.score?.type === "hikiwake" || match.decision === "hikewake") && <span className="match-detail-card__decision">Draw</span>}
+            {(window.isHikiwake(match.score?.type) || window.isHikiwake(match.decision)) && <span className="match-detail-card__decision">Draw</span>}
           </div>
           <div className="match-detail-card__ippons-side match-detail-card__ippons-side--right">
             <span className="match-detail-card__ippons-val">{(match.ipponsA || []).filter(x => x && x !== "•").join("") || "—"}</span>
@@ -649,7 +649,7 @@ function PoolMatrix({ pool, matches, tweaks }) {
                 const ipponsB = (m.ipponsB || []).filter(x => x && x !== "•");
                 const rowIppons = rowIsAka ? ipponsA : ipponsB;
                 const rowWon = winnerName && winnerName === rowPlayer.name;
-                const isDraw = m.decision === "hikewake" || m.score?.type === "hikiwake";
+                const isDraw = window.isHikiwake(m.decision) || window.isHikiwake(m.score?.type);
 
                 let cellContent;
                 if (isDraw) {


### PR DESCRIPTION
## Summary

- The codebase had two spellings for the kendo "draw" concept that both flowed across the wire:
  - `"hikiwake"` (correct romanization) — used as `score.type`
  - `"hikewake"` (misspelled, missing the `i`) — used as the `decision` field
- The misspelling had become a load-bearing protocol string. Any attempt to "fix" the typo in passing would silently break stored matches and SSE patches mid-flight, so it kept getting "fixed" and reverted.
- This change picks **`"hikiwake"`** as the canonical value everywhere and adds backward-compatible read paths so any in-flight state with the old spelling still works.

## Approach

| Layer | Change |
|---|---|
| `internal/state/models.go` | New `DecisionDraw = "hikiwake"` constant + `IsDraw(s)` helper that accepts both spellings |
| `internal/engine/scoring.go` | Uses `state.IsDraw()` instead of inline comparison against the legacy string |
| `web-mobile/js/api.jsx` | New `isHikiwake(v)` helper exported and on `window.*`; translation layer writes `"hikiwake"` only |
| `admin.jsx`, `viewer.jsx` | Use `window.isHikiwake` for draw detection |
| `bracket.jsx` | Local `isHikiwakeBC` helper (file is tested in isolation — doesn't depend on `window.isHikiwake` being present) |
| `specs/openapi.yaml` | Documents canonical spelling + backward-compat read path on both `MatchResult.decision` and `SubMatchResult.decision` |

## Backward compatibility

- All **writes** use `"hikiwake"`.
- All **reads** accept both spellings.
- No on-disk migration is needed — `grep` confirms nothing under `tournament-data/` currently contains `"hikewake"`. The compat path is a safety net for any system mid-event.

## Test plan

- [x] `make go/test` — green; new `TestIsDraw` covers both spellings
- [x] `npx vitest run` — green for new tests; `api.test.jsx` now asserts that both `score.type === "hikiwake"` and the legacy `"hikewake"` normalize to canonical on write; `isHikiwake()` itself has unit coverage
- [x] `make go/build` — green
- [x] Pre-existing failing tests (`score_display`, `viewer`, `ui` — all `React is not defined`) unchanged by this PR
- [ ] Smoke-test by running `make run-mobile` and creating + scoring a draw match end-to-end before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)