### PR TITLE
fix(scoring-ui): auto-award H at 2 fouls, reset counter, disable X when scored

### DIFF
--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -10,6 +10,7 @@ import {
   MAX_IPPONS_PER_SIDE,
   isBoutDecided,
   applyFoulIncrement,
+  reconcileFoulsAtOpen,
   applyFusenshoToggle,
 } from '../admin_scoring_modal.jsx';
 
@@ -659,6 +660,67 @@ describe('applyFoulIncrement (FIK 2-foul auto-award)', () => {
     // Backstop for a hypothetical corrupted state — the function must
     // not push a 3rd ippon onto opp regardless of how it was called.
     expect(applyFoulIncrement(1, ['M', 'K'], ['M', 'K'])).toEqual({ fouls: 0, opponentPts: ['M', 'K'] });
+  });
+});
+
+describe('reconcileFoulsAtOpen (correction-flow normalization)', () => {
+  // Reopen/correction flow: pre-fix builds stored hansoku as a cumulative
+  // raw count (0..N) and folded floor(N/2) "H" entries into the opponent's
+  // ippon array at submit. The post-fix counter is "outstanding fouls not
+  // yet discharged" (0 or 1). Naively stripping rawFouls % 2 is correct
+  // when the H's are already in opp's pts; it silently loses points when
+  // they're not (legacy/imported data). reconcileFoulsAtOpen tops up the
+  // missing H's before returning the remainder.
+
+  it('passes through when no fouls', () => {
+    expect(reconcileFoulsAtOpen(0, [])).toEqual({ outstandingFouls: 0, opponentPts: [] });
+    expect(reconcileFoulsAtOpen(0, ['M'])).toEqual({ outstandingFouls: 0, opponentPts: ['M'] });
+  });
+
+  it('rawFouls=1 has no discharged H, just 1 outstanding', () => {
+    expect(reconcileFoulsAtOpen(1, [])).toEqual({ outstandingFouls: 1, opponentPts: [] });
+    expect(reconcileFoulsAtOpen(1, ['M'])).toEqual({ outstandingFouls: 1, opponentPts: ['M'] });
+  });
+
+  it('idempotent when the discharged H is already present (consistent prior data)', () => {
+    // rawFouls=2 → expected 1 H. Opp already has it from the old buildPatch fold.
+    expect(reconcileFoulsAtOpen(2, ['H'])).toEqual({ outstandingFouls: 0, opponentPts: ['H'] });
+    // Mixed manual + derived: opp already has 1 manual + 1 derived = 2 total.
+    expect(reconcileFoulsAtOpen(2, ['M', 'H'])).toEqual({ outstandingFouls: 0, opponentPts: ['M', 'H'] });
+  });
+
+  it('tops up missing H when legacy/imported data has fouls but no fold', () => {
+    // rawFouls=2 with empty opp pts (corrupted/imported) — top up 1 H.
+    expect(reconcileFoulsAtOpen(2, [])).toEqual({ outstandingFouls: 0, opponentPts: ['H'] });
+    // Manual ippon exists but the foul-derived H was never folded in.
+    expect(reconcileFoulsAtOpen(2, ['M'])).toEqual({ outstandingFouls: 0, opponentPts: ['M', 'H'] });
+  });
+
+  it('handles odd cumulative counts: floor pair discharges, remainder outstanding', () => {
+    // rawFouls=3 → 1 H discharged, 1 outstanding.
+    expect(reconcileFoulsAtOpen(3, [])).toEqual({ outstandingFouls: 1, opponentPts: ['H'] });
+    expect(reconcileFoulsAtOpen(3, ['H'])).toEqual({ outstandingFouls: 1, opponentPts: ['H'] });
+  });
+
+  it('caps the top-up at maxIppons (bout would have ended)', () => {
+    // rawFouls=4 → expected 2 H. Opp slot capped at 2 — top up fills the slot.
+    expect(reconcileFoulsAtOpen(4, [])).toEqual({ outstandingFouls: 0, opponentPts: ['H', 'H'] });
+    // Opp already has 1 ippon, so only room for 1 H top-up despite expecting 2.
+    expect(reconcileFoulsAtOpen(4, ['M'])).toEqual({ outstandingFouls: 0, opponentPts: ['M', 'H'] });
+  });
+
+  it('does not duplicate when opp already has more H than expected', () => {
+    // expected 1 H from fouls, but opp has 2 H's (e.g., two manual H awards).
+    // Don't add — opp's count exceeds the expected fold count.
+    expect(reconcileFoulsAtOpen(2, ['H', 'H'])).toEqual({ outstandingFouls: 0, opponentPts: ['H', 'H'] });
+  });
+
+  it('respects custom maxIppons cap', () => {
+    expect(reconcileFoulsAtOpen(4, [], 1)).toEqual({ outstandingFouls: 0, opponentPts: ['H'] });
+  });
+
+  it('defensive: clamps negative rawFouls to 0', () => {
+    expect(reconcileFoulsAtOpen(-1, ['M'])).toEqual({ outstandingFouls: 0, opponentPts: ['M'] });
   });
 });
 

--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -9,6 +9,7 @@ import {
   DecisionPrompt,
   MAX_IPPONS_PER_SIDE,
   isBoutDecided,
+  applyFoulIncrement,
   applyFusenshoToggle,
 } from '../admin_scoring_modal.jsx';
 
