### PR TITLE
feat(check-in): day-of participant check-in workflow

### DIFF
--- a/internal/domain/player.go
+++ b/internal/domain/player.go
@@ -1,21 +1,18 @@
 // Package domain defines the core domain models for the bracket creator
 package domain
 
-import "time"
-
 // Player represents a tournament participant. It is the canonical
 // participant type across state, engine, mobileapp, and helper
 // packages; internal/helper re-exports it under helper.Player as a
 // type alias for rendering-side ergonomics (NFR-007).
 type Player struct {
-	ID          string     `json:"id,omitempty"` // stable UUID assigned at first persist
-	Name        string     `json:"name"`
-	DisplayName string     `json:"displayName"`
-	Dojo        string     `json:"dojo"`
-	Metadata    []string   `json:"metadata,omitempty"`
-	Tag         string     `json:"tag,omitempty"` // e.g. "manual", "registered", "transfer", "reserved"
-	CheckedIn   bool       `json:"checkedIn"`
-	CheckedInAt *time.Time `json:"checkedInAt,omitempty"`
+	ID          string   `json:"id,omitempty"` // stable UUID assigned at first persist
+	Name        string   `json:"name"`
+	DisplayName string   `json:"displayName"`
+	Dojo        string   `json:"dojo"`
+	Metadata    []string `json:"metadata,omitempty"`
+	Tag         string   `json:"tag,omitempty"` // e.g. "manual", "registered", "transfer", "reserved"
+	CheckedIn   bool     `json:"checkedIn"`
 
 	PoolPosition int64  `json:"-"`
 	Seed         int    `json:"seed"`

--- a/internal/domain/player.go
+++ b/internal/domain/player.go
@@ -1,17 +1,21 @@
 // Package domain defines the core domain models for the bracket creator
 package domain
 
+import "time"
+
 // Player represents a tournament participant. It is the canonical
 // participant type across state, engine, mobileapp, and helper
 // packages; internal/helper re-exports it under helper.Player as a
 // type alias for rendering-side ergonomics (NFR-007).
 type Player struct {
-	ID          string   `json:"id,omitempty"` // stable UUID assigned at first persist
-	Name        string   `json:"name"`
-	DisplayName string   `json:"displayName"`
-	Dojo        string   `json:"dojo"`
-	Metadata    []string `json:"metadata,omitempty"`
-	Tag         string   `json:"tag,omitempty"` // e.g. "manual", "registered", "transfer", "reserved"
+	ID          string     `json:"id,omitempty"` // stable UUID assigned at first persist
+	Name        string     `json:"name"`
+	DisplayName string     `json:"displayName"`
+	Dojo        string     `json:"dojo"`
+	Metadata    []string   `json:"metadata,omitempty"`
+	Tag         string     `json:"tag,omitempty"` // e.g. "manual", "registered", "transfer", "reserved"
+	CheckedIn   bool       `json:"checkedIn"`
+	CheckedInAt *time.Time `json:"checkedInAt,omitempty"`
 
 	PoolPosition int64  `json:"-"`
 	Seed         int    `json:"seed"`

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -1,6 +1,7 @@
 package mobileapp
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -148,7 +149,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 
 		if err != nil {
 			status := http.StatusInternalServerError
-			if err.Error() == "participant not found" {
+			if errors.Is(err, state.ErrParticipantNotFound) {
 				status = http.StatusNotFound
 			}
 			c.JSON(status, gin.H{"error": err.Error()})
@@ -180,7 +181,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 
 		if err != nil {
 			status := http.StatusInternalServerError
-			if err.Error() == "participant not found" {
+			if errors.Is(err, state.ErrParticipantNotFound) {
 				status = http.StatusNotFound
 			}
 			c.JSON(status, gin.H{"error": err.Error()})

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -67,6 +66,16 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			}
 		}
 
+		// Load existing participants so we can preserve check-in state for
+		// players that survive the edit (matched by name). A full roster
+		// replacement via this endpoint must not silently clear check-ins
+		// that were already recorded.
+		existing, _ := store.LoadParticipants(id, comp.WithZekkenName)
+		checkedInByName := make(map[string]bool, len(existing))
+		for _, ep := range existing {
+			checkedInByName[ep.Name] = ep.CheckedIn
+		}
+
 		players := make([]domain.Player, 0, len(req.Players))
 		for i, p := range req.Players {
 			players = append(players, domain.Player{
@@ -76,6 +85,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 				Metadata:     p.Metadata,
 				Tag:          p.Tag,
 				PoolPosition: int64(i),
+				CheckedIn:    checkedInByName[p.Name],
 			})
 		}
 
@@ -142,8 +152,6 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 
 		updatedPlayer, err := store.UpdateParticipant(id, pid, comp.WithZekkenName, func(p *domain.Player) error {
 			p.CheckedIn = true
-			now := time.Now()
-			p.CheckedInAt = &now
 			return nil
 		})
 
@@ -175,7 +183,6 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 
 		updatedPlayer, err := store.UpdateParticipant(id, pid, comp.WithZekkenName, func(p *domain.Player) error {
 			p.CheckedIn = false
-			p.CheckedInAt = nil
 			return nil
 		})
 

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -77,7 +78,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		}
 		checkedInByName := make(map[string]bool, len(existing))
 		for _, ep := range existing {
-			checkedInByName[ep.Name] = ep.CheckedIn
+			checkedInByName[strings.ToLower(strings.TrimSpace(ep.Name))] = ep.CheckedIn
 		}
 
 		players := make([]domain.Player, 0, len(req.Players))
@@ -89,7 +90,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 				Metadata:     p.Metadata,
 				Tag:          p.Tag,
 				PoolPosition: int64(i),
-				CheckedIn:    checkedInByName[p.Name],
+				CheckedIn:    checkedInByName[strings.ToLower(strings.TrimSpace(p.Name))],
 			})
 		}
 

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -70,7 +70,11 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		// players that survive the edit (matched by name). A full roster
 		// replacement via this endpoint must not silently clear check-ins
 		// that were already recorded.
-		existing, _ := store.LoadParticipants(id, comp.WithZekkenName)
+		existing, err := store.LoadParticipants(id, comp.WithZekkenName)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load participants: " + err.Error()})
+			return
+		}
 		checkedInByName := make(map[string]bool, len(existing))
 		for _, ep := range existing {
 			checkedInByName[ep.Name] = ep.CheckedIn

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -3,13 +3,14 @@ package mobileapp
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
-func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store) {
+func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Broadcaster) {
 	r.GET("/competitions/:id/participants", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
@@ -123,5 +124,96 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store) {
 			return
 		}
 		c.JSON(http.StatusOK, assignments)
+	})
+
+	r.PUT("/competitions/:id/participants/:pid/checkin", func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+		pid := c.Param("pid")
+
+		comp, err := store.LoadCompetition(id)
+		if err != nil || comp == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+
+		players, err := store.LoadParticipants(id, comp.WithZekkenName)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		found := false
+		var updatedPlayer domain.Player
+		for i := range players {
+			if players[i].ID == pid {
+				players[i].CheckedIn = true
+				now := time.Now()
+				players[i].CheckedInAt = &now
+				updatedPlayer = players[i]
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			c.JSON(http.StatusNotFound, gin.H{"error": "participant not found"})
+			return
+		}
+
+		if err := store.SaveParticipants(id, players); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		hub.Broadcast(EventParticipantsUpdated, gin.H{"competitionId": id})
+		c.JSON(http.StatusOK, updatedPlayer)
+	})
+
+	r.DELETE("/competitions/:id/participants/:pid/checkin", func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+		pid := c.Param("pid")
+
+		comp, err := store.LoadCompetition(id)
+		if err != nil || comp == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+
+		players, err := store.LoadParticipants(id, comp.WithZekkenName)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		found := false
+		var updatedPlayer domain.Player
+		for i := range players {
+			if players[i].ID == pid {
+				players[i].CheckedIn = false
+				players[i].CheckedInAt = nil
+				updatedPlayer = players[i]
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			c.JSON(http.StatusNotFound, gin.H{"error": "participant not found"})
+			return
+		}
+
+		if err := store.SaveParticipants(id, players); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		hub.Broadcast(EventParticipantsUpdated, gin.H{"competitionId": id})
+		c.JSON(http.StatusOK, updatedPlayer)
 	})
 }

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -139,32 +139,19 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
-		players, err := store.LoadParticipants(id, comp.WithZekkenName)
+		updatedPlayer, err := store.UpdateParticipant(id, pid, comp.WithZekkenName, func(p *domain.Player) error {
+			p.CheckedIn = true
+			now := time.Now()
+			p.CheckedInAt = &now
+			return nil
+		})
+
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-
-		found := false
-		var updatedPlayer domain.Player
-		for i := range players {
-			if players[i].ID == pid {
-				players[i].CheckedIn = true
-				now := time.Now()
-				players[i].CheckedInAt = &now
-				updatedPlayer = players[i]
-				found = true
-				break
+			status := http.StatusInternalServerError
+			if err.Error() == "participant not found" {
+				status = http.StatusNotFound
 			}
-		}
-
-		if !found {
-			c.JSON(http.StatusNotFound, gin.H{"error": "participant not found"})
-			return
-		}
-
-		if err := store.SaveParticipants(id, players); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(status, gin.H{"error": err.Error()})
 			return
 		}
 
