### PR TITLE
fix(scoring-ui): restore prior score when untoggling per-bout fusensho

### DIFF
--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -9,6 +9,7 @@ import {
   DecisionPrompt,
   MAX_IPPONS_PER_SIDE,
   isBoutDecided,
+  applyFusenshoToggle,
 } from '../admin_scoring_modal.jsx';
 
 // admin_scoring_modal.jsx ships seven module-private helpers that together
@@ -590,5 +591,117 @@ describe('isBoutDecided / MAX_IPPONS_PER_SIDE', () => {
     // boutDecided re-evaluates on next render with the shorter array.
     const after = ['M']; // was ['M','K'], operator removed 'K'
     expect(isBoutDecided(after, ['D'])).toBe(false); // back to 1-1, not decided
+  });
+});
+
+describe('applyFusenshoToggle', () => {
+  // Per-bout Fusensho is a toggle in TeamScoreEditorModal. Toggle-on
+  // overwrites the bout to a 2-0 default win for the chosen side; the
+  // pre-fusensho points are stashed in _preFusensho so that toggling off
+  // (re-clicking the active side) can restore them. Bug fix: previously
+  // the untoggle only cleared the flag and left the auto-filled 2-0 in
+  // place, losing the operator's prior score.
+
+  const clean = () => ({ aPts: [], bPts: [], aFouls: 0, bFouls: 0, fusensho: "" });
+
+  it('toggle-on from a clean state captures the snapshot and writes 2-0 for A', () => {
+    const prev = { aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "" };
+    const next = applyFusenshoToggle(prev, "a");
+    expect(next).toEqual({
+      aPts: ['M', 'M'],
+      bPts: [],
+      aFouls: 0,
+      bFouls: 0,
+      fusensho: "a",
+      _preFusensho: { aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0 },
+    });
+  });
+
+  it('toggle-on from a clean state captures the snapshot and writes 2-0 for B', () => {
+    const prev = { aPts: [], bPts: ['K'], aFouls: 1, bFouls: 0, fusensho: "" };
+    const next = applyFusenshoToggle(prev, "b");
+    expect(next).toEqual({
+      aPts: [],
+      bPts: ['M', 'M'],
+      aFouls: 0,
+      bFouls: 0,
+      fusensho: "b",
+      _preFusensho: { aPts: [], bPts: ['K'], aFouls: 1, bFouls: 0 },
+    });
+  });
+
+  it('toggle-off (re-click active side) restores the snapshot exactly', () => {
+    // Round trip: scored 1-0 SHIRO, toggled fusensho A, untoggle should
+    // restore the 1-0 instead of leaving the 2-0 in place.
+    const initial = { aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "" };
+    const afterOn = applyFusenshoToggle(initial, "a");
+    const afterOff = applyFusenshoToggle(afterOn, "a");
+    expect(afterOff).toEqual({
+      aPts: ['M'],
+      bPts: [],
+      aFouls: 0,
+      bFouls: 0,
+      fusensho: "",
+      _preFusensho: undefined,
+    });
+  });
+
+  it('side-switch preserves the original snapshot, untoggle then restores genuine pre-fusensho state', () => {
+    // 1-0 SHIRO → toggle fusensho A (2-0 A) → toggle fusensho B (2-0 B)
+    // → untoggle fusensho B should restore the original 1-0, NOT zeros
+    // and NOT the intermediate 2-0 for A.
+    const initial = { aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "" };
+    const afterA = applyFusenshoToggle(initial, "a");
+    expect(afterA.fusensho).toBe("a");
+    expect(afterA._preFusensho).toEqual({ aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0 });
+
+    const afterSwitch = applyFusenshoToggle(afterA, "b");
+    expect(afterSwitch.fusensho).toBe("b");
+    expect(afterSwitch.aPts).toEqual([]);
+    expect(afterSwitch.bPts).toEqual(['M', 'M']);
+    // Snapshot stays anchored to the genuine pre-fusensho state.
+    expect(afterSwitch._preFusensho).toEqual({ aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0 });
+
+    const afterUntoggleB = applyFusenshoToggle(afterSwitch, "b");
+    expect(afterUntoggleB).toEqual({
+      aPts: ['M'],
+      bPts: [],
+      aFouls: 0,
+      bFouls: 0,
+      fusensho: "",
+      _preFusensho: undefined,
+    });
+  });
+
+  it('fresh-match round-trip: zeros → toggle → untoggle returns to zeros', () => {
+    const afterOn = applyFusenshoToggle(clean(), "a");
+    expect(afterOn.aPts).toEqual(['M', 'M']);
+    expect(afterOn._preFusensho).toEqual({ aPts: [], bPts: [], aFouls: 0, bFouls: 0 });
+    const afterOff = applyFusenshoToggle(afterOn, "a");
+    expect(afterOff).toEqual({
+      aPts: [],
+      bPts: [],
+      aFouls: 0,
+      bFouls: 0,
+      fusensho: "",
+      _preFusensho: undefined,
+    });
+  });
+
+  it('defensive: untoggle without a snapshot just clears the flag', () => {
+    // Models the modal-reopen case: initSubs reads decision="fusensho"
+    // from the backend payload and lights up the button, but does NOT
+    // round-trip the snapshot. Untoggling in that state must not crash;
+    // it falls through to clearing the flag and leaving the score alone.
+    const prev = { aPts: ['M', 'M'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a" };
+    const next = applyFusenshoToggle(prev, "a");
+    expect(next).toEqual({
+      aPts: ['M', 'M'],
+      bPts: [],
+      aFouls: 0,
+      bFouls: 0,
+      fusensho: "",
+      _preFusensho: undefined,
+    });
   });
 });

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -19,6 +19,32 @@ function isBoutDecided(aPts, bPts) {
       || (bPts?.length ?? 0) >= MAX_IPPONS_PER_SIDE;
 }
 
+// applyFusenshoToggle — pure reducer for the per-bout Fusensho button in
+// TeamScoreEditorModal. Implements three behaviours on top of the sub
+// state {aPts, bPts, aFouls, bFouls, fusensho, _preFusensho?}:
+//   1. Toggle-on from a clean state: snapshot {aPts,bPts,aFouls,bFouls}
+//      into _preFusensho, then write the 2-0 default win.
+//   2. Side-switch (fusensho is already on the other side): preserve
+//      the original _preFusensho so a later untoggle restores the
+//      genuine pre-fusensho score, not the intermediate 2-0.
+//   3. Toggle-off (re-clicking the active side): restore from
+//      _preFusensho and clear it. If no snapshot exists (e.g. modal
+//      reopened from saved state — initSubs doesn't round-trip the
+//      snapshot), just clear the flag.
+// Manual pts/fouls edits clear _preFusensho separately (handled in
+// the setPts/setFouls closures) — once the operator hand-edits, the
+// snapshot is stale.
+function applyFusenshoToggle(prev, side) {
+  if (prev.fusensho === side) {
+    const snap = prev._preFusensho;
+    if (snap) return { aPts: snap.aPts, bPts: snap.bPts, aFouls: snap.aFouls, bFouls: snap.bFouls, fusensho: "", _preFusensho: undefined };
+    return { ...prev, fusensho: "", _preFusensho: undefined };
+  }
+  const snap = prev._preFusensho || { aPts: prev.aPts, bPts: prev.bPts, aFouls: prev.aFouls, bFouls: prev.bFouls };
+  if (side === "a") return { aPts: ["M", "M"], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a", _preFusensho: snap };
+  return { aPts: [], bPts: ["M", "M"], aFouls: 0, bFouls: 0, fusensho: "b", _preFusensho: snap };
+}
+
 // Term — kendo-glossary tooltip wrapper. Read lazily off window so the
 // load order between glossary.js and this module doesn't matter (both
 // are type="module" scripts and may execute in any order). Falls back
@@ -951,16 +977,13 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
   const updateSub = (idx, fn) => setSubs(prev => prev.map((s, i) => i === idx ? fn(s) : s));
 
   // T096/FR-031: per-bout Fusensho — award a 2-0 default win to the
-  // present side. Re-clicking the active side toggles the flag off
-  // (keeps the score so operator can edit manually); clicking the other
-  // side switches the default win to that side.
-  const setFusenshoFor = (idx, side) => {
-    updateSub(idx, prev => {
-      if (prev.fusensho === side) return { ...prev, fusensho: "" };
-      if (side === "a") return { aPts: ["M", "M"], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a" };
-      return { aPts: [], bPts: ["M", "M"], aFouls: 0, bFouls: 0, fusensho: "b" };
-    });
-  };
+  // present side. Re-clicking the active side undoes the fusensho and
+  // restores the score that existed before fusensho was applied (the
+  // operator's intent on the active button is "undo this"). Clicking
+  // the OTHER side while fusensho is active is a side-switch; the
+  // original pre-fusensho snapshot is preserved so a later untoggle
+  // still restores the genuine prior state, not the intermediate 2-0.
+  const setFusenshoFor = (idx, side) => updateSub(idx, prev => applyFusenshoToggle(prev, side));
 
   const subTotals = subs.map(s => {
     const aH = Math.floor(s.bFouls / 2);
@@ -1233,17 +1256,18 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
 
             // Each row: [left side, center score, right side] — left=SHIRO, right=AKA
             // T096/FR-031: manual pts/fouls edits clear the per-bout fusensho
-            // flag so the bout becomes a regular fought 2-0 once the operator
-            // intervenes. Re-applying via the Fusensho button is the way to
-            // restore the default-win semantics.
+            // flag AND discard the _preFusensho snapshot so the bout becomes
+            // a regular fought score once the operator intervenes. Re-applying
+            // via the Fusensho button captures a fresh snapshot from the
+            // current (manually-edited) state.
             const rowSides = [
               { key: "b", pts: s.bPts, fouls: s.bFouls, hansokuPts: t.bHansoku,
-                setPts: (pts) => updateSub(idx, prev => ({ ...prev, bPts: pts, fusensho: "" })),
-                setFouls: (f) => updateSub(idx, prev => ({ ...prev, bFouls: f, fusensho: "" })),
+                setPts: (pts) => updateSub(idx, prev => ({ ...prev, bPts: pts, fusensho: "", _preFusensho: undefined })),
+                setFouls: (f) => updateSub(idx, prev => ({ ...prev, bFouls: f, fusensho: "", _preFusensho: undefined })),
                 color: "shiro", label: "SHIRO" },
               { key: "a", pts: s.aPts, fouls: s.aFouls, hansokuPts: t.aHansoku,
-                setPts: (pts) => updateSub(idx, prev => ({ ...prev, aPts: pts, fusensho: "" })),
-                setFouls: (f) => updateSub(idx, prev => ({ ...prev, aFouls: f, fusensho: "" })),
+                setPts: (pts) => updateSub(idx, prev => ({ ...prev, aPts: pts, fusensho: "", _preFusensho: undefined })),
+                setFouls: (f) => updateSub(idx, prev => ({ ...prev, aFouls: f, fusensho: "", _preFusensho: undefined })),
                 color: "aka", label: "AKA" },
             ];
 
@@ -1307,8 +1331,11 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                         </div>
                         {/* T096/FR-031: per-bout Fusensho. Awards the bout
                             2-0 to this side as a default win (opponent
-                            forfeited the bout). Toggle off to keep the
-                            score but clear the fusensho flag. */}
+                            forfeited the bout). Re-clicking the active
+                            side undoes the fusensho and restores the
+                            score that existed before it was applied; a
+                            manual pts/fouls edit while active clears the
+                            flag and discards the snapshot. */}
                         <div className="tsm-fusensho" style={{ marginTop: 4 }}>
                           <button
                             data-testid="scoring-modal-fusensho-button"
@@ -1316,7 +1343,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                             className={`btn btn--sm ${s.fusensho === rs.key ? "btn--primary" : ""}`}
                             onClick={() => setFusenshoFor(idx, rs.key)}
                             title={s.fusensho === rs.key
-                              ? `Click to clear fusensho on this bout (keeps the 2-0 score)`
+                              ? `Click to undo fusensho — restores the previous score`
                               : `Mark bout as fusensho — default win 2-0 to ${rs.label}`}
                           >
                             {s.fusensho === rs.key
@@ -1497,4 +1524,5 @@ export {
   DecisionPrompt,
   MAX_IPPONS_PER_SIDE,
   isBoutDecided,
+  applyFusenshoToggle,
 };


### PR DESCRIPTION
## Summary
- Re-clicking the active Fusensho button on a team sub-match used to leave the auto-filled 2-0 in place; the operator's prior points were overwritten on toggle-on and never saved.
- Snapshot the pre-fusensho `{aPts, bPts, aFouls, bFouls}` into a transient `_preFusensho` field on the sub state at toggle-on, restore on untoggle, preserve across side-switches, discard on manual edits.
- Behaviour extracted into a pure `applyFusenshoToggle` helper with full vitest coverage.

## Test plan
- [x] `npm test` in `web-mobile/` — 580/580 pass, includes 6 new tests on `applyFusenshoToggle` (toggle-on, toggle-off, side-switch, fresh round-trip, defensive fallback).
- [x] `go test ./...` — all 19 packages green.
- [x] `make go/build` — clean, web-mobile esbuild bundle regenerated and re-embedded.
- [ ] Manual smoke (operator UI):
  1. Score 1-0 SHIRO on a team sub-bout → click Fusensho SHIRO (2-0) → click Fusensho SHIRO again → score returns to 1-0.
  2. Score 1-0 SHIRO → Fusensho SHIRO → Fusensho AKA (side switch, 2-0 AKA) → Fusensho AKA → restores to 1-0 SHIRO.
  3. Score 1-0 SHIRO → Fusensho SHIRO (2-0) → manually click K on AKA (2-1, flag clears) → Fusensho SHIRO (2-0) → Fusensho SHIRO → restores to 2-1.
  4. Reopen modal after Save: cross-session untoggle hits the defensive fallback (clears flag, leaves 2-0) — acceptable degraded behaviour since the snapshot doesn't persist server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)