@@ -591,6 +592,57 @@ describe('isBoutDecided / MAX_IPPONS_PER_SIDE', () => {
     // boutDecided re-evaluates on next render with the shorter array.
     const after = ['M']; // was ['M','K'], operator removed 'K'
     expect(isBoutDecided(after, ['D'])).toBe(false); // back to 1-1, not decided
+  });
+});
+
+describe('applyFoulIncrement (FIK 2-foul auto-award)', () => {
+  // Per FIK rules and the project's own glossary (`internal/domain/glossary.go`):
+  // "Two hansoku awarded to a competitor give the opponent one free point."
+  // applyFoulIncrement models a single `+` press on a side's foul counter:
+  // the 2nd press discharges into a hansoku ippon ("H") for the OPPONENT and
+  // resets this side's counter to 0. The 1st press just increments by 1.
+
+  it('first foul increments to 1, opponent untouched', () => {
+    expect(applyFoulIncrement(0, [])).toEqual({ fouls: 1, opponentPts: [] });
+  });
+
+  it('second foul auto-awards H to opponent and resets counter', () => {
+    expect(applyFoulIncrement(1, [])).toEqual({ fouls: 0, opponentPts: ['H'] });
+  });
+
+  it('second foul appends H to existing opponent ippons', () => {
+    // Opponent already has 1 ippon — H is appended into the second slot.
+    expect(applyFoulIncrement(1, ['M'])).toEqual({ fouls: 0, opponentPts: ['M', 'H'] });
+  });
+
+  it('second foul is a no-op when opponent slot is already full', () => {
+    // Best-of-3 cap: with 2 ippons the bout is already decided. Swallow
+    // the extra foul rather than crash. The counter still resets to 0.
+    expect(applyFoulIncrement(1, ['M', 'K'])).toEqual({ fouls: 0, opponentPts: ['M', 'K'] });
+  });
+
+  it('four sequential presses produce 2 H in opponent slots, fouls=0', () => {
+    // Simulate the operator clicking `+` four times in a row. After:
+    //   press 1: fouls=1, opp=[]
+    //   press 2: fouls=0, opp=['H']
+    //   press 3: fouls=1, opp=['H']
+    //   press 4: fouls=0, opp=['H','H']   ← bout now decided
+    let state = { fouls: 0, opponentPts: [] };
+    state = applyFoulIncrement(state.fouls, state.opponentPts);
+    expect(state).toEqual({ fouls: 1, opponentPts: [] });
+    state = applyFoulIncrement(state.fouls, state.opponentPts);
+    expect(state).toEqual({ fouls: 0, opponentPts: ['H'] });
+    state = applyFoulIncrement(state.fouls, state.opponentPts);
+    expect(state).toEqual({ fouls: 1, opponentPts: ['H'] });
+    state = applyFoulIncrement(state.fouls, state.opponentPts);
+    expect(state).toEqual({ fouls: 0, opponentPts: ['H', 'H'] });
+  });
+
+  it('respects custom maxIppons cap (defensive)', () => {
+    // maxIppons param is the same MAX_IPPONS_PER_SIDE default — pinned
+    // here so a future refactor that lifts the cap doesn't silently let
+    // 3+ H pile up in the opponent's slot.
+    expect(applyFoulIncrement(1, ['M'], 1)).toEqual({ fouls: 0, opponentPts: ['M'] });
   });
 });
 

--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -11,6 +11,7 @@ import {
   isBoutDecided,
   applyFoulIncrement,
   reconcileFoulsAtOpen,
+  nextFoulOnDecrement,
   applyFusenshoToggle,
 } from '../admin_scoring_modal.jsx';
 
@@ -721,6 +722,31 @@ describe('reconcileFoulsAtOpen (correction-flow normalization)', () => {
 
   it('defensive: clamps negative rawFouls to 0', () => {
     expect(reconcileFoulsAtOpen(-1, ['M'])).toEqual({ outstandingFouls: 0, opponentPts: ['M'] });
+  });
+});
+
+describe('nextFoulOnDecrement (team `−` button regression)', () => {
+  // Pre-existing bug: the team sub-match `−` button passed a React-style
+  // functional updater (`f => Math.max(0, f - 1)`) to `rs.setFouls`, but
+  // rs.setFouls is a plain setter that wrote the function itself into
+  // bFouls — breaking comparisons and rendering. Extracted to a pure
+  // helper so the contract (returns a NUMBER, not a function) is
+  // directly testable.
+
+  it('returns a number, not a function (regression guard)', () => {
+    expect(typeof nextFoulOnDecrement(2)).toBe('number');
+    expect(typeof nextFoulOnDecrement(0)).toBe('number');
+  });
+
+  it('decrements by 1', () => {
+    expect(nextFoulOnDecrement(1)).toBe(0);
+    expect(nextFoulOnDecrement(2)).toBe(1);
+    expect(nextFoulOnDecrement(3)).toBe(2);
+  });
+
+  it('clamps at 0 (never returns negative)', () => {
+    expect(nextFoulOnDecrement(0)).toBe(0);
+    expect(nextFoulOnDecrement(-1)).toBe(0);
   });
 });
 

--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -642,7 +642,23 @@ describe('applyFoulIncrement (FIK 2-foul auto-award)', () => {
     // maxIppons param is the same MAX_IPPONS_PER_SIDE default — pinned
     // here so a future refactor that lifts the cap doesn't silently let
     // 3+ H pile up in the opponent's slot.
-    expect(applyFoulIncrement(1, ['M'], 1)).toEqual({ fouls: 0, opponentPts: ['M'] });
+    expect(applyFoulIncrement(1, ['M'], [], 1)).toEqual({ fouls: 0, opponentPts: ['M'] });
+  });
+
+  it('second foul is a no-op when THIS side is already at maxIppons', () => {
+    // Bout-decided guard: if THIS side reached 2 ippons (bout already
+    // won by THIS side), the 2nd foul cannot auto-award an H to opp
+    // without producing an invalid 2-2 scoreline that the server's
+    // validateIpponCounts would reject. Counter still resets to 0;
+    // opponent's pts are left untouched.
+    expect(applyFoulIncrement(1, ['X'], ['M', 'K'])).toEqual({ fouls: 0, opponentPts: ['X'] });
+    expect(applyFoulIncrement(1, [], ['M', 'K'])).toEqual({ fouls: 0, opponentPts: [] });
+  });
+
+  it('second foul is a no-op when BOTH sides are at maxIppons (already 2-2 is impossible but defensive)', () => {
+    // Backstop for a hypothetical corrupted state — the function must
+    // not push a 3rd ippon onto opp regardless of how it was called.
+    expect(applyFoulIncrement(1, ['M', 'K'], ['M', 'K'])).toEqual({ fouls: 0, opponentPts: ['M', 'K'] });
   });
 });
 

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -1067,8 +1067,8 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
     // opponent's pts are topped up (defensive against legacy/imported data).
     const rawAFouls = existing ? existing.hansokuA || 0 : 0;
     const rawBFouls = existing ? existing.hansokuB || 0 : 0;
