### PR TITLE
fix(scoring-modal): move decision button tooltips to ？ icon

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4962,6 +4962,24 @@ a:hover {
   letter-spacing: 0.08em;
   margin-top: 2px !important;
 }
+.decision-btn-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ？ icon that carries the glossary tooltip for a decision button. */
+.glossary-hint .tw-term {
+  border-bottom: none;
+  color: var(--ink-3, #888);
+  font-size: 13px;
+  line-height: 1;
+}
+.glossary-hint .tw-term:hover,
+.glossary-hint .tw-term:focus-visible {
+  color: var(--ink-2, #555);
+}
+
 .editor-modal--compact .decision-controls {
   margin-top: 8px !important;
   font-size: 11px !important;

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -109,6 +109,16 @@ function TermAS(props) {
   return React.createElement('span', null, props.children);
 }
 
+// GlossaryHintAS — renders a ？ icon that shows the glossary tooltip for
+// `name` on hover/tap. Placed as a sibling outside a <button> so the
+// tooltip doesn't intercept clicks on the button itself.
+function GlossaryHintAS({ name }) {
+  if (typeof window !== 'undefined' && window.GlossaryHint) {
+    return React.createElement(window.GlossaryHint, { name });
+  }
+  return null;
+}
+
 // T093–T098: shared helpers for the decision (kiken/fusenpai/fusensho) flow.
 //
 // Resolve the password to use for the /decision POST. The modal historically
@@ -825,18 +835,27 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
           {!withdrawnPlayer && !decisionPromptKind && (
             <div className="decision-controls" style={{ display: "flex", gap: 8, marginTop: 12, fontSize: 12, alignItems: "center" }}>
               <span style={{ color: "var(--ink-3)", fontWeight: 600 }}>Decision:</span>
-              <button data-testid="scoring-modal-kiken-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("kiken"); }} disabled={submitting || decisionSubmitting}>
-                <TermAS name="kiken">Kiken</TermAS>
-              </button>
-              <button data-testid="scoring-modal-fusenpai-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("fusenpai"); }} disabled={submitting || decisionSubmitting}>
-                <TermAS name="fusenpai">Fusenpai</TermAS>
-              </button>
+              <div className="decision-btn-group">
+                <button data-testid="scoring-modal-kiken-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("kiken"); }} disabled={submitting || decisionSubmitting}>
+                  Kiken
+                </button>
+                <GlossaryHintAS name="kiken" />
+              </div>
+              <div className="decision-btn-group">
+                <button data-testid="scoring-modal-fusenpai-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("fusenpai"); }} disabled={submitting || decisionSubmitting}>
+                  Fusenpai
+                </button>
+                <GlossaryHintAS name="fusenpai" />
+              </div>
               {/* Per-bout fusensho is a sub-match concept — implemented inside
                   TeamScoreEditorModal. This placeholder explains the affordance
                   to operators who open the individual-match editor. */}
-              <button type="button" className="btn btn--sm" disabled title="Fusensho is recorded per-bout inside the team-match editor">
-                <TermAS name="fusensho">Fusensho</TermAS> (team only)
-              </button>
+              <div className="decision-btn-group">
+                <button type="button" className="btn btn--sm" disabled title="Fusensho is recorded per-bout inside the team-match editor">
+                  Fusensho (team only)
+                </button>
+                <GlossaryHintAS name="fusensho" />
+              </div>
             </div>
           )}
           {decisionErr && (

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -109,9 +109,8 @@ function TermAS(props) {
   return React.createElement('span', null, props.children);
 }
 
-// GlossaryHintAS — renders a ？ icon that shows the glossary tooltip for
-// `name` on hover/tap. Placed as a sibling outside a <button> so the
-// tooltip doesn't intercept clicks on the button itself.
+// Lazily loaded from window for the same load-order reason as TermAS above.
+// Falls back to null — the icon is purely decorative; no content to preserve.
 function GlossaryHintAS({ name }) {
   if (typeof window !== 'undefined' && window.GlossaryHint) {
     return React.createElement(window.GlossaryHint, { name });

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -278,10 +278,23 @@ function capitalise(s) {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+// GlossaryHint — a standalone ？ icon that carries the glossary tooltip
+// for a given term. Renders as a sibling next to a button so the tooltip
+// is accessible without wrapping (and potentially blocking) the button's
+// click target.
+function GlossaryHint({ name }) {
+  return React.createElement(
+    'span',
+    { className: 'glossary-hint' },
+    React.createElement(Term, { name }, '？'),
+  );
+}
+
 if (typeof window !== 'undefined') {
   window.Term = Term;
+  window.GlossaryHint = GlossaryHint;
   window.GlossaryPage = GlossaryPage;
   window.renderTooltipBody = renderTooltipBody;
 }
 
-export { Term, GlossaryPage, renderTooltipBody, GLOSSARY, lookupTerm };
+export { Term, GlossaryHint, GlossaryPage, renderTooltipBody, GLOSSARY, lookupTerm };


### PR DESCRIPTION
## Summary

- **Problem:** \`<TermAS>\` wrapped the text of Kiken, Fusenpai, and Fusensho decision buttons, causing the tooltip hover region to intercept pointer events on the button — making them unreliable on touch devices.
- Added \`GlossaryHint\` component to \`glossary.jsx\`: a standalone \`？\` icon that reuses \`Term\`'s tooltip mechanism.
- Replaced \`<TermAS>\` inside each button with plain text; moved \`<GlossaryHintAS>\` as a sibling **outside** the button, both wrapped in a \`.decision-btn-group\` flex container.
- Added \`.decision-btn-group\` and \`.glossary-hint\` CSS rules.

Closes bracket-creator-e2p.

## Test plan

- [x] \`make run-mobile\` → open scoring modal for a match
- [x] Click Kiken button — decision prompt appears (no hover-block)
- [x] Click Fusenpai button — decision prompt appears cleanly
- [x] Hover/tap the \`？\` icon next to each button — glossary tooltip shows
- [x] Fusensho button remains disabled with its icon visible
- [x] All Go tests pass: \`go test ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)