### PR TITLE
feat(viewer): surface queue position on MyMatchPanel

### DIFF
--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -14,8 +14,8 @@ import (
 )
 
 // annotateQueuePositions fills in MatchResult.QueuePosition for each
-// element of matches in-place, using the same per-court sort key as
-// annotateBracketQueuePositions and the viewer's ScheduleViewer.
+// element of matches in-place, delegating to state.DeriveQueuePositions
+// for the per-court (status priority, ScheduledAt, original index) sort.
 //
 // FR-025, T036: queue positions are derived at serve time rather than
 // persisted — a stored value would go stale the instant any match
@@ -25,73 +25,13 @@ import (
 // "next up: 3" without any background recomputation job. Score-write
 // endpoints return a single MatchResult and intentionally do NOT
 // annotate (a single match has no list ordering to derive against).
-//
-// Ordering basis: per-court, sort by (status priority, ScheduledAt,
-// original slice index) so the result agrees with the bracket helper
-// and with the JS SSE recompute in web-mobile/js/patch.jsx
-// (_orderByCourtKey). UpdateMatchTime / UpdateMatchCourt mutate
-// ScheduledAt/Court in place without reordering pool-matches.csv,
-// so without this sort a subsequent GET refresh would assign
-// queuePosition values that disagree with the viewer's render order —
-// causing flicker / wrong labels after reschedules.
 func annotateQueuePositions(matches []state.MatchResult) {
 	if len(matches) == 0 {
 		return
 	}
-	// Collect indices per court, then sort each bucket and assign.
-	type entry struct {
-		idx   int
-		match *state.MatchResult
-	}
-	byCourt := make(map[string][]entry, 4)
+	positions := state.DeriveQueuePositions(matches)
 	for i := range matches {
-		byCourt[matches[i].Court] = append(byCourt[matches[i].Court], entry{idx: i, match: &matches[i]})
-	}
-
-	statusOrder := func(s state.MatchStatus) int {
-		switch s {
-		case state.MatchStatusRunning:
-			return 0
-		case state.MatchStatusScheduled:
-			return 1
-		default:
-			return 2
-		}
-	}
-
-	// Reset all positions first so non-scheduled stays at 0 even if a
-	// stale persisted value were present (mirror of bracket helper).
-	for i := range matches {
-		matches[i].QueuePosition = 0
-	}
-
-	for _, entries := range byCourt {
-		sort.SliceStable(entries, func(i, j int) bool {
-			oi, oj := statusOrder(entries[i].match.Status), statusOrder(entries[j].match.Status)
-			if oi != oj {
-				return oi < oj
-			}
-			ai := entries[i].match.ScheduledAt
-			aj := entries[j].match.ScheduledAt
-			if ai == "" {
-				ai = "99:99"
-			}
-			if aj == "" {
-				aj = "99:99"
-			}
-			if ai != aj {
-				return ai < aj
-			}
-			return entries[i].idx < entries[j].idx
-		})
-
-		counter := 0
-		for _, e := range entries {
-			if e.match.Status == state.MatchStatusScheduled {
-				counter++
-				e.match.QueuePosition = counter
-			}
-		}
+		matches[i].QueuePosition = positions[i]
 	}
 }
 

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -34,22 +35,81 @@ func annotateQueuePositions(matches []state.MatchResult) {
 }
 
 // annotateBracketQueuePositions fills in BracketMatch.QueuePosition for each
-// scheduled bracket match in-place, using the same per-court counter logic as
-// annotateQueuePositions. Matches are visited in round then position order,
-// which matches the iteration order in the viewer's compMatches() helper.
+// bracket match in-place. Non-scheduled matches are explicitly reset to 0 so
+// any stale value previously persisted in bracket.json (or written by future
+// code paths) cannot leak back out to clients via the omitempty JSON tag.
+//
+// The ordering basis matches the viewer's ScheduleViewer (web-mobile/js/
+// viewer.jsx around the byCourt sort): pointers to all bracket matches are
+// gathered, then sorted per-court by (status priority, ScheduledAt, round,
+// position) before the per-court counter is incremented. This keeps the
+// "Next up / N before yours" label consistent with the row order the viewer
+// actually renders, even when bracket matches are scheduled out of round
+// order (e.g., a finals court that started 30 minutes early).
 func annotateBracketQueuePositions(b *state.Bracket) {
 	if b == nil {
 		return
 	}
-	counters := make(map[string]int)
+
+	// Group pointers per court, preserving the round/position pair as a
+	// stable tie-break key. We can't sort b.Rounds itself — the bracket
+	// tree structure is load-bearing for the renderer.
+	type entry struct {
+		m        *state.BracketMatch
+		round    int
+		position int
+	}
+	byCourt := make(map[string][]entry)
 	for ri := range b.Rounds {
 		for mi := range b.Rounds[ri] {
 			m := &b.Rounds[ri][mi]
-			if m.Status == state.MatchStatusScheduled {
-				counters[m.Court]++
-				m.QueuePosition = counters[m.Court]
+			byCourt[m.Court] = append(byCourt[m.Court], entry{m: m, round: ri, position: mi})
+		}
+	}
+
+	statusOrder := func(s state.MatchStatus) int {
+		switch s {
+		case state.MatchStatusRunning:
+			return 0
+		case state.MatchStatusScheduled:
+			return 1
+		default: // completed and any future status
+			return 2
+		}
+	}
+
+	for _, entries := range byCourt {
+		sort.SliceStable(entries, func(i, j int) bool {
+			oi, oj := statusOrder(entries[i].m.Status), statusOrder(entries[j].m.Status)
+			if oi != oj {
+				return oi < oj
+			}
+			// Empty scheduledAt sinks to the end (mirrors the JS
+			// fallback to "99:99" in ScheduleViewer's sort).
+			ai := entries[i].m.ScheduledAt
+			aj := entries[j].m.ScheduledAt
+			if ai == "" {
+				ai = "99:99"
+			}
+			if aj == "" {
+				aj = "99:99"
+			}
+			if ai != aj {
+				return ai < aj
+			}
+			if entries[i].round != entries[j].round {
+				return entries[i].round < entries[j].round
+			}
+			return entries[i].position < entries[j].position
+		})
+
+		counter := 0
+		for _, e := range entries {
+			if e.m.Status == state.MatchStatusScheduled {
+				counter++
+				e.m.QueuePosition = counter
 			} else {
-				m.QueuePosition = 0
+				e.m.QueuePosition = 0
 			}
 		}
 	}

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -48,6 +48,8 @@ func annotateBracketQueuePositions(b *state.Bracket) {
 			if m.Status == state.MatchStatusScheduled {
 				counters[m.Court]++
 				m.QueuePosition = counters[m.Court]
+			} else {
+				m.QueuePosition = 0
 			}
 		}
 	}

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -14,7 +14,8 @@ import (
 )
 
 // annotateQueuePositions fills in MatchResult.QueuePosition for each
-// element of matches in-place, using state.DeriveQueuePositions.
+// element of matches in-place, using the same per-court sort key as
+// annotateBracketQueuePositions and the viewer's ScheduleViewer.
 //
 // FR-025, T036: queue positions are derived at serve time rather than
 // persisted — a stored value would go stale the instant any match
@@ -24,13 +25,73 @@ import (
 // "next up: 3" without any background recomputation job. Score-write
 // endpoints return a single MatchResult and intentionally do NOT
 // annotate (a single match has no list ordering to derive against).
+//
+// Ordering basis: per-court, sort by (status priority, ScheduledAt,
+// original slice index) so the result agrees with the bracket helper
+// and with the JS SSE recompute in web-mobile/js/patch.jsx
+// (_orderByCourtKey). UpdateMatchTime / UpdateMatchCourt mutate
+// ScheduledAt/Court in place without reordering pool-matches.csv,
+// so without this sort a subsequent GET refresh would assign
+// queuePosition values that disagree with the viewer's render order —
+// causing flicker / wrong labels after reschedules.
 func annotateQueuePositions(matches []state.MatchResult) {
 	if len(matches) == 0 {
 		return
 	}
-	positions := state.DeriveQueuePositions(matches)
+	// Collect indices per court, then sort each bucket and assign.
+	type entry struct {
+		idx   int
+		match *state.MatchResult
+	}
+	byCourt := make(map[string][]entry, 4)
 	for i := range matches {
-		matches[i].QueuePosition = positions[i]
+		byCourt[matches[i].Court] = append(byCourt[matches[i].Court], entry{idx: i, match: &matches[i]})
+	}
+
+	statusOrder := func(s state.MatchStatus) int {
+		switch s {
+		case state.MatchStatusRunning:
+			return 0
+		case state.MatchStatusScheduled:
+			return 1
+		default:
+			return 2
+		}
+	}
+
+	// Reset all positions first so non-scheduled stays at 0 even if a
+	// stale persisted value were present (mirror of bracket helper).
+	for i := range matches {
+		matches[i].QueuePosition = 0
+	}
+
+	for _, entries := range byCourt {
+		sort.SliceStable(entries, func(i, j int) bool {
+			oi, oj := statusOrder(entries[i].match.Status), statusOrder(entries[j].match.Status)
+			if oi != oj {
+				return oi < oj
+			}
+			ai := entries[i].match.ScheduledAt
+			aj := entries[j].match.ScheduledAt
+			if ai == "" {
+				ai = "99:99"
+			}
+			if aj == "" {
+				aj = "99:99"
+			}
+			if ai != aj {
+				return ai < aj
+			}
+			return entries[i].idx < entries[j].idx
+		})
+
+		counter := 0
+		for _, e := range entries {
+			if e.match.Status == state.MatchStatusScheduled {
+				counter++
+				e.match.QueuePosition = counter
+			}
+		}
 	}
 }
 

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -33,6 +33,26 @@ func annotateQueuePositions(matches []state.MatchResult) {
 	}
 }
 
+// annotateBracketQueuePositions fills in BracketMatch.QueuePosition for each
+// scheduled bracket match in-place, using the same per-court counter logic as
+// annotateQueuePositions. Matches are visited in round then position order,
+// which matches the iteration order in the viewer's compMatches() helper.
+func annotateBracketQueuePositions(b *state.Bracket) {
+	if b == nil {
+		return
+	}
+	counters := make(map[string]int)
+	for ri := range b.Rounds {
+		for mi := range b.Rounds[ri] {
+			m := &b.Rounds[ri][mi]
+			if m.Status == state.MatchStatusScheduled {
+				counters[m.Court]++
+				m.QueuePosition = counters[m.Court]
+			}
+		}
+	}
+}
+
 // enchoExceedsCap reports whether an encho block would exceed the
 // competition's MaxEnchoPeriods cap. Returns false (within limit) when
 // encho is unset, comp is nil, the cap is 0 (unlimited — FIK default),

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -802,3 +802,53 @@ func TestAnnotateQueuePositions_Empty(t *testing.T) {
 	annotateQueuePositions(nil)
 	annotateQueuePositions([]state.MatchResult{})
 }
+
+// TestAnnotateBracketQueuePositions_* mirrors the annotateQueuePositions tests
+// for the bracket variant (BracketMatch), covering multiple courts, mixed
+// statuses, nil/empty inputs, and stale-value reset.
+func TestAnnotateBracketQueuePositions_Nil(t *testing.T) {
+	annotateBracketQueuePositions(nil) // must not panic
+}
+
+func TestAnnotateBracketQueuePositions_Empty(t *testing.T) {
+	annotateBracketQueuePositions(&state.Bracket{})
+	annotateBracketQueuePositions(&state.Bracket{Rounds: [][]state.BracketMatch{}})
+}
+
+func TestAnnotateBracketQueuePositions_MultipleCourts(t *testing.T) {
+	b := &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{
+				{ID: "r1m1", Court: "A", Status: state.MatchStatusScheduled},
+				{ID: "r1m2", Court: "B", Status: state.MatchStatusScheduled},
+			},
+			{
+				{ID: "r2m1", Court: "A", Status: state.MatchStatusScheduled},
+			},
+		},
+	}
+	annotateBracketQueuePositions(b)
+
+	assert.Equal(t, 1, b.Rounds[0][0].QueuePosition, "r1m1: first on court A")
+	assert.Equal(t, 1, b.Rounds[0][1].QueuePosition, "r1m2: first on court B")
+	assert.Equal(t, 2, b.Rounds[1][0].QueuePosition, "r2m1: second on court A")
+}
+
+func TestAnnotateBracketQueuePositions_MixedStatuses(t *testing.T) {
+	b := &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{
+				{ID: "m1", Court: "A", Status: state.MatchStatusRunning, QueuePosition: 99},
+				{ID: "m2", Court: "A", Status: state.MatchStatusScheduled},
+				{ID: "m3", Court: "A", Status: state.MatchStatusCompleted, QueuePosition: 77},
+				{ID: "m4", Court: "A", Status: state.MatchStatusScheduled},
+			},
+		},
+	}
+	annotateBracketQueuePositions(b)
+
+	assert.Equal(t, 0, b.Rounds[0][0].QueuePosition, "running: stale value reset to 0")
+	assert.Equal(t, 1, b.Rounds[0][1].QueuePosition, "first scheduled on court A")
+	assert.Equal(t, 0, b.Rounds[0][2].QueuePosition, "completed: stale value reset to 0")
+	assert.Equal(t, 2, b.Rounds[0][3].QueuePosition, "second scheduled on court A")
+}

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -803,6 +803,42 @@ func TestAnnotateQueuePositions_Empty(t *testing.T) {
 	annotateQueuePositions([]state.MatchResult{})
 }
 