-    const seedAPts = existing ? (existing.ipponsA || []).filter(x => x !== "•") : [];
-    const seedBPts = existing ? (existing.ipponsB || []).filter(x => x !== "•") : [];
+    const seedAPts = existing ? (existing.ipponsA || []).filter(x => x && x !== "•") : [];
+    const seedBPts = existing ? (existing.ipponsB || []).filter(x => x && x !== "•") : [];
     const reconA = reconcileFoulsAtOpen(rawAFouls, seedBPts);
     const reconB = reconcileFoulsAtOpen(rawBFouls, seedAPts);
     return {
@@ -1094,13 +1094,12 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
 
   // Hansoku Hs are already in the pts arrays (folded in by
   // applyFoulIncrement at the 2-foul boundary), so totals are just the
-  // pts length. aHansoku/bHansoku stay at 0 because nothing is
-  // outstanding-and-undischarged in the live view.
+  // pts length. No separate hansoku tally is needed in the live view.
   const subTotals = subs.map(s => {
     const aT = s.aPts.length;
     const bT = s.bPts.length;
     const winner = aT > bT ? "a" : bT > aT ? "b" : null;
-    return { aTotal: aT, bTotal: bT, aHansoku: 0, bHansoku: 0, winner };
+    return { aTotal: aT, bTotal: bT, winner };
   });
 
   const ivA = subTotals.filter(s => s.winner === "a").length;

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -68,6 +68,26 @@ function applyFoulIncrement(fouls, opponentPts, thisSidePts = [], maxIppons = MA
   return { fouls: 0, opponentPts: [...opponentPts, "H"] };
 }
 
+// reconcileFoulsAtOpen — pure helper for the reopen/correction flow.
+// Pre-fix builds stored hansoku as a cumulative raw count (0..N) alongside
+// the already-discharged "H" entries in the opponent's pts array. The new
+// counter is "outstanding fouls not yet discharged" (0 or 1). Naively
+// taking `rawFouls % 2` strips full pairs — but if the opponent's pts is
+// MISSING the expected H entries (older data, partial save, imported
+// match), the strip silently loses points. This helper tops up the
+// opponent's pts with the missing H's (capped at maxIppons) before
+// returning the outstanding remainder. Idempotent: when the H's are
+// already present it leaves opponentPts unchanged.
+function reconcileFoulsAtOpen(rawFouls, opponentPts, maxIppons = MAX_IPPONS_PER_SIDE) {
+  const safe = rawFouls > 0 ? rawFouls : 0;
+  const expectedH = Math.floor(safe / 2);
+  const haveH = opponentPts.filter(x => x === "H").length;
+  const missing = Math.max(0, expectedH - haveH);
+  const topUp = Math.min(missing, Math.max(0, maxIppons - opponentPts.length));
+  const newOpp = topUp > 0 ? [...opponentPts, ...Array(topUp).fill("H")] : opponentPts;
+  return { outstandingFouls: safe % 2, opponentPts: newOpp };
+}
+
 // Term — kendo-glossary tooltip wrapper. Read lazily off window so the
 // load order between glossary.js and this module doesn't matter (both
 // are type="module" scripts and may execute in any order). Falls back
@@ -335,19 +355,23 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
   const teamSize = m.teamSize || 5;
   if (isTeam) return <TeamScoreEditorModal match={m} teamSize={teamSize} onClose={onClose} onSubmit={onSubmit} onSubmitAndNext={onSubmitAndNext} prevMatch={prevMatch} nextMatch={nextMatch} onPrev={onPrev} onNext={onNext} password={password} />;
 
-  const initialAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
-  const initialBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
+  const seedAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
+  const seedBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
 
   // Use ?? not || so an explicit 0 isn't treated as "unset".
-  // Mod-2 strip: pre-fix builds stored the cumulative raw count (e.g. 2)
-  // alongside the already-awarded H in the opponent's ippon array. With
-  // applyFoulIncrement, the counter is now "outstanding fouls not yet
-  // discharged" so we drop the discharged portion at init. The H ippons
-  // remain in ipponsA/ipponsB.
+  // reconcileFoulsAtOpen turns the pre-fix cumulative raw count into the
+  // post-fix "outstanding fouls" semantics AND tops up the opponent's pts
+  // with any missing discharged H ippons (legacy/imported data that has
+  // hansokuA >= 2 without matching H's in ipponsB would otherwise silently
+  // lose points on resubmit). A's fouls discharge into B's pts; B's into A's.
   const rawAFouls = m.hansokuA ?? m.score?.fouls?.a ?? 0;
   const rawBFouls = m.hansokuB ?? m.score?.fouls?.b ?? 0;
-  const initialAFouls = rawAFouls % 2;
-  const initialBFouls = rawBFouls % 2;
+  const reconA = reconcileFoulsAtOpen(rawAFouls, seedBPts);
+  const reconB = reconcileFoulsAtOpen(rawBFouls, seedAPts);
+  const initialAPts = reconB.opponentPts;
+  const initialBPts = reconA.opponentPts;
+  const initialAFouls = reconA.outstandingFouls;
+  const initialBFouls = reconB.outstandingFouls;
   // FR-033: encho (overtime) counter rides alongside the score. Initialized
   // from the existing match.encho?.periodCount so re-opens of completed
   // matches retain the toggle. Slice 1 ships the operator-visible toggle and
@@ -1027,17 +1051,22 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
       if (existing.winner === sideAName) fusensho = "a";
       else if (existing.winner === sideBName) fusensho = "b";
     }
-    // Mod-2 strip mirrors ScoreEditorModal: pre-fix builds stored the
-    // cumulative raw foul count alongside the already-awarded H in the
-    // opponent's ippon array. The counter now means "outstanding fouls
-    // not yet discharged" so drop the discharged portion at init.
+    // reconcileFoulsAtOpen mirrors ScoreEditorModal: pre-fix builds
+    // stored the cumulative raw foul count alongside the already-awarded
+    // H in the opponent's ippon array. The counter now means "outstanding
+    // fouls not yet discharged" and any missing discharged H's in the
+    // opponent's pts are topped up (defensive against legacy/imported data).
     const rawAFouls = existing ? existing.hansokuA || 0 : 0;
     const rawBFouls = existing ? existing.hansokuB || 0 : 0;
+    const seedAPts = existing ? (existing.ipponsA || []).filter(x => x !== "•") : [];
+    const seedBPts = existing ? (existing.ipponsB || []).filter(x => x !== "•") : [];
+    const reconA = reconcileFoulsAtOpen(rawAFouls, seedBPts);
+    const reconB = reconcileFoulsAtOpen(rawBFouls, seedAPts);
     return {
-      aPts: existing ? (existing.ipponsA || []).filter(x => x !== "•") : [],
-      bPts: existing ? (existing.ipponsB || []).filter(x => x !== "•") : [],
-      aFouls: rawAFouls % 2,
-      bFouls: rawBFouls % 2,
+      aPts: reconB.opponentPts,
+      bPts: reconA.opponentPts,
+      aFouls: reconA.outstandingFouls,
+      bFouls: reconB.outstandingFouls,
       fusensho,
     };
   });
@@ -1416,7 +1445,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                         <div className="tsm-fouls" data-testid={`scoring-modal-hansoku-${rs.color}`}>
                           <span className="tsm-fouls__label">{rs.label} Fouls</span>
                           <div className="tsm-fouls__controls">
-                            <button className="tsm-fouls__btn" onClick={() => rs.setFouls(f => Math.max(0, f - 1))} disabled={rs.fouls === 0}>−</button>
+                            <button className="tsm-fouls__btn" onClick={() => rs.setFouls(Math.max(0, rs.fouls - 1))} disabled={rs.fouls === 0}>−</button>
                             <span className={`tsm-fouls__count ${rs.fouls >= 1 ? "tsm-fouls__count--warn" : ""}`}>{rs.fouls}</span>
                             <button className="tsm-fouls__btn" onClick={rs.onIncrement} disabled={subBoutDecided}>+</button>
                           </div>
