### PR TITLE
feat(engine): auto-award ippon on every 2 hansoku per FIK Article 20

### DIFF
--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -134,6 +134,8 @@ func (e *Engine) writeMatchResult(compId string, matchId string, result *state.M
 			return err
 		}
 	}
+	// Side-effect writes are non-fatal: the match score is already on disk,
+	// so propagating would cause a 500 retry that double-records the score.
 	if _, err := e.recordIneligibilityFromDecision(compId, matchId, result); err != nil {
 		log.Printf("engine: recordIneligibilityFromDecision compId=%s matchId=%s: %v", compId, matchId, err)
 	}

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -71,23 +71,27 @@ func (e *Engine) withBracketMatch(compId, matchId string, mutate func(*state.Bra
 
 // applyHansokuIppons auto-awards ippons from accumulated hansoku counts per
 // FIK Article 20: every 2 hansoku on one side grants 1 ippon to the opponent.
-// Uses 'H' as the ippon marker, consistent with IpponsA/IpponsB conventions.
-// Never removes existing entries — only appends what's missing.
+// Strips any prior 'H' entries and re-appends the correct count so that both
+// increases and decreases in hansoku are handled correctly on re-scores.
 func applyHansokuIppons(result *state.MatchResult) {
 	if result == nil {
 		return
 	}
 	applyOneSide := func(hansoku int, ippons *[]string) {
 		expected := hansoku / 2
-		existing := 0
+		if *ippons == nil && expected == 0 {
+			return
+		}
+		filtered := make([]string, 0, len(*ippons))
 		for _, v := range *ippons {
-			if v == "H" {
-				existing++
+			if v != "H" {
+				filtered = append(filtered, v)
 			}
 		}
-		for range expected - existing {
-			*ippons = append(*ippons, "H")
+		for range expected {
+			filtered = append(filtered, "H")
 		}
+		*ippons = filtered
 	}
 	applyOneSide(result.HansokuA, &result.IpponsB)
 	applyOneSide(result.HansokuB, &result.IpponsA)
@@ -96,10 +100,14 @@ func applyHansokuIppons(result *state.MatchResult) {
 func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.MatchResult) error {
 	result.ID = matchId // normalize ID-less payloads before overwriting
 	applyHansokuIppons(result)
+	return e.writeMatchResult(compId, matchId, result)
+}
+
+// writeMatchResult persists the result without applying hansoku auto-award.
+// RecordMatchResult calls this after applyHansokuIppons; the K3 rollback
+// path calls it directly to restore the prior result byte-for-byte.
+func (e *Engine) writeMatchResult(compId string, matchId string, result *state.MatchResult) error {
 	err := e.withPoolMatch(compId, matchId, func(r *state.MatchResult) {
-		// Preserve scheduling and side fields if missing in the update payload.
-		// The scoring UI only sends scoring-related fields; without this guard,
-		// `*r = *result` would zero Court/ScheduledAt/SideA/SideB.
 		if result.SideA == "" {
 			result.SideA = r.SideA
 		}
@@ -122,20 +130,9 @@ func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.
 			return err
 		}
 	}
-	// T085 — persist the loser's competitor-status when this update
-	// recorded a kiken or fusenpai decision. Failure to write the
-	// status is non-fatal to the score-recording itself: the match
-	// score is already on disk, so propagating an error here would
-	// give the operator a 500 response that they would retry,
-	// double-recording the score. Log and swallow — the next-match
-	// eligibility gate is the safety net that surfaces a missed
-	// status write (FR-035).
 	if _, err := e.recordIneligibilityFromDecision(compId, matchId, result); err != nil {
 		log.Printf("engine: recordIneligibilityFromDecision compId=%s matchId=%s: %v", compId, matchId, err)
 	}
-	// T128 — freeze any team lineups for this round when the match
-	// transitions to running/completed. Side-effect only; failures are
-	// non-fatal for the same reason as the ineligibility write above.
 	e.maybeLockTeamLineupsForRound(compId, result)
 	return nil
 }
@@ -198,7 +195,7 @@ func (e *Engine) RecordMatchResultWithIneligibility(compId string, matchId strin
 			// to its prior state before returning 409 so the operator
 			// sees a clean rejection rather than a mutated match.
 			if prior != nil {
-				_ = e.RecordMatchResult(compId, matchId, prior)
+				_ = e.writeMatchResult(compId, matchId, prior)
 			}
 			return nil, err
 		}

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -69,8 +69,33 @@ func (e *Engine) withBracketMatch(compId, matchId string, mutate func(*state.Bra
 	})
 }
 
+// applyHansokuIppons auto-awards ippons from accumulated hansoku counts per
+// FIK Article 20: every 2 hansoku on one side grants 1 ippon to the opponent.
+// Uses 'H' as the ippon marker, consistent with IpponsA/IpponsB conventions.
+// Never removes existing entries — only appends what's missing.
+func applyHansokuIppons(result *state.MatchResult) {
+	if result == nil {
+		return
+	}
+	applyOneSide := func(hansoku int, ippons *[]string) {
+		expected := hansoku / 2
+		existing := 0
+		for _, v := range *ippons {
+			if v == "H" {
+				existing++
+			}
+		}
+		for range expected - existing {
+			*ippons = append(*ippons, "H")
+		}
+	}
+	applyOneSide(result.HansokuA, &result.IpponsB)
+	applyOneSide(result.HansokuB, &result.IpponsA)
+}
+
 func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.MatchResult) error {
 	result.ID = matchId // normalize ID-less payloads before overwriting
+	applyHansokuIppons(result)
 	err := e.withPoolMatch(compId, matchId, func(r *state.MatchResult) {
 		// Preserve scheduling and side fields if missing in the update payload.
 		// The scoring UI only sends scoring-related fields; without this guard,
@@ -129,6 +154,7 @@ func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.
 // T085/T092.
 func (e *Engine) RecordMatchResultWithIneligibility(compId string, matchId string, result *state.MatchResult) (*domain.CompetitorStatus, error) {
 	result.ID = matchId
+	applyHansokuIppons(result)
 
 	// T105/CHK047: capture the prior result so we can rollback if the atomic
 	// ineligibility write below fails with AlreadyIneligibleError.

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -95,6 +95,10 @@ func applyHansokuIppons(result *state.MatchResult) {
 	}
 	applyOneSide(result.HansokuA, &result.IpponsB)
 	applyOneSide(result.HansokuB, &result.IpponsA)
+	for i := range result.SubResults {
+		applyOneSide(result.SubResults[i].HansokuA, &result.SubResults[i].IpponsB)
+		applyOneSide(result.SubResults[i].HansokuB, &result.SubResults[i].IpponsA)
+	}
 }
 
 func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.MatchResult) error {

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -778,6 +778,18 @@ func TestApplyHansokuIppons(t *testing.T) {
 			assert.Equal(t, tc.wantIpponsB, r.IpponsB)
 		})
 	}
+
+	t.Run("sub-results also get hansoku auto-award", func(t *testing.T) {
+		r := &state.MatchResult{
+			SubResults: []state.SubMatchResult{
+				{HansokuA: 2, IpponsB: []string{"M"}},
+				{HansokuB: 4, IpponsA: []string{"K"}},
+			},
+		}
+		applyHansokuIppons(r)
+		assert.Equal(t, []string{"M", "H"}, r.SubResults[0].IpponsB)
+		assert.Equal(t, []string{"K", "H", "H"}, r.SubResults[1].IpponsA)
+	})
 }
 
 // TestRecordMatchResult_HansokuAutoAward verifies that saving a pool match

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -680,3 +680,84 @@ func TestMaybeLockTeamLineupsForRound_TeamComp(t *testing.T) {
 	err := eng.RecordMatchResult(compID, "P1-0", result)
 	assert.NoError(t, err)
 }
+
+func TestApplyHansokuIppons(t *testing.T) {
+	cases := []struct {
+		name        string
+		hansokuA    int
+		hansokuB    int
+		ipponsA     []string
+		ipponsB     []string
+		wantIpponsA []string
+		wantIpponsB []string
+	}{
+		{
+			name:        "HansokuA=1 no award",
+			hansokuA:    1,
+			wantIpponsB: nil,
+		},
+		{
+			name:        "HansokuA=2 awards 1 H to IpponsB",
+			hansokuA:    2,
+			wantIpponsB: []string{"H"},
+		},
+		{
+			name:        "HansokuA=4 awards 2 H to IpponsB",
+			hansokuA:    4,
+			wantIpponsB: []string{"H", "H"},
+		},
+		{
+			name:        "HansokuA=2 with existing H — no duplicate",
+			hansokuA:    2,
+			ipponsB:     []string{"H"},
+			wantIpponsB: []string{"H"},
+		},
+		{
+			name:        "HansokuA=2 existing non-H ippons preserved",
+			hansokuA:    2,
+			ipponsB:     []string{"M"},
+			wantIpponsB: []string{"M", "H"},
+		},
+		{
+			name:        "HansokuB=2 awards 1 H to IpponsA",
+			hansokuB:    2,
+			wantIpponsA: []string{"H"},
+		},
+		{
+			name:        "HansokuB=4 awards 2 H to IpponsA",
+			hansokuB:    4,
+			wantIpponsA: []string{"H", "H"},
+		},
+		{
+			name:        "HansokuB=2 with existing H — no duplicate",
+			hansokuB:    2,
+			ipponsA:     []string{"H"},
+			wantIpponsA: []string{"H"},
+		},
+		{
+			name:        "nil result is a no-op",
+			hansokuA:    2,
+			hansokuB:    2,
+			wantIpponsA: nil,
+			wantIpponsB: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "nil result is a no-op" {
+				applyHansokuIppons(nil) // must not panic
+				return
+			}
+			r := &state.MatchResult{
+				HansokuA: tc.hansokuA,
+				HansokuB: tc.hansokuB,
+				IpponsA:  tc.ipponsA,
+				IpponsB:  tc.ipponsB,
+			}
+			applyHansokuIppons(r)
+			assert.Equal(t, tc.wantIpponsA, r.IpponsA)
+			assert.Equal(t, tc.wantIpponsB, r.IpponsB)
+		})
+	}
+}

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -745,6 +745,18 @@ func TestApplyHansokuIppons(t *testing.T) {
 			wantIpponsA: []string{"H"},
 			wantIpponsB: []string{"H"},
 		},
+		{
+			name:        "hansoku reduced from 4 to 2 strips stale H",
+			hansokuA:    2,
+			ipponsB:     []string{"H", "H"},
+			wantIpponsB: []string{"H"},
+		},
+		{
+			name:        "hansoku reduced to 0 strips all H entries",
+			hansokuA:    0,
+			ipponsB:     []string{"M", "H"},
+			wantIpponsB: []string{"M"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -746,15 +746,21 @@ func TestApplyHansokuIppons(t *testing.T) {
 			wantIpponsB: []string{"H"},
 		},
 		{
-			name:        "hansoku reduced from 4 to 2 strips stale H",
+			name:        "hansoku reduced from 4 to 2 strips excess H",
 			hansokuA:    2,
-			ipponsB:     []string{"H", "H"},
-			wantIpponsB: []string{"H"},
+			ipponsB:     []string{"M", "H", "H"},
+			wantIpponsB: []string{"M", "H"},
 		},
 		{
 			name:        "hansoku reduced to 0 strips all H entries",
 			hansokuA:    0,
-			ipponsB:     []string{"M", "H"},
+			ipponsB:     []string{"M", "H", "H"},
+			wantIpponsB: []string{"M"},
+		},
+		{
+			name:        "hansoku reduced to 1 strips interleaved H entries",
+			hansokuA:    1,
+			ipponsB:     []string{"H", "M", "H"},
 			wantIpponsB: []string{"M"},
 		},
 	}

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -795,13 +795,7 @@ func TestApplyHansokuIppons(t *testing.T) {
 // TestRecordMatchResult_HansokuAutoAward verifies that saving a pool match
 // with HansokuA=2 via RecordMatchResult persists IpponsB=["H"] to the store.
 func TestRecordMatchResult_HansokuAutoAward(t *testing.T) {
-	dir, err := os.MkdirTemp("", "engine-hansoku-award-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	store, err := state.NewStore(dir)
-	require.NoError(t, err)
-	eng := New(store)
+	eng, store, _ := setupTestEngine(t)
 
 	compID := "hansoku-award"
 	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, Name: "Hansoku"}))

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -682,6 +682,10 @@ func TestMaybeLockTeamLineupsForRound_TeamComp(t *testing.T) {
 }
 
 func TestApplyHansokuIppons(t *testing.T) {
+	t.Run("nil result is a no-op", func(t *testing.T) {
+		applyHansokuIppons(nil) // must not panic
+	})
+
 	cases := []struct {
 		name        string
 		hansokuA    int
@@ -735,20 +739,16 @@ func TestApplyHansokuIppons(t *testing.T) {
 			wantIpponsA: []string{"H"},
 		},
 		{
-			name:        "nil result is a no-op",
+			name:        "both sides accumulate a pair simultaneously",
 			hansokuA:    2,
 			hansokuB:    2,
-			wantIpponsA: nil,
-			wantIpponsB: nil,
+			wantIpponsA: []string{"H"},
+			wantIpponsB: []string{"H"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.name == "nil result is a no-op" {
-				applyHansokuIppons(nil) // must not panic
-				return
-			}
 			r := &state.MatchResult{
 				HansokuA: tc.hansokuA,
 				HansokuB: tc.hansokuB,
@@ -760,4 +760,54 @@ func TestApplyHansokuIppons(t *testing.T) {
 			assert.Equal(t, tc.wantIpponsB, r.IpponsB)
 		})
 	}
+}
+
+// TestRecordMatchResult_HansokuAutoAward verifies that saving a pool match
+// with HansokuA=2 via RecordMatchResult persists IpponsB=["H"] to the store.
+func TestRecordMatchResult_HansokuAutoAward(t *testing.T) {
+	dir, err := os.MkdirTemp("", "engine-hansoku-award-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	eng := New(store)
+
+	compID := "hansoku-award"
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, Name: "Hansoku"}))
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "P1-1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled},
+	}))
+
+	t.Run("HansokuA=2 persists H ippon in IpponsB", func(t *testing.T) {
+		patch := &state.MatchResult{
+			Winner:   "Alice",
+			HansokuA: 2,
+			IpponsA:  []string{"M"},
+			Status:   state.MatchStatusCompleted,
+		}
+		require.NoError(t, eng.RecordMatchResult(compID, "P1-1", patch))
+
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		assert.Equal(t, []string{"H"}, stored[0].IpponsB)
+		assert.Equal(t, []string{"M"}, stored[0].IpponsA)
+	})
+
+	t.Run("HansokuB=2 persists H ippon in IpponsA", func(t *testing.T) {
+		patch := &state.MatchResult{
+			Winner:   "Bob",
+			HansokuB: 2,
+			IpponsB:  []string{"K"},
+			Status:   state.MatchStatusCompleted,
+		}
+		require.NoError(t, eng.RecordMatchResult(compID, "P1-1", patch))
+
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		assert.Equal(t, []string{"H"}, stored[0].IpponsA)
+		assert.Equal(t, []string{"K"}, stored[0].IpponsB)
+	})
 }

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -194,6 +194,7 @@ func (e *Engine) maybeLockTeamLineupsForRoundTx(tx state.StoreTx, compID string,
 // T156.
 func (e *Engine) RecordMatchResultWithIneligibilityTx(tx state.StoreTx, compID, matchID string, result *state.MatchResult) (*domain.CompetitorStatus, error) {
 	result.ID = matchID
+	applyHansokuIppons(result)
 
 	// Capture the prior result so we can roll back the score on
 	// AlreadyIneligibleError. lookupExistingResultTx reads directly from
@@ -254,6 +255,7 @@ func (e *Engine) RecordMatchResultWithIneligibilityTx(tx state.StoreTx, compID, 
 // through the WithIneligibility variant.
 func (e *Engine) recordMatchResultTx(tx state.StoreTx, compID, matchID string, result *state.MatchResult) error {
 	result.ID = matchID
+	applyHansokuIppons(result)
 	err := e.withPoolMatchTx(tx, compID, matchID, func(r *state.MatchResult) {
 		if result.SideA == "" {
 			result.SideA = r.SideA

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -248,14 +248,11 @@ func (e *Engine) RecordMatchResultWithIneligibilityTx(tx state.StoreTx, compID, 
 }
 
 // recordMatchResultTx is the tx-aware twin of RecordMatchResult. Used
-// by the K3 partial-write rollback inside
-// RecordMatchResultWithIneligibilityTx so the rollback also runs
-// under the same tx. The full RecordMatchResult path is NOT exposed as
-// a handler entrypoint via tx because the score handler always goes
-// through the WithIneligibility variant.
+// exclusively by the K3 partial-write rollback inside
+// RecordMatchResultWithIneligibilityTx — the prior result is restored
+// byte-for-byte, so applyHansokuIppons is intentionally skipped here.
 func (e *Engine) recordMatchResultTx(tx state.StoreTx, compID, matchID string, result *state.MatchResult) error {
 	result.ID = matchID
-	applyHansokuIppons(result)
 	err := e.withPoolMatchTx(tx, compID, matchID, func(r *state.MatchResult) {
 		if result.SideA == "" {
 			result.SideA = r.SideA

--- a/internal/engine/scoring_tx_test.go
+++ b/internal/engine/scoring_tx_test.go
@@ -389,13 +389,11 @@ func TestRecordMatchResultWithIneligibilityTx_HansokuAutoAward(t *testing.T) {
 		IpponsA:  []string{"M"},
 		Status:   state.MatchStatusCompleted,
 	}
-	var engErr error
 	txErr := store.WithTransaction(compID, func(tx state.StoreTx) error {
-		_, engErr = eng.RecordMatchResultWithIneligibilityTx(tx, compID, "Pool A-0", result)
-		return nil
+		_, err := eng.RecordMatchResultWithIneligibilityTx(tx, compID, "Pool A-0", result)
+		return err
 	})
 	require.NoError(t, txErr)
-	require.NoError(t, engErr)
 
 	stored, err := store.LoadPoolMatches(compID)
 	require.NoError(t, err)

--- a/internal/engine/scoring_tx_test.go
+++ b/internal/engine/scoring_tx_test.go
@@ -370,3 +370,36 @@ func TestStoreTxUpdatePoolMatchByIDLockFree(t *testing.T) {
 	require.Len(t, matches, 1)
 	assert.Equal(t, state.MatchStatusRunning, matches[0].Status)
 }
+
+// TestRecordMatchResultWithIneligibilityTx_HansokuAutoAward verifies
+// that the tx-aware scoring path also applies the FIK Article 20
+// hansoku→ippon auto-award.
+func TestRecordMatchResultWithIneligibilityTx_HansokuAutoAward(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "tx-hansoku"
+	createTestCompetition(t, store, compID, "pools", 2)
+
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "Pool A-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled},
+	}))
+
+	result := &state.MatchResult{
+		Winner:   "Alice",
+		HansokuA: 2,
+		IpponsA:  []string{"M"},
+		Status:   state.MatchStatusCompleted,
+	}
+	var engErr error
+	txErr := store.WithTransaction(compID, func(tx state.StoreTx) error {
+		_, engErr = eng.RecordMatchResultWithIneligibilityTx(tx, compID, "Pool A-0", result)
+		return nil
+	})
+	require.NoError(t, txErr)
+	require.NoError(t, engErr)
+
+	stored, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	assert.Equal(t, []string{"H"}, stored[0].IpponsB)
+	assert.Equal(t, []string{"M"}, stored[0].IpponsA)
+}


### PR DESCRIPTION
## Summary

- Adds `applyHansokuIppons` helper in `internal/engine/scoring.go` that syncs auto-awarded ippons with accumulated hansoku counts per FIK Article 20 (every 2 hansoku on one side → 1 ippon for the opponent)
- Strips all existing `'H'` entries and re-appends the correct count, so both increases and decreases in hansoku are handled correctly on re-scores
- Called in `RecordMatchResult`, `RecordMatchResultWithIneligibility`, and `RecordMatchResultWithIneligibilityTx` — covers pool, bracket, and transactional paths
- Intentionally **not** called in `recordMatchResultTx` (the rollback-only path) to preserve byte-for-byte prior state restoration

## Test plan

- [x] `TestApplyHansokuIppons` — 13 table-driven cases: nil guard, single hansoku (no award), pairs (1 and 2 awards), idempotency with existing H, non-H ippons preserved, symmetric B→A direction, dual-side simultaneous, trim on reduction (4→2, →0, interleaved)
- [x] `TestRecordMatchResult_HansokuAutoAward` — integration test verifying H ippons persist in the store through `RecordMatchResult` (both A→B and B→A)
- [x] `TestRecordMatchResultWithIneligibilityTx_HansokuAutoAward` — integration test verifying H ippons persist through the transactional path
- [x] Existing `TestRecordMatchResult_*` and `TestScoring_*` suites unaffected
- [x] `golangci-lint run ./internal/engine/...` — 0 issues
- [x] All CI checks pass (CodeQL, gosec, test suites, validate)

Closes bracket-creator-9ch

🤖 Generated with [Claude Code](https://claude.com/claude-code)