+// TestAnnotateQueuePositions_ScheduledAtOrder verifies that the annotator
+// sorts per-court by ScheduledAt rather than relying on slice order.
+// UpdateMatchTime / UpdateMatchCourt mutate the underlying CSV in place
+// without reordering rows, so the server-side annotation must derive
+// ordering from the data — not the storage order — to agree with the
+// viewer's render order and the client-side SSE recompute. Copilot
+// flagged this on PR #124 (web-mobile/js/patch.jsx:110).
+func TestAnnotateQueuePositions_ScheduledAtOrder(t *testing.T) {
+	matches := []state.MatchResult{
+		// Storage order is out of schedule order: the 09:30 row sits
+		// before the 09:00 row on the same court.
+		{ID: "m1", Court: "A", ScheduledAt: "09:30", Status: state.MatchStatusScheduled},
+		{ID: "m2", Court: "A", ScheduledAt: "09:00", Status: state.MatchStatusScheduled},
+		{ID: "m3", Court: "B", ScheduledAt: "09:15", Status: state.MatchStatusScheduled},
+	}
+	annotateQueuePositions(matches)
+	// m2 (09:00) is up-next on court A, m1 (09:30) is queue-position 2.
+	assert.Equal(t, 2, matches[0].QueuePosition) // m1 at 09:30
+	assert.Equal(t, 1, matches[1].QueuePosition) // m2 at 09:00
+	assert.Equal(t, 1, matches[2].QueuePosition) // m3 on court B
+}
+
+// TestAnnotateQueuePositions_StaleReset verifies that non-scheduled rows
+// have their QueuePosition forced to 0 even if a stale persisted value
+// were present — mirroring the bracket-variant guard so omitempty drops
+// the field cleanly on the wire.
+func TestAnnotateQueuePositions_StaleReset(t *testing.T) {
+	matches := []state.MatchResult{
+		{ID: "m1", Court: "A", Status: state.MatchStatusRunning, QueuePosition: 99},
+		{ID: "m2", Court: "A", Status: state.MatchStatusScheduled, QueuePosition: 77},
+	}
+	annotateQueuePositions(matches)
+	assert.Equal(t, 0, matches[0].QueuePosition)
+	assert.Equal(t, 1, matches[1].QueuePosition)
+}
+
 // TestAnnotateBracketQueuePositions_* mirrors the annotateQueuePositions tests
 // for the bracket variant (BracketMatch), covering multiple courts, mixed
 // statuses, nil/empty inputs, and stale-value reset.

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -852,3 +852,73 @@ func TestAnnotateBracketQueuePositions_MixedStatuses(t *testing.T) {
 	assert.Equal(t, 0, b.Rounds[0][2].QueuePosition, "completed: stale value reset to 0")
 	assert.Equal(t, 2, b.Rounds[0][3].QueuePosition, "second scheduled on court A")
 }
+
+// TestAnnotateBracketQueuePositions_ScheduledAtOrdering verifies that queue
+// positions follow per-court ScheduledAt ordering, not storage order.
+// Mirrors the viewer's ScheduleViewer per-court sort so the "N before yours"
+// label is consistent with the row order the user actually sees.
+func TestAnnotateBracketQueuePositions_ScheduledAtOrdering(t *testing.T) {
+	// Round 0 holds an early match scheduled at 11:00 on court A; round 1
+	// holds an earlier-scheduled match (10:30) on the same court. The
+	// later round should rank first because its scheduledAt is earlier.
+	b := &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{
+				{ID: "r0m0", Court: "A", ScheduledAt: "11:00", Status: state.MatchStatusScheduled},
+				{ID: "r0m1", Court: "A", ScheduledAt: "11:30", Status: state.MatchStatusScheduled},
+			},
+			{
+				{ID: "r1m0", Court: "A", ScheduledAt: "10:30", Status: state.MatchStatusScheduled},
+			},
+		},
+	}
+	annotateBracketQueuePositions(b)
+
+	assert.Equal(t, 2, b.Rounds[0][0].QueuePosition, "r0m0 @ 11:00 = 2nd on court A")
+	assert.Equal(t, 3, b.Rounds[0][1].QueuePosition, "r0m1 @ 11:30 = 3rd on court A")
+	assert.Equal(t, 1, b.Rounds[1][0].QueuePosition, "r1m0 @ 10:30 = 1st on court A despite later round")
+}
+
+// TestAnnotateBracketQueuePositions_RunningRanksFirst verifies that a
+// running match counts ahead of scheduled siblings in the per-court sort
+// (status priority dominates ScheduledAt), matching the viewer.
+func TestAnnotateBracketQueuePositions_RunningRanksFirst(t *testing.T) {
+	b := &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{
+				// Scheduled match at 10:00, but a running match at 11:00
+				// should be ordered first because status=running has the
+				// highest priority in the viewer's sort.
+				{ID: "sched", Court: "A", ScheduledAt: "10:00", Status: state.MatchStatusScheduled},
+				{ID: "live", Court: "A", ScheduledAt: "11:00", Status: state.MatchStatusRunning},
+			},
+		},
+	}
+	annotateBracketQueuePositions(b)
+
+	// Only the scheduled match gets a 1-indexed position; the running
+	// match keeps QueuePosition=0 (it isn't "in queue"). But because the
+	// running match ranks ahead in the sort, the counter doesn't
+	// increment past it before reaching the scheduled match — so the
+	// scheduled match's position is still 1, not 2.
+	assert.Equal(t, 0, b.Rounds[0][1].QueuePosition, "running has no queue position")
+	assert.Equal(t, 1, b.Rounds[0][0].QueuePosition, "lone scheduled = position 1")
+}
+
+// TestAnnotateBracketQueuePositions_EmptyScheduledAt verifies that matches
+// without a ScheduledAt fall to the end of their per-court bucket (matches
+// the JS fallback to "99:99" in ScheduleViewer's sort).
+func TestAnnotateBracketQueuePositions_EmptyScheduledAt(t *testing.T) {
+	b := &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{
+				{ID: "no-time", Court: "A", ScheduledAt: "", Status: state.MatchStatusScheduled},
+				{ID: "has-time", Court: "A", ScheduledAt: "10:00", Status: state.MatchStatusScheduled},
+			},
+		},
+	}
+	annotateBracketQueuePositions(b)
+
+	assert.Equal(t, 1, b.Rounds[0][1].QueuePosition, "has-time = 1st")
+	assert.Equal(t, 2, b.Rounds[0][0].QueuePosition, "no-time = 2nd (sinks to end)")
+}

--- a/internal/mobileapp/handlers_viewer.go
+++ b/internal/mobileapp/handlers_viewer.go
@@ -79,6 +79,7 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 				// so viewers see "Next up: 3" without persisting a value that
 				// would go stale the moment any match transitions.
 				annotateQueuePositions(poolMatches)