@@ -1617,5 +1646,6 @@ export {
   MAX_IPPONS_PER_SIDE,
   isBoutDecided,
   applyFoulIncrement,
+  reconcileFoulsAtOpen,
   applyFusenshoToggle,
 };

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -45,6 +45,27 @@ function applyFusenshoToggle(prev, side) {
   return { aPts: [], bPts: ["M", "M"], aFouls: 0, bFouls: 0, fusensho: "b", _preFusensho: snap };
 }
 
+// applyFoulIncrement — pure helper modelling a single `+` press on a
+// side's foul counter. Per FIK rules (and internal/domain/glossary.go):
+// "Two hansoku awarded to a competitor give the opponent one free point."
+// The 2nd foul auto-awards an "H" ippon to the opponent and resets this
+// side's counter to 0. The counter is "outstanding fouls not yet
+// discharged into an H" — discharged Hs live in the opponent's pts array.
+//
+// Edge case: when the opponent's pts slot is already full (best-of-3
+// cap), the bout is decided and further `+` presses are swallowed
+// (counter stays at the pre-increment value, no new H awarded). The
+// operator must remove an H from the opponent's slot first if they
+// want to undo the awarded point.
+export function applyFoulIncrement(fouls, opponentPts, maxIppons = MAX_IPPONS_PER_SIDE) {
+  const next = fouls + 1;
+  if (next < 2) return { fouls: next, opponentPts };
+  const newOpp = opponentPts.length < maxIppons
+    ? [...opponentPts, "H"]
+    : opponentPts;
+  return { fouls: 0, opponentPts: newOpp };
+}
+
 // Term — kendo-glossary tooltip wrapper. Read lazily off window so the
 // load order between glossary.js and this module doesn't matter (both
 // are type="module" scripts and may execute in any order). Falls back
@@ -280,8 +301,13 @@ function RemainingMatchesPanel({ compID, password, withdrawnPlayer, onAwarded, o
   );
 }
 
-// Reusable foul counter: independent +/- buttons per side with clear labeling
-function FoulCounter({ label, fouls, setFouls, color, hansokuPts }) {
+// Reusable foul counter: independent +/- buttons per side with clear labeling.
+// The `+` button delegates to `onIncrement` which applies the
+// applyFoulIncrement rule (auto-award H + reset at the 2-foul boundary);
+// `setFouls` is kept for the `−` button (simple decrement). After the
+// 2-foul auto-award the awarded H lives in the opponent's pts array, so
+// the counter shows only "outstanding fouls not yet discharged."
+function FoulCounter({ label, fouls, setFouls, onIncrement, color }) {
   // color is "shiro" or "aka" — surface as data-testid so Playwright probes
   // (T023a) can target each side without depending on the className.
   return (
@@ -290,10 +316,9 @@ function FoulCounter({ label, fouls, setFouls, color, hansokuPts }) {
       <div className="foul-counter__controls">
         <button className="foul-counter__btn foul-counter__btn--dec" onClick={() => setFouls(f => Math.max(0, f - 1))} disabled={fouls === 0}>−</button>
         <div className="foul-counter__count">
-          <span className={`foul-counter__num ${fouls >= 2 ? "foul-counter__num--warn" : ""}`}>{fouls}</span>
-          {hansokuPts > 0 && <span className="foul-counter__h">→ +{hansokuPts}H to opp.</span>}
+          <span className={`foul-counter__num ${fouls >= 1 ? "foul-counter__num--warn" : ""}`}>{fouls}</span>
         </div>
-        <button className="foul-counter__btn foul-counter__btn--inc" onClick={() => setFouls(f => Math.min(4, f + 1))} disabled={fouls >= 4}>+</button>
+        <button className="foul-counter__btn foul-counter__btn--inc" onClick={onIncrement}>+</button>
       </div>
     </div>
   );
@@ -309,9 +334,16 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
   const initialAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
   const initialBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
 
-  // Use ?? not || so an explicit 0 isn't treated as "unset"
-  const initialAFouls = m.hansokuA ?? m.score?.fouls?.a ?? 0;
-  const initialBFouls = m.hansokuB ?? m.score?.fouls?.b ?? 0;
+  // Use ?? not || so an explicit 0 isn't treated as "unset".
+  // Mod-2 strip: pre-fix builds stored the cumulative raw count (e.g. 2)
+  // alongside the already-awarded H in the opponent's ippon array. With
+  // applyFoulIncrement, the counter is now "outstanding fouls not yet
+  // discharged" so we drop the discharged portion at init. The H ippons
+  // remain in ipponsA/ipponsB.
+  const rawAFouls = m.hansokuA ?? m.score?.fouls?.a ?? 0;
+  const rawBFouls = m.hansokuB ?? m.score?.fouls?.b ?? 0;
+  const initialAFouls = rawAFouls % 2;
+  const initialBFouls = rawBFouls % 2;
   // FR-033: encho (overtime) counter rides alongside the score. Initialized
   // from the existing match.encho?.periodCount so re-opens of completed
   // matches retain the toggle. Slice 1 ships the operator-visible toggle and
@@ -421,11 +453,11 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     }
   };
 
-  // Hansoku → ippon awarded to opponent on every 2nd foul
-  const aHansokuPts = Math.floor(bFouls / 2);
-  const bHansokuPts = Math.floor(aFouls / 2);
-  const aTotal = aPts.filter((x) => x !== "•").length + aHansokuPts;
-  const bTotal = bPts.filter((x) => x !== "•").length + bHansokuPts;
+  // Hansoku Hs are now physically present in the opponent's pts array
+  // (folded in at the 2-foul boundary by applyFoulIncrement). The counter
+  // is "outstanding fouls" — no derived addends needed.
+  const aTotal = aPts.filter((x) => x !== "•").length;
+  const bTotal = bPts.filter((x) => x !== "•").length;
 
   const addPt = (side, letter) => {
     if (side === "a") setAPts((p) => p.length < 2 ? [...p, letter] : p);
@@ -452,11 +484,13 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
       ...enchoBlock(),
     };
     if (isDrawToggled) return { winner: null, ipponsA: [], ipponsB: [], hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete }, ...enchoBlock() };
-    // ippon
+    // ippon. Hansoku Hs are already physically present in the pts arrays
+    // (folded in by applyFoulIncrement at the 2-foul boundary), so no
+    // additional H fold is needed here.
     const aLetters = aPts.filter(x => x !== "•");
     const bLetters = bPts.filter(x => x !== "•");
-    const aFinal = [...aLetters, ...Array(aHansokuPts).fill("H")].slice(0, 2);
-    const bFinal = [...bLetters, ...Array(bHansokuPts).fill("H")].slice(0, 2);
+    const aFinal = aLetters.slice(0, 2);
+    const bFinal = bLetters.slice(0, 2);
     const winnerSide = aFinal.length > bFinal.length ? "a" : bFinal.length > aFinal.length ? "b" : null;
     if (!winnerSide) return { winner: null, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete }, ...enchoBlock() };
     const winner = winnerSide === "a" ? m.sideA : m.sideB;
