### PR TITLE
feat(viewer): final placement view (1st / 2nd / two 3rds) with dojo + fullscreen

### DIFF
--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -1,0 +1,100 @@
+// Pure-logic tests for deriveAwards — the helper that maps bracket/standings
+// payloads into the 1/2/3/3 podium per FIK convention (no bronze match).
+import { describe, it, expect } from 'vitest';
+import { deriveAwards } from '../viewer.jsx';
+
+const playerMap = (...pairs) => {
+  const m = new Map();
+  pairs.forEach(([name, dojo]) => m.set(name, { name, dojo }));
+  return m;
+};
+
+describe('deriveAwards (bracket-based)', () => {
+  it('returns 1st/2nd and two 3rd places from the final + semis', () => {
+    const bracket = {
+      rounds: [
+        // round 0 — semis (irrelevant)
+        [],
+        // round 1 — semi-finals
+        [
+          { sideA: 'Alice', sideB: 'Bob', winner: 'Alice' },
+          { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' },
+        ],
+        // round 2 — final
+        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+      ],
+    };
+    const m = playerMap(['Alice', 'Aoyama'], ['Bob', 'Bunkyo'], ['Carol', 'Chiba'], ['Dan', 'Denenchofu']);
+    const awards = deriveAwards(bracket, null, null, 'playoffs', m);
+    expect(awards).toEqual([
+      { place: 1, name: 'Alice', dojo: 'Aoyama' },
+      { place: 2, name: 'Carol', dojo: 'Chiba' },
+      { place: 3, name: 'Bob', dojo: 'Bunkyo' },
+      { place: 3, name: 'Dan', dojo: 'Denenchofu' },
+    ]);
+  });
+
+  it('returns [] when the final has no winner yet', () => {
+    const bracket = {
+      rounds: [
+        [{ sideA: 'A', sideB: 'B', winner: 'A' }],
+        [{ sideA: 'A', sideB: 'C', winner: '' }],
+      ],
+    };
+    expect(deriveAwards(bracket, null, null, 'playoffs', new Map())).toEqual([]);
+  });
+
+  it('handles missing dojos by defaulting to empty string', () => {
+    const bracket = {
+      rounds: [
+        [{ sideA: 'X', sideB: 'Y', winner: 'X' }],
+      ],
+    };
+    const awards = deriveAwards(bracket, null, null, 'playoffs', new Map());
+    expect(awards.length).toBe(2);
+    expect(awards[0]).toEqual({ place: 1, name: 'X', dojo: '' });
+    expect(awards[1]).toEqual({ place: 2, name: 'Y', dojo: '' });
+  });
+
+  it('omits a third place when only one semi-final exists (4-player bracket)', () => {
+    const bracket = {
+      rounds: [
+        [{ sideA: 'A', sideB: 'B', winner: 'A' }],
+        [{ sideA: 'A', sideB: 'C', winner: 'A' }],
+      ],
+    };
+    const awards = deriveAwards(bracket, null, null, 'playoffs', new Map());
+    expect(awards.map((a) => a.name)).toEqual(['A', 'C', 'B']);
+  });
+});
+
+describe('deriveAwards (standings-based)', () => {
+  it('falls back to the top 4 of the first pool when no bracket exists', () => {
+    const pools = [{ poolName: 'Pool A' }];
+    const standings = {
+      'Pool A': [
+        { player: { name: 'Alice', dojo: 'Aoyama' } },
+        { player: { name: 'Bob', dojo: 'Bunkyo' } },
+        { player: { name: 'Carol', dojo: 'Chiba' } },
+        { player: { name: 'Dan', dojo: 'Denenchofu' } },
+        { player: { name: 'Eve', dojo: 'Edogawa' } },
+      ],
+    };
+    const awards = deriveAwards(null, standings, pools, 'league', new Map());
+    expect(awards).toEqual([
+      { place: 1, name: 'Alice', dojo: 'Aoyama' },
+      { place: 2, name: 'Bob', dojo: 'Bunkyo' },
+      { place: 3, name: 'Carol', dojo: 'Chiba' },
+      { place: 3, name: 'Dan', dojo: 'Denenchofu' },
+    ]);
+  });
+
+  it('returns [] when standings is empty', () => {
+    const pools = [{ poolName: 'Pool A' }];
+    expect(deriveAwards(null, { 'Pool A': [] }, pools, 'league', new Map())).toEqual([]);
+  });
+
+  it('returns [] when no bracket and no pools/standings', () => {
+    expect(deriveAwards(null, null, null, 'playoffs', new Map())).toEqual([]);
+  });
+});

--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -25,7 +25,7 @@ describe('deriveAwards (bracket-based)', () => {
       ],
     };
     const m = playerMap(['Alice', 'Aoyama'], ['Bob', 'Bunkyo'], ['Carol', 'Chiba'], ['Dan', 'Denenchofu']);
-    const awards = deriveAwards(bracket, null, null, 'playoffs', m);
+    const awards = deriveAwards(bracket, null, null, m);
     expect(awards).toEqual([
       { place: 1, name: 'Alice', dojo: 'Aoyama' },
       { place: 2, name: 'Carol', dojo: 'Chiba' },
@@ -41,7 +41,7 @@ describe('deriveAwards (bracket-based)', () => {
         [{ sideA: 'A', sideB: 'C', winner: '' }],
       ],
     };
-    expect(deriveAwards(bracket, null, null, 'playoffs', new Map())).toEqual([]);
+    expect(deriveAwards(bracket, null, null, new Map())).toEqual([]);
   });
 
   it('handles missing dojos by defaulting to empty string', () => {
@@ -50,7 +50,7 @@ describe('deriveAwards (bracket-based)', () => {
         [{ sideA: 'X', sideB: 'Y', winner: 'X' }],
       ],
     };
-    const awards = deriveAwards(bracket, null, null, 'playoffs', new Map());
+    const awards = deriveAwards(bracket, null, null, new Map());
     expect(awards.length).toBe(2);
     expect(awards[0]).toEqual({ place: 1, name: 'X', dojo: '' });
     expect(awards[1]).toEqual({ place: 2, name: 'Y', dojo: '' });
@@ -63,7 +63,7 @@ describe('deriveAwards (bracket-based)', () => {
         [{ sideA: 'A', sideB: 'C', winner: 'A' }],
       ],
     };
-    const awards = deriveAwards(bracket, null, null, 'playoffs', new Map());
+    const awards = deriveAwards(bracket, null, null, new Map());
     expect(awards.map((a) => a.name)).toEqual(['A', 'C', 'B']);
   });
 });