+				annotateBracketQueuePositions(bracket)
 
 				results[idx] = gin.H{
 					"config":      comp,
@@ -130,7 +131,7 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 			pools         any
 			poolMatches   []state.MatchResult
 			standings     any
-			bracket       any
+			bracket       *state.Bracket
 			schedule      any
 			reservedSlots []state.ReservedSlot
 
@@ -189,6 +190,7 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 		// FR-025, T036: derive per-court queue position at serve time —
 		// see annotateQueuePositions for rationale.
 		annotateQueuePositions(poolMatches)
+		annotateBracketQueuePositions(bracket)
 
 		c.JSON(http.StatusOK, gin.H{
 			"config":        comp,

--- a/internal/state/match.go
+++ b/internal/state/match.go
@@ -1,23 +1,73 @@
 package state
 
+import "sort"
+
 // DeriveQueuePositions assigns a 1-indexed queue position to each
 // scheduled match per court. Live (running) and completed matches
-// receive 0. The slice ordering of the input is treated as the queue
-// order — typically callers sort by scheduledAt or insertion order
-// before calling this.
+// receive 0.
+//
+// Ordering: within each court, positions are assigned in
+// (status priority, scheduledAt, original index) order — the same
+// basis used by ScheduleViewer (viewer.jsx) and the client-side SSE
+// recompute (_orderByCourtKey in patch.jsx) — so "Next up / N before
+// yours" labels are consistent between server responses and the
+// post-SSE client view.
 //
 // FR-025, R3: positions are recomputed at serve time and on every SSE
 // match-state change so viewers see the queue shrink as matches finish.
 // The function is pure and side-effect-free; the caller is responsible
-// for assigning the returned positions onto a separate MatchResult slice
-// if the wire payload needs them.
+// for assigning the returned positions onto the MatchResult slice.
 func DeriveQueuePositions(matches []MatchResult) []int {
 	positions := make([]int, len(matches))
-	counters := make(map[string]int)
+	if len(matches) == 0 {
+		return positions
+	}
+
+	type entry struct {
+		idx int
+		m   MatchResult
+	}
+	byCourt := make(map[string][]entry)
 	for i, m := range matches {
-		if m.Status == MatchStatusScheduled {
-			counters[m.Court]++
-			positions[i] = counters[m.Court]
+		byCourt[m.Court] = append(byCourt[m.Court], entry{idx: i, m: m})
+	}
+
+	statusOrder := func(s MatchStatus) int {
+		switch s {
+		case MatchStatusRunning:
+			return 0
+		case MatchStatusScheduled:
+			return 1
+		default:
+			return 2
+		}
+	}
+
+	for _, entries := range byCourt {
+		sort.SliceStable(entries, func(i, j int) bool {
+			oi, oj := statusOrder(entries[i].m.Status), statusOrder(entries[j].m.Status)
+			if oi != oj {
+				return oi < oj
+			}
+			ai := entries[i].m.ScheduledAt
+			if ai == "" {
+				ai = "99:99"
+			}
+			aj := entries[j].m.ScheduledAt
+			if aj == "" {
+				aj = "99:99"
+			}
+			if ai != aj {
+				return ai < aj
+			}
+			return entries[i].idx < entries[j].idx
+		})
+		counter := 0
+		for _, e := range entries {
+			if e.m.Status == MatchStatusScheduled {
+				counter++
+				positions[e.idx] = counter
+			}
 		}
 	}
 	return positions

--- a/internal/state/match_test.go
+++ b/internal/state/match_test.go
@@ -9,13 +9,9 @@ import (
 // TestQueuePositionDerivation verifies FR-025: per-court queue positions
 // are derived (not stored) from a list of MatchResult values.
 //
-// Rule: live (running) matches and completed matches both have
-// queuePosition = 0. Scheduled (non-completed) matches on the same court
-// are numbered 1, 2, 3, ... in list order.
-//
-// This is a Red test — DeriveQueuePositions does not yet exist in the
-// state package and the build must fail until the Green implementation
-// (T034 family) lands.
+// Positions are assigned in (status priority, scheduledAt, original index)
+// order within each court — matching ScheduleViewer and the JS SSE recompute.
+// Running and completed matches receive 0.
 func TestQueuePositionDerivation(t *testing.T) {
 	input := []MatchResult{
 		{ID: "m1", Status: MatchStatusRunning, Court: "A"},
@@ -28,5 +24,39 @@ func TestQueuePositionDerivation(t *testing.T) {
 	got := DeriveQueuePositions(input)
 
 	assert.Equal(t, []int{0, 1, 2, 0, 3}, got,
-		"queue positions: live=0, scheduled counted in order, completed=0")
+		"queue positions: running=0, scheduled counted in (scheduledAt,idx) order, completed=0")
+}
+
+// TestQueuePositionDerivation_ScheduledAtOrdering verifies that within a court
+// the queue counter increments in scheduledAt order, not slice order.
+// A match at 09:00 that appears after a match at 10:00 in the slice must
+// receive a lower (earlier) queue position — consistent with ScheduleViewer
+// and _orderByCourtKey in patch.jsx.
+func TestQueuePositionDerivation_ScheduledAtOrdering(t *testing.T) {
+	input := []MatchResult{
+		{ID: "late", Status: MatchStatusScheduled, Court: "A", ScheduledAt: "10:00"},
+		{ID: "early", Status: MatchStatusScheduled, Court: "A", ScheduledAt: "09:00"},
+	}
+
+	got := DeriveQueuePositions(input)
+
+	// "early" should be position 1, "late" should be position 2,
+	// regardless of their slice order.
+	assert.Equal(t, []int{2, 1}, got,
+		"scheduledAt ordering: earlier time wins lower queue position regardless of slice order")
+}
+
+// TestQueuePositionDerivation_MultipleCourts verifies independent per-court counters.
+func TestQueuePositionDerivation_MultipleCourts(t *testing.T) {
+	input := []MatchResult{
+		{ID: "a1", Status: MatchStatusScheduled, Court: "A", ScheduledAt: "09:00"},
+		{ID: "b1", Status: MatchStatusScheduled, Court: "B", ScheduledAt: "09:30"},
+		{ID: "a2", Status: MatchStatusScheduled, Court: "A", ScheduledAt: "09:30"},
+		{ID: "b2", Status: MatchStatusRunning, Court: "B"},
+	}
+
+	got := DeriveQueuePositions(input)
+
+	assert.Equal(t, []int{1, 1, 2, 0}, got,
+		"per-court counters are independent; running gets 0")
 }

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -291,9 +291,10 @@ type BracketMatch struct {
 	Court       string      `json:"court"`
 	ScheduledAt string      `json:"scheduledAt"`
 	// Additional fields from design
-	ScoreA       string `json:"scoreA"`
-	ScoreB       string `json:"scoreB"`
-	IsOverridden bool   `json:"isOverridden"`
+	ScoreA        string `json:"scoreA"`
+	ScoreB        string `json:"scoreB"`
+	IsOverridden  bool   `json:"isOverridden"`
+	QueuePosition int    `json:"queuePosition,omitempty"`
 	// Decision-type metadata mirrors MatchResult so an elimination-stage
 	// kiken/fusenpai/encho is reconstructable from bracket.json alone
 	// (label rendering, Excel export, SSE replays).

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -168,6 +168,28 @@ describe('applyPatch', () => {
     expect(next.poolMatches[1].queuePosition).toBe(1);
   });
 
+  // Admin correction case: an SSE patch can revert a completed match back
+  // to scheduled (status set via the score endpoint). The match re-enters
+  // the per-court queue and should claim a non-zero queuePosition while
+  // shifting siblings down. Copilot flagged this on PR #124.
+  it('recomputes queue positions when a completed match transitions back to scheduled', () => {
+    const prev = {
+      poolMatches: [
+        { id: "p1", court: "A", scheduledAt: "09:00", status: "completed", queuePosition: 0 },
+        { id: "p2", court: "A", scheduledAt: "09:10", status: "scheduled", queuePosition: 1 },
+        { id: "p3", court: "A", scheduledAt: "09:20", status: "scheduled", queuePosition: 2 },
+      ],
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "p1", status: "scheduled", winner: null } },
+    });
+    expect(next.poolMatches[0].status).toBe("scheduled");
+    // p1 re-enters the queue at qp=1 (array order); p2 and p3 shift down.
+    expect(next.poolMatches[0].queuePosition).toBe(1);
+    expect(next.poolMatches[1].queuePosition).toBe(2);
+    expect(next.poolMatches[2].queuePosition).toBe(3);
+  });
+
   it('does not recompute queue positions when patch does not change scheduled status', () => {
     const prev = {
       poolMatches: [

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyPatch, recomputeQueuePositions } from '../patch.jsx';
+import { applyPatch, recomputeQueuePositions, recomputeBracketQueuePositions } from '../patch.jsx';
 
 // Tests for the centralised SSE-patch applier (Slice 0 / NFR-006).
 // applyPatch composes mergeMatchPatch (covered in mergeMatchPatch.test.jsx)
@@ -208,5 +208,123 @@ describe('recomputeQueuePositions', () => {
       { id: "a2", court: "A", status: "scheduled" },
     ];
     expect(recomputeQueuePositions(matches)).toBe(matches);
+  });
+});
+
+// FR-025: bracket-side queue position recompute. Mirrors the pool helper
+// tests above. Without this, a knockout-only competition would show
+// stale "N before yours" labels for ~500-1000ms after a bracket match
+// completes (until the jittered GET refresh lands).
+describe('recomputeBracketQueuePositions', () => {
+  it('assigns per-court 1-indexed positions to scheduled bracket matches across rounds', () => {
+    const bracket = {
+      rounds: [
+        [
+          { id: "r1m1", court: "A", status: "scheduled", queuePosition: 99 },
+          { id: "r1m2", court: "B", status: "scheduled" },
+        ],
+        [
+          { id: "r2m1", court: "A", status: "scheduled" },
+        ],
+      ],
+    };
+    const out = recomputeBracketQueuePositions(bracket);
+    expect(out.rounds[0][0].queuePosition).toBe(1);
+    expect(out.rounds[0][1].queuePosition).toBe(1);
+    expect(out.rounds[1][0].queuePosition).toBe(2);
+  });
+
+  it('assigns 0 to running/completed bracket matches', () => {
+    const bracket = {
+      rounds: [
+        [
+          { id: "r1m1", court: "A", status: "running", queuePosition: 99 },
+          { id: "r1m2", court: "A", status: "scheduled" },
+          { id: "r1m3", court: "A", status: "completed", queuePosition: 77 },
+          { id: "r1m4", court: "A", status: "scheduled" },
+        ],
+      ],
+    };
+    const out = recomputeBracketQueuePositions(bracket);
+    expect(out.rounds[0][0].queuePosition).toBe(0);
+    expect(out.rounds[0][1].queuePosition).toBe(1);
+    expect(out.rounds[0][2].queuePosition).toBe(0);
+    expect(out.rounds[0][3].queuePosition).toBe(2);
+  });
+
+  it('preserves identity when nothing needs to change', () => {
+    const bracket = {
+      rounds: [
+        [
+          { id: "r1m1", court: "A", status: "scheduled", queuePosition: 1 },
+          { id: "r1m2", court: "A", status: "scheduled", queuePosition: 2 },
+        ],
+      ],
+    };
+    expect(recomputeBracketQueuePositions(bracket)).toBe(bracket);
+  });
+
+  it('no-ops when no round has a populated queuePosition (older server)', () => {
+    const bracket = {
+      rounds: [
+        [
+          { id: "r1m1", court: "A", status: "scheduled" },
+          { id: "r1m2", court: "A", status: "scheduled" },
+        ],
+      ],
+    };
+    expect(recomputeBracketQueuePositions(bracket)).toBe(bracket);
+  });
+
+  it('handles nil / empty / malformed bracket gracefully', () => {
+    expect(recomputeBracketQueuePositions(null)).toBeNull();
+    expect(recomputeBracketQueuePositions(undefined)).toBeUndefined();
+    expect(recomputeBracketQueuePositions({})).toEqual({});
+    const emptyRounds = { rounds: [] };
+    expect(recomputeBracketQueuePositions(emptyRounds)).toBe(emptyRounds);
+  });
+
+  it('applyPatch recomputes bracket queuePositions on completion', () => {
+    // The applyPatch SSE integration: a single bracket match transitions
+    // to completed; its scheduled siblings on the same court should drop
+    // by one slot. Mirrors the existing pool integration test.
+    const prev = {
+      bracket: {
+        rounds: [
+          [
+            { id: "b1", court: "A", scheduledAt: "11:00", status: "scheduled", queuePosition: 1 },
+            { id: "b2", court: "A", scheduledAt: "11:10", status: "scheduled", queuePosition: 2 },
+            { id: "b3", court: "B", scheduledAt: "11:00", status: "scheduled", queuePosition: 1 },
+          ],
+        ],
+      },
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "b1", winner: "Alice", status: "completed" } },
+    });
+    expect(next.bracket.rounds[0][0].status).toBe("completed");
+    expect(next.bracket.rounds[0][0].queuePosition).toBe(0);
+    expect(next.bracket.rounds[0][1].queuePosition).toBe(1);
+    // Court B is untouched
+    expect(next.bracket.rounds[0][2].queuePosition).toBe(1);
+  });
+
+  it('applyPatch does not recompute bracket queue positions on non-completion', () => {
+    const prev = {
+      bracket: {
+        rounds: [
+          [
+            { id: "b1", court: "A", status: "scheduled", queuePosition: 1 },
+            { id: "b2", court: "A", status: "scheduled", queuePosition: 2 },
+          ],
+        ],
+      },
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "b1", status: "running" } },
+    });
+    expect(next.bracket.rounds[0][0].status).toBe("running");
+    // sibling untouched — same reference
+    expect(next.bracket.rounds[0][1]).toBe(prev.bracket.rounds[0][1]);
   });
 });

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -301,12 +301,27 @@ describe('recomputeQueuePositions', () => {
     expect(out[1].queuePosition).toBe(2);
   });
 
-  it('no-ops when no matches are scheduled (all running/completed)', () => {
+  it('no-ops when no matches are scheduled and no stale qps to clear', () => {
     const matches = [
       { id: "a1", court: "A", status: "running" },
       { id: "a2", court: "A", status: "completed" },
     ];
     expect(recomputeQueuePositions(matches)).toBe(matches);
+  });
+
+  it('clears stale non-zero queuePosition when the last scheduled match transitions off', () => {
+    // The contract is that non-scheduled matches must have queuePosition === 0.
+    // When the last scheduled match in a court flips to running/completed,
+    // _mergeMatchPatch preserves the old queuePosition field, so the recompute
+    // must still run to zero it out — even though no match is `scheduled`.
+    const matches = [
+      { id: "a1", court: "A", status: "running", queuePosition: 1 },
+      { id: "a2", court: "A", status: "completed", queuePosition: 0 },
+    ];
+    const out = recomputeQueuePositions(matches);
+    expect(out).not.toBe(matches);
+    expect(out[0].queuePosition).toBe(0);
+    expect(out[1].queuePosition).toBe(0);
   });
 });
 
@@ -380,7 +395,7 @@ describe('recomputeBracketQueuePositions', () => {
     expect(out.rounds[0][1].queuePosition).toBe(2);
   });
 
