### PR TITLE
feat(mobile-app): honor TOURNAMENT_DATA_DIR env var as --folder default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Before implementing features or making architectural decisions, read the project
 - **Single test:** `go test -v -run <TestName> ./internal/helper/...`
 - **Generate examples:** `make examples`
 - **Mobile app (local):** `make run-mobile` (default data dir `./tournament-data`, port 8080)
-- **Mobile app (custom port/dir):** `PORT=8082 TOURNAMENT_DATA_DIR=/path make run-mobile`
+- **Mobile app (custom port/dir):** `PORT=8082 TOURNAMENT_DATA_DIR=/path make run-mobile` — env vars (`PORT`, `BIND_ADDRESS`, `TOURNAMENT_DATA_DIR`) are also honored when invoking the binary directly without `make`. Explicit flags (`--port`, `--bind`, `--folder`) win over the env vars.
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
 ## Beads Issue Tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ make run               # Build and start web server (localhost:8080)
 PORT=8081 make run      # Use alternate port
 make run-mobile        # Build and start the mobile/live app (localhost:8080, ./tournament-data)
 PORT=8082 make run-mobile   # Use alternate port
-TOURNAMENT_DATA_DIR=/path make run-mobile  # Custom data folder
+TOURNAMENT_DATA_DIR=/path make run-mobile  # Custom data folder (also works without make: TOURNAMENT_DATA_DIR=/path ./bin/bracket-creator mobile-app)
 make examples          # Generate example Excel files from mock data
 
 # Run a single test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,9 @@ make go/test           # Lint + security scan + tests with coverage
 make go/test-race      # Lint + tests with race detection (slow)
 make go/lint           # golangci-lint only
 make run               # Build and start web server (localhost:8080)
-PORT=8081 make run      # Use alternate port
+PORT=8081 make run      # Use alternate port (also works direct: PORT=8081 ./bin/bracket-creator serve)
 make run-mobile        # Build and start the mobile/live app (localhost:8080, ./tournament-data)
-PORT=8082 make run-mobile   # Use alternate port
+PORT=8082 make run-mobile   # Use alternate port (also works direct: PORT=8082 ./bin/bracket-creator mobile-app)
 TOURNAMENT_DATA_DIR=/path make run-mobile  # Custom data folder (also works without make: TOURNAMENT_DATA_DIR=/path ./bin/bracket-creator mobile-app)
 make examples          # Generate example Excel files from mock data
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -93,6 +93,7 @@ On tree and playoff brackets, the player/team on the top of the bracket is alway
 - **Run the mobile/live app:** `make run-mobile` (default: `./tournament-data`, port 8080)
   - Override port: `PORT=8082 make run-mobile`
   - Override data dir: `TOURNAMENT_DATA_DIR=/path make run-mobile`
+  - The binary reads `PORT`, `BIND_ADDRESS`, and `TOURNAMENT_DATA_DIR` directly, so the env vars also apply when running without `make` (e.g. `TOURNAMENT_DATA_DIR=/path bracket-creator mobile-app`). Explicit `--port`/`--bind`/`--folder` flags win.
 - **Run Tests (fast):** `make go/test`
 - **Run Tests (with race detection):** `make go/test-race`
 - **Run Linters:** `make go/lint`

--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ When using the CSV formatted style, `Dojo` is only used to try to ensure players
 ### Customizing the web server
 To set the listen address and port run:
 ```bash
-bracket-creator serve --listen-address 0.0.0.0 --listen-port 8080
+bracket-creator serve --bind 0.0.0.0 --port 8080
 ```
 
-You can also use the environment variables:
+You can also use the environment variables (the flags above take precedence):
 ```bash
 export BIND_ADDRESS=0.0.0.0
 export PORT=8080
+bracket-creator serve
 ```
 
 
@@ -246,6 +247,12 @@ The `mobile-app` command starts a live tournament management server you can use 
 
 ```bash
 bracket-creator mobile-app --folder ./tournament-data
+```
+
+The `--folder`, `--port`, and `--bind` flags are also read from `TOURNAMENT_DATA_DIR`, `PORT`, and `BIND_ADDRESS` respectively (flag takes precedence):
+
+```bash
+TOURNAMENT_DATA_DIR=/path PORT=8082 bracket-creator mobile-app
 ```
 
 Or with the Makefile:

--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -47,7 +47,7 @@ func newMobileAppCmd() *cobra.Command {
 			port = p
 		}
 	}
-	cmd.Flags().IntVarP(&o.port, "port", "p", port, "port number")
+	cmd.Flags().IntVarP(&o.port, "port", "p", port, "port number (env: PORT)")
 
 	return cmd
 }

