### PR TITLE
feat(mp-h60): implement admin announcement broadcast system

### DIFF
--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -15,9 +15,23 @@ type announcementRequest struct {
 	DurationMinutes int    `json:"durationMinutes"`
 }
 
+// maxAnnounceBodyBytes caps the POST /api/tournament/announce request
+// body. Worst-case JSON encoding of a valid payload:
+//
+//	message         200 chars × 6 chars/escape = 1200 bytes (full \uXXXX)
+//	durationMinutes 2 digits                    =    2 bytes
+//	JSON overhead (keys, braces, quotes)        =   ~40 bytes
+//	Total                                       = ~1242 bytes
+//
+// 4096 bytes gives a ~3x safety margin while still bounding malicious
+// or accidental large-body uploads. Mirrors the pattern established in
+// handlers_reset.go for body-bounded admin endpoints.
+const maxAnnounceBodyBytes = 4096
+
 func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
 	// POST /api/tournament/announce is protected (requires admin credentials)
 	r.POST("/tournament/announce", func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxAnnounceBodyBytes)
 		var req announcementRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})

--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -15,6 +15,10 @@ type announcementRequest struct {
 	DurationMinutes int    `json:"durationMinutes"`
 }
 
+// Allowed announcement TTLs. Package-level so the validation map isn't
+// reallocated on every POST /api/tournament/announce.
+var validAnnouncementDurations = map[int]bool{5: true, 10: true, 15: true, 30: true}
+
 // maxAnnounceBodyBytes caps the POST /api/tournament/announce request
 // body. Worst-case JSON encoding of a valid payload:
 //
@@ -49,8 +53,7 @@ func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *H
 			return
 		}
 
-		validDurations := map[int]bool{5: true, 10: true, 15: true, 30: true}
-		if !validDurations[req.DurationMinutes] {
+		if !validAnnouncementDurations[req.DurationMinutes] {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Duration must be 5, 10, 15, or 30 minutes"})
 			return
 		}

--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -1,0 +1,64 @@
+package mobileapp
+
+import (
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+type announcementRequest struct {
+	Message         string `json:"message"`
+	DurationMinutes int    `json:"durationMinutes"`
+}
+
+func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
+	// POST /api/tournament/announce is protected (requires admin credentials)
+	r.POST("/tournament/announce", func(c *gin.Context) {
+		var req announcementRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+			return
+		}
+
+		trimmedMsg := strings.TrimSpace(req.Message)
+		if trimmedMsg == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Announcement message cannot be empty"})
+			return
+		}
+
+		if utf8.RuneCountInString(trimmedMsg) > 200 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Announcement message cannot exceed 200 characters"})
+			return
+		}
+
+		validDurations := map[int]bool{5: true, 10: true, 15: true, 30: true}
+		if !validDurations[req.DurationMinutes] {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Duration must be 5, 10, 15, or 30 minutes"})
+			return
+		}
+
+		duration := time.Duration(req.DurationMinutes) * time.Minute
+		ann := store.AnnouncementStore().Set(trimmedMsg, duration)
+
+		// Broadcast new announcement to all connected SSE clients
+		hub.Broadcast(EventAnnouncement, ann)
+
+		c.JSON(http.StatusOK, ann)
+	})
+}
+
+func RegisterPublicAnnouncementHandlers(r *gin.RouterGroup, store *state.Store) {
+	// GET /api/tournament/announcement is public
+	r.GET("/tournament/announcement", func(c *gin.Context) {
+		ann := store.AnnouncementStore().Get()
+		if ann == nil {
+			c.Status(http.StatusNoContent)
+			return
+		}
+		c.JSON(http.StatusOK, ann)
+	})
+}