-  it('no-ops when no bracket match is scheduled (all running/completed)', () => {
+  it('no-ops when no bracket match is scheduled and no stale qps to clear', () => {
     const bracket = {
       rounds: [
         [
@@ -390,6 +405,24 @@ describe('recomputeBracketQueuePositions', () => {
       ],
     };
     expect(recomputeBracketQueuePositions(bracket)).toBe(bracket);
+  });
+
+  it('clears stale non-zero queuePosition on bracket matches that transitioned off scheduled', () => {
+    // Mirror of the pool case: when the last scheduled bracket match
+    // completes, the recompute must still zero out the stale qp left
+    // behind by _mergeMatchPatch.
+    const bracket = {
+      rounds: [
+        [
+          { id: "r1m1", court: "A", status: "running", queuePosition: 1 },
+          { id: "r1m2", court: "A", status: "completed", queuePosition: 0 },
+        ],
+      ],
+    };
+    const out = recomputeBracketQueuePositions(bracket);
+    expect(out).not.toBe(bracket);
+    expect(out.rounds[0][0].queuePosition).toBe(0);
+    expect(out.rounds[0][1].queuePosition).toBe(0);
   });
 
   it('handles nil / empty / malformed bracket gracefully', () => {

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -176,6 +176,33 @@ describe('applyPatch', () => {
     // sibling untouched — same reference
     expect(next.poolMatches[1]).toBe(prev.poolMatches[1]);
   });
+
+  it('recomputes pool queue positions when a scheduled match moves to a different court', () => {
+    // p1 starts on court A (qp=1) and moves to court B. recomputeQueuePositions
+    // walks the array in order, so p1 lands at B-qp=1 and b1 shifts down to
+    // B-qp=2; p2 becomes A-qp=1. The point is *that the recompute happens at
+    // all* (not waiting for a refetch) — the exact numbering follows the
+    // existing helper's array-order contract.
+    const prev = {
+      poolMatches: [
+        { id: "p1", court: "A", scheduledAt: "09:00", status: "scheduled", queuePosition: 1 },
+        { id: "p2", court: "A", scheduledAt: "09:10", status: "scheduled", queuePosition: 2 },
+        { id: "b1", court: "B", scheduledAt: "08:30", status: "scheduled", queuePosition: 1 },
+      ],
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "p1", court: "B", scheduledAt: "09:00", status: "scheduled" } },
+    });
+    const byId = Object.fromEntries(next.poolMatches.map(m => [m.id, m]));
+    expect(byId.p1.court).toBe("B");
+    expect(byId.p1.queuePosition).toBe(1);
+    expect(byId.p2.queuePosition).toBe(1);
+    expect(byId.b1.queuePosition).toBe(2);
+    // Sibling identities updated (regression guard: without the court-move
+    // trigger, p2 and b1 would keep their stale qp values from `prev`).
+    expect(next.poolMatches[1]).not.toBe(prev.poolMatches[1]);
+    expect(next.poolMatches[2]).not.toBe(prev.poolMatches[2]);
+  });
 });
 
 describe('recomputeQueuePositions', () => {
@@ -360,5 +387,33 @@ describe('recomputeBracketQueuePositions', () => {
     expect(next.bracket.rounds[0][0].scoreA).toBe("M");
     // sibling untouched — same reference
     expect(next.bracket.rounds[0][1]).toBe(prev.bracket.rounds[0][1]);
+  });
+
+  it('applyPatch recomputes bracket queue positions when a scheduled match moves to a different court', () => {
+    // b1 (court A, qp=1) moves to court B. recomputeBracketQueuePositions
+    // walks rounds in order, so b1 lands at B-qp=1, b2 becomes A-qp=1, and
+    // c1 shifts down to B-qp=2. Same array-order contract as the pool helper —
+    // the test pins that the recompute fires *immediately on a court move*
+    // (not just on a status flip), which is the bug Copilot flagged.
+    const prev = {
+      bracket: {
+        rounds: [
+          [
+            { id: "b1", court: "A", scheduledAt: "11:00", status: "scheduled", queuePosition: 1 },
+            { id: "b2", court: "A", scheduledAt: "11:30", status: "scheduled", queuePosition: 2 },
+            { id: "c1", court: "B", scheduledAt: "10:30", status: "scheduled", queuePosition: 1 },
+          ],
+        ],
+      },
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "b1", court: "B", scheduledAt: "11:00", status: "scheduled" } },
+    });
+    const flat = next.bracket.rounds[0];
+    const byId = Object.fromEntries(flat.map(m => [m.id, m]));
+    expect(byId.b1.court).toBe("B");
+    expect(byId.b1.queuePosition).toBe(1);
+    expect(byId.b2.queuePosition).toBe(1);
+    expect(byId.c1.queuePosition).toBe(2);
   });
 });

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -43,8 +43,9 @@ describe('applyPatch', () => {
     expect(next).not.toBe(prev);
     expect(next.poolMatches[0].winner).toBe("Alice");
     expect(next.poolMatches[0].status).toBe("completed");
-    // unchanged matches keep their reference and values
-    expect(next.poolMatches[1]).toBe(prev.poolMatches[1]);
+    // p2 is the only remaining scheduled match on court B — it gets
+    // queuePosition: 1 via the post-patch recompute (FR-025).
+    expect(next.poolMatches[1].queuePosition).toBe(1);
   });
 
   it('applies an array of results to multiple poolMatches', () => {
@@ -285,10 +286,25 @@ describe('recomputeQueuePositions', () => {
     expect(recomputeQueuePositions(matches)).toBe(matches);
   });
 
-  it('no-ops when the payload never populated queuePosition (older server)', () => {
+  it('derives positions even when no prior queuePosition fields exist (omitempty payload)', () => {
+    // Backend omits queuePosition=0 via omitempty. A viewer opened while
+    // all matches were running/completed gets a payload with no
+    // queuePosition fields. An SSE patch that transitions one match back
+    // to scheduled must still derive positions from scratch.
     const matches = [
       { id: "a1", court: "A", status: "scheduled" },
       { id: "a2", court: "A", status: "scheduled" },
+    ];
+    const out = recomputeQueuePositions(matches);
+    expect(out).not.toBe(matches);
+    expect(out[0].queuePosition).toBe(1);
+    expect(out[1].queuePosition).toBe(2);
+  });
+
+  it('no-ops when no matches are scheduled (all running/completed)', () => {
+    const matches = [
+      { id: "a1", court: "A", status: "running" },
+      { id: "a2", court: "A", status: "completed" },
     ];
     expect(recomputeQueuePositions(matches)).toBe(matches);
   });
@@ -347,12 +363,29 @@ describe('recomputeBracketQueuePositions', () => {
     expect(recomputeBracketQueuePositions(bracket)).toBe(bracket);
   });
 
-  it('no-ops when no round has a populated queuePosition (older server)', () => {
+  it('derives positions even when no prior queuePosition fields exist (omitempty payload)', () => {
+    // Same omitempty scenario as the pool helper: bracket matches can
+    // arrive without queuePosition when all were running/completed.
     const bracket = {
       rounds: [
         [
           { id: "r1m1", court: "A", status: "scheduled" },
           { id: "r1m2", court: "A", status: "scheduled" },
+        ],
+      ],
+    };
+    const out = recomputeBracketQueuePositions(bracket);
+    expect(out).not.toBe(bracket);
+    expect(out.rounds[0][0].queuePosition).toBe(1);
+    expect(out.rounds[0][1].queuePosition).toBe(2);
+  });
+
+  it('no-ops when no bracket match is scheduled (all running/completed)', () => {
+    const bracket = {
+      rounds: [
+        [
+          { id: "r1m1", court: "A", status: "running" },
+          { id: "r1m2", court: "A", status: "completed" },
         ],
       ],
     };

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -147,7 +147,12 @@ describe('applyPatch', () => {
     expect(next.poolMatches[3].queuePosition).toBe(1);
   });
 
-  it('recomputes queue positions when patch transitions a scheduled match to running', () => {
+  // Any transition off "scheduled" releases a slot in the per-court
+  // queue — running included. Previously this test asserted "no
+  // recompute on scheduled → running"; the Copilot review on PR #124
+  // flagged that as wrong because the remaining scheduled siblings
+  // need to shift up immediately rather than wait for a refresh.
+  it('recomputes queue positions when a scheduled match transitions to running', () => {
     const prev = {
       poolMatches: [
         { id: "p1", court: "A", scheduledAt: "09:00", status: "scheduled", queuePosition: 1 },
@@ -158,6 +163,7 @@ describe('applyPatch', () => {
       data: { result: { id: "p1", status: "running" } },
     });
     expect(next.poolMatches[0].status).toBe("running");
+    // p1 dropped out of the queue (running ⇒ 0); p2 shifts up to 1.
     expect(next.poolMatches[0].queuePosition).toBe(0);
     expect(next.poolMatches[1].queuePosition).toBe(1);
   });
@@ -177,12 +183,26 @@ describe('applyPatch', () => {
     expect(next.poolMatches[1]).toBe(prev.poolMatches[1]);
   });
 
+  it('does not recompute queue positions for a no-op patch on a non-scheduled match', () => {
+    const prev = {
+      poolMatches: [
+        { id: "p1", court: "A", scheduledAt: "09:00", status: "completed", queuePosition: 0 },
+        { id: "p2", court: "A", scheduledAt: "09:10", status: "scheduled", queuePosition: 1 },
+      ],
+    };
+    const next = applyPatch(prev, {
+      // Patch a completed match's metadata — no queue impact.
+      data: { result: { id: "p1", status: "completed", winner: "Alice" } },
+    });
+    // sibling untouched — same reference
+    expect(next.poolMatches[1]).toBe(prev.poolMatches[1]);
+  });
+
   it('recomputes pool queue positions when a scheduled match moves to a different court', () => {
-    // p1 starts on court A (qp=1) and moves to court B. recomputeQueuePositions
-    // walks the array in order, so p1 lands at B-qp=1 and b1 shifts down to
+    // p1 (09:00) moves to court B where b1 (08:30) already is. recomputeQueuePositions
+    // sorts per-court by scheduledAt, so b1 (08:30) is B-qp=1 and p1 (09:00) is
     // B-qp=2; p2 becomes A-qp=1. The point is *that the recompute happens at
-    // all* (not waiting for a refetch) — the exact numbering follows the
-    // existing helper's array-order contract.
+    // all* (not waiting for a refetch) — exact ordering follows scheduledAt.
     const prev = {
       poolMatches: [
         { id: "p1", court: "A", scheduledAt: "09:00", status: "scheduled", queuePosition: 1 },
@@ -195,13 +215,12 @@ describe('applyPatch', () => {
     });
     const byId = Object.fromEntries(next.poolMatches.map(m => [m.id, m]));
     expect(byId.p1.court).toBe("B");
-    expect(byId.p1.queuePosition).toBe(1);
-    expect(byId.p2.queuePosition).toBe(1);
-    expect(byId.b1.queuePosition).toBe(2);
-    // Sibling identities updated (regression guard: without the court-move
-    // trigger, p2 and b1 would keep their stale qp values from `prev`).
+    expect(byId.p1.queuePosition).toBe(2); // 09:00 is after b1's 08:30 on court B
+    expect(byId.p2.queuePosition).toBe(1); // sole match on A
+    expect(byId.b1.queuePosition).toBe(1); // 08:30 is first on B
+    // p2's qp changed (2→1), so it's a new object; b1's qp stayed 1 (identity preserved).
     expect(next.poolMatches[1]).not.toBe(prev.poolMatches[1]);
-    expect(next.poolMatches[2]).not.toBe(prev.poolMatches[2]);
+    expect(next.poolMatches[2]).toBe(prev.poolMatches[2]);
   });
 });
 
@@ -351,7 +370,10 @@ describe('recomputeBracketQueuePositions', () => {
     expect(next.bracket.rounds[0][2].queuePosition).toBe(1);
   });
 
-  it('applyPatch recomputes bracket queue positions when patch transitions a scheduled match to running', () => {
+  it('applyPatch recomputes bracket queue positions when a scheduled match transitions to running', () => {
+    // Bracket-side counterpart of the pool test above. Any off-scheduled
+    // transition (running/forfeit/cancelled/kiken) releases a slot in
+    // the per-court queue and triggers a recompute.
     const prev = {
       bracket: {
         rounds: [
@@ -366,6 +388,7 @@ describe('recomputeBracketQueuePositions', () => {
       data: { result: { id: "b1", status: "running" } },
     });
     expect(next.bracket.rounds[0][0].status).toBe("running");
+    // b1 dropped to 0 (running); b2 shifted up to 1.
     expect(next.bracket.rounds[0][0].queuePosition).toBe(0);
     expect(next.bracket.rounds[0][1].queuePosition).toBe(1);
   });
@@ -392,8 +415,9 @@ describe('recomputeBracketQueuePositions', () => {
   it('applyPatch recomputes bracket queue positions when a scheduled match moves to a different court', () => {
     // b1 (court A, qp=1) moves to court B. recomputeBracketQueuePositions
     // walks rounds in order, so b1 lands at B-qp=1, b2 becomes A-qp=1, and
-    // c1 shifts down to B-qp=2. Same array-order contract as the pool helper —
-    // the test pins that the recompute fires *immediately on a court move*
+    // c1 (10:30) lands ahead of b1 (11:00) on court B in scheduledAt order,
+    // so c1=1 and b1=2. b2 is the only match left on court A → b2=1. The
+    // test pins that the recompute fires *immediately on a court move*
     // (not just on a status flip), which is the bug Copilot flagged.
     const prev = {
       bracket: {
@@ -412,8 +436,8 @@ describe('recomputeBracketQueuePositions', () => {
     const flat = next.bracket.rounds[0];
     const byId = Object.fromEntries(flat.map(m => [m.id, m]));
     expect(byId.b1.court).toBe("B");
-    expect(byId.b1.queuePosition).toBe(1);
-    expect(byId.b2.queuePosition).toBe(1);
-    expect(byId.c1.queuePosition).toBe(2);
+    expect(byId.b1.queuePosition).toBe(2); // 11:00 > c1's 10:30 → b1 is second on B
+    expect(byId.b2.queuePosition).toBe(1); // sole match on A
+    expect(byId.c1.queuePosition).toBe(1); // 10:30 is first on B
   });
 });

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -147,7 +147,7 @@ describe('applyPatch', () => {
     expect(next.poolMatches[3].queuePosition).toBe(1);
   });
 
-  it('does not recompute queue positions when patch is not a completion', () => {
+  it('recomputes queue positions when patch transitions a scheduled match to running', () => {
     const prev = {
       poolMatches: [
         { id: "p1", court: "A", scheduledAt: "09:00", status: "scheduled", queuePosition: 1 },
@@ -158,6 +158,21 @@ describe('applyPatch', () => {
       data: { result: { id: "p1", status: "running" } },
     });
     expect(next.poolMatches[0].status).toBe("running");
+    expect(next.poolMatches[0].queuePosition).toBe(0);
+    expect(next.poolMatches[1].queuePosition).toBe(1);
+  });
+
+  it('does not recompute queue positions when patch does not change scheduled status', () => {
+    const prev = {
+      poolMatches: [
+        { id: "p1", court: "A", scheduledAt: "09:00", status: "scheduled", queuePosition: 1 },
+        { id: "p2", court: "A", scheduledAt: "09:10", status: "scheduled", queuePosition: 2 },
+      ],
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "p1", winner: "Alice" } },
+    });
+    expect(next.poolMatches[0].winner).toBe("Alice");
     // sibling untouched — same reference
     expect(next.poolMatches[1]).toBe(prev.poolMatches[1]);
   });
@@ -309,7 +324,7 @@ describe('recomputeBracketQueuePositions', () => {
     expect(next.bracket.rounds[0][2].queuePosition).toBe(1);
   });
 
-  it('applyPatch does not recompute bracket queue positions on non-completion', () => {
+  it('applyPatch recomputes bracket queue positions when patch transitions a scheduled match to running', () => {
     const prev = {
       bracket: {
         rounds: [
@@ -324,6 +339,25 @@ describe('recomputeBracketQueuePositions', () => {
       data: { result: { id: "b1", status: "running" } },
     });
     expect(next.bracket.rounds[0][0].status).toBe("running");
+    expect(next.bracket.rounds[0][0].queuePosition).toBe(0);
+    expect(next.bracket.rounds[0][1].queuePosition).toBe(1);
+  });
+
+  it('applyPatch does not recompute bracket queue positions when patch does not change scheduled status', () => {
+    const prev = {
+      bracket: {
+        rounds: [
+          [
+            { id: "b1", court: "A", status: "scheduled", queuePosition: 1 },
+            { id: "b2", court: "A", status: "scheduled", queuePosition: 2 },
+          ],
+        ],
+      },
+    };
+    const next = applyPatch(prev, {
+      data: { result: { id: "b1", scoreA: "M" } },
+    });
+    expect(next.bracket.rounds[0][0].scoreA).toBe("M");
     // sibling untouched — same reference
     expect(next.bracket.rounds[0][1]).toBe(prev.bracket.rounds[0][1]);
   });

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -1,7 +1,7 @@
 // Pure-logic tests for buildPlayerMatchHighlight (FR-020, FR-022).
 // Slice 4 / T108–T109: drives "Find my matches" filtering on the viewer home.
 import { describe, it, expect } from 'vitest';
-import { buildPlayerMatchHighlight } from '../viewer.jsx';
+import { buildPlayerMatchHighlight, mymatchQueueLabel } from '../viewer.jsx';
 
 describe('buildPlayerMatchHighlight', () => {
   it('returns matches where playerId is on SideA', () => {
@@ -66,5 +66,52 @@ describe('buildPlayerMatchHighlight', () => {
   it('handles empty / non-array inputs gracefully', () => {
     expect(buildPlayerMatchHighlight('p1', null)).toEqual([]);
     expect(buildPlayerMatchHighlight('', [{ id: 'm1', sideAId: 'p1' }])).toEqual([]);
+  });
+});
+
+// FR-025 — MyMatchPanel Queue chip label. Sibling helpers in display.jsx
+// (queueLabel) and lower in viewer.jsx (VSchedItem inline) must agree on
+// wording so a viewer who looks at "Your next match" then scrolls down to
+// the per-court schedule sees the same label.
+describe('mymatchQueueLabel', () => {
+  it('returns "Up next" when scheduled and queuePosition === 1', () => {
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 1 })).toBe('Up next');
+  });
+
+  it('returns "N before yours" for queuePosition > 1 (1-indexed → N-1 ahead)', () => {
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 2 })).toBe('1 before yours');
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 5 })).toBe('4 before yours');
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 99 })).toBe('98 before yours');
+  });
+
+  it('returns "LIVE NOW" when status === "running" regardless of queuePosition', () => {
+    expect(mymatchQueueLabel({ status: 'running', queuePosition: 0 })).toBe('LIVE NOW');
+    expect(mymatchQueueLabel({ status: 'running' })).toBe('LIVE NOW');
+    // qp is meant to be 0 for running per FR-025, but a stale 3 must not bleed through.
+    expect(mymatchQueueLabel({ status: 'running', queuePosition: 3 })).toBe('LIVE NOW');
+  });
+
+  it('returns null for non-running / non-scheduled statuses', () => {
+    for (const status of ['completed', 'forfeit', 'cancelled', '', undefined]) {
+      expect(mymatchQueueLabel({ status, queuePosition: 1 })).toBeNull();
+    }
+  });
+
+  it('returns null when scheduled but queuePosition is missing / 0 / negative', () => {
+    expect(mymatchQueueLabel({ status: 'scheduled' })).toBeNull();
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 0 })).toBeNull();
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: null })).toBeNull();
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: -1 })).toBeNull();
+  });
+
+  it('rejects non-numeric queuePosition values', () => {
+    // Older payloads or buggy fixtures may send strings; we should not render
+    // "1 before yours" if qp is the string "2".
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: '2' })).toBeNull();
+  });
+
+  it('handles null / undefined match gracefully', () => {
+    expect(mymatchQueueLabel(null)).toBeNull();
+    expect(mymatchQueueLabel(undefined)).toBeNull();
   });
 });

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -69,13 +69,12 @@ describe('buildPlayerMatchHighlight', () => {
   });
 });
 
-// FR-025 — MyMatchPanel Queue chip label. Sibling helpers in display.jsx
-// (queueLabel) and lower in viewer.jsx (VSchedItem inline) must agree on
-// wording so a viewer who looks at "Your next match" then scrolls down to
+// FR-025 — MyMatchPanel Queue chip label. Wording mirrors VSchedItem (also in
+// viewer.jsx) so a viewer who looks at "Your next match" then scrolls down to
 // the per-court schedule sees the same label.
 describe('mymatchQueueLabel', () => {
-  it('returns "Up next" when scheduled and queuePosition === 1', () => {
-    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 1 })).toBe('Up next');
+  it('returns "Next up" when scheduled and queuePosition === 1', () => {
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 1 })).toBe('Next up');
   });
 
   it('returns "N before yours" for queuePosition > 1 (1-indexed → N-1 ahead)', () => {
@@ -84,11 +83,12 @@ describe('mymatchQueueLabel', () => {
     expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 99 })).toBe('98 before yours');
   });
 
-  it('returns "LIVE NOW" when status === "running" regardless of queuePosition', () => {
-    expect(mymatchQueueLabel({ status: 'running', queuePosition: 0 })).toBe('LIVE NOW');
-    expect(mymatchQueueLabel({ status: 'running' })).toBe('LIVE NOW');
-    // qp is meant to be 0 for running per FR-025, but a stale 3 must not bleed through.
-    expect(mymatchQueueLabel({ status: 'running', queuePosition: 3 })).toBe('LIVE NOW');
+  it('returns null when status === "running" (round label already shows LIVE NOW)', () => {
+    // The my-match__round element appends " · LIVE NOW" for running matches, so
+    // the Queue chip must not duplicate it.
+    expect(mymatchQueueLabel({ status: 'running', queuePosition: 0 })).toBeNull();
+    expect(mymatchQueueLabel({ status: 'running' })).toBeNull();
+    expect(mymatchQueueLabel({ status: 'running', queuePosition: 3 })).toBeNull();
   });
 
   it('returns null for non-running / non-scheduled statuses', () => {

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -104,10 +104,10 @@ describe('mymatchQueueLabel', () => {
     expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: -1 })).toBeNull();
   });
 
-  it('rejects non-numeric queuePosition values', () => {
-    // Older payloads or buggy fixtures may send strings; we should not render
-    // "1 before yours" if qp is the string "2".
-    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: '2' })).toBeNull();
+  it('accepts numeric strings and rejects non-numeric queuePosition values', () => {
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: '1' })).toBe('Next up');
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: '2' })).toBe('1 before yours');
+    expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 'abc' })).toBeNull();
   });
 
   it('handles null / undefined match gracefully', () => {

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -202,8 +202,12 @@ function AdminSchedulePage({ tournament, onBack, onMoveCourt, onLogout, onViewer
   });
   const courtOrder = (a, b) => {
     const order = { running: 0, scheduled: 1, completed: 2 };
-    const ao = order[a.status] ?? 99;
-    const bo = order[b.status] ?? 99;
+    // Unknown / new statuses sink to "completed" (=2) — matches the
+    // ScheduleViewer in viewer.jsx and the patch.jsx _orderByCourtKey
+    // helper, so admin and viewer surfaces stay in sync if a new
+    // terminal status (kiken / fusenpai / forfeit) ever appears.
+    const ao = order[a.status] ?? 2;
+    const bo = order[b.status] ?? 2;
     if (ao !== bo) return ao - bo;
     return (a.scheduledAt || "99:99").localeCompare(b.scheduledAt || "99:99");
   };

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -172,14 +172,14 @@ function findActiveCourts(tournament, competitions) {
 }
 
 // Queue-position label per T068. We mirror the contract from VSchedItem in
-// viewer.jsx: position 1 → "Up next"; position N → "(N-1) before yours".
+// viewer.jsx: position 1 → "Next up"; position N → "(N-1) before yours".
 // Falls back to scheduledAt time if no queue position is present (pre-T046
 // payloads or unannotated matches). Keep this synchronised with the
 // equivalent helper in viewer.jsx so the two surfaces agree.
 function queueLabel(m) {
     const qp = m.queuePosition;
     if (qp && qp > 0) {
-        if (qp === 1) return "Up next";
+        if (qp === 1) return "Next up";
         return `${qp - 1} before yours`;
     }
     if (m.scheduledAt) return `Scheduled ${m.scheduledAt}`;
@@ -422,7 +422,7 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
 
             {/* T068: upcoming-match list with queue-position labels.
                 Pulls m.queuePosition (1-indexed, populated by handlers_viewer
-                annotateQueuePositions). Position 1 → "Up next"; position N
+                annotateQueuePositions). Position 1 → "Next up"; position N
                 (>1) → "(N-1) before yours" to match VSchedItem's wording.
                 T061: capped at 2 entries when live, falls back to up to 2
                 additional cards when auto-promoting (so we still show a

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -435,7 +435,7 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
                     {queueMatches.map((m) => {
                         const compZekken = m._comp?.withZekkenName;
                         const label = queueLabel(m);
-                        const qp = m.queuePosition;
+                        const qp = Number(m.queuePosition);
                         return (
                             <div key={(m._comp?.id || '') + m.id} className="tvd__upcoming-card" style={{
                                 flex: 1,

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -177,8 +177,8 @@ function findActiveCourts(tournament, competitions) {
 // payloads or unannotated matches). Keep this synchronised with the
 // equivalent helper in viewer.jsx so the two surfaces agree.
 function queueLabel(m) {
-    const qp = m.queuePosition;
-    if (qp && qp > 0) {
+    const qp = Number(m.queuePosition);
+    if (Number.isFinite(qp) && qp > 0) {
         if (qp === 1) return "Next up";
         return `${qp - 1} before yours`;
     }

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -41,6 +41,40 @@
 // than fall through to a wrong-shape merge.
 import { mergeMatchPatch as _mergeMatchPatch } from './data.jsx';
 
+// statusSortOrder mirrors annotateBracketQueuePositions in
+// internal/mobileapp/handlers_match.go and the per-court sort in
+// ScheduleViewer (viewer.jsx). Running ranks ahead of scheduled, which
+// ranks ahead of completed/everything-else.
+const statusSortOrder = (s) => (s === "running" ? 0 : s === "scheduled" ? 1 : 2);
+
+// Stable per-court ordering: gather pointers to the original entries,
+// sort them by (status priority, scheduledAt, original index) without
+// mutating the input array. The result is a flat list of [origIndex,
+// match] pairs in display order — caller iterates and increments a
+// per-court counter to derive queue positions.
+function _orderByCourtKey(entries) {
+    // `entries` is [{ idx, m, court }]; we sort within each court so
+    // the per-court counter increments in viewer-visible order.
+    const byCourt = new Map();
+    for (const e of entries) {
+        const arr = byCourt.get(e.court) || [];
+        arr.push(e);
+        byCourt.set(e.court, arr);
+    }
+    for (const arr of byCourt.values()) {
+        arr.sort((a, b) => {
+            const oa = statusSortOrder(a.m.status);
+            const ob = statusSortOrder(b.m.status);
+            if (oa !== ob) return oa - ob;
+            const sa = a.m.scheduledAt || "99:99";
+            const sb = b.m.scheduledAt || "99:99";
+            if (sa !== sb) return sa < sb ? -1 : 1;
+            return a.idx - b.idx;
+        });
+    }
+    return byCourt;
+}
+
 // Recompute queuePosition on scheduled poolMatches per court after an
 // SSE patch transitions a match to completed. The backend recomputes
 // server-side on the next GET (see internal/state/match.go), but SSE
@@ -48,11 +82,12 @@ import { mergeMatchPatch as _mergeMatchPatch } from './data.jsx';
 // step the UI would still show stale "3 before yours" labels until the
 // next viewer refresh. FR-025, R3.
 //
-// Algorithm mirrors state.DeriveQueuePositions: walk the slice in its
-// current order and assign 1, 2, 3, … to scheduled matches per court.
-// Running/completed get 0. The slice is already ordered by the server
-// (typically by scheduledAt), so re-walking in array order produces the
-// same positions the server would on its next response.
+// Algorithm mirrors annotateBracketQueuePositions in handlers_match.go:
+// gather per-court entries, sort by (status priority, scheduledAt) so
+// the counter increments in viewer-display order, then assign 1, 2,
+// 3, … to scheduled matches. Running/completed get 0. This handles
+// the case where an SSE patch moves a match's court/scheduledAt and
+// the array order no longer reflects the displayed order.
 //
 // Touches only matches whose existing queuePosition differs from the
 // recomputed value, preserving object identity for unaffected matches
@@ -66,15 +101,25 @@ function recomputeQueuePositions(matches) {
     // churn for memoised match-card components.
     const hasAnyQueuePosition = matches.some(m => m.queuePosition !== undefined);
     if (!hasAnyQueuePosition) return matches;
-    const counters = {};
-    let touched = false;
-    const next = matches.map(m => {
-        let pos = 0;
-        if (m.status === "scheduled") {
-            const court = m.court || "";
-            counters[court] = (counters[court] || 0) + 1;
-            pos = counters[court];
+
+    // Build per-court ordered buckets, then derive positions by court
+    // and write them back into a positions-by-index lookup.
+    const entries = matches.map((m, idx) => ({ idx, m, court: m.court || "" }));
+    const byCourt = _orderByCourtKey(entries);
+    const newPositions = new Array(matches.length).fill(0);
+    for (const bucket of byCourt.values()) {
+        let counter = 0;
+        for (const e of bucket) {
+            if (e.m.status === "scheduled") {
+                counter++;
+                newPositions[e.idx] = counter;
+            }
         }
+    }
+
+    let touched = false;
+    const next = matches.map((m, idx) => {
+        const pos = newPositions[idx];
         if ((m.queuePosition || 0) !== pos) {
             touched = true;
             return { ...m, queuePosition: pos };
@@ -84,16 +129,18 @@ function recomputeQueuePositions(matches) {
     return touched ? next : matches;
 }
 
-// Bracket-variant of recomputeQueuePositions. Walks bracket.rounds in
-// round-then-position order (mirrors the Go-side annotateBracketQueuePositions
-// in internal/mobileapp/handlers_match.go) and assigns 1-indexed positions to
-// scheduled matches per court. Running/completed get 0.
+// Bracket-variant of recomputeQueuePositions. Mirrors the Go-side
+// annotateBracketQueuePositions in internal/mobileapp/handlers_match.go:
+// per-court entries are sorted by (status priority, scheduledAt) before
+// the counter is incremented, so positions match the order the viewer's
+// ScheduleViewer actually renders rows in — including when a match's
+// scheduledAt or court changed under SSE and storage order no longer
+// reflects display order.
 //
 // FR-025: without this, an SSE patch transitioning a bracket match to
 // completed would leave sibling bracket matches showing stale "N before
 // yours" labels until the jittered fetchCompetitionDetails refresh lands
-// (~500-1000ms later). Mirrors the pool helper exactly — the only
-// structural difference is the nested round-then-position iteration.
+// (~500-1000ms later).
 //
 // Returns the original `bracket` reference when nothing needed to change,
 // preserving React identity for memoised bracket components.
@@ -105,17 +152,40 @@ function recomputeBracketQueuePositions(bracket) {
         round.some(m => m.queuePosition !== undefined)
     );
     if (!hasAnyQueuePosition) return bracket;
-    const counters = {};
-    let touched = false;
-    const nextRounds = bracket.rounds.map(round => {
-        let roundTouched = false;
-        const nextRound = round.map(m => {
+
+    // Flatten round/position pairs into entries the per-court sorter
+    // can consume; idx encodes "round-position" for stable tie-break.
+    const entries = [];
+    bracket.rounds.forEach((round, ri) => {
+        round.forEach((m, mi) => {
+            entries.push({
+                idx: ri * 100000 + mi, // safe room for any realistic round size
+                m,
+                court: m.court || "",
+                ri,
+                mi,
+            });
+        });
+    });
+    const byCourt = _orderByCourtKey(entries);
+    const positionsByKey = new Map();
+    for (const bucket of byCourt.values()) {
+        let counter = 0;
+        for (const e of bucket) {
             let pos = 0;
-            if (m.status === "scheduled") {
-                const court = m.court || "";
-                counters[court] = (counters[court] || 0) + 1;
-                pos = counters[court];
+            if (e.m.status === "scheduled") {
+                counter++;
+                pos = counter;
             }
+            positionsByKey.set(`${e.ri}:${e.mi}`, pos);
+        }
+    }
+
+    let touched = false;
+    const nextRounds = bracket.rounds.map((round, ri) => {
+        let roundTouched = false;
+        const nextRound = round.map((m, mi) => {
+            const pos = positionsByKey.get(`${ri}:${mi}`) || 0;
             if ((m.queuePosition || 0) !== pos) {
                 roundTouched = true;
                 touched = true;
@@ -231,6 +301,26 @@ function applyPatch(prev, event) {
     // only then is a queue-position recompute meaningful.
     let needsQueueRecompute = false;
 
+    // Queue positions count *scheduled* matches only, so a recompute
+    // is needed whenever a match leaves the scheduled state (→ running,
+    // → completed, → cancelled / forfeit / kiken / etc.) OR when a
+    // scheduled match's court/scheduledAt changes — the remaining
+    // scheduled siblings on the same court need to shift up/down
+    // immediately rather than waiting for the next jittered refresh.
+    const isScheduleAffecting = (prevStatus, nextStatus, prevMatch, nextMatch) => {
+        // Status transition off "scheduled" — any such transition
+        // releases a slot in the per-court queue.
+        if (prevStatus === "scheduled" && nextStatus !== "scheduled") return true;
+        // Court or scheduledAt move while still scheduled — the
+        // per-court bucket itself changes (or the within-court sort
+        // order does), so siblings on either side need to re-rank.
+        if (prevStatus === "scheduled" && nextStatus === "scheduled") {
+            if ((prevMatch.court || "") !== (nextMatch.court || "")) return true;
+            if ((prevMatch.scheduledAt || "") !== (nextMatch.scheduledAt || "")) return true;
+        }
+        return false;
+    };
+
     if (next.poolMatches) {
         next.poolMatches = next.poolMatches.map(m => {
             const update = resultMap.get(m.id);
@@ -259,8 +349,8 @@ function applyPatch(prev, event) {
 
     if (next.bracket && next.bracket.rounds) {
         let bChanged = false;
-        // Track whether any bracket patch changed a match's scheduled state;
-        // same trigger as the pool branch above.
+        // Track whether any bracket patch was a schedule-affecting
+        // transition; same trigger semantics as the pool branch above.
         let bracketNeedsQueueRecompute = false;
         const rounds = next.bracket.rounds.map(round =>
             round.map(m => {

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -302,15 +302,16 @@ function applyPatch(prev, event) {
     let needsQueueRecompute = false;
 
     // Queue positions count *scheduled* matches only, so a recompute
-    // is needed whenever a match leaves the scheduled state (→ running,
-    // → completed, → cancelled / forfeit / kiken / etc.) OR when a
-    // scheduled match's court/scheduledAt changes — the remaining
-    // scheduled siblings on the same court need to shift up/down
-    // immediately rather than waiting for the next jittered refresh.
+    // is needed whenever a match's "scheduled-ness" changes — leaving
+    // (→ running / completed / cancelled / forfeit / kiken / …) OR
+    // entering (admin correction reverts a completed match back to
+    // scheduled) — and whenever a still-scheduled match's
+    // court/scheduledAt moves so siblings on either side re-rank.
     const isScheduleAffecting = (prevStatus, nextStatus, prevMatch, nextMatch) => {
-        // Status transition off "scheduled" — any such transition
-        // releases a slot in the per-court queue.
-        if (prevStatus === "scheduled" && nextStatus !== "scheduled") return true;
+        // Any change in scheduled-ness flips the per-court queue's
+        // membership: either releasing a slot (leaving scheduled) or
+        // claiming one (entering scheduled). Both directions matter.
+        if ((prevStatus === "scheduled") !== (nextStatus === "scheduled")) return true;
         // Court or scheduledAt move while still scheduled — the
         // per-court bucket itself changes (or the within-court sort
         // order does), so siblings on either side need to re-rank.

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -75,19 +75,25 @@ function _orderByCourtKey(entries) {
     return byCourt;
 }
 
-// Recompute queuePosition on scheduled poolMatches per court after an
-// SSE patch transitions a match to completed. The backend recomputes
-// server-side on the next GET (see internal/state/match.go), but SSE
-// patches only carry the single updated match — without this client-side
-// step the UI would still show stale "3 before yours" labels until the
-// next viewer refresh. FR-025, R3.
+// Recompute queuePosition on poolMatches per court after any SSE patch
+// that could invalidate the queue. The backend recomputes server-side
+// on the next GET (see internal/state/match.go), but SSE patches only
+// carry the single updated match — without this client-side step the
+// UI would show stale "N before yours" labels until the next viewer
+// refresh. FR-025, R3.
 //
-// Algorithm mirrors annotateBracketQueuePositions in handlers_match.go:
-// gather per-court entries, sort by (status priority, scheduledAt) so
-// the counter increments in viewer-display order, then assign 1, 2,
-// 3, … to scheduled matches. Running/completed get 0. This handles
-// the case where an SSE patch moves a match's court/scheduledAt and
-// the array order no longer reflects the displayed order.
+// Triggered by applyPatch's `isScheduleAffecting` on any change that
+// affects the per-court queue:
+//   - status transition into or out of `scheduled` (completed, running,
+//     forfeit, kiken, and the admin-correction reverse direction)
+//   - court move while still scheduled
+//   - scheduledAt move while still scheduled
+//
+// Algorithm mirrors annotateQueuePositions in handlers_match.go (which
+// delegates to state.DeriveQueuePositions): gather per-court entries,
+// sort by (status priority, scheduledAt, original index) so the counter
+// increments in viewer-display order, assign 1, 2, 3, … to scheduled
+// matches and 0 to everything else.
 //
 // Touches only matches whose existing queuePosition differs from the
 // recomputed value, preserving object identity for unaffected matches
@@ -99,11 +105,11 @@ function recomputeQueuePositions(matches) {
     // — even when no matches are scheduled — because we also need to
     // clear stale non-zero queuePosition values on matches that just
     // transitioned off `scheduled` (the last scheduled match becoming
-    // running/completed must drop from "Up next" to 0). _mergeMatchPatch
-    // preserves fields not in the patch, so a stale qp would linger on
-    // the transitioned match until the next GET refresh otherwise.
-    // The touched-tracking below still preserves identity when nothing
-    // actually changes (e.g. all qps already 0).
+    // running/completed must drop its "Next up" label to 0).
+    // _mergeMatchPatch preserves fields not in the patch, so a stale
+    // qp would linger on the transitioned match until the next GET
+    // refresh otherwise. The touched-tracking below still preserves
+    // identity when nothing actually changes (e.g. all qps already 0).
     const entries = matches.map((m, idx) => ({ idx, m, court: m.court || "" }));
     const byCourt = _orderByCourtKey(entries);
     const newPositions = new Array(matches.length).fill(0);
@@ -155,12 +161,15 @@ function recomputeBracketQueuePositions(bracket) {
     // tracking below still preserves identity when nothing changes.
 
     // Flatten round/position pairs into entries the per-court sorter
-    // can consume; idx encodes "round-position" for stable tie-break.
+    // can consume. `idx` is a monotonic push-order counter so the
+    // (round, position) traversal order doubles as a stable tie-break
+    // for _orderByCourtKey when status + scheduledAt are equal. No
+    // magic number, no upper-bound assumption on round size.
     const entries = [];
     bracket.rounds.forEach((round, ri) => {
         round.forEach((m, mi) => {
             entries.push({
-                idx: ri * 100000 + mi, // safe room for any realistic round size
+                idx: entries.length,
                 m,
                 court: m.court || "",
                 ri,

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -94,13 +94,15 @@ function _orderByCourtKey(entries) {
 // (matters for React.memo on VSchedItem / TWMatch).
 function recomputeQueuePositions(matches) {
     if (!matches || matches.length === 0) return matches;
-    // If the server's payload never populated queuePosition (older
-    // backends or non-annotated views), do nothing — there's no UI
-    // baseline to keep in sync and assigning positions risks adding a
-    // field the UI doesn't currently render. Avoids gratuitous identity
-    // churn for memoised match-card components.
-    const hasAnyQueuePosition = matches.some(m => m.queuePosition !== undefined);
-    if (!hasAnyQueuePosition) return matches;
+    // Skip when nothing is scheduled — all positions are 0 and there is
+    // no label to derive, so we preserve identity without extra work.
+    // We no longer gate on existing queuePosition fields: the backend
+    // emits queuePosition with omitempty, so a payload where every match
+    // is running/completed arrives with all queuePosition fields missing.
+    // If an SSE patch later transitions a match to scheduled we must still
+    // be able to derive positions from scratch (FR-025).
+    const hasAnyScheduled = matches.some(m => m.status === "scheduled");
+    if (!hasAnyScheduled) return matches;
 
     // Build per-court ordered buckets, then derive positions by court
     // and write them back into a positions-by-index lookup.
@@ -146,12 +148,15 @@ function recomputeQueuePositions(matches) {
 // preserving React identity for memoised bracket components.
 function recomputeBracketQueuePositions(bracket) {
     if (!bracket || !bracket.rounds || bracket.rounds.length === 0) return bracket;
-    // Same older-payload guard as the pool helper: if no round has a
-    // populated queuePosition, do nothing.
-    const hasAnyQueuePosition = bracket.rounds.some(round =>
-        round.some(m => m.queuePosition !== undefined)
+    // Same rationale as the pool helper: gate on scheduled matches, not
+    // on pre-existing queuePosition fields. omitempty means a bracket
+    // where every match is running/completed arrives with all
+    // queuePosition fields missing; an SSE patch transitioning one back
+    // to scheduled must still derive positions from scratch (FR-025).
+    const hasAnyScheduled = bracket.rounds.some(round =>
+        round.some(m => m.status === "scheduled")
     );
-    if (!hasAnyQueuePosition) return bracket;
+    if (!hasAnyScheduled) return bracket;
 
     // Flatten round/position pairs into entries the per-court sorter
     // can consume; idx encodes "round-position" for stable tie-break.

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -227,8 +227,8 @@ function applyPatch(prev, event) {
     const resultMap = new Map(resultsToApply.map(r => [r.id, r]));
     const next = { ...prev };
     let changed = false;
-    // Track whether any patch was a scheduled/running → completed
-    // transition; only then is a queue-position recompute meaningful.
+    // Track whether any pool patch changed a match's scheduled state;
+    // only then is a queue-position recompute meaningful.
     let needsQueueRecompute = false;
 
     if (next.poolMatches) {
@@ -252,8 +252,8 @@ function applyPatch(prev, event) {
 
     if (next.bracket && next.bracket.rounds) {
         let bChanged = false;
-        // Track whether any bracket patch was a scheduled/running →
-        // completed transition; same trigger as the pool branch above.
+        // Track whether any bracket patch changed a match's scheduled state;
+        // same trigger as the pool branch above.
         let bracketNeedsQueueRecompute = false;
         const rounds = next.bracket.rounds.map(round =>
             round.map(m => {

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -49,9 +49,9 @@ const statusSortOrder = (s) => (s === "running" ? 0 : s === "scheduled" ? 1 : 2)
 
 // Stable per-court ordering: gather pointers to the original entries,
 // sort them by (status priority, scheduledAt, original index) without
-// mutating the input array. The result is a flat list of [origIndex,
-// match] pairs in display order — caller iterates and increments a
-// per-court counter to derive queue positions.
+// mutating the input array. Returns a Map of court → sorted entry
+// arrays; caller iterates per-court and increments a counter to derive
+// queue positions.
 function _orderByCourtKey(entries) {
     // `entries` is [{ idx, m, court }]; we sort within each court so
     // the per-court counter increments in viewer-visible order.
@@ -326,16 +326,8 @@ function applyPatch(prev, event) {
             const update = resultMap.get(m.id);
             if (update) {
                 changed = true;
-                const prevStatus = m.status;
-                const prevCourt = m.court || "";
                 const merged = _mergeMatchPatch(m, update);
-                const statusFlipped = (prevStatus === "scheduled") !== (merged.status === "scheduled");
-                // Court moves also stale per-court queue positions: a scheduled
-                // match leaving court A and arriving on court B must re-number
-                // both courts' remaining scheduled siblings.
-                const courtMoved = (merged.court || "") !== prevCourt
-                    && (prevStatus === "scheduled" || merged.status === "scheduled");
-                if (statusFlipped || courtMoved) {
+                if (isScheduleAffecting(m.status, merged.status, m, merged)) {
                     needsQueueRecompute = true;
                 }
                 return merged;
@@ -364,14 +356,8 @@ function applyPatch(prev, event) {
                     const patch = { ...update };
                     if (patch.ipponsA) patch.scoreA = patch.ipponsA.join("");
                     if (patch.ipponsB) patch.scoreB = patch.ipponsB.join("");
-                    const prevStatus = m.status;
-                    const prevCourt = m.court || "";
                     const merged = _mergeMatchPatch(m, patch);
-                    const statusFlipped = (prevStatus === "scheduled") !== (merged.status === "scheduled");
-                    // Same court-move invalidation as the pool branch above.
-                    const courtMoved = (merged.court || "") !== prevCourt
-                        && (prevStatus === "scheduled" || merged.status === "scheduled");
-                    if (statusFlipped || courtMoved) {
+                    if (isScheduleAffecting(m.status, merged.status, m, merged)) {
                         bracketNeedsQueueRecompute = true;
                     }
                     return merged;

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -238,7 +238,7 @@ function applyPatch(prev, event) {
                 changed = true;
                 const prevStatus = m.status;
                 const merged = _mergeMatchPatch(m, update);
-                if (merged.status === "completed" && (prevStatus === "scheduled" || prevStatus === "running")) {
+                if ((prevStatus === "scheduled") !== (merged.status === "scheduled")) {
                     needsQueueRecompute = true;
                 }
                 return merged;
@@ -269,7 +269,7 @@ function applyPatch(prev, event) {
                     if (patch.ipponsB) patch.scoreB = patch.ipponsB.join("");
                     const prevStatus = m.status;
                     const merged = _mergeMatchPatch(m, patch);
-                    if (merged.status === "completed" && (prevStatus === "scheduled" || prevStatus === "running")) {
+                    if ((prevStatus === "scheduled") !== (merged.status === "scheduled")) {
                         bracketNeedsQueueRecompute = true;
                     }
                     return merged;

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -94,18 +94,16 @@ function _orderByCourtKey(entries) {
 // (matters for React.memo on VSchedItem / TWMatch).
 function recomputeQueuePositions(matches) {
     if (!matches || matches.length === 0) return matches;
-    // Skip when nothing is scheduled — all positions are 0 and there is
-    // no label to derive, so we preserve identity without extra work.
-    // We no longer gate on existing queuePosition fields: the backend
-    // emits queuePosition with omitempty, so a payload where every match
-    // is running/completed arrives with all queuePosition fields missing.
-    // If an SSE patch later transitions a match to scheduled we must still
-    // be able to derive positions from scratch (FR-025).
-    const hasAnyScheduled = matches.some(m => m.status === "scheduled");
-    if (!hasAnyScheduled) return matches;
 
-    // Build per-court ordered buckets, then derive positions by court
-    // and write them back into a positions-by-index lookup.
+    // Build per-court ordered buckets and derive positions unconditionally
+    // — even when no matches are scheduled — because we also need to
+    // clear stale non-zero queuePosition values on matches that just
+    // transitioned off `scheduled` (the last scheduled match becoming
+    // running/completed must drop from "Up next" to 0). _mergeMatchPatch
+    // preserves fields not in the patch, so a stale qp would linger on
+    // the transitioned match until the next GET refresh otherwise.
+    // The touched-tracking below still preserves identity when nothing
+    // actually changes (e.g. all qps already 0).
     const entries = matches.map((m, idx) => ({ idx, m, court: m.court || "" }));
     const byCourt = _orderByCourtKey(entries);
     const newPositions = new Array(matches.length).fill(0);
@@ -148,15 +146,13 @@ function recomputeQueuePositions(matches) {
 // preserving React identity for memoised bracket components.
 function recomputeBracketQueuePositions(bracket) {
     if (!bracket || !bracket.rounds || bracket.rounds.length === 0) return bracket;
-    // Same rationale as the pool helper: gate on scheduled matches, not
-    // on pre-existing queuePosition fields. omitempty means a bracket
-    // where every match is running/completed arrives with all
-    // queuePosition fields missing; an SSE patch transitioning one back
-    // to scheduled must still derive positions from scratch (FR-025).
-    const hasAnyScheduled = bracket.rounds.some(round =>
-        round.some(m => m.status === "scheduled")
-    );
-    if (!hasAnyScheduled) return bracket;
+    // Run unconditionally — even when no bracket match is currently
+    // scheduled — because we also need to clear stale non-zero
+    // queuePosition values on matches that just transitioned off
+    // `scheduled` (last scheduled bracket match completing must drop
+    // its qp to 0). _mergeMatchPatch preserves fields not in the patch,
+    // so a stale qp would linger otherwise. The per-round touched-
+    // tracking below still preserves identity when nothing changes.
 
     // Flatten round/position pairs into entries the per-court sorter
     // can consume; idx encodes "round-position" for stable tie-break.

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -237,8 +237,15 @@ function applyPatch(prev, event) {
             if (update) {
                 changed = true;
                 const prevStatus = m.status;
+                const prevCourt = m.court || "";
                 const merged = _mergeMatchPatch(m, update);
-                if ((prevStatus === "scheduled") !== (merged.status === "scheduled")) {
+                const statusFlipped = (prevStatus === "scheduled") !== (merged.status === "scheduled");
+                // Court moves also stale per-court queue positions: a scheduled
+                // match leaving court A and arriving on court B must re-number
+                // both courts' remaining scheduled siblings.
+                const courtMoved = (merged.court || "") !== prevCourt
+                    && (prevStatus === "scheduled" || merged.status === "scheduled");
+                if (statusFlipped || courtMoved) {
                     needsQueueRecompute = true;
                 }
                 return merged;
@@ -268,8 +275,13 @@ function applyPatch(prev, event) {
                     if (patch.ipponsA) patch.scoreA = patch.ipponsA.join("");
                     if (patch.ipponsB) patch.scoreB = patch.ipponsB.join("");
                     const prevStatus = m.status;
+                    const prevCourt = m.court || "";
                     const merged = _mergeMatchPatch(m, patch);
-                    if ((prevStatus === "scheduled") !== (merged.status === "scheduled")) {
+                    const statusFlipped = (prevStatus === "scheduled") !== (merged.status === "scheduled");
+                    // Same court-move invalidation as the pool branch above.
+                    const courtMoved = (merged.court || "") !== prevCourt
+                        && (prevStatus === "scheduled" || merged.status === "scheduled");
+                    if (statusFlipped || courtMoved) {
                         bracketNeedsQueueRecompute = true;
                     }
                     return merged;

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -84,6 +84,50 @@ function recomputeQueuePositions(matches) {
     return touched ? next : matches;
 }
 
+// Bracket-variant of recomputeQueuePositions. Walks bracket.rounds in
+// round-then-position order (mirrors the Go-side annotateBracketQueuePositions
+// in internal/mobileapp/handlers_match.go) and assigns 1-indexed positions to
+// scheduled matches per court. Running/completed get 0.
+//
+// FR-025: without this, an SSE patch transitioning a bracket match to
+// completed would leave sibling bracket matches showing stale "N before
+// yours" labels until the jittered fetchCompetitionDetails refresh lands
+// (~500-1000ms later). Mirrors the pool helper exactly — the only
+// structural difference is the nested round-then-position iteration.
+//
+// Returns the original `bracket` reference when nothing needed to change,
+// preserving React identity for memoised bracket components.
+function recomputeBracketQueuePositions(bracket) {
+    if (!bracket || !bracket.rounds || bracket.rounds.length === 0) return bracket;
+    // Same older-payload guard as the pool helper: if no round has a
+    // populated queuePosition, do nothing.
+    const hasAnyQueuePosition = bracket.rounds.some(round =>
+        round.some(m => m.queuePosition !== undefined)
+    );
+    if (!hasAnyQueuePosition) return bracket;
+    const counters = {};
+    let touched = false;
+    const nextRounds = bracket.rounds.map(round => {
+        let roundTouched = false;
+        const nextRound = round.map(m => {
+            let pos = 0;
+            if (m.status === "scheduled") {
+                const court = m.court || "";
+                counters[court] = (counters[court] || 0) + 1;
+                pos = counters[court];
+            }
+            if ((m.queuePosition || 0) !== pos) {
+                roundTouched = true;
+                touched = true;
+                return { ...m, queuePosition: pos };
+            }
+            return m;
+        });
+        return roundTouched ? nextRound : round;
+    });
+    return touched ? { ...bracket, rounds: nextRounds } : bracket;
+}
+
 // T099: re-broadcast competitor_status_updated SSE events as a window-level
 // CustomEvent. Backend wire shape (per specs/003-tournament-gap-closure/
 // contracts/match-decisions.md §SSE):
@@ -208,6 +252,9 @@ function applyPatch(prev, event) {
 
     if (next.bracket && next.bracket.rounds) {
         let bChanged = false;
+        // Track whether any bracket patch was a scheduled/running →
+        // completed transition; same trigger as the pool branch above.
+        let bracketNeedsQueueRecompute = false;
         const rounds = next.bracket.rounds.map(round =>
             round.map(m => {
                 const update = resultMap.get(m.id);
@@ -220,15 +267,25 @@ function applyPatch(prev, event) {
                     const patch = { ...update };
                     if (patch.ipponsA) patch.scoreA = patch.ipponsA.join("");
                     if (patch.ipponsB) patch.scoreB = patch.ipponsB.join("");
-                    return _mergeMatchPatch(m, patch);
+                    const prevStatus = m.status;
+                    const merged = _mergeMatchPatch(m, patch);
+                    if (merged.status === "completed" && (prevStatus === "scheduled" || prevStatus === "running")) {
+                        bracketNeedsQueueRecompute = true;
+                    }
+                    return merged;
                 }
                 return m;
             })
         );
-        if (bChanged) next.bracket = { ...next.bracket, rounds };
+        if (bChanged) {
+            next.bracket = { ...next.bracket, rounds };
+            if (bracketNeedsQueueRecompute) {
+                next.bracket = recomputeBracketQueuePositions(next.bracket);
+            }
+        }
     }
 
     return changed ? next : prev;
 }
 
-export { applyPatch, applyPatchOrdered, recomputeQueuePositions };
+export { applyPatch, applyPatchOrdered, recomputeQueuePositions, recomputeBracketQueuePositions };

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -562,13 +562,13 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
 // does — the MyMatchPanel already has a dedicated Time chip.
 // Exported for unit-testing.
 export function mymatchQueueLabel(m) {
-    if (!m) return null;
-    if (m.status === "running") return null;
-    if (m.status !== "scheduled") return null;
-    const qp = m.queuePosition;
-    if (typeof qp !== "number" || qp <= 0) return null;
-    if (qp === 1) return "Next up";
-    return `${qp - 1} before yours`;
+  if (!m) return null;
+  if (m.status === "running") return null;
+  if (m.status !== "scheduled") return null;
+  const qp = Number(m.queuePosition);
+  if (!Number.isFinite(qp) || qp <= 0) return null;
+  if (qp === 1) return "Next up";
+  return `${qp - 1} before yours`;
 }
 
 // MyMatchPanel — "Find my matches" entry point + active "Your next match"
@@ -638,7 +638,7 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   // surfaces agree. Running matches show null here because the round label
   // already appends " · LIVE NOW".
   const queueLabel = mymatchQueueLabel(nextMatch);
-  const queueHighlight = nextMatch.queuePosition === 1 || nextMatch.status === "running";
+  const queueHighlight = queueLabel === "Next up";
 
   return (
     <div className="my-match" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1891,8 +1891,8 @@ function ScheduleViewer({ tournament, tweaks }) {
   dayFiltered.forEach((m) => { (byCourt[m.court] = byCourt[m.court] || []).push(m); });
   Object.values(byCourt).forEach((list) => list.sort((a, b) => {
     const order = { running: 0, scheduled: 1, completed: 2 };
-    const ao = order[a.status] ?? 1;
-    const bo = order[b.status] ?? 1;
+    const ao = order[a.status] ?? 2;
+    const bo = order[b.status] ?? 2;
     if (ao !== bo) return ao - bo;
     return (a.scheduledAt || "99:99").localeCompare(b.scheduledAt || "99:99");
   }));

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -607,6 +607,13 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   const isOnSideA = aId === followedPlayer.id;
   const opponent = isOnSideA ? nextMatch.sideB : nextMatch.sideA;
   const phaseLabel = nextMatch.phase === "pool" ? nextMatch.poolName : (nextMatch.round || "Bracket");
+  // FR-025: queue position is 1-indexed per court for scheduled matches; 0 for
+  // running/completed. Treat null/undefined/0 as "don't render" so we stay
+  // gracefully empty for non-queued matches and pre-T046 responses.
+  const qp = nextMatch.queuePosition;
+  const queueLabel = (nextMatch.status === "scheduled" && qp && qp > 0)
+    ? (qp === 1 ? "Up next" : `${qp - 1} before you`)
+    : (nextMatch.status === "running" ? "LIVE NOW" : null);
 
   return (
     <div className="my-match" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
@@ -626,6 +633,12 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
           <span className="l">Time</span>
           <span className="v">{nextMatch.scheduledAt || "TBA"}</span>
         </div>
+        {queueLabel && (
+          <div className="my-match__chip" data-testid="my-match-queue">
+            <span className="l">Queue</span>
+            <span className="v" style={{ color: (qp === 1 || nextMatch.status === "running") ? "var(--accent)" : "inherit" }}>{queueLabel}</span>
+          </div>
+        )}
       </div>
       {opponent && (typeof opponent === "object") ? (
         <button

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1302,8 +1302,8 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick }) => {
   // running/completed are 0 (set server-side, omitempty in JSON → undefined
   // on older payloads). Treat null/undefined/0 as "don't render" so the UI
   // stays gracefully empty for non-queued matches and pre-T046 responses.
-  const qp = m.queuePosition;
-  const queueLabel = (m.status === "scheduled" && qp && qp > 0)
+  const qp = Number(m.queuePosition);
+  const queueLabel = (m.status === "scheduled" && Number.isFinite(qp) && qp > 0)
     ? (qp === 1 ? "Next up" : `${qp - 1} before yours`)
     : null;
   return (
@@ -1894,8 +1894,8 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
   // FR-025: per-court queue position — see VSchedItem for the contract.
   // Short pill form here because the tw-match row is denser than the
   // upcoming-list row in the per-competition viewer.
-  const qp = m.queuePosition;
-  const queuePill = (m.status === "scheduled" && qp && qp > 0)
+  const qp = Number(m.queuePosition);
+  const queuePill = (m.status === "scheduled" && Number.isFinite(qp) && qp > 0)
     ? (qp === 1 ? "Next" : `#${qp}`)
     : null;
   return (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -555,11 +555,12 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
 //   - status==="running"                       → null (round label already shows " · LIVE NOW")
 //   - anything else (completed/forfeit/cancelled, or no qp)  → null (hide chip)
 //
-// Wording mirrors the VSchedItem helper below so both viewer surfaces agree.
-// Running matches return null because the my-match__round label already appends
-// " · LIVE NOW" — rendering it again in the Queue chip would be a duplicate.
-// We intentionally do NOT fall back to "Scheduled HH:MM" the way display.jsx
-// does — the MyMatchPanel already has a dedicated Time chip.
+// Wording mirrors the VSchedItem helper below and display.jsx::queueLabel
+// so all three viewer surfaces agree. Running matches return null because
+// the my-match__round label already appends " · LIVE NOW" — rendering it
+// again in the Queue chip would be a duplicate. We intentionally do NOT
+// fall back to "Scheduled HH:MM" the way display.jsx does — the
+// MyMatchPanel already has a dedicated Time chip.
 // Exported for unit-testing.
 export function mymatchQueueLabel(m) {
   if (!m) return null;
@@ -634,9 +635,9 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   // FR-025: queue position is 1-indexed per court for scheduled matches; 0 for
   // running/completed. Treat null/undefined/0 as "don't render" so we stay
   // gracefully empty for non-queued matches and pre-T046 responses. Wording
-  // ("Next up" / "N before yours") mirrors VSchedItem below so both viewer
-  // surfaces agree. Running matches show null here because the round label
-  // already appends " · LIVE NOW".
+  // ("Next up" / "N before yours") mirrors VSchedItem below and display.jsx
+  // so all three viewer surfaces agree. Running matches show null here
+  // because the round label already appends " · LIVE NOW".
   const queueLabel = mymatchQueueLabel(nextMatch);
   const queueHighlight = queueLabel === "Next up";
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -550,23 +550,24 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
 // mymatchQueueLabel — FR-025 label for the "Your next match" Queue chip.
 //
 // Contract:
-//   - status==="scheduled" + queuePosition===1 → "Up next"
+//   - status==="scheduled" + queuePosition===1 → "Next up"
 //   - status==="scheduled" + queuePosition>1   → "<qp-1> before yours"
-//   - status==="running"                       → "LIVE NOW"
+//   - status==="running"                       → null (round label already shows " · LIVE NOW")
 //   - anything else (completed/forfeit/cancelled, or no qp)  → null (hide chip)
 //
-// Wording mirrors display.jsx::queueLabel and the VSchedItem helper below so
-// the three viewer surfaces agree. We intentionally do NOT fall back to
-// "Scheduled HH:MM" the way display.jsx does — the MyMatchPanel already has a
-// dedicated Time chip, and an extra "Scheduled 10:30" would just duplicate it.
+// Wording mirrors the VSchedItem helper below so both viewer surfaces agree.
+// Running matches return null because the my-match__round label already appends
+// " · LIVE NOW" — rendering it again in the Queue chip would be a duplicate.
+// We intentionally do NOT fall back to "Scheduled HH:MM" the way display.jsx
+// does — the MyMatchPanel already has a dedicated Time chip.
 // Exported for unit-testing.
 export function mymatchQueueLabel(m) {
     if (!m) return null;
-    if (m.status === "running") return "LIVE NOW";
+    if (m.status === "running") return null;
     if (m.status !== "scheduled") return null;
     const qp = m.queuePosition;
     if (typeof qp !== "number" || qp <= 0) return null;
-    if (qp === 1) return "Up next";
+    if (qp === 1) return "Next up";
     return `${qp - 1} before yours`;
 }
 
@@ -633,9 +634,9 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   // FR-025: queue position is 1-indexed per court for scheduled matches; 0 for
   // running/completed. Treat null/undefined/0 as "don't render" so we stay
   // gracefully empty for non-queued matches and pre-T046 responses. Wording
-  // ("Up next" / "N before yours") mirrors display.jsx::queueLabel so the
-  // three viewer surfaces — MyMatchPanel here, VSchedItem, and the per-court
-  // queue list in display.jsx — agree.
+  // ("Next up" / "N before yours") mirrors VSchedItem below so both viewer
+  // surfaces agree. Running matches show null here because the round label
+  // already appends " · LIVE NOW".
   const queueLabel = mymatchQueueLabel(nextMatch);
   const queueHighlight = nextMatch.queuePosition === 1 || nextMatch.status === "running";
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -547,6 +547,29 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
   );
 }
 
+// mymatchQueueLabel — FR-025 label for the "Your next match" Queue chip.
+//
+// Contract:
+//   - status==="scheduled" + queuePosition===1 → "Up next"
+//   - status==="scheduled" + queuePosition>1   → "<qp-1> before yours"
+//   - status==="running"                       → "LIVE NOW"
+//   - anything else (completed/forfeit/cancelled, or no qp)  → null (hide chip)
+//
+// Wording mirrors display.jsx::queueLabel and the VSchedItem helper below so
+// the three viewer surfaces agree. We intentionally do NOT fall back to
+// "Scheduled HH:MM" the way display.jsx does — the MyMatchPanel already has a
+// dedicated Time chip, and an extra "Scheduled 10:30" would just duplicate it.
+// Exported for unit-testing.
+export function mymatchQueueLabel(m) {
+    if (!m) return null;
+    if (m.status === "running") return "LIVE NOW";
+    if (m.status !== "scheduled") return null;
+    const qp = m.queuePosition;
+    if (typeof qp !== "number" || qp <= 0) return null;
+    if (qp === 1) return "Up next";
+    return `${qp - 1} before yours`;
+}
+
 // MyMatchPanel — "Find my matches" entry point + active "Your next match"
 // card. Two states:
 //   1) No followed player yet → render a picker; selecting persists to
@@ -609,11 +632,12 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   const phaseLabel = nextMatch.phase === "pool" ? nextMatch.poolName : (nextMatch.round || "Bracket");
   // FR-025: queue position is 1-indexed per court for scheduled matches; 0 for
   // running/completed. Treat null/undefined/0 as "don't render" so we stay
-  // gracefully empty for non-queued matches and pre-T046 responses.
-  const qp = nextMatch.queuePosition;
-  const queueLabel = (nextMatch.status === "scheduled" && qp && qp > 0)
-    ? (qp === 1 ? "Up next" : `${qp - 1} before you`)
-    : (nextMatch.status === "running" ? "LIVE NOW" : null);
+  // gracefully empty for non-queued matches and pre-T046 responses. Wording
+  // ("Up next" / "N before yours") mirrors display.jsx::queueLabel so the
+  // three viewer surfaces — MyMatchPanel here, VSchedItem, and the per-court
+  // queue list in display.jsx — agree.
+  const queueLabel = mymatchQueueLabel(nextMatch);
+  const queueHighlight = nextMatch.queuePosition === 1 || nextMatch.status === "running";
 
   return (
     <div className="my-match" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
@@ -634,9 +658,19 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
           <span className="v">{nextMatch.scheduledAt || "TBA"}</span>
         </div>
         {queueLabel && (
-          <div className="my-match__chip" data-testid="my-match-queue">
+          <div
+            className="my-match__chip"
+            data-testid="my-match-queue"
+            aria-live={queueHighlight ? "polite" : "off"}
+          >
             <span className="l">Queue</span>
-            <span className="v" style={{ color: (qp === 1 || nextMatch.status === "running") ? "var(--accent)" : "inherit" }}>{queueLabel}</span>
+            {/* The .my-match card background is var(--accent) (dark blue), so
+                colouring text with var(--accent) renders unreadable. The chip
+                inherits white from --accent-fg; emphasise the live/up-next
+                state with full opacity + a Unicode bullet instead. */}
+            <span className="v" style={{ opacity: queueHighlight ? 1 : 0.92 }}>
+              {queueHighlight ? "• " : ""}{queueLabel}
+            </span>
           </div>
         )}
       </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -663,15 +663,19 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
           <div
             className="my-match__chip"
             data-testid="my-match-queue"
-            aria-live={queueHighlight ? "polite" : "off"}
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
           >
             <span className="l">Queue</span>
             {/* The .my-match card background is var(--accent) (dark blue), so
                 colouring text with var(--accent) renders unreadable. The chip
                 inherits white from --accent-fg; emphasise the live/up-next
-                state with full opacity + a Unicode bullet instead. */}
+                state with full opacity + a Unicode bullet instead.
+                Wrap the decorative bullet in aria-hidden to keep screen reader
+                announcements clean and focused on the queue label text. */}
             <span className="v" style={{ opacity: queueHighlight ? 1 : 0.92 }}>