@@ -80,7 +80,7 @@ describe('deriveAwards (standings-based)', () => {
         { player: { name: 'Eve', dojo: 'Edogawa' } },
       ],
     };
-    const awards = deriveAwards(null, standings, pools, 'league', new Map());
+    const awards = deriveAwards(null, standings, pools, new Map());
     expect(awards).toEqual([
       { place: 1, name: 'Alice', dojo: 'Aoyama' },
       { place: 2, name: 'Bob', dojo: 'Bunkyo' },
@@ -91,11 +91,11 @@ describe('deriveAwards (standings-based)', () => {
 
   it('returns [] when standings is empty', () => {
     const pools = [{ poolName: 'Pool A' }];
-    expect(deriveAwards(null, { 'Pool A': [] }, pools, 'league', new Map())).toEqual([]);
+    expect(deriveAwards(null, { 'Pool A': [] }, pools, new Map())).toEqual([]);
   });
 
   it('returns [] when no bracket and no pools/standings', () => {
-    expect(deriveAwards(null, null, null, 'playoffs', new Map())).toEqual([]);
+    expect(deriveAwards(null, null, null, new Map())).toEqual([]);
   });
 
   it('accepts a flat Swiss-shape standings array (no pool key)', () => {
@@ -105,7 +105,7 @@ describe('deriveAwards (standings-based)', () => {
       { player: { name: 'Carol', dojo: 'Chiba' } },
       { player: { name: 'Dan', dojo: 'Denenchofu' } },
     ];
-    const awards = deriveAwards(null, standings, null, 'swiss', new Map());
+    const awards = deriveAwards(null, standings, null, new Map());
     expect(awards).toEqual([
       { place: 1, name: 'Alice', dojo: 'Aoyama' },
       { place: 2, name: 'Bob', dojo: 'Bunkyo' },
@@ -136,7 +136,7 @@ describe('deriveAwards (standings-based)', () => {
         { player: { name: 'Dan', dojo: 'Denenchofu' } },
       ],
     };
-    const awards = deriveAwards(bracket, standings, pools, 'pools', new Map());
+    const awards = deriveAwards(bracket, standings, pools, new Map());
     expect(awards.map((a) => a.name)).toEqual(['Alice', 'Bob', 'Carol', 'Dan']);
     expect(awards.map((a) => a.place)).toEqual([1, 2, 3, 3]);
   });

--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -97,4 +97,47 @@ describe('deriveAwards (standings-based)', () => {
   it('returns [] when no bracket and no pools/standings', () => {
     expect(deriveAwards(null, null, null, 'playoffs', new Map())).toEqual([]);
   });
+
+  it('accepts a flat Swiss-shape standings array (no pool key)', () => {
+    const standings = [
+      { player: { name: 'Alice', dojo: 'Aoyama' } },
+      { player: { name: 'Bob', dojo: 'Bunkyo' } },
+      { player: { name: 'Carol', dojo: 'Chiba' } },
+      { player: { name: 'Dan', dojo: 'Denenchofu' } },
+    ];
+    const awards = deriveAwards(null, standings, null, 'swiss', new Map());
+    expect(awards).toEqual([
+      { place: 1, name: 'Alice', dojo: 'Aoyama' },
+      { place: 2, name: 'Bob', dojo: 'Bunkyo' },
+      { place: 3, name: 'Carol', dojo: 'Chiba' },
+      { place: 3, name: 'Dan', dojo: 'Denenchofu' },
+    ]);
+  });
+
+  it('falls back to standings when a bracket exists but the final has no winner (pools+playoffs placeholder)', () => {
+    // Simulates a pools-only competition where derivedBracket is a TBD
+    // placeholder (rounds present, no winners). The standings fallback
+    // should still produce the podium.
+    const bracket = {
+      rounds: [
+        [
+          { sideA: null, sideB: null, winner: null },
+          { sideA: null, sideB: null, winner: null },
+        ],
+        [{ sideA: null, sideB: null, winner: null }],
+      ],
+    };
+    const pools = [{ poolName: 'Pool A' }];
+    const standings = {
+      'Pool A': [
+        { player: { name: 'Alice', dojo: 'Aoyama' } },
+        { player: { name: 'Bob', dojo: 'Bunkyo' } },
+        { player: { name: 'Carol', dojo: 'Chiba' } },
+        { player: { name: 'Dan', dojo: 'Denenchofu' } },
+      ],
+    };
+    const awards = deriveAwards(bracket, standings, pools, 'pools', new Map());
+    expect(awards.map((a) => a.name)).toEqual(['Alice', 'Bob', 'Carol', 'Dan']);
+    expect(awards.map((a) => a.place)).toEqual([1, 2, 3, 3]);
+  });
 });

--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -34,6 +34,32 @@ describe('deriveAwards (bracket-based)', () => {
     ]);
   });
 
+  it('handles normalized object fields (as produced by normalizeMatch)', () => {
+    // Simulate the shape produced by normalizeMatch() / normalizeCompetitionDetail()
+    // where sideA/sideB/winner are objects {id, name, dojo} rather than strings.
+    const mkPlayer = (name, dojo) => ({ id: name.toLowerCase(), name, dojo });
+    const bracket = {
+      rounds: [
+        // round 0 — semis (irrelevant)
+        [],
+        // round 1 — semi-finals
+        [
+          { sideA: mkPlayer('Alice', 'Aoyama'), sideB: mkPlayer('Bob', 'Bunkyo'), winner: mkPlayer('Alice', 'Aoyama') },
+          { sideA: mkPlayer('Carol', 'Chiba'), sideB: mkPlayer('Dan', 'Denenchofu'), winner: mkPlayer('Carol', 'Chiba') },
+        ],
+        // round 2 — final
+        [{ sideA: mkPlayer('Alice', 'Aoyama'), sideB: mkPlayer('Carol', 'Chiba'), winner: mkPlayer('Alice', 'Aoyama') }],
+      ],
+    };
+    const awards = deriveAwards(bracket, null, null, new Map());
+    expect(awards).toEqual([
+      { place: 1, name: 'Alice', dojo: 'Aoyama' },
+      { place: 2, name: 'Carol', dojo: 'Chiba' },
+      { place: 3, name: 'Bob', dojo: 'Bunkyo' },
+      { place: 3, name: 'Dan', dojo: 'Denenchofu' },
+    ]);
+  });
+
   it('returns [] when the final has no winner yet', () => {
     const bracket = {
       rounds: [

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1887,7 +1887,7 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
 // entries with dojo info; missing names fall back to {name, dojo: ""}.
 // `standings` may be either a flat array (Swiss-shape) or an object keyed by
 // pool name (pools/league shape).
-function deriveAwards(bracket, standings, pools, format, nameToPlayer) {
+function deriveAwards(bracket, standings, pools, nameToPlayer) {
   const lookup = (name) => {
     if (!name) return null;
     const p = nameToPlayer && nameToPlayer.get(name);
@@ -1979,9 +1979,10 @@ function AwardsView({ c, bracket, standings, pools, players }) {
   }, [players]);
 
   const effectiveStandings = c?.format === "swiss" ? swissStandings : standings;
+  const isSwissLoading = c?.format === "swiss" && swissStandings === null;
   const awards = useMemo(
-    () => deriveAwards(bracket, effectiveStandings, pools, c?.format, nameToPlayer),
-    [bracket, effectiveStandings, pools, c?.format, nameToPlayer]
+    () => deriveAwards(bracket, effectiveStandings, pools, nameToPlayer),
+    [bracket, effectiveStandings, pools, nameToPlayer]
   );
 
   const toggleFs = () => {
@@ -1994,6 +1995,15 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     }
   };
 
+  if (isSwissLoading) {
+    return (
+      <div className="empty" data-testid="awards-loading">
+        <div className="icon">🏆</div>
+        <h3>Loading final standings…</h3>
+      </div>
+    );
+  }
+
   if (awards.length === 0) {
     return (
       <div className="empty" data-testid="awards-empty">
@@ -2003,7 +2013,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     );
   }
 
-  // FIK ordering for podium display: 3 left, 1 center, 2 right, 3 right-most.
+  // Podium ordering follows CSS order rules: 2 left, 1 center, then 3rd-place cards.
   // For the fullscreen ceremony layout we keep the same order but enlarge.
   return (
     <div
@@ -2036,7 +2046,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
             <div
               key={`${a.place}-${a.name}-${idx}`}
               className={`podium-step podium-step--${a.place}`}
-              data-testid={`awards-place-${a.place}`}
+              data-testid={`awards-place-${a.place}-${idx}`}
               style={{ borderTop: `4px solid ${style.accent}` }}
             >
               <div style={{ fontSize: isFs ? 56 : 28 }}>{style.icon}</div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -932,7 +932,7 @@ function ViewerCompetition({ _tournament, competition, pools, poolMatches, stand
     isSwiss ? { id: "swiss", label: "Standings" } : null,
     hasPools && !isSwiss ? { id: "pools", label: "Pools" } : null,
     hasBracket && !isSwiss ? { id: "bracket", label: "Bracket" } : null,
-    c.status === "completed" && !isSwiss ? { id: "results", label: "Results" } : null,
+    c.status === "completed" ? { id: "results", label: "Awards" } : null,
   ].filter(Boolean);
 
   const currentMatch = useMemo(() => {
@@ -1013,8 +1013,8 @@ function ViewerCompetition({ _tournament, competition, pools, poolMatches, stand
           {tab === "swiss" && isSwiss && (
             <SwissStandingsViewer competition={c} poolMatches={poolMatches} tweaks={tweaks} />
           )}
-          {tab === "results" && c.status === "completed" && derivedBracket && (
-            <ResultsViewer c={c} bracket={derivedBracket} />
+          {tab === "results" && c.status === "completed" && (
+            <ResultsViewer c={c} bracket={derivedBracket} standings={standings} pools={pools} players={c.players} />
           )}
         </div>
       </div>
@@ -1637,7 +1637,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, deriveAwards };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -1645,6 +1645,7 @@ if (typeof window !== 'undefined') {
     window.matchHighlightedBy = matchHighlightedBy;
     window.buildPlayerMatchHighlight = buildPlayerMatchHighlight;
     window.buildWatchlistUpcoming = buildWatchlistUpcoming;
+    window.deriveAwards = deriveAwards;
 }
 
 // Tournament-wide schedule (across competitions) — grouped by day, then court swimlanes + filter
@@ -1853,47 +1854,153 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
   );
 }
 
-function ResultsViewer({ _c, bracket }) {
-  const final = bracket.rounds[bracket.rounds.length - 1][0];
-  const sf = bracket.rounds[bracket.rounds.length - 2] || [];
-  const champion = final.winner;
-  const runnerUp = final.winner === final.sideA ? final.sideB : final.sideA;
-  const third = sf.map((m) => m.winner === m.sideA ? m.sideB : m.sideA).filter(Boolean);
-  return (
-    <div>
-      <div className="podium">
-        {third[0] && (
-          <div className="podium-step podium-step--3">
-            <div className="place">3</div>
-            <div className="name">{third[0]}</div>
-          </div>
-        )}
-        {champion && (
-          <div className="podium-step podium-step--1">
-            <div style={{ fontSize: 28 }}>🏆</div>
-            <div className="place">1</div>
-            <div className="name">{champion}</div>
-          </div>
-        )}
-        {runnerUp && (
-          <div className="podium-step podium-step--2">
-            <div className="place">2</div>
-            <div className="name">{runnerUp}</div>
-          </div>
-        )}
-        {third[1] && (
-          <div className="podium-step podium-step--3" style={{ order: 4 }}>
-            <div className="place">3</div>
-            <div className="name">{third[1]}</div>
-          </div>
-        )}
+// deriveAwards returns up to four placements for the closing ceremony per
+// FIK convention: 1st, 2nd, and two 3rds (semi-final losers — no bronze match).
+// Returns [] when the final isn't decided yet or no podium data exists.
+// `nameToPlayer` is an optional Map(name → {name, dojo}) to enrich entries
+// with dojo info; missing names fall back to {name, dojo: ""}.
+function deriveAwards(bracket, standings, pools, format, nameToPlayer) {
+  const lookup = (name) => {
+    if (!name) return null;
+    const p = nameToPlayer && nameToPlayer.get(name);
+    return { name, dojo: (p && p.dojo) || "" };
+  };
+
+  // Bracket-based: final + semi-finals
+  if (bracket && bracket.rounds && bracket.rounds.length > 0) {
+    const finalRound = bracket.rounds[bracket.rounds.length - 1];
+    const sfRound = bracket.rounds[bracket.rounds.length - 2] || [];
+    const final = finalRound[0];
+    if (!final || !final.winner) return [];
+    const champion = final.winner;
+    const runnerUp = final.winner === final.sideA ? final.sideB : final.sideA;
+    const thirds = sfRound
+      .map((m) => (m.winner ? (m.winner === m.sideA ? m.sideB : m.sideA) : null))
+      .filter(Boolean);
+    return [
+      { place: 1, ...lookup(champion) },
+      runnerUp ? { place: 2, ...lookup(runnerUp) } : null,
+      thirds[0] ? { place: 3, ...lookup(thirds[0]) } : null,
+      thirds[1] ? { place: 3, ...lookup(thirds[1]) } : null,
+    ].filter(Boolean);
+  }
+
+  // League / Swiss / pools-only: take the top four from the single standings.
+  // For pools-only with multiple pools we still want the first pool's leader
+  // (consistent with PoolsViewer's leagueWinner pick).
+  if (standings && pools && pools.length > 0) {
+    const list = standings[pools[0].poolName] || [];
+    const slice = list.slice(0, 4).map((s, i) => ({
+      place: i < 3 ? i + 1 : 3,
+      name: s.player?.name || "",
+      dojo: s.player?.dojo || "",
+    }));
+    return slice.filter((e) => e.name);
+  }
+
+  return [];
+}
+
+const PLACE_STYLE = {
+  1: { icon: "🏆", label: "1st Place", accent: "var(--gold, #d4af37)" },
+  2: { icon: "🥈", label: "2nd Place", accent: "var(--silver, #c0c0c0)" },
+  3: { icon: "🥉", label: "3rd Place", accent: "var(--bronze, #cd7f32)" },
+};
+
+function AwardsView({ c, bracket, standings, pools, players }) {
+  const containerRef = useRefV(null);
+  const [isFs, setIsFs] = useState(false);
+
+  React.useEffect(() => {
+    const onFsChange = () => setIsFs(!!document.fullscreenElement);
+    document.addEventListener("fullscreenchange", onFsChange);
+    return () => document.removeEventListener("fullscreenchange", onFsChange);
+  }, []);
+
+  const nameToPlayer = useMemo(() => {
+    const m = new Map();
+    (players || []).forEach((p) => {
+      if (p && p.name) m.set(p.name, p);
+    });
+    return m;
+  }, [players]);
+
+  const awards = useMemo(
+    () => deriveAwards(bracket, standings, pools, c?.format, nameToPlayer),
+    [bracket, standings, pools, c?.format, nameToPlayer]
+  );
+
+  const toggleFs = () => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    } else if (el.requestFullscreen) {
+      el.requestFullscreen().catch(() => {});
+    }
+  };
+
+  if (awards.length === 0) {
+    return (
+      <div className="empty" data-testid="awards-empty">
+        <div className="icon">🏆</div>
+        <h3>Final standings not yet available</h3>
       </div>
-      <div className="card" style={{ marginTop: 16 }}>
-        <div className="card__title" style={{ marginBottom: 10 }}>Final match</div>
-        <window.MatchCard match={final} variant={1} showDojo={true} />
+    );
+  }
+
+  // FIK ordering for podium display: 3 left, 1 center, 2 right, 3 right-most.
+  // For the fullscreen ceremony layout we keep the same order but enlarge.
+  return (
+    <div
+      ref={containerRef}
+      className="awards"
+      data-testid="awards-view"
+      style={{
+        background: isFs ? "var(--bg)" : "transparent",
+        padding: isFs ? 40 : 0,
+        minHeight: isFs ? "100vh" : "auto",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+        <div>
+          <div className="section-title" style={{ margin: 0, fontSize: isFs ? 28 : 18 }}>
+            {c?.name ? `${c.name} — Awards` : "Awards"}
+          </div>
+          <div style={{ fontSize: isFs ? 16 : 12, color: "var(--ink-3)" }}>
+            Closing ceremony · {awards.length} place{awards.length === 1 ? "" : "s"}
+          </div>
+        </div>
+        <button className="btn btn--sm" onClick={toggleFs} data-testid="awards-fullscreen">
+          {isFs ? "Exit fullscreen" : "Fullscreen"}
+        </button>
+      </div>
+      <div className="podium" style={isFs ? { gap: 24, fontSize: 18 } : null}>
+        {awards.map((a, idx) => {
+          const style = PLACE_STYLE[a.place] || PLACE_STYLE[3];
+          return (
+            <div
+              key={`${a.place}-${a.name}-${idx}`}
+              className={`podium-step podium-step--${a.place}`}
+              data-testid={`awards-place-${a.place}`}
+              style={{ borderTop: `4px solid ${style.accent}` }}
+            >
+              <div style={{ fontSize: isFs ? 56 : 28 }}>{style.icon}</div>
+              <div className="place" style={{ fontSize: isFs ? 18 : 12 }}>{style.label}</div>
+              <div className="name" style={{ fontSize: isFs ? 28 : 16 }}>{a.name}</div>
+              {a.dojo && (
+                <div className="d" style={{ fontSize: isFs ? 16 : 12, color: "var(--ink-3)" }}>{a.dojo}</div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
+}
+
+function ResultsViewer({ c, bracket, standings, pools, players }) {
+  return <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={players} />;
 }
 
 // Tournament-wide schedule wrapper for the viewer (its own screen)

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1037,7 +1037,10 @@ function ViewerCompetition({ _tournament, competition, pools, poolMatches, stand
             <SwissStandingsViewer competition={c} poolMatches={poolMatches} tweaks={tweaks} />
           )}
           {tab === "results" && c.status === "completed" && (
-            <ResultsViewer c={c} bracket={derivedBracket} standings={standings} pools={pools} players={c.players} />
+            // Pass the *real* server bracket (not derivedBracket) — the latter
+            // is a TBD placeholder for visualization that has no winners and
+            // would short-circuit the standings fallback inside AwardsView.
+            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} />
           )}
         </div>
       </div>
@@ -1879,9 +1882,11 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
 
 // deriveAwards returns up to four placements for the closing ceremony per
 // FIK convention: 1st, 2nd, and two 3rds (semi-final losers — no bronze match).
-// Returns [] when the final isn't decided yet or no podium data exists.
-// `nameToPlayer` is an optional Map(name → {name, dojo}) to enrich entries
-// with dojo info; missing names fall back to {name, dojo: ""}.
+// Returns [] when no podium data exists yet.
+// `nameToPlayer` is an optional Map(name → {name, dojo}) to enrich bracket
+// entries with dojo info; missing names fall back to {name, dojo: ""}.
+// `standings` may be either a flat array (Swiss-shape) or an object keyed by
+// pool name (pools/league shape).
 function deriveAwards(bracket, standings, pools, format, nameToPlayer) {
   const lookup = (name) => {
     if (!name) return null;
@@ -1889,30 +1894,42 @@ function deriveAwards(bracket, standings, pools, format, nameToPlayer) {
     return { name, dojo: (p && p.dojo) || "" };
   };
 
-  // Bracket-based: final + semi-finals
+  // Bracket-based: final + semi-finals. Only used when the final has a
+  // decided winner; if it doesn't, fall through to standings below so a
+  // pools-only competition that has a TBD-placeholder bracket still shows
+  // the podium from its pool standings.
   if (bracket && bracket.rounds && bracket.rounds.length > 0) {
     const finalRound = bracket.rounds[bracket.rounds.length - 1];
     const sfRound = bracket.rounds[bracket.rounds.length - 2] || [];
     const final = finalRound[0];
-    if (!final || !final.winner) return [];
-    const champion = final.winner;
-    const runnerUp = final.winner === final.sideA ? final.sideB : final.sideA;
-    const thirds = sfRound
-      .map((m) => (m.winner ? (m.winner === m.sideA ? m.sideB : m.sideA) : null))
-      .filter(Boolean);
-    return [
-      { place: 1, ...lookup(champion) },
-      runnerUp ? { place: 2, ...lookup(runnerUp) } : null,
-      thirds[0] ? { place: 3, ...lookup(thirds[0]) } : null,
-      thirds[1] ? { place: 3, ...lookup(thirds[1]) } : null,
-    ].filter(Boolean);
+    if (final && final.winner) {
+      const champion = final.winner;
+      const runnerUp = final.winner === final.sideA ? final.sideB : final.sideA;
+      const thirds = sfRound
+        .map((m) => (m.winner ? (m.winner === m.sideA ? m.sideB : m.sideA) : null))
+        .filter(Boolean);
+      return [
+        { place: 1, ...lookup(champion) },
+        runnerUp ? { place: 2, ...lookup(runnerUp) } : null,
+        thirds[0] ? { place: 3, ...lookup(thirds[0]) } : null,
+        thirds[1] ? { place: 3, ...lookup(thirds[1]) } : null,
+      ].filter(Boolean);
+    }
   }
 
-  // League / Swiss / pools-only: take the top four from the single standings.
-  // For pools-only with multiple pools we still want the first pool's leader
-  // (consistent with PoolsViewer's leagueWinner pick).
-  if (standings && pools && pools.length > 0) {
-    const list = standings[pools[0].poolName] || [];
+  // Standings-based fallback. Two payload shapes are supported:
+  //   - Swiss/`/swiss/standings`: a flat array of standings rows.
+  //   - Pools/league: an object keyed by poolName → array of rows.
+  // We take the top four from the (single) leaderboard; for pools-only with
+  // multiple pools we use the first pool (consistent with PoolsViewer's
+  // leagueWinner pick).
+  let list = null;
+  if (Array.isArray(standings)) {
+    list = standings;
+  } else if (standings && pools && pools.length > 0) {
+    list = standings[pools[0].poolName] || [];
+  }
+  if (list && list.length > 0) {
     const slice = list.slice(0, 4).map((s, i) => ({
       place: i < 3 ? i + 1 : 3,
       name: s.player?.name || "",
@@ -1933,12 +1950,25 @@ const PLACE_STYLE = {
 function AwardsView({ c, bracket, standings, pools, players }) {
   const containerRef = useRefV(null);
   const [isFs, setIsFs] = useState(false);
+  // Swiss standings aren't part of the competition-detail payload — they live
+  // behind /swiss/standings. Fetch them here when the format is swiss so the
+  // Awards tab works for Swiss competitions too.
+  const [swissStandings, setSwissStandings] = useState(null);
 
   React.useEffect(() => {
     const onFsChange = () => setIsFs(!!document.fullscreenElement);
     document.addEventListener("fullscreenchange", onFsChange);
     return () => document.removeEventListener("fullscreenchange", onFsChange);
   }, []);
+
+  React.useEffect(() => {
+    if (c?.format !== "swiss" || !window.API?.swissStandings) return undefined;
+    let cancelled = false;
+    window.API.swissStandings(c.id)
+      .then((data) => { if (!cancelled) setSwissStandings(Array.isArray(data) ? data : []); })
+      .catch(() => { if (!cancelled) setSwissStandings([]); });
+    return () => { cancelled = true; };
+  }, [c?.id, c?.format, c?.swissCurrentRound]);
 
   const nameToPlayer = useMemo(() => {
     const m = new Map();
@@ -1948,9 +1978,10 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     return m;
   }, [players]);
 
+  const effectiveStandings = c?.format === "swiss" ? swissStandings : standings;
   const awards = useMemo(
-    () => deriveAwards(bracket, standings, pools, c?.format, nameToPlayer),
-    [bracket, standings, pools, c?.format, nameToPlayer]
+    () => deriveAwards(bracket, effectiveStandings, pools, c?.format, nameToPlayer),
+    [bracket, effectiveStandings, pools, c?.format, nameToPlayer]
   );
 
   const toggleFs = () => {
@@ -2020,10 +2051,6 @@ function AwardsView({ c, bracket, standings, pools, players }) {
       </div>
     </div>
   );
-}
-
-function ResultsViewer({ c, bracket, standings, pools, players }) {
-  return <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={players} />;
 }
 
 // Tournament-wide schedule wrapper for the viewer (its own screen)

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1885,13 +1885,25 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
 // Returns [] when no podium data exists yet.
 // `nameToPlayer` is an optional Map(name → {name, dojo}) to enrich bracket
 // entries with dojo info; missing names fall back to {name, dojo: ""}.
+// Bracket match fields (sideA/sideB/winner) may be either plain strings (raw
+// backend payload) or normalized objects ({id, name, dojo}) as produced by
+// normalizeMatch() in api_serializers.jsx — both shapes are handled.
 // `standings` may be either a flat array (Swiss-shape) or an object keyed by
 // pool name (pools/league shape).
 function deriveAwards(bracket, standings, pools, nameToPlayer) {
-  const lookup = (name) => {
+  // Extract the name string from a match field that may be a string (raw
+  // backend payload) or a normalized object ({id, name, dojo}) produced by
+  // normalizeMatch() in api_serializers.jsx.
+  const toName = (v) => (v && typeof v === "object" ? v.name || "" : v || "");
+
+  // Enrich a player field with dojo info. If the field is already a normalized
+  // object with a dojo, use it directly; otherwise fall back to nameToPlayer.
+  const lookup = (v) => {
+    const name = toName(v);
     if (!name) return null;
+    const fromField = v && typeof v === "object" ? v.dojo : null;
     const p = nameToPlayer && nameToPlayer.get(name);
-    return { name, dojo: (p && p.dojo) || "" };
+    return { name, dojo: fromField || (p && p.dojo) || "" };
   };
 
   // Bracket-based: final + semi-finals. Only used when the final has a
@@ -1903,10 +1915,14 @@ function deriveAwards(bracket, standings, pools, nameToPlayer) {
     const sfRound = bracket.rounds[bracket.rounds.length - 2] || [];
     const final = finalRound[0];
     if (final && final.winner) {
+      const winnerName = toName(final.winner);
       const champion = final.winner;
-      const runnerUp = final.winner === final.sideA ? final.sideB : final.sideA;
+      const runnerUp = winnerName === toName(final.sideA) ? final.sideB : final.sideA;
       const thirds = sfRound
-        .map((m) => (m.winner ? (m.winner === m.sideA ? m.sideB : m.sideA) : null))
+        .map((m) => {
+          if (!m.winner) return null;
+          return toName(m.winner) === toName(m.sideA) ? m.sideB : m.sideA;
+        })
         .filter(Boolean);
       return [
         { place: 1, ...lookup(champion) },

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2043,7 +2043,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
               <div className="place" style={{ fontSize: isFs ? 18 : 12 }}>{style.label}</div>
               <div className="name" style={{ fontSize: isFs ? 28 : 16 }}>{a.name}</div>
               {a.dojo && (
-                <div className="d" style={{ fontSize: isFs ? 16 : 12, color: "var(--ink-3)" }}>{a.dojo}</div>
+                <div className="dojo" style={{ fontSize: isFs ? 16 : 12, color: "var(--ink-3)" }}>{a.dojo}</div>
               )}
             </div>
           );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1962,7 +1962,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
   }, []);
 
   React.useEffect(() => {
-    if (c?.format !== "swiss" || !window.API?.swissStandings) return undefined;
+    if (c?.format !== "swiss" || !window.API?.swissStandings) return;
     let cancelled = false;
     window.API.swissStandings(c.id)
       .then((data) => { if (!cancelled) setSwissStandings(Array.isArray(data) ? data : []); })
@@ -2013,7 +2013,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     );
   }
 
-  // Podium ordering follows CSS order rules: 2 left, 1 center, then 3rd-place cards.
+  // Visual podium ordering is driven by CSS order rules: 2 left, 1 center, then 3rd-place cards.
   // For the fullscreen ceremony layout we keep the same order but enlarge.
   return (
     <div


### PR DESCRIPTION
## Summary
- Adds a `deriveAwards(bracket, standings, pools, format, nameToPlayer)` pure helper in `web-mobile/js/viewer.jsx` that returns up to four FIK placements (1st, 2nd, and two 3rd places — no bronze match per the doc § Awards).
- Replaces the simple inline ResultsViewer podium with an `AwardsView` component that uses the helper, shows dojo info, has gold/silver/bronze accents, and a Fullscreen toggle for closing-ceremony projection.
- Widens the "Awards" tab so it shows for any completed competition (now including Swiss/league, not just bracket-based formats).

## Why
The doc § Awards calls out 1st, 2nd, and two 3rd places (semi-final losers) as the FIK convention. The existing ResultsViewer hard-coded that layout but only worked for bracket-based formats, gave no dojo info, and had no fullscreen mode usable on a ceremony projector. League/swiss completions had no awards surface at all. See running_a_kendo_tournament.md § Awards.

## Implementation notes
- `deriveAwards` is a pure function (no React, no DOM) so it's covered by Vitest unit tests in `web-mobile/js/__tests__/viewer_awards.test.jsx` (9 cases: typical bracket, no-winner-yet, missing dojos, 4-player single-semi bracket, league standings happy path, empty standings, no data, Swiss flat-array shape, pools-only with TBD bracket placeholder).
- Bracket carries names only (`BracketMatch.Winner` is a string per `internal/state/models.go:283`), so the component looks up dojos through a `Map(name → player)` built from `c.players`.
- Fullscreen mode uses native `el.requestFullscreen()` / `document.exitFullscreen()` and listens to `fullscreenchange` so external exits stay in sync.
- `AwardsView` fetches Swiss standings on mount when `c.format === "swiss"` since Swiss standings aren't part of the competition-detail payload.
- The tab label changed from "Results" → "Awards" to match the ceremony framing.

Closes bracket-creator-duq.

## Test plan
- [x] `cd web-mobile && npm test` — 24 files, 658 tests all green (incl. 9 awards cases)
- [x] `cd web-mobile && npm run lint` (eslint --max-warnings 0)
- [x] `make esbuild-jsx` — all bundles compile
- [x] `make go/build` — Go binary builds cleanly
- [x] Review-pass fix: pools-only completed comp now renders standings podium (previously empty because `derivedBracket` placeholder short-circuited the fallback)
- [x] Review-pass fix: Swiss competitions now fetch `/swiss/standings` inside `AwardsView` and populate the podium
- [ ] Manual: `make run-mobile`, complete a small playoffs comp, click Awards, verify 1/2/3/3 podium with dojo info; click Fullscreen, verify projector-friendly layout
- [ ] Manual: same with a Swiss competition, verify top 4 standings populate the same podium
- [ ] Manual: same with a pools-only (no-bracket) league competition

Generated with [Claude Code](https://claude.com/claude-code)