@@ -185,31 +172,18 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
-		players, err := store.LoadParticipants(id, comp.WithZekkenName)
+		updatedPlayer, err := store.UpdateParticipant(id, pid, comp.WithZekkenName, func(p *domain.Player) error {
+			p.CheckedIn = false
+			p.CheckedInAt = nil
+			return nil
+		})
+
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-
-		found := false
-		var updatedPlayer domain.Player
-		for i := range players {
-			if players[i].ID == pid {
-				players[i].CheckedIn = false
-				players[i].CheckedInAt = nil
-				updatedPlayer = players[i]
-				found = true
-				break
+			status := http.StatusInternalServerError
+			if err.Error() == "participant not found" {
+				status = http.StatusNotFound
 			}
-		}
-
-		if !found {
-			c.JSON(http.StatusNotFound, gin.H{"error": "participant not found"})
-			return
-		}
-
-		if err := store.SaveParticipants(id, players); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(status, gin.H{"error": err.Error()})
 			return
 		}
 

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -1882,6 +1882,73 @@ func TestParticipantHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestCheckInHandlers(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	comp := state.Competition{ID: "ci-comp"}
+	store.SaveCompetition(&comp)
+
+	// PUT on unknown competition → 404
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/competitions/nonexistent/participants/any-pid/checkin", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// DELETE on unknown competition → 404
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/competitions/nonexistent/participants/any-pid/checkin", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// Seed a participant.
+	require.NoError(t, store.SaveParticipants("ci-comp", []domain.Player{{Name: "Alice", Dojo: "Kenshikan"}}))
+	existing, err := store.LoadParticipants("ci-comp", false)
+	require.NoError(t, err)
+	aliceID := existing[0].ID
+
+	// PUT on unknown participant → 404
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/competitions/ci-comp/participants/nonexistent-pid/checkin", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// PUT (check in) known participant → 200, checkedIn=true in response
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/competitions/ci-comp/participants/"+aliceID+"/checkin", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp domain.Player
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.CheckedIn, "PUT response must have checkedIn=true")
+
+	// Verify check-in persists to disk.
+	reloaded, err := store.LoadParticipants("ci-comp", false)
+	require.NoError(t, err)
+	require.Len(t, reloaded, 1)
+	assert.True(t, reloaded[0].CheckedIn, "check-in must persist to disk")
+
+	// DELETE (undo check-in) known participant → 200, checkedIn=false in response
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/competitions/ci-comp/participants/"+aliceID+"/checkin", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.CheckedIn, "DELETE response must have checkedIn=false")
+
+	// Verify undo persists to disk.
+	reloaded, err = store.LoadParticipants("ci-comp", false)
+	require.NoError(t, err)
+	require.Len(t, reloaded, 1)
+	assert.False(t, reloaded[0].CheckedIn, "undo check-in must persist to disk")
+
+	// DELETE on unknown participant → 404
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/competitions/ci-comp/participants/nonexistent-pid/checkin", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestMatchHandlers(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -974,9 +974,29 @@ func TestTournamentHandlers_CheckInWindowValidation(t *testing.T) {
 			field: "checkInWindowStart",
 			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = strings.Repeat("x", 6); return t }(),
 		},
-		{
+			{
 			field: "checkInWindowEnd",
 			tour:  func() state.Tournament { t := base; t.CheckInWindowEnd = "invalid"; return t }(),
+		},
+		// Cross-field: only start set → rejected (end missing).
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "09:00"; return t }(),
+		},
+		// Cross-field: only end set → rejected (start missing).
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowEnd = "17:00"; return t }(),
+		},
+		// Cross-field: start == end → rejected.
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "09:00"; t.CheckInWindowEnd = "09:00"; return t }(),
+		},
+		// Cross-field: start after end → rejected.
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "17:00"; t.CheckInWindowEnd = "09:00"; return t }(),
 		},
 	}
 	for _, tc := range invalid {

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -974,7 +974,7 @@ func TestTournamentHandlers_CheckInWindowValidation(t *testing.T) {
 			field: "checkInWindowStart",
 			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = strings.Repeat("x", 6); return t }(),
 		},
-			{
+		{
 			field: "checkInWindowEnd",
 			tour:  func() state.Tournament { t := base; t.CheckInWindowEnd = "invalid"; return t }(),
 		},
@@ -991,12 +991,22 @@ func TestTournamentHandlers_CheckInWindowValidation(t *testing.T) {
 		// Cross-field: start == end → rejected.
 		{
 			field: "checkInWindowStart",
-			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "09:00"; t.CheckInWindowEnd = "09:00"; return t }(),
+			tour: func() state.Tournament {
+				t := base
+				t.CheckInWindowStart = "09:00"
+				t.CheckInWindowEnd = "09:00"
+				return t
+			}(),
 		},
 		// Cross-field: start after end → rejected.
 		{
 			field: "checkInWindowStart",
-			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "17:00"; t.CheckInWindowEnd = "09:00"; return t }(),
+			tour: func() state.Tournament {
+				t := base
+				t.CheckInWindowStart = "17:00"
+				t.CheckInWindowEnd = "09:00"
+				return t
+			}(),
 		},
 	}
 	for _, tc := range invalid {

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -946,6 +946,70 @@ func TestTournamentHandlers_MaxLengthCaps(t *testing.T) {
 		"PUT /api/tournament with exactly-200-char Name/Venue must be accepted")
 }
 