-              {queueHighlight ? "• " : ""}{queueLabel}
+              {queueHighlight && <span aria-hidden="true">• </span>}{queueLabel}
             </span>
           </div>
         )}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -675,7 +675,11 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
                 Wrap the decorative bullet in aria-hidden to keep screen reader
                 announcements clean and focused on the queue label text. */}
             <span className="v" style={{ opacity: queueHighlight ? 1 : 0.92 }}>
-              {queueHighlight && <span aria-hidden="true">• </span>}{queueLabel}
+              {/* Decorative bullet glyph — hidden from screen readers so the
+                  announcement is just the queue label text ("Next up" /
+                  "1 before yours") without a spurious "bullet" prefix. */}
+              {queueHighlight ? <span aria-hidden="true">{"• "}</span> : null}
+              {queueLabel}
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds a Queue chip next to the existing Court/Time chips on the MyMatchPanel "Your next match" card in `web-mobile/js/viewer.jsx`, surfacing the per-court queue position to a participant who has followed themselves.
- Reuses the FR-025 contract that VSchedItem already implements: 1-indexed for scheduled matches, 0/undefined for running/completed/legacy payloads, hidden when not applicable.
- Label logic extracted to a unit-testable, exported `mymatchQueueLabel` helper with full Vitest coverage.

