### PR TITLE
feat(viewer): dojo bulk-watch affordance for coaches

### DIFF
--- a/web-mobile/js/__tests__/viewer_watchlist_dojo.test.jsx
+++ b/web-mobile/js/__tests__/viewer_watchlist_dojo.test.jsx
@@ -1,0 +1,68 @@
+// Pure-logic tests for addDojoToWatchlist — coach-oriented bulk-add affordance.
+import { describe, it, expect } from 'vitest';
+import { addDojoToWatchlist } from '../viewer.jsx';
+
+const roster = [
+  { id: 'a1', name: 'Alice', dojo: 'Aoyama' },
+  { id: 'a2', name: 'Akira', dojo: 'Aoyama' },
+  { id: 'b1', name: 'Bob', dojo: 'Bunkyo' },
+  { id: 'b2', name: 'Beni', dojo: 'Bunkyo' },
+  { id: 'x1', name: 'Xena', dojo: '' }, // empty dojo — never matches
+];
+
+describe('addDojoToWatchlist', () => {
+  it('adds every roster player from the dojo and dedups against existing', () => {
+    const current = [{ id: 'a1', name: 'Alice', dojo: 'Aoyama' }];
+    const { next, added, skipped } = addDojoToWatchlist(current, roster, 'Aoyama', 50);
+    expect(added).toBe(1); // a2
+    expect(skipped).toBe(0);
+    expect(next.map((w) => w.id)).toEqual(['a1', 'a2']);
+  });
+
+  it('respects the max cap and reports the skipped count', () => {
+    const current = [{ id: 'b1', name: 'Bob', dojo: 'Bunkyo' }];
+    // max=2 → already at 1, only 1 slot left, but 1 candidate (a1) → fits.
+    let r = addDojoToWatchlist(current, roster, 'Aoyama', 2);
+    expect(r.added).toBe(1);
+    expect(r.skipped).toBe(1); // a2 didn't fit
+    expect(r.next.length).toBe(2);
+
+    // Already full
+    r = addDojoToWatchlist(r.next, roster, 'Bunkyo', 2);
+    expect(r.added).toBe(0);
+    expect(r.skipped).toBe(1); // b2 didn't fit (b1 was already in)
+  });
+
+  it('returns the original list unchanged when no dojo passed', () => {
+    const current = [{ id: 'a1', name: 'Alice', dojo: 'Aoyama' }];
+    const { next, added, skipped } = addDojoToWatchlist(current, roster, '', 50);
+    expect(next).toBe(current);
+    expect(added).toBe(0);
+    expect(skipped).toBe(0);
+  });
+
+  it('never matches roster entries with an empty dojo', () => {
+    const { next, added } = addDojoToWatchlist([], roster, '', 50);
+    expect(next).toEqual([]);
+    expect(added).toBe(0);
+  });
+
+  it('preserves dojo field on the watchlist entry', () => {
+    const { next } = addDojoToWatchlist([], roster, 'Bunkyo', 50);
+    expect(next).toEqual([
+      { id: 'b1', name: 'Bob', dojo: 'Bunkyo' },
+      { id: 'b2', name: 'Beni', dojo: 'Bunkyo' },
+    ]);
+  });
+
+  it('is a no-op when everyone from the dojo is already watched', () => {
+    const current = [
+      { id: 'a1', name: 'Alice', dojo: 'Aoyama' },
+      { id: 'a2', name: 'Akira', dojo: 'Aoyama' },
+    ];
+    const { next, added, skipped } = addDojoToWatchlist(current, roster, 'Aoyama', 50);
+    expect(next).toEqual(current);
+    expect(added).toBe(0);
+    expect(skipped).toBe(0);
+  });
+});