@@ -474,10 +508,29 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
   const initialIsDrawToggled = window.isHikiwake(m.score?.type) || window.isHikiwake(m.decision);
   const [isDrawToggled, setIsDrawToggled] = useStateA(initialIsDrawToggled);
 
-  // Arranged as [left, right] — left is always SHIRO (White), right is always AKA (Red)
+  // Arranged as [left, right] — left is always SHIRO (White), right is always AKA (Red).
+  // onIncrement applies the FIK 2-foul auto-award rule via applyFoulIncrement:
+  // every 2nd foul on this side discharges into a hansoku ippon ("H") for
+  // the OPPONENT and resets this side's counter to 0.
   const sides = [
-    { key: "b", name: m.sideB?.name, dojo: m.sideB?.dojo, pts: bPts, fouls: bFouls, setFouls: setBFouls, hansokuPts: bHansokuPts, color: "shiro", label: "SHIRO (White)" },
-    { key: "a", name: m.sideA?.name, dojo: m.sideA?.dojo, pts: aPts, fouls: aFouls, setFouls: setAFouls, hansokuPts: aHansokuPts, color: "aka", label: "AKA (Red)" },
+    {
+      key: "b", name: m.sideB?.name, dojo: m.sideB?.dojo, pts: bPts, fouls: bFouls, setFouls: setBFouls,
+      onIncrement: () => {
+        const r = applyFoulIncrement(bFouls, aPts);
+        setBFouls(r.fouls);
+        setAPts(r.opponentPts);
+      },
+      color: "shiro", label: "SHIRO (White)",
+    },
+    {
+      key: "a", name: m.sideA?.name, dojo: m.sideA?.dojo, pts: aPts, fouls: aFouls, setFouls: setAFouls,
+      onIncrement: () => {
+        const r = applyFoulIncrement(aFouls, bPts);
+        setAFouls(r.fouls);
+        setBPts(r.opponentPts);
+      },
+      color: "aka", label: "AKA (Red)",
+    },
   ];
 
   // Bout is decided once either side reaches 2 ippons — disable add-ippon
@@ -512,7 +565,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
   // Scoring shortcuts (Enter/M/K/D/T/H/X) are skipped when any interactive
   // element (input, button, link, …) has focus so native activation still works.
   const kbRef = React.useRef(null);
-  kbRef.current = { submitting, canFinish, isDrawToggled, handleDismiss, onPrev, onNext, onSubmit, onSubmitAndNext, buildPatch, addPt, doSubmit };
+  kbRef.current = { submitting, canFinish, isDrawToggled, aTotal, bTotal, handleDismiss, onPrev, onNext, onSubmit, onSubmitAndNext, buildPatch, addPt, doSubmit };
 
   useEffectA(() => {
     const onKeyDown = (ev) => {
@@ -554,8 +607,12 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
       if (k === "x" || k === "X") {
         ev.preventDefault();
         if (s.isDrawToggled) {
+          // Cancel-draw is always allowed (mirrors the active-state X button).
           setIsDrawToggled(false);
-        } else {
+        } else if (s.aTotal === 0 && s.bTotal === 0) {
+          // Toggle-on guarded: any existing score would be silently wiped by
+          // the setAPts([])/setBPts([]) below. The clickable X button has
+          // disabled={aTotal > 0 || bTotal > 0} for the same reason.
           setIsDrawToggled(true);
           setAPts([]); setBPts([]);
         }
@@ -658,7 +715,8 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                             <button
                               className="sb-draw-toggle"
                               onClick={() => { setIsDrawToggled(true); setAPts([]); setBPts([]); }}
-                              title="Mark as draw (hikiwake)"
+                              disabled={aTotal > 0 || bTotal > 0}
+                              title={aTotal > 0 || bTotal > 0 ? "Clear scores before marking a draw" : "Mark as draw (hikiwake)"}
                               aria-label="Mark as draw (hikiwake)"
                             >{aTotal === 0 && bTotal === 0 ? "vs" : "X"}</button>
                           </>
@@ -677,8 +735,8 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                     label={s.label}
                     fouls={s.fouls}
                     setFouls={s.setFouls}
+                    onIncrement={s.onIncrement}
                     color={s.color}
-                    hansokuPts={s.hansokuPts}
                   />
                 ))}
               </div>
@@ -964,11 +1022,17 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
       if (existing.winner === sideAName) fusensho = "a";
       else if (existing.winner === sideBName) fusensho = "b";
     }
+    // Mod-2 strip mirrors ScoreEditorModal: pre-fix builds stored the
+    // cumulative raw foul count alongside the already-awarded H in the
+    // opponent's ippon array. The counter now means "outstanding fouls
+    // not yet discharged" so drop the discharged portion at init.
+    const rawAFouls = existing ? existing.hansokuA || 0 : 0;
+    const rawBFouls = existing ? existing.hansokuB || 0 : 0;
     return {
       aPts: existing ? (existing.ipponsA || []).filter(x => x !== "•") : [],
       bPts: existing ? (existing.ipponsB || []).filter(x => x !== "•") : [],
-      aFouls: existing ? existing.hansokuA || 0 : 0,
-      bFouls: existing ? existing.hansokuB || 0 : 0,
+      aFouls: rawAFouls % 2,
+      bFouls: rawBFouls % 2,
       fusensho,
     };
   });
@@ -985,13 +1049,15 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
   // still restores the genuine prior state, not the intermediate 2-0.
   const setFusenshoFor = (idx, side) => updateSub(idx, prev => applyFusenshoToggle(prev, side));
 
+  // Hansoku Hs are already in the pts arrays (folded in by
+  // applyFoulIncrement at the 2-foul boundary), so totals are just the
+  // pts length. aHansoku/bHansoku stay at 0 because nothing is
+  // outstanding-and-undischarged in the live view.
   const subTotals = subs.map(s => {
-    const aH = Math.floor(s.bFouls / 2);
-    const bH = Math.floor(s.aFouls / 2);
-    const aT = s.aPts.length + aH;
-    const bT = s.bPts.length + bH;
+    const aT = s.aPts.length;
+    const bT = s.bPts.length;
     const winner = aT > bT ? "a" : bT > aT ? "b" : null;
-    return { aTotal: aT, bTotal: bT, aHansoku: aH, bHansoku: bH, winner };
+    return { aTotal: aT, bTotal: bT, aHansoku: 0, bHansoku: 0, winner };
   });
 
   const ivA = subTotals.filter(s => s.winner === "a").length;