## Why
The MyMatchPanel card is hand-rendered (not via VSchedItem), so the queue label that VSchedItem and TWMatch already surface for upcoming-list and TV-wall rows was missing from the most personally relevant view: "your" next match. Participants asked for "X matches before yours" so they can warm up in time — see running_a_kendo_tournament.md § Information Needs by Audience.

The new chip:
- `qp === 1` → **Next up**
- `qp > 1` → **N before yours** (wording aligned with `display.jsx::queueLabel` and `VSchedItem`)
- `status === "running"` → chip hidden; **· LIVE NOW** appears in the round label instead
- otherwise → hidden

Up-next state is emphasised with full opacity + a leading bullet glyph. The earlier `color: var(--accent)` styling was a contrast bug — `.my-match` already uses `var(--accent)` as its background, so dark-blue text on the chip's translucent-white-over-accent background was unreadable.

The chip wrapper carries `aria-live="polite"` so screen readers announce transitions into the up-next state.

Closes bracket-creator-bw2.

## Test plan
- [x] `cd web-mobile && npm test` — 656/656 pass (was 649; +7 new `mymatchQueueLabel` cases)
- [x] `cd web-mobile && npm run lint` (eslint --max-warnings 0) — clean
- [x] `make esbuild-jsx` — JSX compiles cleanly to `web-mobile/dist/viewer.js`
- [x] `go build` succeeds (binary embeds the rebuilt dist)
- [x] Manual: `make run-mobile`, register participants, start a competition, follow a participant, confirm the Queue chip renders with the correct label for scheduled / live / when up-next

## Review-pass fixes (post initial review)
- Wording aligned: `N before you` → `N before yours` (matches sibling surfaces).
- Contrast bug fixed: dropped `color: var(--accent)` (dark-on-dark over the accent-coloured card); use full opacity + leading bullet for the highlighted state.
- Logic extracted to exported `mymatchQueueLabel(m)` with 7 Vitest cases (`scheduled`/`running` flows; missing / 0 / negative / string `queuePosition`; `completed`/`forfeit`/`cancelled` statuses; null match).
- `aria-live="polite"` added on the chip wrapper.
- Backend fix: `BracketMatch` was missing `QueuePosition` field, so the chip never showed for Knockout-only competitions. Added `annotateBracketQueuePositions` and call it alongside `annotateQueuePositions` in both viewer handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)