--- a/web-mobile/js/__tests__/viewer_watchlist_dojo.test.jsx
+++ b/web-mobile/js/__tests__/viewer_watchlist_dojo.test.jsx
@@ -21,7 +21,7 @@ describe('addDojoToWatchlist', () => {
 
   it('respects the max cap and reports the skipped count', () => {
     const current = [{ id: 'b1', name: 'Bob', dojo: 'Bunkyo' }];
-    // max=2 → already at 1, only 1 slot left, but 1 candidate (a1) → fits.
+    // max=2 → already at 1, only 1 slot left, with 2 candidates (a1, a2) so one is skipped.
     let r = addDojoToWatchlist(current, roster, 'Aoyama', 2);
     expect(r.added).toBe(1);
     expect(r.skipped).toBe(1); // a2 didn't fit

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -667,6 +667,8 @@ function addDojoToWatchlist(watchlist, roster, dojo, max) {
 function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatchClick }) {
   const [dojoSel, setDojoSel] = useState("");
   const [bulkMsg, setBulkMsg] = useState(null);
+  const bulkMsgTimer = useRefV(null);
+  React.useEffect(() => () => clearTimeout(bulkMsgTimer.current), []);
   const removeOne = (id) => setWatchlist(watchlist.filter((w) => w.id !== id));
   const addOne = (p) => {
     if (watchlist.find((w) => w.id === p.id)) return;
@@ -717,8 +719,12 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
     );
     setDojoSel("");
     // Auto-clear the toast after a few seconds so it doesn't linger.
-    setTimeout(() => setBulkMsg(null), 4000);
+    clearTimeout(bulkMsgTimer.current);
+    bulkMsgTimer.current = setTimeout(() => setBulkMsg(null), 4000);
   };
+
+  const selStats = dojoStats.get(dojoSel);
+  const addDojoDisabled = !dojoSel || !selStats || selStats.watched >= selStats.total;
 
   return (
     <div className="card" data-testid="viewer-home-watchlist" style={{ marginBottom: 16, padding: 14 }}>
@@ -776,10 +782,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
           </select>
           <button
             className="btn btn--sm"
-            disabled={!dojoSel || (() => {
-              const s = dojoStats.get(dojoSel);
-              return !s || s.watched >= s.total;
-            })()}
+            disabled={addDojoDisabled}
             onClick={addDojo}
             data-testid="watchlist-dojo-add"
           >

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -711,10 +711,12 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
     const { next, added, skipped } = addDojoToWatchlist(watchlist, roster, dojoSel, WATCHLIST_MAX);
     setWatchlist(next);
     setBulkMsg(
-      added === 0
+      skipped > 0
+        ? added === 0
+          ? `Watchlist full · ${skipped} from ${dojoSel} skipped`
+          : `Added ${added} from ${dojoSel} · ${skipped} skipped (watchlist full)`
+        : added === 0
         ? `Everyone from ${dojoSel} is already in your watchlist`
-        : skipped > 0
-        ? `Added ${added} from ${dojoSel} · ${skipped} skipped (watchlist full)`
         : `Added ${added} from ${dojoSel}`
     );
     setDojoSel("");
@@ -724,7 +726,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
   };
 
   const selStats = dojoStats.get(dojoSel);
-  const addDojoDisabled = !dojoSel || !selStats || selStats.watched >= selStats.total;
+  const addDojoDisabled = watchlist.length >= WATCHLIST_MAX || !dojoSel || !selStats || selStats.watched >= selStats.total;
 
   return (
     <div className="card" data-testid="viewer-home-watchlist" style={{ marginBottom: 16, padding: 14 }}>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -646,7 +646,27 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
 // Empty state hides the list; once at least one watched player exists,
 // renders the chip list, an "Add another" picker, and (when applicable)
 // the upcoming-matches preview.
+// addDojoToWatchlist — pure helper extracted for testability.
+// Given the current watchlist and a roster, return a new watchlist with every
+// roster player from `dojo` added (dedup by id, cap at `max`). Players not
+// matching the dojo (and any already in the list) are unchanged.
+function addDojoToWatchlist(watchlist, roster, dojo, max) {
+  if (!dojo) return { next: watchlist, added: 0, skipped: 0 };
+  const have = new Set(watchlist.map((w) => w.id));
+  const candidates = (roster || []).filter((p) => p && p.id && p.dojo === dojo && !have.has(p.id));
+  const room = Math.max(0, max - watchlist.length);
+  const added = candidates.slice(0, room);
+  const skipped = candidates.length - added.length;
+  return {
+    next: [...watchlist, ...added.map((p) => ({ id: p.id, name: p.name, dojo: p.dojo || "" }))],
+    added: added.length,
+    skipped,
+  };
+}
+
 function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatchClick }) {
+  const [dojoSel, setDojoSel] = useState("");
+  const [bulkMsg, setBulkMsg] = useState(null);
   const removeOne = (id) => setWatchlist(watchlist.filter((w) => w.id !== id));
   const addOne = (p) => {
     if (watchlist.find((w) => w.id === p.id)) return;
@@ -660,6 +680,45 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
     return Array.from(map.values());
   }, [tournament]);
   const rosterById = useMemo(() => new Map(roster.map(p => [p.id, p])), [roster]);
+
+  // Unique sorted dojos from the roster, excluding empty values.
+  const dojos = useMemo(() => {
+    const set = new Set();
+    roster.forEach((p) => { if (p.dojo) set.add(p.dojo); });
+    return Array.from(set).sort();
+  }, [roster]);
+
+  // Per-dojo summary: total members + currently watched. Used to label the
+  // dropdown options and to disable the "Add dojo" button when nothing new
+  // would be added.
+  const dojoStats = useMemo(() => {
+    const have = new Set(watchlist.map((w) => w.id));
+    const stats = new Map();
+    roster.forEach((p) => {
+      if (!p.dojo) return;
+      const s = stats.get(p.dojo) || { total: 0, watched: 0 };
+      s.total += 1;
+      if (have.has(p.id)) s.watched += 1;
+      stats.set(p.dojo, s);
+    });
+    return stats;
+  }, [roster, watchlist]);
+
+  const addDojo = () => {
+    if (!dojoSel) return;
+    const { next, added, skipped } = addDojoToWatchlist(watchlist, roster, dojoSel, WATCHLIST_MAX);
+    setWatchlist(next);
+    setBulkMsg(
+      added === 0
+        ? `Everyone from ${dojoSel} is already in your watchlist`
+        : skipped > 0
+        ? `Added ${added} from ${dojoSel} · ${skipped} skipped (watchlist full)`
+        : `Added ${added} from ${dojoSel}`
+    );
+    setDojoSel("");
+    // Auto-clear the toast after a few seconds so it doesn't linger.
+    setTimeout(() => setBulkMsg(null), 4000);
+  };
 
   return (
     <div className="card" data-testid="viewer-home-watchlist" style={{ marginBottom: 16, padding: 14 }}>
@@ -695,6 +754,40 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
         placeholder={watchlist.length === 0 ? "Add a participant to watch…" : "Add another participant…"}
         excludeIds={watchlist.map((w) => w.id)}
       />
+      {dojos.length > 0 && (
+        <div style={{ marginTop: 8, display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }} data-testid="watchlist-dojo-picker">
+          <label style={{ fontSize: 12, color: "var(--ink-3)" }} htmlFor="watchlist-dojo-select">Watch all from dojo</label>
+          <select
+            id="watchlist-dojo-select"
+            value={dojoSel}
+            onChange={(e) => setDojoSel(e.target.value)}
+            style={{ fontSize: 13, padding: "4px 8px" }}
+            data-testid="watchlist-dojo-select"
+          >
+            <option value="">— pick a dojo —</option>
+            {dojos.map((d) => {
+              const s = dojoStats.get(d) || { total: 0, watched: 0 };
+              const remaining = s.total - s.watched;
+              const label = remaining === 0
+                ? `${d} (all ${s.total} watched)`
+                : `${d} (+${remaining} of ${s.total})`;
+              return <option key={d} value={d}>{label}</option>;
+            })}
+          </select>
+          <button
+            className="btn btn--sm"
+            disabled={!dojoSel || (() => {
+              const s = dojoStats.get(dojoSel);
+              return !s || s.watched >= s.total;
+            })()}
+            onClick={addDojo}
+            data-testid="watchlist-dojo-add"
+          >
+            Add dojo
+          </button>
+          {bulkMsg && <span style={{ fontSize: 11, color: "var(--ink-3)" }} role="status">{bulkMsg}</span>}
+        </div>
+      )}
 
       {upcoming.length > 0 && (
         <>
@@ -1660,7 +1753,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, addDojoToWatchlist };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -1668,6 +1761,7 @@ if (typeof window !== 'undefined') {
     window.matchHighlightedBy = matchHighlightedBy;
     window.buildPlayerMatchHighlight = buildPlayerMatchHighlight;
     window.buildWatchlistUpcoming = buildWatchlistUpcoming;
+    window.addDojoToWatchlist = addDojoToWatchlist;
 }
 
 // Tournament-wide schedule (across competitions) — grouped by day, then court swimlanes + filter


### PR DESCRIPTION
## Summary
- Adds a per-dojo bulk-add affordance to `WatchlistPanel` in `web-mobile/js/viewer.jsx`: a select listing every distinct dojo in the roster (with a "(+N of M)" hint) and an "Add dojo" button that expands the dojo into individual watchlist entries.
- Extracts `addDojoToWatchlist(watchlist, roster, dojo, max)` as a pure helper, exported from viewer.jsx and via `window.*` for parity with the other watchlist helpers; covered by 6 Vitest cases.

## Why
A coach managing several students from one dojo previously had to add each player one at a time via the SinglePlayerPicker. The doc § Information Needs by Audience calls this out for coaches. Players already carry a `dojo` field on the wire, so this is a UI-only feature with no backend changes.

## Implementation notes
- Picked Option A from the bead's plan: expand a selected dojo into individual entries in the existing watchlist. Pros: reuses `buildWatchlistUpcoming` unchanged, the `WATCHLIST_MAX` cap naturally bounds the list. Cons: a player who registers mid-tournament for a watched dojo won't auto-appear — Option B (separate watched-dojos set) would solve that but adds plumbing for a small gain.
- The button disables when everyone from the dojo is already watched or the cap is hit, so the operator doesn't get a misleading "added 0" toast.
- The status message lives in a `role="status"` span (screen-reader friendly) and auto-clears after 4 seconds.

Closes bracket-creator-8fs.

## Test plan
- [x] `cd web-mobile && npm test` — 24 files, 655 tests (incl. 6 new dojo cases)
- [x] `cd web-mobile && npm run lint` — clean (0 warnings)
- [x] `make esbuild-jsx` — bundles compile
- [x] `make go/build` — binary builds (rebased onto main with pool-stage daihyosen / check-in / hansoku docs landed)
- [ ] Manual: `make run-mobile`, register participants across multiple dojos, open Watchlist, pick a dojo, click Add dojo, verify all members of that dojo land in the chip list and their upcoming matches appear in the watched-matches list; confirm the status toast clears after ~4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)