--- a/internal/mobileapp/handlers_announcement_test.go
+++ b/internal/mobileapp/handlers_announcement_test.go
@@ -1,0 +1,135 @@
+package mobileapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/engine"
+	"github.com/gitrgoliveira/bracket-creator/internal/resources"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnouncementHandlers(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "announcement-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{
+		"web-mobile/index.html": {Data: []byte("<html><body>Mobile</body></html>")},
+	}
+	res := resources.NewResources(nil, mockFS)
+
+	// Save tournament config with a password so AuthMiddleware doesn't run in bootstrap mode
+	tourney := state.Tournament{
+		Name:     "Test Tournament",
+		Password: "secret-password",
+	}
+	err = store.SaveTournament(&tourney)
+	require.NoError(t, err)
+
+	// Construct router using NewRouter so we test full middleware integration
+	router := NewRouter(store, eng, res, NewFileVerifier(store))
+
+	// 1. GET /api/tournament/announcement - initially empty (204 No Content)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/tournament/announcement", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// 2. POST /api/tournament/announce - unauthorized without header
+	payload := announcementRequest{
+		Message:         "Lunch break for 30 minutes",
+		DurationMinutes: 30,
+	}
+	body, _ := json.Marshal(payload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// 3. POST /api/tournament/announce - unauthorized with wrong password
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "wrong-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// 4. POST /api/tournament/announce - bad request with empty message
+	badPayload := announcementRequest{
+		Message:         "   ",
+		DurationMinutes: 30,
+	}
+	body, _ = json.Marshal(badPayload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "cannot be empty")
+
+	// 5. POST /api/tournament/announce - bad request with too long message (>200 chars)
+	tooLongMsg := strings.Repeat("A", 201)
+	badPayload = announcementRequest{
+		Message:         tooLongMsg,
+		DurationMinutes: 30,
+	}
+	body, _ = json.Marshal(badPayload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "cannot exceed 200 characters")
+
+	// 6. POST /api/tournament/announce - bad request with invalid duration (e.g. 7 minutes)
+	badPayload = announcementRequest{
+		Message:         "Valid message",
+		DurationMinutes: 7,
+	}
+	body, _ = json.Marshal(badPayload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Duration must be 5, 10, 15, or 30 minutes")
+
+	// 7. POST /api/tournament/announce - happy path (200 OK)
+	body, _ = json.Marshal(payload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response state.Announcement
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+	assert.Equal(t, "Lunch break for 30 minutes", response.Message)
+	assert.False(t, response.SentAt.IsZero())
+	assert.False(t, response.ExpiresAt.IsZero())
+	assert.True(t, response.ExpiresAt.After(response.SentAt))
+
+	// 8. GET /api/tournament/announcement - should now return the active announcement (200 OK)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/tournament/announcement", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var retrieved state.Announcement
+	err = json.Unmarshal(w.Body.Bytes(), &retrieved)
+	require.NoError(t, err)
+	assert.Equal(t, "Lunch break for 30 minutes", retrieved.Message)
+}

--- a/internal/mobileapp/handlers_announcement_test.go
+++ b/internal/mobileapp/handlers_announcement_test.go
@@ -106,7 +106,24 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "Duration must be 5, 10, 15, or 30 minutes")
 
-	// 7. POST /api/tournament/announce - happy path (200 OK)
+	// 7. POST /api/tournament/announce - oversized body (>maxAnnounceBodyBytes)
+	// returns 400 from MaxBytesReader unwinding through ShouldBindJSON.
+	// Build a JSON body whose `message` field alone exceeds the 4096-byte
+	// cap so we exercise the body-cap path (not the post-bind 200-char
+	// validation).
+	hugeMsg := strings.Repeat("A", maxAnnounceBodyBytes+10)
+	hugePayload := announcementRequest{
+		Message:         hugeMsg,
+		DurationMinutes: 30,
+	}
+	body, _ = json.Marshal(hugePayload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for body over %d bytes", maxAnnounceBodyBytes)
+
+	// 8. POST /api/tournament/announce - happy path (200 OK)
 	body, _ = json.Marshal(payload)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
@@ -122,7 +139,7 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.False(t, response.ExpiresAt.IsZero())
 	assert.True(t, response.ExpiresAt.After(response.SentAt))
 
-	// 8. GET /api/tournament/announcement - should now return the active announcement (200 OK)
+	// 9. GET /api/tournament/announcement - should now return the active announcement (200 OK)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/api/tournament/announcement", nil)
 	router.ServeHTTP(w, req)

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -40,6 +40,7 @@ const (
 	// instead of waiting for their next write to fail with 401. Viewers
 	// ignore the event — their flow doesn't depend on the admin password.
 	EventPasswordReset EventType = "password_reset"
+	EventAnnouncement  EventType = "announcement"
 )
 
 // AutoCompleteErrorHeader is set on score/start responses when the

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -71,6 +71,7 @@ func NewRouter(store *state.Store, eng *engine.Engine, res *resources.Resources,
 	RegisterPublicEligibilityHandlers(api, store)
 	RegisterPublicLineupHandlers(api, store)
 	RegisterPublicSwissHandlers(api, store, eng)
+	RegisterPublicAnnouncementHandlers(api, store)
 
 	// Public password-reset + auth-config endpoints. Both must live
 	// outside the admin group: /reset is the recovery path for a
@@ -97,6 +98,7 @@ func NewRouter(store *state.Store, eng *engine.Engine, res *resources.Resources,
 		RegisterLineupHandlers(admin, store, store, store)
 		RegisterDaihyosenHandlers(admin, eng, store, hub)
 		RegisterSwissHandlers(admin, store, eng, hub)
+		RegisterAnnouncementHandlers(admin, store, hub)
 	}
 
 	// Static files & SPA Fallback

--- a/internal/state/announcement_store.go
+++ b/internal/state/announcement_store.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"sync"
+	"time"
+)
+
+type AnnouncementStore struct {
+	mu      sync.RWMutex
+	current *Announcement
+}
+
+func NewAnnouncementStore() *AnnouncementStore {
+	return &AnnouncementStore{}
+}
+
+func (s *AnnouncementStore) Set(msg string, dur time.Duration) Announcement {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	ann := Announcement{
+		Message:   msg,
+		SentAt:    now,
+		ExpiresAt: now.Add(dur),
+	}
+	s.current = &Announcement{
+		Message:   ann.Message,
+		SentAt:    ann.SentAt,
+		ExpiresAt: ann.ExpiresAt,
+	}
+	return ann
+}
+
+func (s *AnnouncementStore) Get() *Announcement {
+	s.mu.RLock()
+	if s.current == nil {
+		s.mu.RUnlock()
+		return nil
+	}
+	if time.Now().Before(s.current.ExpiresAt) {
+		annCopy := *s.current
+		s.mu.RUnlock()
+		return &annCopy
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Double check under write lock
+	if s.current != nil && time.Now().After(s.current.ExpiresAt) {
+		s.current = nil
+	}
+	return nil
+}
+
+func (s *AnnouncementStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = nil
+}

--- a/internal/state/announcement_store.go
+++ b/internal/state/announcement_store.go
@@ -47,11 +47,18 @@ func (s *AnnouncementStore) Get() *Announcement {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Double check under write lock
-	if s.current != nil && time.Now().After(s.current.ExpiresAt) {
-		s.current = nil
+	// Double-check under write lock: a concurrent Set() may have replaced
+	// the expired announcement with a fresh one between our RUnlock and
+	// Lock above. Only clear if still expired; if fresh, return a copy.
+	if s.current == nil {
+		return nil
 	}
-	return nil
+	if time.Now().After(s.current.ExpiresAt) {
+		s.current = nil
+		return nil
+	}
+	annCopy := *s.current
+	return &annCopy
 }
 
 func (s *AnnouncementStore) Clear() {

--- a/internal/state/announcement_store.go
+++ b/internal/state/announcement_store.go
@@ -53,7 +53,7 @@ func (s *AnnouncementStore) Get() *Announcement {
 	if s.current == nil {
 		return nil
 	}
-	if time.Now().After(s.current.ExpiresAt) {
+	if !time.Now().Before(s.current.ExpiresAt) {
 		s.current = nil
 		return nil
 	}

--- a/internal/state/announcement_store_test.go
+++ b/internal/state/announcement_store_test.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAnnouncementStore(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	// Initial state: should be nil
+	if ann := store.Get(); ann != nil {
+		t.Errorf("expected initial announcement to be nil, got: %v", ann)
+	}
+
+	// Set active announcement
+	msg := "Lunch break for 30 minutes"
+	dur := 30 * time.Minute
+	ann := store.Set(msg, dur)
+
+	if ann.Message != msg {
+		t.Errorf("expected message %q, got %q", msg, ann.Message)
+	}
+
+	// Retrieve active announcement
+	retrieved := store.Get()
+	if retrieved == nil {
+		t.Fatal("expected retrieved announcement to be non-nil")
+	}
+	if retrieved.Message != msg {
+		t.Errorf("expected retrieved message %q, got %q", msg, retrieved.Message)
+	}
+
+	// Set replaces previous
+	newMsg := "Delay on court B"
+	newDur := 5 * time.Minute
+	newAnn := store.Set(newMsg, newDur)
+
+	if newAnn.Message != newMsg {
+		t.Errorf("expected new message %q, got %q", newMsg, newAnn.Message)
+	}
+
+	retrievedNew := store.Get()
+	if retrievedNew == nil {
+		t.Fatal("expected retrieved new announcement to be non-nil")
+	}
+	if retrievedNew.Message != newMsg {
+		t.Errorf("expected retrieved new message %q, got %q", newMsg, retrievedNew.Message)
+	}
+
+	// Expiration test: set an announcement with very short duration
+	store.Set("Short notice", 10*time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+
+	if expired := store.Get(); expired != nil {
+		t.Errorf("expected announcement to be expired (nil), got: %v", expired)
+	}
+
+	// Clear test
+	store.Set("Clear me", 10*time.Minute)
+	if retrieved := store.Get(); retrieved == nil {
+		t.Fatal("expected announcement to be set before clear")
+	}
+	store.Clear()
+	if cleared := store.Get(); cleared != nil {
+		t.Errorf("expected announcement to be cleared (nil), got: %v", cleared)
+	}
+}

--- a/internal/state/announcement_store_test.go
+++ b/internal/state/announcement_store_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -67,21 +68,17 @@ func TestAnnouncementStore(t *testing.T) {
 	}
 }
 
-// TestAnnouncementStoreGetAfterConcurrentSet guards against the race where
-// Get() sees an expired announcement under the read lock, then a concurrent
-// Set() replaces it before Get() acquires the write lock. The fresh
-// announcement must be visible to the caller, not swallowed.
-func TestAnnouncementStoreGetAfterConcurrentSet(t *testing.T) {
+// TestAnnouncementStoreGetAfterSetReplacesExpired verifies the sequential
+// contract: after Set() replaces an expired announcement, Get() returns the
+// fresh value rather than the expired one or nil. (See the concurrent
+// variant below for the read-lock/write-lock race guard.)
+func TestAnnouncementStoreGetAfterSetReplacesExpired(t *testing.T) {
 	store := NewAnnouncementStore()
 
 	// Set an announcement that expires immediately.
 	store.Set("expires now", 1*time.Nanosecond)
 	time.Sleep(5 * time.Millisecond) // ensure it is expired
 
-	// Simulate: a concurrent writer calls Set() with a fresh announcement
-	// just as Get() is about to acquire the write lock.  We test the
-	// outcome rather than the timing, which is deterministic: after Set()
-	// completes, Get() must return the new announcement (not nil).
 	store.Set("fresh announcement", 10*time.Minute)
 
 	got := store.Get()
@@ -90,5 +87,48 @@ func TestAnnouncementStoreGetAfterConcurrentSet(t *testing.T) {
 	}
 	if got.Message != "fresh announcement" {
 		t.Errorf("expected message %q, got %q", "fresh announcement", got.Message)
+	}
+}
+
+// TestAnnouncementStoreGetSetRace exercises the actual race between Get()
+// and Set(). Get() reads under the read lock, releases, then under the write
+// lock decides whether to clear an expired announcement. A concurrent Set()
+// can land in that window with a fresh announcement, and the double-check
+// in Get() must NOT clear that fresh value.
+//
+// We run many short rounds: each round seeds an immediately-expired
+// announcement, then runs Set("fresh") and Get() concurrently. After both
+// goroutines return, Get() must always observe a non-nil "fresh"
+// announcement on the next call. If the race guard regresses, the
+// concurrent Get() inside the round can race-clear the fresh announcement
+// and the post-round assertion catches it.
+func TestAnnouncementStoreGetSetRace(t *testing.T) {
+	const rounds = 200
+	for i := 0; i < rounds; i++ {
+		store := NewAnnouncementStore()
+		store.Set("expires now", 1*time.Nanosecond)
+		time.Sleep(time.Microsecond) // ensure expired
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			store.Set("fresh announcement", 10*time.Minute)
+		}()
+		go func() {
+			defer wg.Done()
+			// May see nil (expired cleared before Set lands) or "fresh"
+			// (Set landed first). Must NOT race-clear the fresh value.
+			_ = store.Get()
+		}()
+		wg.Wait()
+
+		got := store.Get()
+		if got == nil {
+			t.Fatalf("round %d: expected Get() to return the fresh announcement after the concurrent pair, got nil — race guard regressed", i)
+		}
+		if got.Message != "fresh announcement" {
+			t.Fatalf("round %d: expected message %q, got %q", i, "fresh announcement", got.Message)
+		}
 	}
 }

--- a/internal/state/announcement_store_test.go
+++ b/internal/state/announcement_store_test.go
@@ -66,3 +66,29 @@ func TestAnnouncementStore(t *testing.T) {
 		t.Errorf("expected announcement to be cleared (nil), got: %v", cleared)
 	}
 }
+
+// TestAnnouncementStoreGetAfterConcurrentSet guards against the race where
+// Get() sees an expired announcement under the read lock, then a concurrent
+// Set() replaces it before Get() acquires the write lock. The fresh
+// announcement must be visible to the caller, not swallowed.
+func TestAnnouncementStoreGetAfterConcurrentSet(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	// Set an announcement that expires immediately.
+	store.Set("expires now", 1*time.Nanosecond)
+	time.Sleep(5 * time.Millisecond) // ensure it is expired
+
+	// Simulate: a concurrent writer calls Set() with a fresh announcement
+	// just as Get() is about to acquire the write lock.  We test the
+	// outcome rather than the timing, which is deterministic: after Set()
+	// completes, Get() must return the new announcement (not nil).
+	store.Set("fresh announcement", 10*time.Minute)
+
+	got := store.Get()
+	if got == nil {
+		t.Fatal("expected Get() to return the fresh announcement, got nil")
+	}
+	if got.Message != "fresh announcement" {
+		t.Errorf("expected message %q, got %q", "fresh announcement", got.Message)
+	}
+}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 )
@@ -314,4 +315,10 @@ type ReservedSlot struct {
 	ParticipantID string `json:"participantID"` // ID of the placeholder in participants.csv
 	SourceCompID  string `json:"sourceCompID"`
 	SourceRank    int    `json:"sourceRank"`
+}
+
+type Announcement struct {
+	Message   string    `json:"message" yaml:"message"`
+	SentAt    time.Time `json:"sentAt" yaml:"sent_at"`
+	ExpiresAt time.Time `json:"expiresAt" yaml:"expires_at"`
 }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -45,6 +45,8 @@ type Store struct {
 
 	// cache for competition-level files
 	compCache sync.Map // map[string]*compCache
+
+	announcementStore *AnnouncementStore
 }
 
 type compCache struct {
@@ -59,8 +61,9 @@ type fileCache struct {
 
 func NewStore(folder string) (*Store, error) {
 	s := &Store{
-		folder: folder,
-		walDir: filepath.Join(folder, ".wal"),
+		folder:            folder,
+		walDir:            filepath.Join(folder, ".wal"),
+		announcementStore: NewAnnouncementStore(),
 	}
 
 	if err := s.init(); err != nil {
@@ -68,6 +71,10 @@ func NewStore(folder string) (*Store, error) {
 	}
 
 	return s, nil
+}
+
+func (s *Store) AnnouncementStore() *AnnouncementStore {
+	return s.announcementStore
 }
 
 func (s *Store) init() error {

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -20,6 +20,7 @@ info:
     - **`GET /api/competitions/{id}/competitor-status`** — public read; the `POST` write is protected.
     - **`GET /api/competitions/{id}/teams/{tid}/lineups/{round}`** — public read; `PUT`/`DELETE` are protected.
     - **`GET /api/competitions/{id}/swiss/standings`** — public read; always public.
+    - **`GET /api/tournament/announcement`** — public read; returns the currently active admin broadcast announcement (204 when none/expired).
   version: 2.1.0
 
 servers:
@@ -530,6 +531,81 @@ paths:
                             `save competition: ...`,
                             `parse participants: ...`. Empty when the row
                             imported successfully.
+
+  # ── Announcements ──────────────────────────────────────────────────────────
+
+  /api/tournament/announcement:
+    get:
+      tags: [tournament]
+      summary: Get active announcement
+      description: |
+        Returns the currently active admin broadcast announcement.
+        Returns `204 No Content` when there is no active announcement or the
+        last one has already expired. No authentication required — viewer screens
+        poll this endpoint on SSE connect to catch announcements they may have
+        missed before subscribing.
+      responses:
+        '200':
+          description: Active announcement.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Announcement'
+        '204':
+          description: No active announcement (none set, or the last one has expired).
+
+  /api/tournament/announce:
+    post:
+      tags: [tournament]
+      summary: Broadcast announcement to all viewers
+      description: |
+        Sends a transient text announcement to all connected viewer screens via SSE.
+        The announcement is stored in-memory only (not persisted to disk); a server
+        restart clears it. Late-connecting viewers can retrieve the active announcement
+        via `GET /api/tournament/announcement`.
+
+        **Validation:**
+        - `message` must be non-empty after trimming whitespace.
+        - `message` may not exceed 200 characters (Unicode code-point count).
+        - `durationMinutes` must be one of `5`, `10`, `15`, or `30`.
+      security:
+        - TournamentPassword: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [message, durationMinutes]
+              properties:
+                message:
+                  type: string
+                  description: Announcement text (max 200 chars after trim).
+                  example: "Lunch break for 30 minutes"
+                durationMinutes:
+                  type: integer
+                  enum: [5, 10, 15, 30]
+                  description: How long (minutes) the announcement banner stays visible.
+                  example: 30
+      responses:
+        '200':
+          description: Announcement sent; returns the stored record.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Announcement'
+        '400':
+          description: Validation failure (empty/too-long message or invalid duration).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid X-Tournament-Password.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   # ── Competitions (Admin, requires auth) ────────────────────────────────────
 
@@ -1643,8 +1719,9 @@ components:
         recovery endpoints `/api/auth-config` and `/api/tournament/reset`,
         the public read endpoints `GET /api/schedule/estimate`,
         `GET /api/competitions/{id}/competitor-status`,
-        `GET /api/competitions/{id}/teams/{tid}/lineups/{round}`, and
-        `GET /api/competitions/{id}/swiss/standings`,
+        `GET /api/competitions/{id}/teams/{tid}/lineups/{round}`,
+        `GET /api/competitions/{id}/swiss/standings`, and
+        `GET /api/tournament/announcement`,
         and (in file mode only) the bootstrap PUT/POST `/api/tournament`
         while no tournament has been configured yet.
 
@@ -1748,6 +1825,24 @@ components:
       properties:
         error:
           type: string
+
+    Announcement:
+      type: object
+      description: A transient admin broadcast announcement stored in-memory.
+      properties:
+        message:
+          type: string
+          description: Announcement text (max 200 Unicode characters after trim).
+          example: "Lunch break for 30 minutes"
+        sentAt:
+          type: string
+          format: date-time
+          description: Server timestamp when the announcement was sent (RFC 3339).
+        expiresAt:
+          type: string
+          format: date-time
+          description: Timestamp at which the announcement banner auto-dismisses (RFC 3339).
+      required: [message, sentAt, expiresAt]
 
     AppStatus:
       type: object

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5081,3 +5081,89 @@ a:hover {
   }
 }
 
+/* Announcement Banner - Feature mp-h60 */
+.announcement-banner {
+  position: relative;
+  width: 100%;
+  background: linear-gradient(135deg, #d97706, #b45309);
+  color: #ffffff;
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 1001;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.announcement-banner__content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.announcement-banner__icon {
+  font-size: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.announcement-banner__message {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin: 0;
+  word-break: break-word;
+  flex: 1;
+}
+
+.announcement-banner__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.announcement-banner__badge {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.announcement-banner__dismiss {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.announcement-banner__dismiss:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+}
+
+

--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveCompetitionName, validatePoolSettings, validateSwissSettings } from '../admin_setup.jsx';
+import { deriveCompetitionName, validatePoolSettings, validateSwissSettings, isSendAnnouncementDisabled, sendAnnouncementLabel } from '../admin_setup.jsx';
 
 describe('deriveCompetitionName', () => {
   // Copilot round-8 finding: AdminCreateCompetition.create used
@@ -231,5 +231,33 @@ describe('validateSwissSettings (T190 / FR-050a)', () => {
       const r = validateSwissSettings('swiss', -3);
       expect(r.ok).toBe(false);
     });
+  });
+});
+
+describe('isSendAnnouncementDisabled', () => {
+  it('disabled when message is empty', () => {
+    expect(isSendAnnouncementDisabled('', false)).toBe(true);
+  });
+
+  it('disabled when message is whitespace-only (trimming guard)', () => {
+    expect(isSendAnnouncementDisabled('   ', false)).toBe(true);
+  });
+
+  it('disabled when in-flight (prevents double-send)', () => {
+    expect(isSendAnnouncementDisabled('Hello', true)).toBe(true);
+  });
+
+  it('enabled when message is non-empty and not in-flight', () => {
+    expect(isSendAnnouncementDisabled('Hello', false)).toBe(false);
+  });
+});
+
+describe('sendAnnouncementLabel', () => {
+  it('returns "Send announcement" when idle', () => {
+    expect(sendAnnouncementLabel(false)).toBe('Send announcement');
+  });
+
+  it('returns "Sending..." during in-flight request', () => {
+    expect(sendAnnouncementLabel(true)).toBe('Sending...');
   });
 });

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { isAnnouncementActive } from '../app.jsx';
+
+// isAnnouncementActive encapsulates the gate that decides whether an
+// announcement fetched at mount (or received via SSE) should be shown.
+// Three cases: active → show, dismissed → hide, expired → hide.
+
+const future = new Date(Date.now() + 60_000).toISOString();
+const past = new Date(Date.now() - 60_000).toISOString();
+
+describe('isAnnouncementActive', () => {
+  it('returns true for a non-dismissed, non-expired announcement', () => {
+    const ann = { sentAt: 'ts1', expiresAt: future, message: 'Hello' };
+    expect(isAnnouncementActive(ann, null, new Date())).toBe(true);
+  });
+
+  it('returns false when the announcement has been dismissed (sessionStorage key set)', () => {
+    const ann = { sentAt: 'ts1', expiresAt: future, message: 'Hello' };
+    expect(isAnnouncementActive(ann, 'true', new Date())).toBe(false);
+  });
+
+  it('returns false when the announcement has expired', () => {
+    const ann = { sentAt: 'ts1', expiresAt: past, message: 'Hello' };
+    expect(isAnnouncementActive(ann, null, new Date())).toBe(false);
+  });
+
+  it('returns false for null announcement', () => {
+    expect(isAnnouncementActive(null, null, new Date())).toBe(false);
+  });
+
+  it('treats an announcement expiring exactly now as inactive', () => {
+    const now = new Date();
+    const ann = { sentAt: 'ts1', expiresAt: now.toISOString() };
+    expect(isAnnouncementActive(ann, null, now)).toBe(false);
+  });
+});

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -553,6 +553,8 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       onLogout={onLogout}
       onViewerMode={onViewerMode}
       authConfig={authConfig}
+      password={password}
+      showToast={showToast}
     />;
   }
 

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -845,6 +845,16 @@ window.AdminEditTournament = AdminEditTournament;
 window.AdminCreateCompetition = AdminCreateCompetition;
 window.AdminImportPage = AdminImportPage;
 
+// Pure helpers for the announcement-broadcast controls.
+// isSendDisabled drives the button's `disabled` attribute.
+// sendLabel drives the button's text (inFlight → "Sending…").
+function isSendAnnouncementDisabled(message, inFlight) {
+  return !message.trim() || inFlight;
+}
+function sendAnnouncementLabel(inFlight) {
+  return inFlight ? "Sending..." : "Send announcement";
+}
+
 // ES export for the vitest suite — pure helpers only. Components stay
 // behind the window.* pattern to match the rest of admin_*.jsx.
-export { deriveCompetitionName, validatePoolSettings, validateSwissSettings };
+export { deriveCompetitionName, validatePoolSettings, validateSwissSettings, isSendAnnouncementDisabled, sendAnnouncementLabel };

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -91,7 +91,7 @@ function validateSwissSettings(format, swissRounds) {
   return { ok: true, error: null };
 }
 
-function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerMode, authConfig }) {
+function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerMode, authConfig, password, showToast }) {
   // In locked mode the on-disk Password is irrelevant — auth comes
   // from TOURNAMENT_PASSWORD_HASH and the backend rejects PUTs that
   // try to set a non-empty password. Surfacing the field anyway would
@@ -107,6 +107,29 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [checkInEnd, setCheckInEnd] = useStateA(tournament.checkInWindowEnd || "");
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
+
+  const [announcementMessage, setAnnouncementMessage] = useStateA("");
+  const [announcementDuration, setAnnouncementDuration] = useStateA(5);
+  const [announcementInFlight, setAnnouncementInFlight] = useStateA(false);
+
+  const handleSendAnnouncement = async () => {
+    const trimmed = announcementMessage.trim();
+    if (!trimmed) return;
+    setAnnouncementInFlight(true);
+    try {
+      await window.API.sendAnnouncement(trimmed, announcementDuration, password);
+      setAnnouncementMessage("");
+      if (showToast) {
+        showToast(`Announcement broadcast for ${announcementDuration} minutes!`, "success");
+      }
+    } catch (e) {
+      if (showToast) {
+        showToast(e.message, "error");
+      }
+    } finally {
+      setAnnouncementInFlight(false);
+    }
+  };
 
   const handleSave = () => {
     // Trim early and send the trimmed value. The empty-name check below
@@ -205,6 +228,51 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
             <button className="btn" onClick={onCancel}>Cancel</button>
             <button className="btn btn--primary" onClick={handleSave}>Save changes</button>
+          </div>
+        </div>
+
+        <div className="page-head" style={{ marginTop: 32 }}><h1 className="page-head__title">Broadcast announcement</h1></div>
+        <div className="card card--pad-lg">
+          <div className="field">
+            <label className="field__label">Message</label>
+            <textarea
+              className="input"
+              style={{ width: "100%", height: 80, boxSizing: "border-box", padding: "8px 12px", resize: "vertical" }}
+              maxLength={200}
+              placeholder="e.g. Lunch break for 30 minutes, Delay on court B..."
+              value={announcementMessage}
+              onChange={(e) => setAnnouncementMessage(e.target.value)}
+            />
+            <div className="field__hint" style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+              <span>Maximum 200 characters. Pushes a temporary announcement to all active viewer screens.</span>
+              <span>{announcementMessage.length}/200</span>
+            </div>
+          </div>
+          <div className="field">
+            <label className="field__label">Duration</label>
+            <div style={{ display: "flex", gap: 16, marginTop: 8 }}>
+              {[5, 10, 15, 30].map((m) => (
+                <label key={m} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontWeight: 500 }}>
+                  <input
+                    type="radio"
+                    name="duration"
+                    value={m}
+                    checked={announcementDuration === m}
+                    onChange={() => setAnnouncementDuration(m)}
+                  />
+                  <span>{m} min</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
+            <button
+              className="btn btn--primary"
+              disabled={!announcementMessage.trim() || announcementInFlight}
+              onClick={handleSendAnnouncement}
+            >
+              {announcementInFlight ? "Sending..." : "Send announcement"}
+            </button>
           </div>
         </div>
       </div>

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -268,10 +268,10 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
             <button
               className="btn btn--primary"
-              disabled={!announcementMessage.trim() || announcementInFlight}
+              disabled={isSendAnnouncementDisabled(announcementMessage, announcementInFlight)}
               onClick={handleSendAnnouncement}
             >
-              {announcementInFlight ? "Sending..." : "Send announcement"}
+              {sendAnnouncementLabel(announcementInFlight)}
             </button>
           </div>
         </div>

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -575,6 +575,32 @@ const API = {
             throw new Error(err.error || `Failed to ${checkedIn ? 'check in' : 'undo check-in'} participant`);
         }
         return res.json();
+    },
+    async sendAnnouncement(message, durationMinutes, password) {
+        const res = await fetch('/api/tournament/announce', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Tournament-Password': password
+            },
+            body: JSON.stringify({ message, durationMinutes })
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to send announcement (Status ${res.status})`);
+        }
+        return res.json();
+    },
+    async fetchAnnouncement() {
+        const res = await fetch('/api/tournament/announcement');
+        if (res.status === 204) {
+            return null;
+        }
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to fetch announcement (Status ${res.status})`);
+        }
+        return res.json();
     }
 };
 

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -3,7 +3,7 @@
 
 import { applyPatch as patchCompetitionData } from './patch.jsx';
 
-const { useState: useS, useEffect: useE, useRef: useR } = React;
+const { useState: useS, useEffect: useE, useRef: useR, useCallback: useC } = React;
 
 // preact-router wrapper from router.jsx (T005). Used for URL → state
 // synchronisation. The render path itself still drives off
@@ -583,18 +583,26 @@ function App() {
     );
   }
 
+  // Stable dismiss callback — wrapping in useCallback prevents the
+  // AnnouncementBanner countdown useEffect from re-running on every
+  // parent render (the effect lists onDismiss as a dependency, so an
+  // inline arrow function would reset the interval on every re-render).
+  const handleDismissAnnouncement = useC(() => {
+    setActiveAnnouncement(prev => {
+      if (prev?.sentAt) {
+        sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
+      }
+      return null;
+    });
+  }, []);
+
   // viewer mode
   return (
     <>
       {activeAnnouncement && window.AnnouncementBanner && (
         <window.AnnouncementBanner
           announcement={activeAnnouncement}
-          onDismiss={() => {
-            if (activeAnnouncement?.sentAt) {
-              sessionStorage.setItem(`bc_dismissed_announcement_${activeAnnouncement.sentAt}`, "true");
-            }
-            setActiveAnnouncement(null);
-          }}
+          onDismiss={handleDismissAnnouncement}
         />
       )}
       {selectedCompData ? (

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -130,6 +130,7 @@ class ErrorBoundary extends React.Component {
 function App() {
   const [tournament, setTournament] = useS(null);
   const [loading, setLoading] = useS(true);
+  const [activeAnnouncement, setActiveAnnouncement] = useS(null);
   // Hydrate the route state from the URL synchronously, BEFORE the first
   // render. The post-mount useEffect that previously did this ran AFTER
   // the URL-sync effect, so a direct load of /reset (or any non-`/`
@@ -316,6 +317,21 @@ function App() {
 
   useE(() => { load(); }, []);
 
+  useE(() => {
+    window.API.fetchAnnouncement()
+      .then(ann => {
+        if (ann) {
+          const dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+          if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
+            setActiveAnnouncement(ann);
+          }
+        }
+      })
+      .catch(err => {
+        console.error("Failed to fetch initial announcement:", err);
+      });
+  }, []);
+
   // Fetch the auth-config once on mount. Always resolves the null
   // initial state — success sets the actual config; fail-open
   // (5xx/timeout/parse-error) falls back to file mode so the
@@ -454,6 +470,18 @@ function App() {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), jitter);
             }
             jitteredTimeout(load, jitter);
+        } else if (event.type === "announcement") {
+            const ann = event.data;
+            if (ann) {
+                const dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+                if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
+                    setActiveAnnouncement(ann);
+                } else {
+                    setActiveAnnouncement(null);
+                }
+            } else {
+                setActiveAnnouncement(null);
+            }
         }
     }, (status) => {
         // T063: track SSE connection status so /display surfaces can
@@ -558,6 +586,17 @@ function App() {
   // viewer mode
   return (
     <>
+      {activeAnnouncement && window.AnnouncementBanner && (
+        <window.AnnouncementBanner
+          announcement={activeAnnouncement}
+          onDismiss={() => {
+            if (activeAnnouncement?.sentAt) {
+              sessionStorage.setItem(`bc_dismissed_announcement_${activeAnnouncement.sentAt}`, "true");
+            }
+            setActiveAnnouncement(null);
+          }}
+        />
+      )}
       {selectedCompData ? (
         <window.ViewerCompetition
           tournament={tournament}

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -536,6 +536,24 @@ function App() {
     localStorage.removeItem("bc_password");
   };
 
+  // Stable dismiss callback — wrapping in useCallback prevents the
+  // AnnouncementBanner countdown useEffect from re-running on every
+  // parent render (the effect lists onDismiss as a dependency, so an
+  // inline arrow function would reset the interval on every re-render).
+  // Must be declared before any conditional returns to satisfy Rules of Hooks.
+  const handleDismissAnnouncement = useC(() => {
+    setActiveAnnouncement(prev => {
+      if (prev?.sentAt) {
+        try {
+          sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
+        } catch (_e) {
+          // private-browsing modes can throw
+        }
+      }
+      return null;
+    });
+  }, []);
+
   if (loading && !selectedCompData) return <div className="loading">Loading...</div>;
   if (!tournament) return (
     <CreateTournament
@@ -592,23 +610,6 @@ function App() {
       </>
     );
   }
-
-  // Stable dismiss callback — wrapping in useCallback prevents the
-  // AnnouncementBanner countdown useEffect from re-running on every
-  // parent render (the effect lists onDismiss as a dependency, so an
-  // inline arrow function would reset the interval on every re-render).
-  const handleDismissAnnouncement = useC(() => {
-    setActiveAnnouncement(prev => {
-      if (prev?.sentAt) {
-        try {
-          sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
-        } catch (_e) {
-          // private-browsing modes can throw
-        }
-      }
-      return null;
-    });
-  }, []);
 
   // viewer mode
   return (
@@ -968,4 +969,12 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   </ErrorBoundary>
 );
 
-export { parsePath, pathFromState, ErrorBoundary };
+// Pure helper: returns true when an announcement should be shown.
+// `dismissedKey` is the sessionStorage value for this sentAt (truthy = dismissed).
+// `now` defaults to new Date() and can be overridden in tests for determinism.
+function isAnnouncementActive(ann, dismissedKey, now) {
+  if (!ann || dismissedKey) return false;
+  return (now || new Date()) < new Date(ann.expiresAt);
+}
+
+export { parsePath, pathFromState, ErrorBoundary, isAnnouncementActive };

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -321,13 +321,13 @@ function App() {
     window.API.fetchAnnouncement()
       .then(ann => {
         if (ann) {
-          let dismissedAt = null;
+          let dismissedKey = null;
           try {
-            dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+            dismissedKey = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
           } catch (_e) {
             // private-browsing modes can throw
           }
-          if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
+          if (isAnnouncementActive(ann, dismissedKey)) {
             setActiveAnnouncement(ann);
           }
         }
@@ -478,17 +478,13 @@ function App() {
         } else if (event.type === "announcement") {
             const ann = event.data;
             if (ann) {
-                let dismissedAt = null;
+                let dismissedKey = null;
                 try {
-                    dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+                    dismissedKey = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
                 } catch (_e) {
                     // private-browsing modes can throw
                 }
-                if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
-                    setActiveAnnouncement(ann);
-                } else {
-                    setActiveAnnouncement(null);
-                }
+                setActiveAnnouncement(isAnnouncementActive(ann, dismissedKey) ? ann : null);
             } else {
                 setActiveAnnouncement(null);
             }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -324,7 +324,7 @@ function App() {
           let dismissedAt = null;
           try {
             dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
-          } catch (e) {
+          } catch (_e) {
             // private-browsing modes can throw
           }
           if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
@@ -481,7 +481,7 @@ function App() {
                 let dismissedAt = null;
                 try {
                     dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
-                } catch (e) {
+                } catch (_e) {
                     // private-browsing modes can throw
                 }
                 if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
@@ -602,7 +602,7 @@ function App() {
       if (prev?.sentAt) {
         try {
           sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
-        } catch (e) {
+        } catch (_e) {
           // private-browsing modes can throw
         }
       }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -321,7 +321,12 @@ function App() {
     window.API.fetchAnnouncement()
       .then(ann => {
         if (ann) {
-          const dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+          let dismissedAt = null;
+          try {
+            dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+          } catch (e) {
+            // private-browsing modes can throw
+          }
           if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
             setActiveAnnouncement(ann);
           }
@@ -473,7 +478,12 @@ function App() {
         } else if (event.type === "announcement") {
             const ann = event.data;
             if (ann) {
-                const dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+                let dismissedAt = null;
+                try {
+                    dismissedAt = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
+                } catch (e) {
+                    // private-browsing modes can throw
+                }
                 if (!dismissedAt && new Date(ann.expiresAt) > new Date()) {
                     setActiveAnnouncement(ann);
                 } else {
@@ -590,7 +600,11 @@ function App() {
   const handleDismissAnnouncement = useC(() => {
     setActiveAnnouncement(prev => {
       if (prev?.sentAt) {
-        sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
+        try {
+          sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
+        } catch (e) {
+          // private-browsing modes can throw
+        }
       }
       return null;
     });

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2032,8 +2032,22 @@ function MatchViewerModal({ match, onClose }) {
   );
 }
 
+// Shared formatter so the synchronous initializer and the useEffect tick
+// produce identical strings — keeps the first paint stable.
+function formatAnnouncementTimeLeft(expiresAtIso) {
+  const diff = new Date(expiresAtIso).getTime() - Date.now();
+  if (diff <= 0) return "";
+  const totalSeconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const paddedSeconds = seconds.toString().padStart(2, "0");
+  return minutes > 0 ? `${minutes}:${paddedSeconds} left` : `${seconds}s left`;
+}
+
 function AnnouncementBanner({ announcement, onDismiss }) {
-  const [timeLeft, setTimeLeft] = useState("");
+  // Initialize synchronously so the badge isn't blank on the first paint
+  // (Copilot finding on PR #128). The useEffect tick keeps it accurate.
+  const [timeLeft, setTimeLeft] = useState(() => formatAnnouncementTimeLeft(announcement.expiresAt));
 
   useEffect(() => {
     const updateTimer = () => {
@@ -2046,16 +2060,7 @@ function AnnouncementBanner({ announcement, onDismiss }) {
         return;
       }
 
-      const totalSeconds = Math.floor(diff / 1000);
-      const minutes = Math.floor(totalSeconds / 60);
-      const seconds = totalSeconds % 60;
-      const paddedSeconds = seconds.toString().padStart(2, '0');
-
-      if (minutes > 0) {
-        setTimeLeft(`${minutes}:${paddedSeconds} left`);
-      } else {
-        setTimeLeft(`${seconds}s left`);
-      }
+      setTimeLeft(formatAnnouncementTimeLeft(announcement.expiresAt));
     };
 
     updateTimer();

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1,7 +1,7 @@
 // Viewer side — mobile-first. Single tournament. Shows competitions as the home;
 // each competition opens to its own Overview/Bracket/Pools/Schedule/Results.
 
-const { useState, useMemo, useRef: useRefV } = React;
+const { useState, useMemo, useRef: useRefV, useEffect } = React;
 const StatusBadge = window.StatusBadge;
 const formatDate = window.formatDate;
 
@@ -2024,6 +2024,61 @@ function MatchViewerModal({ match, onClose }) {
   );
 }
 
+function AnnouncementBanner({ announcement, onDismiss }) {
+  const [timeLeft, setTimeLeft] = useState("");
+
+  useEffect(() => {
+    const updateTimer = () => {
+      const expiresAt = new Date(announcement.expiresAt).getTime();
+      const now = Date.now();
+      const diff = expiresAt - now;
+
+      if (diff <= 0) {
+        onDismiss();
+        return;
+      }
+
+      const totalSeconds = Math.floor(diff / 1000);
+      const minutes = Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      const paddedSeconds = seconds.toString().padStart(2, '0');
+
+      if (minutes > 0) {
+        setTimeLeft(`${minutes}:${paddedSeconds} left`);
+      } else {
+        setTimeLeft(`${seconds}s left`);
+      }
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+
+    return () => clearInterval(interval);
+  }, [announcement.expiresAt, onDismiss]);
+
+  return (
+    <div className="announcement-banner">
+      <div className="announcement-banner__content">
+        <div className="announcement-banner__icon" aria-hidden="true">📢</div>
+        <p className="announcement-banner__message">{announcement.message}</p>
+      </div>
+      <div className="announcement-banner__meta">
+        <span className="announcement-banner__badge">
+          {timeLeft}
+        </span>
+        <button
+          className="announcement-banner__dismiss"
+          onClick={onDismiss}
+          aria-label="Dismiss announcement"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
+
+window.AnnouncementBanner = AnnouncementBanner;
 window.ViewerHome = ViewerHome;
 window.ViewerCompetition = ViewerCompetition;
 window.ViewerSchedule = ViewerSchedule;
@@ -2033,3 +2088,4 @@ window.competitionKindLabel = competitionKindLabel;
 window.compMatches = compMatches;
 window.tournamentMatches = tournamentMatches;
 window.currentMatchOf = currentMatchOf;
+

--- a/web-mobile/vitest.setup.js
+++ b/web-mobile/vitest.setup.js
@@ -26,6 +26,10 @@ afterEach(() => {
 });
 
 // Mock React since it's used as a global in the browser
+class _ReactComponent {
+  constructor(props) { this.props = props; this.state = {}; }
+  setState() {}
+}
 global.React = {
   createElement: (type, props, ...children) => ({ type, props, children }),
   useState: (val) => [val, vi.fn()],
@@ -34,6 +38,13 @@ global.React = {
   useRef: (val) => ({ current: val }),
   useLayoutEffect: vi.fn(),
   memo: (c) => c,
+  Component: _ReactComponent,
+};
+
+// ReactDOM stub — prevents the top-level ReactDOM.createRoot() call in
+// app.jsx from throwing when the module is imported in tests.
+global.ReactDOM = {
+  createRoot: () => ({ render: vi.fn() }),
 };
 
 // Mock other browser globals if needed

--- a/web-mobile/vitest.setup.js
+++ b/web-mobile/vitest.setup.js
@@ -37,6 +37,7 @@ global.React = {
   useMemo: (fn) => fn(),
   useRef: (val) => ({ current: val }),
   useLayoutEffect: vi.fn(),
+  useCallback: (fn) => fn,
   memo: (c) => c,
   Component: _ReactComponent,
 };


### PR DESCRIPTION
This PR implements the `mp-h60` feature: Admin announcement broadcast system.

### Key Changes
1. **Backend**:
   - Thread-safe in-memory `AnnouncementStore` (`internal/state/announcement_store.go`).
   - Gated endpoints: `POST /api/tournament/announce` and `GET /api/tournament/announcement`.
   - Real-time event propagation via Server-Sent Events (SSE) using the new `announcement` event type.
   - Per-handler body cap (4 KiB) on `POST /tournament/announce` via `MaxBytesReader`, matching the `handlers_reset.go` pattern.
2. **Admin UI**:
   - Added a "Broadcast announcement" form card inside the `AdminEditTournament` view with character limits and duration selections.
3. **Viewer UI**:
   - Integrated `<AnnouncementBanner>` showing real-time countdown ticking and manual dismissal (storing state in `sessionStorage`).

### Verification & Testing
- Fully covered by unit tests (Go & JS/Preact) and integration tests.
- All code styles, linters (`golangci-lint`), vulnerability checks, and security scans pass.

### Deep-review checklist (verified)
- [x] `POST /api/tournament/announce` is gated by `AuthMiddleware` (test asserts 401 without/with wrong `X-Tournament-Password`).
- [x] `GET /api/tournament/announcement` is public; returns 204 when none/expired, 200 with JSON otherwise.
- [x] Viewer renders `announcement.message` via a Preact text node (no `dangerouslySetInnerHTML`) — XSS-safe.
- [x] `announcement` event type is dispatched in `app.jsx` SSE handler — banner appears in real time, no page reload needed.
- [x] Banner auto-dismisses when `expiresAt <= now` (1 s tick), and `onDismiss` is memoised with `useCallback` so the interval is not reset on every parent render.
- [x] `sessionStorage` dismissal key is per-`sentAt`, so a fresh broadcast with a new timestamp re-shows the banner (intentional).
- [x] Body cap test (4096 bytes via `MaxBytesReader`) — oversized payloads rejected with 400.
- [x] Race-detector clean (`make go/test-race`) for the announcement store + SSE concurrency.
- [x] OpenAPI spec updated with both endpoints + `Announcement` schema + public-endpoint catalog.

### Out-of-scope follow-ups (filed separately)
- Codebase-wide audit: most admin POST/PUT handlers lack a body cap — should be solved by a global `MaxBodyBytes` middleware rather than per-handler.