@@ -1006,8 +1072,9 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
     if (targetStatus === "scheduled") return { winner: null, status: "scheduled", score: null, ipponsA: [], ipponsB: [], subResults: [] };
     const subResults = subs.map((s, idx) => {
       const t = subTotals[idx];
-      const aAll = [...s.aPts, ...Array(t.aHansoku).fill("H")].slice(0, 2);
-      const bAll = [...s.bPts, ...Array(t.bHansoku).fill("H")].slice(0, 2);
+      // Hansoku Hs already in pts arrays via applyFoulIncrement — no fold.
+      const aAll = s.aPts.slice(0, 2);
+      const bAll = s.bPts.slice(0, 2);
       const w = t.winner === "a" ? m.sideA : t.winner === "b" ? m.sideB : null;
       // T096/FR-031: per-bout fusensho overrides the default hikiwake/fought
       // mapping. The bout was awarded as a default win — backend tally treats
@@ -1260,15 +1327,32 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
             // a regular fought score once the operator intervenes. Re-applying
             // via the Fusensho button captures a fresh snapshot from the
             // current (manually-edited) state.
+            // onIncrement applies the FIK 2-foul rule via applyFoulIncrement:
+            // the 2nd foul auto-awards an H to the OPPONENT and resets this
+            // side's foul counter. The auto-award also invalidates the
+            // _preFusensho snapshot — once an H lands in the slot the prior
+            // pre-fusensho state is stale.
             const rowSides = [
-              { key: "b", pts: s.bPts, fouls: s.bFouls, hansokuPts: t.bHansoku,
+              {
+                key: "b", pts: s.bPts, fouls: s.bFouls,
                 setPts: (pts) => updateSub(idx, prev => ({ ...prev, bPts: pts, fusensho: "", _preFusensho: undefined })),
                 setFouls: (f) => updateSub(idx, prev => ({ ...prev, bFouls: f, fusensho: "", _preFusensho: undefined })),
-                color: "shiro", label: "SHIRO" },
-              { key: "a", pts: s.aPts, fouls: s.aFouls, hansokuPts: t.aHansoku,
+                onIncrement: () => updateSub(idx, prev => {
+                  const r = applyFoulIncrement(prev.bFouls, prev.aPts);
+                  return { ...prev, bFouls: r.fouls, aPts: r.opponentPts, fusensho: "", _preFusensho: undefined };
+                }),
+                color: "shiro", label: "SHIRO",
+              },
+              {
+                key: "a", pts: s.aPts, fouls: s.aFouls,
                 setPts: (pts) => updateSub(idx, prev => ({ ...prev, aPts: pts, fusensho: "", _preFusensho: undefined })),
                 setFouls: (f) => updateSub(idx, prev => ({ ...prev, aFouls: f, fusensho: "", _preFusensho: undefined })),
-                color: "aka", label: "AKA" },
+                onIncrement: () => updateSub(idx, prev => {
+                  const r = applyFoulIncrement(prev.aFouls, prev.bPts);
+                  return { ...prev, aFouls: r.fouls, bPts: r.opponentPts, fusensho: "", _preFusensho: undefined };
+                }),
+                color: "aka", label: "AKA",
+              },
             ];
 
             // Sub-bout is decided once either side reaches 2 ippons — disable
@@ -1319,15 +1403,18 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                               disabled={subBoutDecided}>{cc}</button>
                           ))}
                         </div>
-                        {/* Independent foul counter */}
+                        {/* Independent foul counter. The `+` button calls
+                            onIncrement which applies the FIK 2-foul rule via
+                            applyFoulIncrement (auto-award H to opponent, reset
+                            counter to 0). The discharged H is physically in
+                            the opponent's pts array — no derived display. */}
                         <div className="tsm-fouls" data-testid={`scoring-modal-hansoku-${rs.color}`}>
                           <span className="tsm-fouls__label">{rs.label} Fouls</span>
                           <div className="tsm-fouls__controls">
                             <button className="tsm-fouls__btn" onClick={() => rs.setFouls(f => Math.max(0, f - 1))} disabled={rs.fouls === 0}>−</button>
-                            <span className={`tsm-fouls__count ${rs.fouls >= 2 ? "tsm-fouls__count--warn" : ""}`}>{rs.fouls}</span>
-                            <button className="tsm-fouls__btn" onClick={() => rs.setFouls(f => Math.min(4, f + 1))} disabled={rs.fouls >= 4}>+</button>
+                            <span className={`tsm-fouls__count ${rs.fouls >= 1 ? "tsm-fouls__count--warn" : ""}`}>{rs.fouls}</span>
+                            <button className="tsm-fouls__btn" onClick={rs.onIncrement}>+</button>
                           </div>
