### PR TITLE
docs(scoring): document post-#110 hansoku semantics in formatScore

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1394,11 +1394,22 @@ func TestOverrideBracketWinner_NotFound(t *testing.T) {
 // --- Scoring and Standing Logic Tests ---
 
 func TestFormatScore_HansokuOnly(t *testing.T) {
+	// Legacy disk values: hansoku used to be cumulative, so values >1 still
+	// appear when reading old saves. The renderer must keep displaying them.
 	score := formatScore([]string{}, 2)
 	assert.Equal(t, "(H2)", score)
 
 	score = formatScore([]string{"M"}, 1)
 	assert.Equal(t, "M (H1)", score)
+
+	// Post-PR-#110 saves: the discharged foul pair is recorded as an "H" ippon
+	// on the opponent's slice and HansokuA resets to 0. No redundant "(H...)"
+	// suffix should appear alongside the H ippon.
+	score = formatScore([]string{"H"}, 0)
+	assert.Equal(t, "H", score)
+
+	score = formatScore([]string{"M", "H"}, 0)
+	assert.Equal(t, "MH", score)
 }
 
 func TestCalculatePoolStandings_WithManualOverrides(t *testing.T) {

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -625,6 +625,11 @@ func parseWinnerOf(s string, numRounds int) (int, int) {
 	return numRounds - depth, matchIdx
 }
 
+// formatScore renders a side's ippons plus any "(HN)" hansoku suffix for the
+// Excel bracket cell. Since PR #110 hansoku is 0 or 1 (outstanding undischarged
+// fouls); the discharged pair appears as an "H" ippon in the opponent's slice
+// instead of a redundant counter on this side. Values >1 only surface when
+// reading legacy disk entries written before the shift.
 func formatScore(ippons []string, hansoku int) string {
 	score := strings.Join(ippons, "")
 	if hansoku > 0 {


### PR DESCRIPTION
## Summary
- Adds a doc comment on `formatScore` (internal/engine/scoring.go) explaining the post-PR-#110 invariant: hansoku is 0 or 1 (outstanding undischarged fouls), values >1 only appear when reading legacy disk entries.
- Extends `TestFormatScore_HansokuOnly` to pin the post-fix behaviour: `formatScore([]string{"H"}, 0)` → `"H"` and `formatScore([]string{"M", "H"}, 0)` → `"MH"` — no redundant `(H...)` suffix alongside the H ippon recorded in the opponent's slice.

## Why
PR #110 shifted hansoku semantics from "cumulative raw count" to "outstanding fouls not yet discharged". Post-fix saves stopped showing the redundant `(H2)` suffix because the H ippon already appears in the opponent's score. The renderer itself didn't change but its contract did — the existing test only pinned the legacy code path, leaving the new path unmarked. Decision: accept the cleaner display (Option 1 in the bead) — restoring cumulative display would overcount when H ippons are manually entered rather than foul-derived.

Closes bracket-creator-6m9.

## Test plan
- [x] `go test -run TestFormatScore_HansokuOnly ./internal/engine/...`
- [x] `go test ./internal/...`
- [ ] Manual: open `make examples` output and confirm no scoring regression in the rendered Excel brackets

🤖 Generated with [Claude Code](https://claude.com/claude-code)