+// TestTournamentHandlers_CheckInWindowValidation verifies that the
+// checkInWindowStart/End fields are validated as HH:MM strings and
+// rejected when malformed or over-cap.
+func TestTournamentHandlers_CheckInWindowValidation(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "Seed", Password: "secret", Courts: []string{"A"},
+	}))
+
+	base := state.Tournament{Name: "OK", Password: "secret", Courts: []string{"A"}}
+
+	invalid := []struct {
+		field string
+		tour  state.Tournament
+	}{
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "9:00"; return t }(),
+		},
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = "25:00"; return t }(),
+		},
+		{
+			field: "checkInWindowStart",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowStart = strings.Repeat("x", 6); return t }(),
+		},
+		{
+			field: "checkInWindowEnd",
+			tour:  func() state.Tournament { t := base; t.CheckInWindowEnd = "invalid"; return t }(),
+		},
+	}
+	for _, tc := range invalid {
+		body, _ := json.Marshal(tc.tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "field %s value %q must be rejected", tc.field, tc.tour.CheckInWindowStart+tc.tour.CheckInWindowEnd)
+		assert.Contains(t, w.Body.String(), tc.field, "rejection must name the field")
+	}
+
+	// Valid HH:MM values must be accepted.
+	valid := base
+	valid.CheckInWindowStart = "09:00"
+	valid.CheckInWindowEnd = "17:30"
+	body, _ := json.Marshal(valid)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "valid HH:MM check-in window must be accepted")
+
+	// Empty values (window not set) must also pass.
+	noWindow := base
+	body, _ = json.Marshal(noWindow)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "omitted check-in window must be accepted")
+}
+
 // TestTournamentHandlers_ConcurrentPUT_PasswordChangeNotLost pins the
 // TOCTOU fix in store.UpdateTournamentChanged. Pre-atomic-primitive,
 // the PUT handler called LoadTournament + SaveTournamentChanged

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -1981,7 +1981,7 @@ func TestCheckInHandlers(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	comp := state.Competition{ID: "ci-comp"}
-	store.SaveCompetition(&comp)
+	require.NoError(t, store.SaveCompetition(&comp))
 
 	// PUT on unknown competition → 404
 	w := httptest.NewRecorder()

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -2043,6 +2043,60 @@ func TestCheckInHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestCheckInPreservedOnRosterReplace(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "ci-pr"}))
+
+	// Seed an initial roster with Alice.
+	body, _ := json.Marshal(map[string]interface{}{
+		"players": []map[string]string{{"name": "Alice", "dojo": "Dojo A"}},
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/competitions/ci-pr/participants", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Retrieve Alice's ID.
+	existing, err := store.LoadParticipants("ci-pr", false)
+	require.NoError(t, err)
+	require.Len(t, existing, 1)
+	aliceID := existing[0].ID
+	require.NotEmpty(t, aliceID)
+
+	// Check Alice in via PUT /checkin.
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/competitions/ci-pr/participants/"+aliceID+"/checkin", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Replace the roster via POST (Alice still in the list, Bob added).
+	body, _ = json.Marshal(map[string]interface{}{
+		"players": []map[string]string{
+			{"name": "Alice", "dojo": "Dojo A"},
+			{"name": "Bob", "dojo": "Dojo B"},
+		},
+	})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/competitions/ci-pr/participants", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Alice's check-in must be preserved; Bob (new) must be unchecked.
+	reloaded, err := store.LoadParticipants("ci-pr", false)
+	require.NoError(t, err)
+	require.Len(t, reloaded, 2)
+	byName := map[string]domain.Player{}
+	for _, p := range reloaded {
+		byName[p.Name] = p
+	}
+	assert.True(t, byName["Alice"].CheckedIn, "Alice's check-in must survive a roster replace")
+	assert.False(t, byName["Bob"].CheckedIn, "Bob (newly added) must start unchecked")
+}
+
 func TestMatchHandlers(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -49,7 +49,7 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *state.Store, *engine.Engine, *
 	RegisterTournamentHandlers(admin, store, hub, NewFileVerifier(store))
 	RegisterImportHandlers(admin, store, hub)
 	RegisterCompetitionHandlers(admin, store, eng, hub)
-	RegisterParticipantHandlers(admin, store)
+	RegisterParticipantHandlers(admin, store, hub)
 	RegisterMatchHandlers(admin, eng, store, store, hub)
 	RegisterDecisionHandlers(admin, eng, store, store, hub)
 	RegisterEligibilityHandlers(admin, store, hub)

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -152,6 +152,12 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("closingBlock", t.ClosingBlock, MaxLenCeremonyBlock); err != nil {
 		return err
 	}
+	if err := validateCheckInWindow("checkInWindowStart", t.CheckInWindowStart); err != nil {
+		return err
+	}
+	if err := validateCheckInWindow("checkInWindowEnd", t.CheckInWindowEnd); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -158,6 +158,15 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateCheckInWindow("checkInWindowEnd", t.CheckInWindowEnd); err != nil {
 		return err
 	}
+	// Cross-field invariants: both fields must be set together, and start < end.
+	hasStart := t.CheckInWindowStart != ""
+	hasEnd := t.CheckInWindowEnd != ""
+	if hasStart != hasEnd {
+		return &ValidationError{Field: "checkInWindowStart", Message: "checkInWindowStart and checkInWindowEnd must both be set or both be empty"}
+	}
+	if hasStart && hasEnd && t.CheckInWindowStart >= t.CheckInWindowEnd {
+		return &ValidationError{Field: "checkInWindowStart", Message: "checkInWindowStart must be before checkInWindowEnd"}
+	}
 	return nil
 }
 

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -23,6 +23,7 @@ const (
 	EventTournamentUpdated       EventType = "tournament_updated"
 	EventScheduleUpdated         EventType = "schedule_updated"
 	EventCompetitorStatusUpdated EventType = "competitor_status_updated"
+	EventParticipantsUpdated     EventType = "participants_updated"
 	// EventPasswordReset fires when the admin password is rotated. Three
 	// broadcast sites (file mode only; never emitted in locked mode):
 	//   - POST /api/tournament/reset — the public recovery endpoint for

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -89,7 +89,7 @@ func NewRouter(store *state.Store, eng *engine.Engine, res *resources.Resources,
 		RegisterTournamentHandlers(admin, store, hub, verifier)
 		RegisterImportHandlers(admin, store, hub)
 		RegisterCompetitionHandlers(admin, store, eng, hub)
-		RegisterParticipantHandlers(admin, store)
+		RegisterParticipantHandlers(admin, store, hub)
 		RegisterMatchHandlers(admin, eng, store, store, hub)
 		RegisterDecisionHandlers(admin, eng, store, store, hub)
 		RegisterEligibilityHandlers(admin, store, hub)

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -19,6 +19,7 @@ package mobileapp
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
@@ -55,7 +56,27 @@ const (
 	MaxLenEntityID          = 64 // matches state.ValidateCompetitionID cap
 
 	MaxLenSeedAssignmentName = 100
+
+	MaxLenCheckInWindow = 5 // "HH:MM"
 )
+
+// hhmmRE matches HH:MM time strings (00:00–23:59).
+var hhmmRE = regexp.MustCompile(`^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$`)
+
+// validateCheckInWindow returns a ValidationError when val is non-empty and
+// not a valid HH:MM string (hour 00-23, minute 00-59).
+func validateCheckInWindow(field, val string) error {
+	if val == "" {
+		return nil
+	}
+	if err := validateMaxLen(field, val, MaxLenCheckInWindow); err != nil {
+		return err
+	}
+	if !hhmmRE.MatchString(val) {
+		return &ValidationError{Field: field, Message: "must be a valid HH:MM time (e.g. 09:00)"}
+	}
+	return nil
+}
 
 // validateMaxLen returns a ValidationError when val exceeds max bytes.
 // Empty strings pass — required-field checks live separately so callers

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -33,6 +33,12 @@ type Tournament struct {
 	// runs longer than the mean. Defaults to 10 via ApplyTournamentDefaults
 	// when zero. FR-057, R9.
 	SlowestCourtBufferPct int `yaml:"slowest_court_buffer_pct,omitempty" json:"slowestCourtBufferPct,omitempty"`
+
+	// Check-in window configuration (ISO time strings or HH:MM relative
+	// to the tournament day). Informational only; the head table can
+	// still manually toggle check-ins after the window closes.
+	CheckInWindowStart string `yaml:"check_in_window_start,omitempty" json:"checkInWindowStart,omitempty"`
+	CheckInWindowEnd   string `yaml:"check_in_window_end,omitempty" json:"checkInWindowEnd,omitempty"`
 }
 
 // ApplyTournamentDefaults fills zero-valued schedule-estimator tuning

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -34,9 +34,9 @@ type Tournament struct {
 	// when zero. FR-057, R9.
 	SlowestCourtBufferPct int `yaml:"slowest_court_buffer_pct,omitempty" json:"slowestCourtBufferPct,omitempty"`
 
-	// Check-in window configuration (ISO time strings or HH:MM relative
-	// to the tournament day). Informational only; the head table can
-	// still manually toggle check-ins after the window closes.
+	// Check-in window configuration (HH:MM strings on the tournament day).
+	// Informational only; the head table can still manually toggle check-ins
+	// after the window closes.
 	CheckInWindowStart string `yaml:"check_in_window_start,omitempty" json:"checkInWindowStart,omitempty"`
 	CheckInWindowEnd   string `yaml:"check_in_window_end,omitempty" json:"checkInWindowEnd,omitempty"`
 }

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -202,7 +202,8 @@ func (s *Store) UpdateParticipant(compID string, pid string, withZekkenName bool
 	mu.Lock()
 	defer mu.Unlock()
 
-	players, err := s.loadParticipantsNoLock(compID, withZekkenName, LoadParticipantsOpts{})
+	// Seeds are not merged here — check-in mutations don't need seed data.
+	players, err := s.loadParticipantsNoLock(compID, withZekkenName, LoadParticipantsOpts{WithSeeds: false})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -8,6 +9,9 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 )
+
+// ErrParticipantNotFound is returned by UpdateParticipant when the pid is not in the roster.
+var ErrParticipantNotFound = errors.New("participant not found")
 
 // LoadParticipantsOpts controls optional behavior in LoadParticipants.
 type LoadParticipantsOpts struct {
@@ -189,7 +193,7 @@ func (s *Store) UpdateParticipant(compID string, pid string, withZekkenName bool
 	}
 
 	if foundIdx == -1 {
-		return nil, fmt.Errorf("participant not found")
+		return nil, ErrParticipantNotFound
 	}
 
 	if err := transform(&players[foundIdx]); err != nil {

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -95,24 +95,39 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 	for _, line := range lines {
 		isCheckedIn := false
 
-		// Robust column-based detection: only treat as checked_in if the
-		// LAST column is exactly that string. This prevents accidental
-		// suffix matches on dojo names or metadata.
-		// For UUID rows the minimum valid row is "uuid,Name,Dojo", so we
-		// need at least 4 parts before checked_in is a valid trailing token.
-		// For non-UUID rows "Name,Dojo" is the minimum (2 parts), so 3+ is
-		// sufficient. Using hasIDs to pick the right threshold.
+		// Robust column-based detection: strip the UUID prefix first so
+		// the threshold is applied to the data columns only (per Copilot
+		// review). After stripping the ID the minimum valid data row is
+		// "Name,Dojo" (2 parts), so checked_in is only treated as a
+		// marker when at least 3 data parts are present (Name, Dojo,
+		// checked_in).
+		//
+		// Known limitation: a dojo literally named "checked_in" in a
+		// zekken competition that also has a distinct DisplayName column
+		// produces "Name, DisplayName, checked_in" (3 data parts) after
+		// UUID strip, which the threshold cannot distinguish from the
+		// legitimate "Name, Dojo, checked_in" row. Resolving this
+		// ambiguity without a format version or column header is not
+		// possible; in practice no real dojo uses this name.
 		line = strings.TrimSpace(line)
-		parts := strings.Split(line, ",")
-		minParts := 2
+
+		// Strip UUID prefix for threshold calculation only (idLine is
+		// what remains after the ID field).
+		idLine := line
 		if hasIDs {
-			minParts = 3
+			if _, rest, ok := strings.Cut(line, ","); ok {
+				idLine = strings.TrimSpace(rest)
+			}
 		}
-		if len(parts) > minParts {
-			last := strings.TrimSpace(parts[len(parts)-1])
+		dataParts := strings.Split(idLine, ",")
+		if len(dataParts) > 2 {
+			last := strings.TrimSpace(dataParts[len(dataParts)-1])
 			if strings.ToLower(last) == "checked_in" {
 				isCheckedIn = true
-				line = strings.Join(parts[:len(parts)-1], ",")
+				// Strip from the full original line (preserves UUID prefix).
+				if li := strings.LastIndex(line, ","); li >= 0 {
+					line = strings.TrimRight(line[:li], " ")
+				}
 			}
 		}
 

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -98,9 +98,17 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 		// Robust column-based detection: only treat as checked_in if the
 		// LAST column is exactly that string. This prevents accidental
 		// suffix matches on dojo names or metadata.
+		// For UUID rows the minimum valid row is "uuid,Name,Dojo", so we
+		// need at least 4 parts before checked_in is a valid trailing token.
+		// For non-UUID rows "Name,Dojo" is the minimum (2 parts), so 3+ is
+		// sufficient. Using hasIDs to pick the right threshold.
 		line = strings.TrimSpace(line)
 		parts := strings.Split(line, ",")
-		if len(parts) > 2 { // Min 3 columns (ID, Name, Dojo)
+		minParts := 2
+		if hasIDs {
+			minParts = 3
+		}
+		if len(parts) > minParts {
 			last := strings.TrimSpace(parts[len(parts)-1])
 			if strings.ToLower(last) == "checked_in" {
 				isCheckedIn = true

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -82,20 +82,32 @@ func (s *Store) loadParticipants(compID string, withZekkenName bool, opts LoadPa
 	}
 
 	var ids []string
+	var checkedInFlags []bool
 	var plainLines []string
-	if hasIDs {
-		for _, line := range lines {
+
+	for _, line := range lines {
+		isCheckedIn := false
+		if strings.HasSuffix(strings.TrimSpace(line), ", checked_in") {
+			isCheckedIn = true
+			line = strings.TrimSpace(line)
+			line = line[:len(line)-len(", checked_in")]
+		}
+
+		if hasIDs {
 			id, rest, ok := strings.Cut(line, ",")
 			if !ok {
 				plainLines = append(plainLines, line)
 				ids = append(ids, "")
+				checkedInFlags = append(checkedInFlags, isCheckedIn)
 				continue
 			}
 			ids = append(ids, strings.TrimSpace(id))
 			plainLines = append(plainLines, rest)
+			checkedInFlags = append(checkedInFlags, isCheckedIn)
+		} else {
+			plainLines = append(plainLines, line)
+			checkedInFlags = append(checkedInFlags, isCheckedIn)
 		}
-	} else {
-		plainLines = lines
 	}
 
 	players, err := helper.CreatePlayers(plainLines, withZekkenName)
@@ -103,11 +115,12 @@ func (s *Store) loadParticipants(compID string, withZekkenName bool, opts LoadPa
 		return nil, err
 	}
 
-	if hasIDs {
-		for i := range players {
-			if i < len(ids) {
-				players[i].ID = ids[i]
-			}
+	for i := range players {
+		if hasIDs && i < len(ids) {
+			players[i].ID = ids[i]
+		}
+		if i < len(checkedInFlags) {
+			players[i].CheckedIn = checkedInFlags[i]
 		}
 	}
 
@@ -163,6 +176,9 @@ func (s *Store) SaveParticipants(compID string, players []domain.Player) error {
 		}
 		if p.Tag != "" {
 			row += ", " + p.Tag
+		}
+		if p.CheckedIn {
+			row += ", checked_in"
 		}
 		sb.WriteString(id + ", " + row + "\n")
 	}

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -29,7 +29,10 @@ func (s *Store) loadParticipants(compID string, withZekkenName bool, opts LoadPa
 	mu := s.getCompLock(compID)
 	mu.RLock()
 	defer mu.RUnlock()
+	return s.loadParticipantsNoLock(compID, withZekkenName, opts)
+}
 
+func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts LoadParticipantsOpts) ([]domain.Player, error) {
 	// Use a virtual filename for cache to distinguish between with/without seeds.
 	cacheKey := "participants.csv"
 	if opts.WithSeeds {
@@ -87,10 +90,18 @@ func (s *Store) loadParticipants(compID string, withZekkenName bool, opts LoadPa
 
 	for _, line := range lines {
 		isCheckedIn := false
-		if strings.HasSuffix(strings.TrimSpace(line), ", checked_in") {
-			isCheckedIn = true
-			line = strings.TrimSpace(line)
-			line = line[:len(line)-len(", checked_in")]
+
+		// Robust column-based detection: only treat as checked_in if the
+		// LAST column is exactly that string. This prevents accidental
+		// suffix matches on dojo names or metadata.
+		line = strings.TrimSpace(line)
+		parts := strings.Split(line, ",")
+		if len(parts) > 2 { // Min 3 columns (ID, Name, Dojo)
+			last := strings.TrimSpace(parts[len(parts)-1])
+			if strings.ToLower(last) == "checked_in" {
+				isCheckedIn = true
+				line = strings.Join(parts[:len(parts)-1], ",")
+			}
 		}
 
 		if hasIDs {
@@ -153,7 +164,46 @@ func (s *Store) SaveParticipants(compID string, players []domain.Player) error {
 	mu := s.getCompLock(compID)
 	mu.Lock()
 	defer mu.Unlock()
+	return s.saveParticipantsNoLock(compID, players)
+}
 
+// UpdateParticipant atomically loads the participant list, applies transform
+// to the target player, and persists the result. Used to avoid TOCTOU races
+// on concurrent check-ins.
+func (s *Store) UpdateParticipant(compID string, pid string, withZekkenName bool, transform func(p *domain.Player) error) (*domain.Player, error) {
+	mu := s.getCompLock(compID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	players, err := s.loadParticipantsNoLock(compID, withZekkenName, LoadParticipantsOpts{})
+	if err != nil {
+		return nil, err
+	}
+
+	foundIdx := -1
+	for i := range players {
+		if players[i].ID == pid {
+			foundIdx = i
+			break
+		}
+	}
+
+	if foundIdx == -1 {
+		return nil, fmt.Errorf("participant not found")
+	}
+
+	if err := transform(&players[foundIdx]); err != nil {
+		return nil, err
+	}
+
+	if err := s.saveParticipantsNoLock(compID, players); err != nil {
+		return nil, err
+	}
+
+	return &players[foundIdx], nil
+}
+
+func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) error {
 	path := s.compPath(compID, "participants.csv")
 
 	var sb strings.Builder

--- a/internal/state/participants_test.go
+++ b/internal/state/participants_test.go
@@ -294,6 +294,15 @@ func TestCheckedInColumnBasedDetection(t *testing.T) {
 	assert.True(t, loaded[0].CheckedIn, "Alice must be detected as checked-in from 3-column row")
 	assert.Equal(t, "Kenshikan", loaded[0].Dojo, "Dojo must not be consumed by checked_in detection")
 	assert.False(t, loaded[1].CheckedIn, "Bob must not be checked-in")
+
+	// Negative: dojo literally named "checked_in" must NOT be consumed.
+	content2 := "Carol, checked_in\n"
+	require.NoError(t, os.WriteFile(path, []byte(content2), 0600))
+	loaded2, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded2, 1)
+	assert.False(t, loaded2[0].CheckedIn, "2-column row must never trigger checked_in detection")
+	assert.Equal(t, "checked_in", loaded2[0].Dojo, "dojo named checked_in must be preserved")
 }
 
 func TestUpdateParticipant(t *testing.T) {

--- a/internal/state/participants_test.go
+++ b/internal/state/participants_test.go
@@ -248,3 +248,94 @@ func TestParticipantsDistinctDisplayNameRoundTrip(t *testing.T) {
 	assert.Equal(t, "C. CAROL", loaded[0].DisplayName)
 	assert.Equal(t, "Dojo C", loaded[0].Dojo)
 }
+
+func TestCheckedInRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "checkin-rt"
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "competitions", compID), 0700))
+
+	players := []domain.Player{
+		{Name: "Alice", Dojo: "Dojo A", CheckedIn: true},
+		{Name: "Bob", Dojo: "Dojo B", CheckedIn: false},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	raw, err := os.ReadFile(filepath.Join(dir, "competitions", compID, "participants.csv"))
+	require.NoError(t, err)
+	rawStr := string(raw)
+	assert.Contains(t, rawStr, "checked_in", "checked-in flag must be written to CSV")
+
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.True(t, loaded[0].CheckedIn, "Alice must round-trip as checked-in")
+	assert.False(t, loaded[1].CheckedIn, "Bob must round-trip as not checked-in")
+}
+
+func TestCheckedInColumnBasedDetection(t *testing.T) {
+	// Regression: checked_in must be detected by column position, not suffix match.
+	// A dojo literally named "checked_in" must not be consumed.
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "checkin-col"
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "competitions", compID), 0700))
+
+	path := filepath.Join(dir, "competitions", compID, "participants.csv")
+	// Minimal "Name, Dojo, checked_in" (3-column) format.
+	content := "Alice, Kenshikan, checked_in\nBob, Mumeishi\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.True(t, loaded[0].CheckedIn, "Alice must be detected as checked-in from 3-column row")
+	assert.Equal(t, "Kenshikan", loaded[0].Dojo, "Dojo must not be consumed by checked_in detection")
+	assert.False(t, loaded[1].CheckedIn, "Bob must not be checked-in")
+}
+
+func TestUpdateParticipant(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "update-p"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Update"}))
+
+	players := []domain.Player{
+		{Name: "Alice", Dojo: "Dojo A"},
+		{Name: "Bob", Dojo: "Dojo B"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	aliceID := loaded[0].ID
+
+	// Check Alice in.
+	updated, err := store.UpdateParticipant(compID, aliceID, false, func(p *domain.Player) error {
+		p.CheckedIn = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, updated.CheckedIn)
+
+	// Reload and verify persistence.
+	reloaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	var alice domain.Player
+	for _, p := range reloaded {
+		if p.ID == aliceID {
+			alice = p
+		}
+	}
+	assert.True(t, alice.CheckedIn, "check-in must persist to disk")
+	assert.False(t, reloaded[1].CheckedIn, "Bob must remain unchecked")
+
+	// Not-found case.
+	_, err = store.UpdateParticipant(compID, "nonexistent-id", false, func(p *domain.Player) error {
+		return nil
+	})
+	assert.Error(t, err)
+}

--- a/internal/state/participants_test.go
+++ b/internal/state/participants_test.go
@@ -346,5 +346,5 @@ func TestUpdateParticipant(t *testing.T) {
 	_, err = store.UpdateParticipant(compID, "nonexistent-id", false, func(p *domain.Player) error {
 		return nil
 	})
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrParticipantNotFound)
 }

--- a/internal/state/participants_test.go
+++ b/internal/state/participants_test.go
@@ -348,3 +348,34 @@ func TestUpdateParticipant(t *testing.T) {
 	})
 	assert.ErrorIs(t, err, ErrParticipantNotFound)
 }
+
+func TestCheckedInColumnBasedDetectionUUIDRows(t *testing.T) {
+	// Regression (Copilot review): UUID rows have format "uuid,Name,Dojo[,tag][,checked_in]".
+	// A 3-part UUID row "uuid,Alice,checked_in" must NOT be misclassified: "checked_in" is the Dojo.
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "checkin-uuid"
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "competitions", compID), 0700))
+
+	path := filepath.Join(dir, "competitions", compID, "participants.csv")
+
+	// 3-col UUID row: uuid, Name, Dojo — "checked_in" is the Dojo value, not a marker.
+	require.NoError(t, os.WriteFile(path,
+		[]byte("550e8400-e29b-41d4-a716-446655440000, Alice, checked_in\n"), 0600))
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.False(t, loaded[0].CheckedIn, "3-part UUID row must NOT be misclassified as checked-in")
+	assert.Equal(t, "checked_in", loaded[0].Dojo, "dojo value must be preserved for 3-part UUID row")
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", loaded[0].ID)
+
+	// 4-col UUID row: uuid, Name, Dojo, checked_in — trailing checked_in IS a valid marker.
+	require.NoError(t, os.WriteFile(path,
+		[]byte("550e8400-e29b-41d4-a716-446655440001, Bob, Kenshikan, checked_in\n"), 0600))
+	loaded2, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded2, 1)
+	assert.True(t, loaded2[0].CheckedIn, "4-part UUID row must be detected as checked-in")
+	assert.Equal(t, "Kenshikan", loaded2[0].Dojo, "Dojo must survive after checked_in token is stripped")
+}

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2238,12 +2238,21 @@ a:hover {
 
 .seed-row {
   display: grid;
-  grid-template-columns: 20px 36px 1fr 32px 64px;
+  grid-template-columns: 24px 20px 36px 1fr 32px 64px;
   gap: 8px;
   align-items: center;
   padding: 7px 10px;
   border-radius: 6px;
   border: 1px solid transparent;
+}
+
+.seed-row.is-checked-in {
+  background: #f0fdf4; /* Very light green */
+  border-color: #dcfce7;
+}
+
+.seed-row.is-checked-in .seed-row__name {
+  color: var(--ink-2);
 }
 
 .seed-row:hover {
@@ -2258,6 +2267,10 @@ a:hover {
 .seed-row.has-seed {
   background: #fffbeb;
   border-color: #fde68a;
+}
+
+.seed-row.has-seed.is-checked-in {
+  background: linear-gradient(90deg, #fffbeb 0%, #f0fdf4 100%);
 }
 
 .seed-row__handle {
@@ -2409,6 +2422,11 @@ a:hover {
   border-radius: 999px;
   font-size: 12px;
   font-weight: 600;
+}
+
+.pmf__chip.is-checked-in {
+  background: #f0fdf4;
+  color: #166534;
 }
 
 .pmf__chip button {

--- a/web-mobile/js/__tests__/data.test.jsx
+++ b/web-mobile/js/__tests__/data.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { 
-  standardSeedOrder, nextPow2, buildBracket, advanceByes, 
-  buildPools, computeStandings 
+import {
+  standardSeedOrder, nextPow2, buildBracket, advanceByes,
+  buildPools, computeStandings, parseParticipantLines
 } from '../data.jsx';
 
 describe('Data Utils', () => {
@@ -81,5 +81,30 @@ describe('Data Utils', () => {
       expect(standings[1].losses).toBe(1);
       expect(standings[1].ippons).toBe(1);
     });
+  });
+});
+
+describe('parseParticipantLines', () => {
+  it('sets checkedIn=true when last column is "checked_in" and parts > 2', () => {
+    const [p] = parseParticipantLines(['Name, Dojo, checked_in'], false);
+    expect(p.checkedIn).toBe(true);
+    expect(p.name).toBe('Name');
+    expect(p.dojo).toBe('Dojo');
+  });
+
+  it('does NOT set checkedIn when only 2 parts (below threshold)', () => {
+    // "Name, checked_in" has only 2 parts — must not be treated as the flag.
+    const [p] = parseParticipantLines(['Name, checked_in'], false);
+    expect(p.checkedIn).toBe(false);
+    // The second column is read as dojo.
+    expect(p.dojo).toBe('checked_in');
+  });
+
+  it('detects both tag and checkedIn when "..., tag, checked_in"', () => {
+    const [p] = parseParticipantLines(['Name, Dojo, registered, checked_in'], false);
+    expect(p.checkedIn).toBe(true);
+    expect(p.tag).toBe('registered');
+    expect(p.name).toBe('Name');
+    expect(p.dojo).toBe('Dojo');
   });
 });

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -29,6 +29,8 @@ const REFRESHABLE_EVENTS = new Set([
   // detail so the round counter, match list, and "Generate next round"
   // button enable-state all reconcile.
   "swiss_round_generated",
+  // participants_updated fires when a participant is checked in or out.
+  "participants_updated",
 ]);
 
 // Page components rendered by AdminApp's view switch (produced by sibling

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -137,6 +137,50 @@ function levenshtein(a, b) {
   return prev[n];
 }
 
+function CheckInBanner({ tournament, players }) {
+  const [nowStr, setNowStr] = useStateA(() => {
+    const d = new Date();
+    return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  });
+
+  useEffectA(() => {
+    const timer = setInterval(() => {
+      const d = new Date();
+      setNowStr(`${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`);
+    }, 60000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!tournament?.checkInWindowStart || !tournament?.checkInWindowEnd) return null;
+  const start = tournament.checkInWindowStart;
+  const end = tournament.checkInWindowEnd;
+
+  const diffStart = window.diffMinutes(start, nowStr);
+  const diffEnd = window.diffMinutes(end, nowStr);
+
+  if (diffStart > 0) {
+    return (
+      <div className="alert alert--info" style={{ marginBottom: 12 }}>
+        🕒 Check-in window starts at {start} (in {diffStart}m)
+      </div>
+    );
+  }
+  if (diffEnd > 0) {
+    return (
+      <div className="alert alert--success" style={{ marginBottom: 12 }}>
+        ✅ Check-in window is OPEN: {start}–{end} (closes in {diffEnd}m)
+      </div>
+    );
+  }
+
+  const uncheckeds = (players || []).filter(p => !p.checkedIn).length;
+  return (
+    <div className="alert alert--warn" style={{ marginBottom: 12 }}>
+      ⌛ Check-in CLOSED — {uncheckeds > 0 ? `${uncheckeds} participants did not check in` : "all participants checked in"}
+    </div>
+  );
+}
+
 function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, showToast, onSection }) {
   const [showOnlyUnchecked, setShowOnlyUnchecked] = useStateA(false);
   const [showAllPreview, setShowAllPreview] = useStateA(false);
@@ -401,11 +445,8 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
     if (!confirm(`Mark all ${targets.length} participants from ${dojo} as checked-in?`)) return;
 
     try {
-      // We do these in sequence to avoid overwhelming the server or hit rate limits
-      // though for a dojo it's usually small.
-      for (const p of targets) {
-        await window.API.toggleCheckIn(c.id, p.id, true, password);
-      }
+      // Parallel execution for better UX and performance
+      await Promise.all(targets.map(p => window.API.toggleCheckIn(c.id, p.id, true, password)));
       showToast(`Checked in ${targets.length} participants from ${dojo}`);
     } catch (err) {
       console.error("AdminParticipants: bulkCheckInDojo failed", err);
@@ -562,53 +603,9 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
 
   const isStarted = c.status !== "setup";
 
-  const [nowStr, setNowStr] = useStateA(() => {
-    const d = new Date();
-    return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
-  });
-
-  useEffectA(() => {
-    const timer = setInterval(() => {
-      const d = new Date();
-      setNowStr(`${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`);
-    }, 60000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const checkInBanner = useMemoA(() => {
-    if (!tournament?.checkInWindowStart || !tournament?.checkInWindowEnd) return null;
-    const start = tournament.checkInWindowStart;
-    const end = tournament.checkInWindowEnd;
-    
-    const diffStart = window.diffMinutes(start, nowStr);
-    const diffEnd = window.diffMinutes(end, nowStr);
-
-    if (diffStart > 0) {
-      return (
-        <div className="alert alert--info" style={{ marginBottom: 12 }}>
-          🕒 Check-in window starts at {start} (in {diffStart}m)
-        </div>
-      );
-    }
-    if (diffEnd > 0) {
-      return (
-        <div className="alert alert--success" style={{ marginBottom: 12 }}>
-          ✅ Check-in window is OPEN: {start}–{end} (closes in {diffEnd}m)
-        </div>
-      );
-    }
-    
-    const uncheckeds = players.filter(p => !p.checkedIn).length;
-    return (
-      <div className="alert alert--warn" style={{ marginBottom: 12 }}>
-        ⌛ Check-in CLOSED — {uncheckeds > 0 ? `${uncheckeds} participants did not check in` : "all participants checked in"}
-      </div>
-    );
-  }, [tournament?.checkInWindowStart, tournament?.checkInWindowEnd, nowStr, players]);
-
   return (
     <>
-      {checkInBanner}
+      <CheckInBanner tournament={tournament} players={players} />
       {isStarted && (
         <div style={{ marginBottom: 16, display: "flex", justifyContent: "flex-end" }}>
           <button className="btn btn--primary" onClick={() => onSection("scores")}>Go to Scoring →</button>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -452,13 +452,14 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
 
     if (!confirm(`Mark all ${targets.length} participants from ${dojo} as checked-in?`)) return;
 
-    try {
-      // Parallel execution for better UX and performance
-      await Promise.all(targets.map(p => window.API.toggleCheckIn(c.id, p.id, true, password)));
-      showToast(`Checked in ${targets.length} participants from ${dojo}`);
-    } catch (err) {
-      console.error("AdminParticipants: bulkCheckInDojo failed", err);
-      showToast(err.message, "error");
+    const results = await Promise.allSettled(targets.map(p => window.API.toggleCheckIn(c.id, p.id, true, password)));
+    const failed = results.filter(r => r.status === "rejected").length;
+    const succeeded = results.length - failed;
+    if (failed > 0) {
+      console.error("AdminParticipants: bulkCheckInDojo partial failure", results.filter(r => r.status === "rejected").map(r => r.reason));
+      showToast(`${succeeded}/${results.length} checked in from ${dojo} (${failed} failed)`, "error");
+    } else {
+      showToast(`Checked in ${succeeded} participants from ${dojo}`);
     }
   };
 

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -335,6 +335,14 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
     if (showOnlyUnchecked) out = out.filter(p => !p.checkedIn);
     return out;
   }, [players, tagFilter, showOnlyUnchecked]);
+  const dojoFirstRowSet = useMemoA(() => {
+    const seen = new Set();
+    const first = new Set();
+    visiblePlayers.forEach((p, i) => {
+      if (!seen.has(p.dojo)) { seen.add(p.dojo); first.add(i); }
+    });
+    return first;
+  }, [visiblePlayers]);
   const { gaps, hasGaps } = useMemoA(() => {
     const sortedSeeds = players.filter(p => p.seed).map(p => p.seed).sort((a, b) => a - b);
     const gaps = [];
@@ -843,7 +851,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                       <div className="seed-row__name" title={p.name}>{p.name}{p.tag && <span className="tag-badge">{p.tag}</span>}</div>
                       <div className="seed-row__dojo">
                         {p.dojo}
-                        {players.filter(px => px.dojo === p.dojo && !px.checkedIn).length > 0 && (
+                        {dojoFirstRowSet.has(i) && players.filter(px => px.dojo === p.dojo && !px.checkedIn).length > 0 && (
                           <button
                             className="btn--link"
                             style={{ marginLeft: 8, fontSize: 10, padding: 0 }}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -812,14 +812,14 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
               {/* When a tag filter is active, reorder controls would operate on */}
               {/* full-list indices but rows are filtered — so they'd swap with hidden */}
               {/* neighbours. Disable reordering until the filter is cleared. */}
-              {tagFilter && (
+              {(tagFilter || showOnlyUnchecked) && (
                 <div className="field__hint" style={{ padding: "0 16px 8px" }}>
-                  Reordering disabled while filtered by tag. Clear the filter to drag rows or use the arrows.
+                  Reordering disabled while a filter is active. Clear all filters to drag rows or use the arrows.
                 </div>
               )}
               {visiblePlayers.map((p) => {
                 const i = players.indexOf(p);
-                const reorderDisabled = !!tagFilter;
+                const reorderDisabled = !!tagFilter || showOnlyUnchecked;
                 return (
                   <div
                     key={p.id}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -447,8 +447,10 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   const toggleCheckIn = async (pid, checkedIn) => {
     try {
       await window.API.toggleCheckIn(c.id, pid, checkedIn, password);
-      // No onUpdate() call needed here because the SSE broadcast will trigger
-      // a reload of the competition data in the parent component.
+      // Call onUpdate() immediately so the checkbox reflects the new state
+      // without waiting for the SSE round-trip. The SSE event still fires
+      // and triggers a second (harmless) refresh.
+      await onUpdate();
     } catch (err) {
       console.error("AdminParticipants: toggleCheckIn failed", err);
       showToast(err.message, "error");

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -138,6 +138,7 @@ function levenshtein(a, b) {
 }
 
 function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, showToast, onSection }) {
+  const [showOnlyUnchecked, setShowOnlyUnchecked] = useStateA(false);
   const [showAllPreview, setShowAllPreview] = useStateA(false);
   const [seedImportResult, setSeedImportResult] = useStateA(null);
   const [importSummary, setImportSummary] = useStateA(null);
@@ -284,7 +285,12 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   const lines = useMemoA(() => text.split("\n").filter((l) => l.trim()), [text]);
   const players = useMemoA(() => c.players || [], [c.players]);
   const allTags = useMemoA(() => [...new Set(players.map(p => p.tag).filter(Boolean))], [players]);
-  const visiblePlayers = useMemoA(() => tagFilter ? players.filter(p => p.tag === tagFilter) : players, [players, tagFilter]);
+  const visiblePlayers = useMemoA(() => {
+    let out = players;
+    if (tagFilter) out = out.filter(p => p.tag === tagFilter);
+    if (showOnlyUnchecked) out = out.filter(p => !p.checkedIn);
+    return out;
+  }, [players, tagFilter, showOnlyUnchecked]);
   const { gaps, hasGaps } = useMemoA(() => {
     const sortedSeeds = players.filter(p => p.seed).map(p => p.seed).sort((a, b) => a - b);
     const gaps = [];
@@ -375,6 +381,36 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
       return;
     }
     if (mountedRef.current) showToast("Unseeded list shuffled");
+  };
+
+  const toggleCheckIn = async (pid, checkedIn) => {
+    try {
+      await window.API.toggleCheckIn(c.id, pid, checkedIn, password);
+      // No onUpdate() call needed here because the SSE broadcast will trigger
+      // a reload of the competition data in the parent component.
+    } catch (err) {
+      console.error("AdminParticipants: toggleCheckIn failed", err);
+      showToast(err.message, "error");
+    }
+  };
+
+  const bulkCheckInDojo = async (dojo) => {
+    const targets = (c.players || []).filter(p => p.dojo === dojo && !p.checkedIn);
+    if (targets.length === 0) return;
+
+    if (!confirm(`Mark all ${targets.length} participants from ${dojo} as checked-in?`)) return;
+
+    try {
+      // We do these in sequence to avoid overwhelming the server or hit rate limits
+      // though for a dojo it's usually small.
+      for (const p of targets) {
+        await window.API.toggleCheckIn(c.id, p.id, true, password);
+      }
+      showToast(`Checked in ${targets.length} participants from ${dojo}`);
+    } catch (err) {
+      console.error("AdminParticipants: bulkCheckInDojo failed", err);
+      showToast(err.message, "error");
+    }
   };
 
   const [showSlotForm, setShowSlotForm] = useStateA(false);
@@ -525,8 +561,54 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   };
 
   const isStarted = c.status !== "setup";
+
+  const [nowStr, setNowStr] = useStateA(() => {
+    const d = new Date();
+    return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+  });
+
+  useEffectA(() => {
+    const timer = setInterval(() => {
+      const d = new Date();
+      setNowStr(`${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`);
+    }, 60000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const checkInBanner = useMemoA(() => {
+    if (!tournament?.checkInWindowStart || !tournament?.checkInWindowEnd) return null;
+    const start = tournament.checkInWindowStart;
+    const end = tournament.checkInWindowEnd;
+    
+    const diffStart = window.diffMinutes(start, nowStr);
+    const diffEnd = window.diffMinutes(end, nowStr);
+
+    if (diffStart > 0) {
+      return (
+        <div className="alert alert--info" style={{ marginBottom: 12 }}>
+          🕒 Check-in window starts at {start} (in {diffStart}m)
+        </div>
+      );
+    }
+    if (diffEnd > 0) {
+      return (
+        <div className="alert alert--success" style={{ marginBottom: 12 }}>
+          ✅ Check-in window is OPEN: {start}–{end} (closes in {diffEnd}m)
+        </div>
+      );
+    }
+    
+    const uncheckeds = players.filter(p => !p.checkedIn).length;
+    return (
+      <div className="alert alert--warn" style={{ marginBottom: 12 }}>
+        ⌛ Check-in CLOSED — {uncheckeds > 0 ? `${uncheckeds} participants did not check in` : "all participants checked in"}
+      </div>
+    );
+  }, [tournament?.checkInWindowStart, tournament?.checkInWindowEnd, nowStr, players]);
+
   return (
     <>
+      {checkInBanner}
       {isStarted && (
         <div style={{ marginBottom: 16, display: "flex", justifyContent: "flex-end" }}>
           <button className="btn btn--primary" onClick={() => onSection("scores")}>Go to Scoring →</button>
@@ -662,10 +744,15 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
         <div className="card">
           <div className="card__head">
             <div>
-              <div className="card__title">Seeding</div>
-              <div className="card__sub">{players.filter((p) => p.seed).length} of {players.length} seeded</div>
+              <div className="card__title">Check-in & Seeding</div>
+              <div className="card__sub">
+                {players.filter(p => p.checkedIn).length} / {players.length} checked in · {players.filter((p) => p.seed).length} seeded
+              </div>
             </div>
             <div style={{ display: "flex", gap: 6 }}>
+              <button className={`btn btn--sm ${showOnlyUnchecked ? "btn--primary" : ""}`} type="button" onClick={() => setShowOnlyUnchecked(!showOnlyUnchecked)}>
+                {showOnlyUnchecked ? "Show all" : "Show unchecked"}
+              </button>
               <button className="btn btn--sm" type="button" onClick={shuffleUnseeded} disabled={players.length === 0} title="Shuffle unseeded players">Shuffle unseeded</button>
               <button className="btn btn--sm" type="button" onClick={() => seedFileRef.current?.click()} disabled={players.length === 0} title={players.length === 0 ? "Add participants first" : undefined}>Import Seeds CSV</button>
               <input ref={seedFileRef} type="file" accept=".csv,.txt,text/csv,text/plain" style={{ display: "none" }} onChange={(e) => handleSeedFile(e.target.files[0])} />
@@ -731,7 +818,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                 return (
                   <div
                     key={p.id}
-                    className={`seed-row ${p.seed ? "has-seed" : ""} ${dragOverIdx === i ? "seed-row--drop-target" : ""}`}
+                    className={`seed-row ${p.seed ? "has-seed" : ""} ${p.checkedIn ? "is-checked-in" : ""} ${dragOverIdx === i ? "seed-row--drop-target" : ""}`}
                     draggable={!reorderDisabled}
                     onDragStart={() => { dragIdxRef.current = i; }}
                     onDragOver={(e) => { if (reorderDisabled) return; e.preventDefault(); setDragOverIdx(i); }}
@@ -744,11 +831,31 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     }}
                     style={{ cursor: reorderDisabled ? "default" : "grab" }}
                   >
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginRight: 4 }}>
+                      <input
+                        type="checkbox"
+                        checked={p.checkedIn}
+                        onChange={(e) => toggleCheckIn(p.id, e.target.checked)}
+                        style={{ width: 18, height: 18, cursor: "pointer" }}
+                        title={p.checkedIn ? "Undo check-in" : "Mark as checked-in"}
+                      />
+                    </div>
                     <span className="seed-row__handle" title={reorderDisabled ? "Clear the tag filter to reorder" : "Drag to reorder"}>⠿</span>
                     <span className="seed-row__rank">{p.seed ? `#${p.seed}` : ""}</span>
                     <div style={{ flex: 1 }}>
                       <div className="seed-row__name" title={p.name}>{p.name}{p.tag && <span className="tag-badge">{p.tag}</span>}</div>
-                      <div className="seed-row__dojo">{p.dojo}</div>
+                      <div className="seed-row__dojo">
+                        {p.dojo}
+                        {players.filter(px => px.dojo === p.dojo && !px.checkedIn).length > 0 && (
+                          <button
+                            className="btn--link"
+                            style={{ marginLeft: 8, fontSize: 10, padding: 0 }}
+                            onClick={() => bulkCheckInDojo(p.dojo)}
+                          >
+                            Mark all from {p.dojo}
+                          </button>
+                        )}
+                      </div>
                     </div>
                     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                       <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0 || reorderDisabled} aria-label="Move up">↑</button>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -447,10 +447,9 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   const toggleCheckIn = async (pid, checkedIn) => {
     try {
       await window.API.toggleCheckIn(c.id, pid, checkedIn, password);
-      // Call onUpdate() immediately so the checkbox reflects the new state
-      // without waiting for the SSE round-trip. The SSE event still fires
-      // and triggers a second (harmless) refresh.
-      await onUpdate();
+      // State refresh is handled by the SSE participants_updated event,
+      // which admin.jsx's REFRESHABLE_EVENTS subscriber picks up and
+      // uses to call fetchCompetitionDetails. No onUpdate() call needed.
     } catch (err) {
       console.error("AdminParticipants: toggleCheckIn failed", err);
       showToast(err.message, "error");

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -338,8 +338,8 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   const dojoFirstRowSet = useMemoA(() => {
     const seen = new Set();
     const first = new Set();
-    visiblePlayers.forEach((p, i) => {
-      if (!seen.has(p.dojo)) { seen.add(p.dojo); first.add(i); }
+    visiblePlayers.forEach((p) => {
+      if (!seen.has(p.dojo)) { seen.add(p.dojo); first.add(p.id); }
     });
     return first;
   }, [visiblePlayers]);
@@ -845,13 +845,13 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                         title={p.checkedIn ? "Undo check-in" : "Mark as checked-in"}
                       />
                     </div>
-                    <span className="seed-row__handle" title={reorderDisabled ? "Clear the tag filter to reorder" : "Drag to reorder"}>⠿</span>
+                    <span className="seed-row__handle" title={reorderDisabled ? "Clear all filters to reorder" : "Drag to reorder"}>⠿</span>
                     <span className="seed-row__rank">{p.seed ? `#${p.seed}` : ""}</span>
                     <div style={{ flex: 1 }}>
                       <div className="seed-row__name" title={p.name}>{p.name}{p.tag && <span className="tag-badge">{p.tag}</span>}</div>
                       <div className="seed-row__dojo">
                         {p.dojo}
-                        {dojoFirstRowSet.has(i) && players.filter(px => px.dojo === p.dojo && !px.checkedIn).length > 0 && (
+                        {dojoFirstRowSet.has(p.id) && players.filter(px => px.dojo === p.dojo && !px.checkedIn).length > 0 && (
                           <button
                             className="btn--link"
                             style={{ marginLeft: 8, fontSize: 10, padding: 0 }}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -106,18 +106,20 @@ function mintParticipantIds(compID, existingPlayers, parsed) {
   });
   let nextSlot = 1;
   let added = 0, updatedCount = 0;
-  const np = parsed.map(({ name, displayName, dojo, danGrade, tag }) => {
+  const np = parsed.map(({ name, displayName, dojo, danGrade, tag, checkedIn: parsedCheckedIn }) => {
     const existing = existingMap.get(name.toLowerCase());
     if (existing) {
       updatedCount++;
-      return { id: existing.id, name, displayName, dojo, danGrade, tag, seed: existing.seed || null };
+      // Preserve existing check-in state; CSV token takes precedence if explicitly set.
+      const checkedIn = parsedCheckedIn || existing.checkedIn || false;
+      return { id: existing.id, name, displayName, dojo, danGrade, tag, seed: existing.seed || null, checkedIn };
     }
     added++;
     while (usedIds.has(`${compID}-p${nextSlot}`)) nextSlot++;
     const id = `${compID}-p${nextSlot}`;
     usedIds.add(id);
     nextSlot++;
-    return { id, name, displayName, dojo, danGrade, tag, seed: null };
+    return { id, name, displayName, dojo, danGrade, tag, seed: null, checkedIn: parsedCheckedIn || false };
   });
   return { np, added, updatedCount };
 }
@@ -343,6 +345,13 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
     });
     return first;
   }, [visiblePlayers]);
+  const dojoUncheckedCount = useMemoA(() => {
+    const counts = new Map();
+    players.forEach(p => {
+      if (!p.checkedIn) counts.set(p.dojo, (counts.get(p.dojo) || 0) + 1);
+    });
+    return counts;
+  }, [players]);
   const { gaps, hasGaps } = useMemoA(() => {
     const sortedSeeds = players.filter(p => p.seed).map(p => p.seed).sort((a, b) => a - b);
     const gaps = [];
@@ -843,7 +852,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                         checked={p.checkedIn}
                         onChange={(e) => toggleCheckIn(p.id, e.target.checked)}
                         style={{ width: 18, height: 18, cursor: "pointer" }}
-                        title={p.checkedIn ? "Undo check-in" : "Mark as checked-in"}
+                        aria-label={p.checkedIn ? `Undo check-in for ${p.name}` : `Mark ${p.name} as checked-in`}
                       />
                     </div>
                     <span className="seed-row__handle" title={reorderDisabled ? "Clear all filters to reorder" : "Drag to reorder"}>⠿</span>
@@ -852,7 +861,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                       <div className="seed-row__name" title={p.name}>{p.name}{p.tag && <span className="tag-badge">{p.tag}</span>}</div>
                       <div className="seed-row__dojo">
                         {p.dojo}
-                        {dojoFirstRowSet.has(p.id) && players.filter(px => px.dojo === p.dojo && !px.checkedIn).length > 0 && (
+                        {dojoFirstRowSet.has(p.id) && (dojoUncheckedCount.get(p.dojo) || 0) > 0 && (
                           <button
                             className="btn--link"
                             style={{ marginLeft: 8, fontSize: 10, padding: 0 }}

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -119,6 +119,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     const { norm, error: dateError } = validateAndNormalizeDate(date);
     if (dateError) { setError(dateError); return; }
     if (!Number.isInteger(courts) || courts < 1 || courts > MAX_COURTS) { setError(`Number of courts must be a whole number between 1 and ${MAX_COURTS}.`); return; }
+    if (checkInStart && checkInEnd && checkInStart >= checkInEnd) { setError("Check-in start must be before check-in end."); return; }
 
     onSave({
       name: trimmedName,

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -103,6 +103,8 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [venue, setVenue] = useStateA(tournament.venue);
   const [date, setDate] = useStateA(tournament.date);
   const [courts, setCourts] = useStateA(tournament.courts.length);
+  const [checkInStart, setCheckInStart] = useStateA(tournament.checkInWindowStart || "");
+  const [checkInEnd, setCheckInEnd] = useStateA(tournament.checkInWindowEnd || "");
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
 
@@ -123,7 +125,9 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       venue: venue.trim(),
       date: norm,
       password: pass || undefined,
-      courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i))
+      courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i)),
+      checkInWindowStart: checkInStart || undefined,
+      checkInWindowEnd: checkInEnd || undefined
     });
   };
 
@@ -171,6 +175,16 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               onChange={(e) => { setCourts(decideNumericUpdate(e.target.value, 1).value); setError(""); }}
             />
             <div className="field__hint">{`Enter a number (1-${MAX_COURTS}). Courts will be automatically labeled A, B, C, etc.`}</div>
+          </div>
+          <div className="row" style={{ marginTop: 16 }}>
+            <div className="field">
+              <label className="field__label">Check-in start (HH:MM)</label>
+              <input className="input" type="time" value={checkInStart} onChange={(e) => setCheckInStart(e.target.value)} />
+            </div>
+            <div className="field">
+              <label className="field__label">Check-in end (HH:MM)</label>
+              <input className="input" type="time" value={checkInEnd} onChange={(e) => setCheckInEnd(e.target.value)} />
+            </div>
           </div>
           {locked ? (
             <div className="field">

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -119,6 +119,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     const { norm, error: dateError } = validateAndNormalizeDate(date);
     if (dateError) { setError(dateError); return; }
     if (!Number.isInteger(courts) || courts < 1 || courts > MAX_COURTS) { setError(`Number of courts must be a whole number between 1 and ${MAX_COURTS}.`); return; }
+    if ((checkInStart && !checkInEnd) || (!checkInStart && checkInEnd)) { setError("Both check-in start and end must be set together, or both must be empty."); return; }
     if (checkInStart && checkInEnd && checkInStart >= checkInEnd) { setError("Check-in start must be before check-in end."); return; }
 
     onSave({

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -546,6 +546,18 @@ const API = {
             throw new Error(err.error || "Failed to load Swiss standings");
         }
         return res.json();
+    },
+    async toggleCheckIn(compID, pid, checkedIn, password) {
+        const method = checkedIn ? 'PUT' : 'DELETE';
+        const res = await fetch(`/api/competitions/${compID}/participants/${pid}/checkin`, {
+            method,
+            headers: { 'X-Tournament-Password': password }
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to ${checkedIn ? 'check in' : 'undo check-in'} participant`);
+        }
+        return res.json();
     }
 };
 

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -445,6 +445,15 @@ function App() {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), jitter);
             }
             jitteredTimeout(load, jitter);
+        } else if (event.type === "participants_updated") {
+            // Check-in toggle: viewer-side badges (checked-in indicator) need
+            // the updated player list. Refetch the selected competition when the
+            // event targets it; also refresh the tournament list so participant
+            // counts stay accurate.
+            if (viewerCompId === event.data?.competitionId) {
+                jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), jitter);
+            }
+            jitteredTimeout(load, jitter);
         }
     }, (status) => {
         // T063: track SSE connection status so /display surfaces can

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -325,8 +325,9 @@ function parseParticipantLines(lines, withZekken) {
     let displayName = "", dojo = "", danGrade = "", tag = "";
     let checkedIn = false;
 
-    // Detect trailing checked_in column
-    if (parts[parts.length - 1]?.toLowerCase() === "checked_in") {
+    // Detect trailing checked_in column — mirrors Go's column-based check (len > 2).
+    // Requires at least 3 parts so a bare "Name, Dojo" row is never affected.
+    if (parts.length > 2 && parts[parts.length - 1]?.toLowerCase() === "checked_in") {
       checkedIn = true;
       parts.pop();
     }

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -135,6 +135,12 @@ function scheduleRound(matches, startTime, perMatchMin, courtNames) {
 }
 function addMinutes(t, mins) { const [h, m] = t.split(":").map(Number); const total = h * 60 + m + mins; const hh = Math.floor(total / 60) % 24; const mm = total % 60; return `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`; }
 
+function diffMinutes(t1, t2) {
+  const [h1, m1] = t1.split(":").map(Number);
+  const [h2, m2] = t2.split(":").map(Number);
+  return (h1 * 60 + m1) - (h2 * 60 + m2);
+}
+
 // ---------- Pools ----------
 // poolMode: "max" => poolSize is a maximum (never more than N per pool — flex pool count to fit)
 //           "min" => poolSize is a minimum (try to keep at least N per pool — fewer, larger pools)
@@ -317,6 +323,13 @@ function parseParticipantLines(lines, withZekken) {
     const parts = line.split(",").map((s) => s.trim());
     const name = parts[0] || "";
     let displayName = "", dojo = "", danGrade = "", tag = "";
+    let checkedIn = false;
+
+    // Detect trailing checked_in column
+    if (parts[parts.length - 1]?.toLowerCase() === "checked_in") {
+      checkedIn = true;
+      parts.pop();
+    }
 
     // Detect trailing tag column (must be a known tag string, not a number)
     const last = parts[parts.length - 1]?.toLowerCase();
@@ -333,7 +346,7 @@ function parseParticipantLines(lines, withZekken) {
       dojo = parts[1] || "";
       danGrade = parts[2] || "";
     }
-    return { name, displayName, dojo, danGrade, tag };
+    return { name, displayName, dojo, danGrade, tag, checkedIn };
   });
 }
 
@@ -345,7 +358,7 @@ function arraysEqual(a, b) {
 
 export {
   makePlayer, makeTeam, makeCompetitors, standardSeedOrder, nextPow2, newMatchId,
-  buildBracket, advanceByes, pickIppons, simulateRounds, scheduleRound, addMinutes,
+  buildBracket, advanceByes, pickIppons, simulateRounds, scheduleRound, addMinutes, diffMinutes,
   buildPools, simulatePools, computeStandings, poolWinners,
   buildEmptyCompetition, applyFormat, buildCompetition,
   buildTournament, competitionStatus, SAMPLE_TOURNAMENTS, parseParticipantLines,

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -380,5 +380,6 @@ if (typeof window !== 'undefined') {
   window.parseParticipantLines = parseParticipantLines;
   window.mergeMatchPatch = mergeMatchPatch;
   window.addMinutes = addMinutes;
+  window.diffMinutes = diffMinutes;
   window.arraysEqual = arraysEqual;
 }

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -563,7 +563,7 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   }
 
   // Followed-player state: header indicator + next-match details.
-  const pRecord = roster.find(p => p.id === followedPlayer.id);
+  const pRecord = useMemo(() => roster.find(p => p.id === followedPlayer.id), [roster, followedPlayer.id]);
   const header = (
     <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
       <span style={{ fontSize: 12, color: "var(--ink-3)" }}>Following:</span>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -523,13 +523,15 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
               className="pmf__option"
               onClick={() => { onPick(p); setQuery(""); setOpen(false); }}
             >
-              <span className="pmf__check"></span>
+              <span className="pmf__check">{p.checkedIn ? "✓" : ""}</span>
               <span className="pmf__opt-body">
-                <span className="pmf__opt-name">{p.name}</span>
+                <span className="pmf__opt-name">
+                  {p.name}
+                  {p.checkedIn && <span className="tag-badge" style={{ marginLeft: 8, fontSize: 9 }}>Checked in</span>}
+                </span>
                 <span className="pmf__opt-dojo">{p.dojo || ""}</span>
               </span>
-            </button>
-          ))}
+            </button>          ))}
         </div>
       )}
     </div>
@@ -561,10 +563,12 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   }
 
   // Followed-player state: header indicator + next-match details.
+  const pRecord = roster.find(p => p.id === followedPlayer.id);
   const header = (
     <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
       <span style={{ fontSize: 12, color: "var(--ink-3)" }}>Following:</span>
       <span style={{ fontWeight: 600 }}>{followedPlayer.name || "(unknown)"}</span>
+      {pRecord && pRecord.checkedIn && <span className="tag-badge" style={{ fontSize: 9 }}>✓ Checked in</span>}
       <button
         className="btn btn--ghost btn--sm"
         onClick={() => setFollowedPlayer(null)}
@@ -658,14 +662,17 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
         </div>
       ) : (
         <div className="pmf__bar" style={{ marginBottom: 8 }}>
-          {watchlist.map((w) => (
-            <span key={w.id} className="pmf__chip">
-              {w.name}
-              <button onClick={() => removeOne(w.id)} aria-label={`Remove ${w.name}`}>×</button>
-            </span>
-          ))}
-        </div>
-      )}
+          {watchlist.map((w) => {
+            const pRecord = roster.find(p => p.id === w.id);
+            return (
+              <span key={w.id} className={`pmf__chip ${pRecord && pRecord.checkedIn ? "is-checked-in" : ""}`} title={pRecord && pRecord.checkedIn ? "Checked in" : undefined}>
+                {w.name}
+                {pRecord && pRecord.checkedIn && <span style={{ marginLeft: 4, fontSize: 10 }}>✓</span>}
+                <button onClick={() => removeOne(w.id)} aria-label={`Remove ${w.name}`}>×</button>
+              </span>
+            );
+          })}
+        </div>      )}
       <SinglePlayerPicker
         roster={roster}
         onPick={addOne}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -547,8 +547,8 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
 //      empty-state if all matches are complete) + a "Following: name [X]"
 //      header so the viewer can clear the selection (FR-022).
 function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, onMatchClick }) {
-  // Hoisted above the early return to satisfy the Rules of Hooks — hook order
-  // must be stable across renders regardless of followedPlayer being set.
+  // Hoisted above the early return so it is always computed before the guard;
+  // used in the non-empty branch to show the check-in badge.
   const pRecord = followedPlayer?.id
     ? (roster.find(p => p.id === followedPlayer.id) ?? null)
     : null;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -531,7 +531,8 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
                 </span>
                 <span className="pmf__opt-dojo">{p.dojo || ""}</span>
               </span>
-            </button>          ))}
+            </button>
+          ))}
         </div>
       )}
     </div>
@@ -645,6 +646,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
     });
     return Array.from(map.values());
   }, [tournament]);
+  const rosterById = useMemo(() => new Map(roster.map(p => [p.id, p])), [roster]);
 
   return (
     <div className="card" data-testid="viewer-home-watchlist" style={{ marginBottom: 16, padding: 14 }}>
@@ -663,7 +665,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
       ) : (
         <div className="pmf__bar" style={{ marginBottom: 8 }}>
           {watchlist.map((w) => {
-            const pRecord = roster.find(p => p.id === w.id);
+            const pRecord = rosterById.get(w.id);
             return (
               <span key={w.id} className={`pmf__chip ${pRecord && pRecord.checkedIn ? "is-checked-in" : ""}`} title={pRecord && pRecord.checkedIn ? "Checked in" : undefined}>
                 {w.name}
@@ -672,7 +674,8 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
               </span>
             );
           })}
-        </div>      )}
+        </div>
+      )}
       <SinglePlayerPicker
         roster={roster}
         onPick={addOne}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -547,6 +547,12 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
 //      empty-state if all matches are complete) + a "Following: name [X]"
 //      header so the viewer can clear the selection (FR-022).
 function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, onMatchClick }) {
+  // Hoisted above the early return to satisfy the Rules of Hooks — hook order
+  // must be stable across renders regardless of followedPlayer being set.
+  const pRecord = followedPlayer?.id
+    ? (roster.find(p => p.id === followedPlayer.id) ?? null)
+    : null;
+
   if (!followedPlayer || !followedPlayer.id) {
     return (
       <div className="card" data-testid="viewer-home-mymatch" style={{ marginBottom: 16, padding: 14 }}>
@@ -564,7 +570,6 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   }
 
   // Followed-player state: header indicator + next-match details.
-  const pRecord = useMemo(() => roster.find(p => p.id === followedPlayer.id), [roster, followedPlayer.id]);
   const header = (
     <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
       <span style={{ fontSize: 12, color: "var(--ink-3)" }}>Following:</span>


### PR DESCRIPTION
## Summary

- Adds \`CheckedIn\` field to \`domain.Player\`, with CSV round-trip via a new \`checked_in\` column token
- \`PUT\`/\`DELETE\` \`/api/competitions/:id/participants/:pid/checkin\` toggle endpoints using an atomic \`UpdateParticipant\` helper (avoids TOCTOU races)
- Fixes a **deadlock** in the original \`UpdateParticipant\` implementation — it held the comp write-lock then called \`loadParticipants\` which re-acquired the read-lock; fixed by introducing \`loadParticipantsNoLock\`
- Admin UI: per-row check-in toggle, bulk dojo check-in, checked-in counter \`N/total\`, unchecked-only filter chip, \`CheckInBanner\` (window open/closed/upcoming — timer isolated in its own component to avoid re-rendering the participant list)
- Viewer: \`✓ Checked in\` badge on \`MyMatchPanel\`, memoised roster lookup
- Optional \`checkInWindowStart\`/\`checkInWindowEnd\` tournament config fields (HH:MM format, validated)
- JS CSV parser threshold corrected to \`> 2\` (mirrors Go backend); \`diffMinutes\` helper exposed on \`window\`

## Test plan

- [ ] \`make go/test\` passes
- [ ] \`make run-mobile\` — register 5 participants, toggle 3 checked-in, reload page, verify state persists
- [ ] Toggle check-in off (uncheck) and reload — verify it clears
- [ ] Bulk check-in a dojo — all members toggle atomically
- [ ] Set \`checkInWindowStart\`/\`checkInWindowEnd\` in tournament config — banner shows correct state (upcoming / open / closed)
- [ ] After window closes, banner reports unchecked-in count
- [ ] Viewer: follow a checked-in participant — badge shows ✓
- [ ] Run a match where one side is not checked-in — confirm no automatic block (informational only)
- [ ] Concurrent check-in requests for the same participant do not corrupt the CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)