-                          {rs.hansokuPts > 0 && <span className="tsm-fouls__h">→ +{rs.hansokuPts}H</span>}
                         </div>
                         {/* T096/FR-031: per-bout Fusensho. Awards the bout
                             2-0 to this side as a default win (opponent
@@ -1514,6 +1601,8 @@ window.ScoreEditorModal = ScoreEditorModal;
 
 // ES exports for the vitest suite — pure helpers only. Components stay
 // behind the window.* pattern to match the rest of admin_*.jsx.
+// applyFoulIncrement is also exported inline (above the FoulCounter) via
+// `export function`; it is re-listed here for grep discoverability.
 export {
   resolveDecisionPassword,
   buildDecisionBody,

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -53,11 +53,11 @@ function applyFusenshoToggle(prev, side) {
 // discharged into an H" — discharged Hs live in the opponent's pts array.
 //
 // Edge case: when the opponent's pts slot is already full (best-of-3
-// cap), the bout is decided and further `+` presses are swallowed
-// (counter stays at the pre-increment value, no new H awarded). The
-// operator must remove an H from the opponent's slot first if they
-// want to undo the awarded point.
-export function applyFoulIncrement(fouls, opponentPts, maxIppons = MAX_IPPONS_PER_SIDE) {
+// cap), the bout is already decided — the counter still resets to 0
+// but no new H is awarded (the extra foul is consumed without effect).
+// To undo a previously awarded H, the operator removes it from the
+// opponent's slot directly.
+function applyFoulIncrement(fouls, opponentPts, maxIppons = MAX_IPPONS_PER_SIDE) {
   const next = fouls + 1;
   if (next < 2) return { fouls: next, opponentPts };
   const newOpp = opponentPts.length < maxIppons
@@ -489,8 +489,8 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     // additional H fold is needed here.
     const aLetters = aPts.filter(x => x !== "•");
     const bLetters = bPts.filter(x => x !== "•");
-    const aFinal = aLetters.slice(0, 2);
-    const bFinal = bLetters.slice(0, 2);
+    const aFinal = aLetters.slice(0, MAX_IPPONS_PER_SIDE);
+    const bFinal = bLetters.slice(0, MAX_IPPONS_PER_SIDE);
     const winnerSide = aFinal.length > bFinal.length ? "a" : bFinal.length > aFinal.length ? "b" : null;
     if (!winnerSide) return { winner: null, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "hikiwake", winnerPts: 0, loserPts: 0, fouls, corrected: isComplete }, ...enchoBlock() };
     const winner = winnerSide === "a" ? m.sideA : m.sideB;
@@ -1073,8 +1073,8 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
     const subResults = subs.map((s, idx) => {
       const t = subTotals[idx];
       // Hansoku Hs already in pts arrays via applyFoulIncrement — no fold.
-      const aAll = s.aPts.slice(0, 2);
-      const bAll = s.bPts.slice(0, 2);
+      const aAll = s.aPts.slice(0, MAX_IPPONS_PER_SIDE);
+      const bAll = s.bPts.slice(0, MAX_IPPONS_PER_SIDE);
       const w = t.winner === "a" ? m.sideA : t.winner === "b" ? m.sideB : null;
       // T096/FR-031: per-bout fusensho overrides the default hikiwake/fought
       // mapping. The bout was awarded as a default win — backend tally treats
@@ -1601,8 +1601,6 @@ window.ScoreEditorModal = ScoreEditorModal;
 
 // ES exports for the vitest suite — pure helpers only. Components stay
 // behind the window.* pattern to match the rest of admin_*.jsx.
-// applyFoulIncrement is also exported inline (above the FoulCounter) via
-// `export function`; it is re-listed here for grep discoverability.
 export {
   resolveDecisionPassword,
   buildDecisionBody,
@@ -1613,5 +1611,6 @@ export {
   DecisionPrompt,
   MAX_IPPONS_PER_SIDE,
   isBoutDecided,
+  applyFoulIncrement,
   applyFusenshoToggle,
 };

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -79,13 +79,22 @@ function applyFoulIncrement(fouls, opponentPts, thisSidePts = [], maxIppons = MA
 // returning the outstanding remainder. Idempotent: when the H's are
 // already present it leaves opponentPts unchanged.
 function reconcileFoulsAtOpen(rawFouls, opponentPts, maxIppons = MAX_IPPONS_PER_SIDE) {
-  const safe = rawFouls > 0 ? rawFouls : 0;
+  const safe = Math.max(0, rawFouls);
   const expectedH = Math.floor(safe / 2);
   const haveH = opponentPts.filter(x => x === "H").length;
   const missing = Math.max(0, expectedH - haveH);
   const topUp = Math.min(missing, Math.max(0, maxIppons - opponentPts.length));
   const newOpp = topUp > 0 ? [...opponentPts, ...Array(topUp).fill("H")] : opponentPts;
   return { outstandingFouls: safe % 2, opponentPts: newOpp };
+}
+
+// nextFoulOnDecrement — pure helper for the `−` button. Returns the new
+// foul value (a NUMBER, not a React-style functional updater), suitable
+// for setters like the team sub-match `rs.setFouls(value)` shape that
+// doesn't accept fn-updaters. Extracted so the team-modal `−` regression
+// (a fn-updater silently storing as state) is unit-testable.
+function nextFoulOnDecrement(currentFouls) {
+  return Math.max(0, currentFouls - 1);
 }
 
 // Term — kendo-glossary tooltip wrapper. Read lazily off window so the
@@ -1445,7 +1454,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                         <div className="tsm-fouls" data-testid={`scoring-modal-hansoku-${rs.color}`}>
                           <span className="tsm-fouls__label">{rs.label} Fouls</span>
                           <div className="tsm-fouls__controls">
-                            <button className="tsm-fouls__btn" onClick={() => rs.setFouls(Math.max(0, rs.fouls - 1))} disabled={rs.fouls === 0}>−</button>
+                            <button className="tsm-fouls__btn" onClick={() => rs.setFouls(nextFoulOnDecrement(rs.fouls))} disabled={rs.fouls === 0}>−</button>
                             <span className={`tsm-fouls__count ${rs.fouls >= 1 ? "tsm-fouls__count--warn" : ""}`}>{rs.fouls}</span>
                             <button className="tsm-fouls__btn" onClick={rs.onIncrement} disabled={subBoutDecided}>+</button>
                           </div>
@@ -1647,5 +1656,6 @@ export {
   isBoutDecided,
   applyFoulIncrement,
   reconcileFoulsAtOpen,
+  nextFoulOnDecrement,
   applyFusenshoToggle,
 };

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -52,18 +52,20 @@ function applyFusenshoToggle(prev, side) {
 // side's counter to 0. The counter is "outstanding fouls not yet
 // discharged into an H" — discharged Hs live in the opponent's pts array.
 //
-// Edge case: when the opponent's pts slot is already full (best-of-3
-// cap), the bout is already decided — the counter still resets to 0
-// but no new H is awarded (the extra foul is consumed without effect).
+// Bout-decided guard: if EITHER side is already at maxIppons the bout is
+// over — the counter still resets to 0 on the 2nd foul but no new H is
+// awarded. This prevents an auto-award from creating an invalid 2-2
+// scoreline that the server's validateIpponCounts would reject. The UI
+// also disables the `+` button via isBoutDecided as a defense in depth.
 // To undo a previously awarded H, the operator removes it from the
 // opponent's slot directly.
-function applyFoulIncrement(fouls, opponentPts, maxIppons = MAX_IPPONS_PER_SIDE) {
+function applyFoulIncrement(fouls, opponentPts, thisSidePts = [], maxIppons = MAX_IPPONS_PER_SIDE) {
   const next = fouls + 1;
   if (next < 2) return { fouls: next, opponentPts };
-  const newOpp = opponentPts.length < maxIppons
-    ? [...opponentPts, "H"]
-    : opponentPts;
-  return { fouls: 0, opponentPts: newOpp };
+  if (opponentPts.length >= maxIppons || thisSidePts.length >= maxIppons) {
+    return { fouls: 0, opponentPts };
+  }
+  return { fouls: 0, opponentPts: [...opponentPts, "H"] };
 }
 
 // Term — kendo-glossary tooltip wrapper. Read lazily off window so the
@@ -307,9 +309,11 @@ function RemainingMatchesPanel({ compID, password, withdrawnPlayer, onAwarded, o
 // `setFouls` is kept for the `−` button (simple decrement). After the
 // 2-foul auto-award the awarded H lives in the opponent's pts array, so
 // the counter shows only "outstanding fouls not yet discharged."
-function FoulCounter({ label, fouls, setFouls, onIncrement, color }) {
+function FoulCounter({ label, fouls, setFouls, onIncrement, color, disabled }) {
   // color is "shiro" or "aka" — surface as data-testid so Playwright probes
   // (T023a) can target each side without depending on the className.
+  // `disabled` freezes the `+` button when the bout is already decided —
+  // a 2nd-foul auto-award in that state would create an invalid 2-2.
   return (
     <div className={`foul-counter foul-counter--${color}`} data-testid={`scoring-modal-hansoku-${color}`}>
       <div className="foul-counter__label">{label} Fouls</div>
@@ -318,7 +322,7 @@ function FoulCounter({ label, fouls, setFouls, onIncrement, color }) {
         <div className="foul-counter__count">
           <span className={`foul-counter__num ${fouls >= 1 ? "foul-counter__num--warn" : ""}`}>{fouls}</span>
         </div>
-        <button className="foul-counter__btn foul-counter__btn--inc" onClick={onIncrement}>+</button>
+        <button className="foul-counter__btn foul-counter__btn--inc" onClick={onIncrement} disabled={disabled}>+</button>
       </div>
     </div>
   );
@@ -516,7 +520,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     {
       key: "b", name: m.sideB?.name, dojo: m.sideB?.dojo, pts: bPts, fouls: bFouls, setFouls: setBFouls,
       onIncrement: () => {
-        const r = applyFoulIncrement(bFouls, aPts);
+        const r = applyFoulIncrement(bFouls, aPts, bPts);
         setBFouls(r.fouls);
         setAPts(r.opponentPts);
       },
@@ -525,7 +529,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     {
       key: "a", name: m.sideA?.name, dojo: m.sideA?.dojo, pts: aPts, fouls: aFouls, setFouls: setAFouls,
       onIncrement: () => {
-        const r = applyFoulIncrement(aFouls, bPts);
+        const r = applyFoulIncrement(aFouls, bPts, aPts);
         setAFouls(r.fouls);
         setBPts(r.opponentPts);
       },
@@ -737,6 +741,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                     setFouls={s.setFouls}
                     onIncrement={s.onIncrement}
                     color={s.color}
+                    disabled={boutDecided}
                   />
                 ))}
               </div>
@@ -1338,7 +1343,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                 setPts: (pts) => updateSub(idx, prev => ({ ...prev, bPts: pts, fusensho: "", _preFusensho: undefined })),
                 setFouls: (f) => updateSub(idx, prev => ({ ...prev, bFouls: f, fusensho: "", _preFusensho: undefined })),
                 onIncrement: () => updateSub(idx, prev => {
-                  const r = applyFoulIncrement(prev.bFouls, prev.aPts);
+                  const r = applyFoulIncrement(prev.bFouls, prev.aPts, prev.bPts);
                   return { ...prev, bFouls: r.fouls, aPts: r.opponentPts, fusensho: "", _preFusensho: undefined };
                 }),
                 color: "shiro", label: "SHIRO",
@@ -1348,7 +1353,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                 setPts: (pts) => updateSub(idx, prev => ({ ...prev, aPts: pts, fusensho: "", _preFusensho: undefined })),
                 setFouls: (f) => updateSub(idx, prev => ({ ...prev, aFouls: f, fusensho: "", _preFusensho: undefined })),
                 onIncrement: () => updateSub(idx, prev => {
-                  const r = applyFoulIncrement(prev.aFouls, prev.bPts);
+                  const r = applyFoulIncrement(prev.aFouls, prev.bPts, prev.aPts);
                   return { ...prev, aFouls: r.fouls, bPts: r.opponentPts, fusensho: "", _preFusensho: undefined };
                 }),
                 color: "aka", label: "AKA",
@@ -1413,7 +1418,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                           <div className="tsm-fouls__controls">
                             <button className="tsm-fouls__btn" onClick={() => rs.setFouls(f => Math.max(0, f - 1))} disabled={rs.fouls === 0}>−</button>
                             <span className={`tsm-fouls__count ${rs.fouls >= 1 ? "tsm-fouls__count--warn" : ""}`}>{rs.fouls}</span>
-                            <button className="tsm-fouls__btn" onClick={rs.onIncrement}>+</button>
+                            <button className="tsm-fouls__btn" onClick={rs.onIncrement} disabled={subBoutDecided}>+</button>
                           </div>
                         </div>
                         {/* T096/FR-031: per-bout Fusensho. Awards the bout


### PR DESCRIPTION
## Summary

Two related bugs in the live scoring modal (`admin_scoring_modal.jsx`), reported from a screenshot showing AKA with 2 fouls but no hansoku point awarded:

1. **2-foul auto-award missing**: when a side accumulates 2 fouls (hansoku), FIK rules award an "H" ippon to the opponent and reset the counter. The modal previously only folded the derived H into the ippon array at submit time inside `buildPatch`, so during scoring the H was invisible to the operator.
2. **X (draw) button wiped scored points**: the button stayed clickable even when a side had scored, and clicking it ran `setAPts([]); setBPts([])` — silently destroying the score (including any auto-awarded H).

## Changes

- New pure helper `applyFoulIncrement(fouls, opponentPts)` — the 2nd `+` press appends "H" to the opponent's slot and resets the counter to 0. Wired through `FoulCounter`'s new `onIncrement` prop in both `ScoreEditorModal` and `TeamScoreEditorModal`. Decrement (`−`) is unchanged.
- X draw button: `disabled={aTotal > 0 || bTotal > 0}` on the toggle-on branch; cancel-draw stays unguarded. Same guard applied to the keyboard `x`/`X` shortcut.
- Dropped obsolete `aHansokuPts`/`bHansokuPts` derivation, the `+ aHansokuPts` addends to totals, the `Array(...).fill("H")` fold in `buildPatch`, and the `→ +NH to opp.` display label. The H now lives in the actual pts array.
- Mod-2 init on `initialAFouls`/`initialBFouls` so reopening pre-fix completed matches with cumulative `hansokuA` doesn't double-display the H (the H is already in `ipponsA`/`ipponsB`).
- Same flow applied to team sub-matches in `TeamScoreEditorModal`. Each sub's `onIncrement` also clears `fusensho`/`_preFusensho` (matches the existing `setPts`/`setFouls` contract — a foul auto-award is an "intervention" that invalidates the pre-fusensho snapshot).

## Test plan

- [x] `cd web-mobile && npm test` — **586/586 pass** including 6 new `applyFoulIncrement` describe cases and the existing 6 `applyFusenshoToggle` cases (regression coverage)
- [x] `make go/build` clean (esbuild rebuilds `web-mobile/dist/admin_scoring_modal.js`)
- [x] `make go/test` clean (lint, gosec, govulncheck, eslint, vitest, all Go suites)
- [ ] Manual smoke in `make run-mobile`: open individual match → click `+` foul twice on AKA → H appears in SHIRO's slot, AKA's fouls show 0
- [ ] Manual smoke: confirm X (draw) button is greyed/disabled once any point exists; press `M` then try `x` keyboard → no draw mode
- [ ] Manual smoke: same flow in a team sub-match
- [ ] Manual smoke: reopen a previously completed match with `hansokuA=2` (pre-fix data) — display shows 1H in correct slot with 0 outstanding fouls, not 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)