--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -38,7 +38,7 @@ func newMobileAppCmd() *cobra.Command {
 	if bindAddress == "" {
 		bindAddress = "localhost"
 	}
-	cmd.Flags().StringVarP(&o.bindAddress, "bind", "b", bindAddress, "bind address")
+	cmd.Flags().StringVarP(&o.bindAddress, "bind", "b", bindAddress, "bind address (env: BIND_ADDRESS)")
 
 	portStr := os.Getenv("PORT")
 	port := 8080

--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -28,7 +28,11 @@ func newMobileAppCmd() *cobra.Command {
 		RunE:         o.run,
 	}
 
-	cmd.Flags().StringVarP(&o.folder, "folder", "f", ".", "folder to store tournament state")
+	folder := os.Getenv("TOURNAMENT_DATA_DIR")
+	if folder == "" {
+		folder = "."
+	}
+	cmd.Flags().StringVarP(&o.folder, "folder", "f", folder, "folder to store tournament state (env: TOURNAMENT_DATA_DIR)")
 
 	bindAddress := os.Getenv("BIND_ADDRESS")
 	if bindAddress == "" {

--- a/cmd/mobile_app_test.go
+++ b/cmd/mobile_app_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,12 +13,9 @@ func TestNewMobileAppCmd(t *testing.T) {
 }
 
 func TestMobileAppOptions_EnvVars(t *testing.T) {
-	os.Setenv("BIND_ADDRESS", "1.2.3.4")
-	os.Setenv("PORT", "9999")
-	os.Setenv("TOURNAMENT_DATA_DIR", "/tmp/td-env-test")
-	defer os.Unsetenv("BIND_ADDRESS")
-	defer os.Unsetenv("PORT")
-	defer os.Unsetenv("TOURNAMENT_DATA_DIR")
+	t.Setenv("BIND_ADDRESS", "1.2.3.4")
+	t.Setenv("PORT", "9999")
+	t.Setenv("TOURNAMENT_DATA_DIR", "/tmp/td-env-test")
 
 	cmd := newMobileAppCmd()
 	bind, _ := cmd.Flags().GetString("bind")
@@ -32,7 +28,7 @@ func TestMobileAppOptions_EnvVars(t *testing.T) {
 }
 
 func TestMobileAppOptions_FolderDefault(t *testing.T) {
-	os.Unsetenv("TOURNAMENT_DATA_DIR")
+	t.Setenv("TOURNAMENT_DATA_DIR", "")
 
 	cmd := newMobileAppCmd()
 	folder, _ := cmd.Flags().GetString("folder")
@@ -41,7 +37,7 @@ func TestMobileAppOptions_FolderDefault(t *testing.T) {
 }
 
 func TestMobileAppOptions_PortDefault(t *testing.T) {
-	os.Unsetenv("PORT")
+	t.Setenv("PORT", "")
 
 	cmd := newMobileAppCmd()
 	port, _ := cmd.Flags().GetInt("port")
@@ -50,8 +46,7 @@ func TestMobileAppOptions_PortDefault(t *testing.T) {
 }
 
 func TestMobileAppOptions_PortInvalid(t *testing.T) {
-	os.Setenv("PORT", "not-a-number")
-	defer os.Unsetenv("PORT")
+	t.Setenv("PORT", "not-a-number")
 
 	cmd := newMobileAppCmd()
 	port, _ := cmd.Flags().GetInt("port")

--- a/cmd/mobile_app_test.go
+++ b/cmd/mobile_app_test.go
@@ -16,15 +16,28 @@ func TestNewMobileAppCmd(t *testing.T) {
 func TestMobileAppOptions_EnvVars(t *testing.T) {
 	os.Setenv("BIND_ADDRESS", "1.2.3.4")
 	os.Setenv("PORT", "9999")
+	os.Setenv("TOURNAMENT_DATA_DIR", "/tmp/td-env-test")
 	defer os.Unsetenv("BIND_ADDRESS")
 	defer os.Unsetenv("PORT")
+	defer os.Unsetenv("TOURNAMENT_DATA_DIR")
 
 	cmd := newMobileAppCmd()
 	bind, _ := cmd.Flags().GetString("bind")
 	port, _ := cmd.Flags().GetInt("port")
+	folder, _ := cmd.Flags().GetString("folder")
 
 	assert.Equal(t, "1.2.3.4", bind)
 	assert.Equal(t, 9999, port)
+	assert.Equal(t, "/tmp/td-env-test", folder)
+}
+
+func TestMobileAppOptions_FolderDefault(t *testing.T) {
+	os.Unsetenv("TOURNAMENT_DATA_DIR")
+
+	cmd := newMobileAppCmd()
+	folder, _ := cmd.Flags().GetString("folder")
+
+	assert.Equal(t, ".", folder)
 }
 
 func TestMobileAppOptions_RunError(t *testing.T) {

--- a/cmd/mobile_app_test.go
+++ b/cmd/mobile_app_test.go
@@ -40,6 +40,25 @@ func TestMobileAppOptions_FolderDefault(t *testing.T) {
 	assert.Equal(t, ".", folder)
 }
 
+func TestMobileAppOptions_PortDefault(t *testing.T) {
+	os.Unsetenv("PORT")
+
+	cmd := newMobileAppCmd()
+	port, _ := cmd.Flags().GetInt("port")
+
+	assert.Equal(t, 8080, port)
+}
+
+func TestMobileAppOptions_PortInvalid(t *testing.T) {
+	os.Setenv("PORT", "not-a-number")
+	defer os.Unsetenv("PORT")
+
+	cmd := newMobileAppCmd()
+	port, _ := cmd.Flags().GetInt("port")
+
+	assert.Equal(t, 8080, port)
+}
+
 func TestMobileAppOptions_RunError(t *testing.T) {
 	o := &mobileAppOptions{
 		folder: "/non/existent/dir",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,7 +57,7 @@ func newServeCmd() *cobra.Command {
 			port = 8080
 		}
 	}
-	cmd.Flags().IntVarP(&o.port, "port", "p", port, "port number")
+	cmd.Flags().IntVarP(&o.port, "port", "p", port, "port number (env: PORT)")
 
 	return cmd
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -45,7 +45,7 @@ func newServeCmd() *cobra.Command {
 	if bindAddress == "" {
 		bindAddress = "localhost" // default value
 	}
-	cmd.Flags().StringVarP(&o.bindAddress, "bind", "b", bindAddress, "bind address")
+	cmd.Flags().StringVarP(&o.bindAddress, "bind", "b", bindAddress, "bind address (env: BIND_ADDRESS)")
 
 	portStr := os.Getenv("PORT")
 	port := 8080 // default value

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -65,6 +65,14 @@ PORT=8082 make run-mobile                           # custom port
 TOURNAMENT_DATA_DIR=/path/to/data make run-mobile  # custom data dir
 ```
 
+`PORT`, `BIND_ADDRESS`, and `TOURNAMENT_DATA_DIR` are read by the binary directly, so they also work without `make`:
+
+```sh
+TOURNAMENT_DATA_DIR=/path PORT=8082 ./bin/bracket-creator mobile-app
+```
+
+An explicit `--folder`, `--port`, or `--bind` flag still overrides the env var.
+
 **Important:** `web-mobile/` is a Preact/JSX frontend compiled by esbuild into `web-mobile/dist/` and then embedded into the Go binary at build time. Any change to `web-mobile/js/*.js` or `web-mobile/css/*.css` requires:
 
 1. Rebuild the JS bundle: `cd web-mobile && npm run build` (or `npx esbuild ...` — see the project `Makefile`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ bracket-creator serve
 
 # Or run the live tournament app (for use on the day)
 bracket-creator mobile-app --folder ./tournament-data
+# (or set TOURNAMENT_DATA_DIR / PORT in the environment instead of flags)
 ```
 
 Open `tournament.xlsx` in Excel or LibreOffice and print.

--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -8,6 +8,20 @@ The `mobile-app` command starts a live tournament management server for use **on
 bracket-creator mobile-app --folder ./tournament-data
 ```
 
+The `--folder` and `--port` flags can also be supplied via environment variables — useful for systemd units, Docker, or any deploy that doesn't run via `make`:
+
+```bash
+TOURNAMENT_DATA_DIR=/path/to/data PORT=8082 bracket-creator mobile-app
+```
+
+| Flag | Env var | Default |
+|------|---------|---------|
+| `--folder` / `-f` | `TOURNAMENT_DATA_DIR` | `.` |
+| `--port` / `-p` | `PORT` | `8080` |
+| `--bind` / `-b` | `BIND_ADDRESS` | `localhost` |
+
+An explicit flag always wins over the env var.
+
 Or with the Makefile:
 
 ```bash


### PR DESCRIPTION
The Makefile already documented this env var, but the Go binary only read
it via the flag value injected by `make run-mobile`. Direct invocations
(Docker, systemd, ad-hoc shells) had to remember `--folder`. Mirror the
existing BIND_ADDRESS / PORT pattern so an explicit `--folder` still wins.