### PR TITLE
fix(mobileapp): close process crash vectors (safeGo, timeouts, body cap, SSE cap)

### DIFF
--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -1,10 +1,16 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/engine"
 	"github.com/gitrgoliveira/bracket-creator/internal/mobileapp"
@@ -108,7 +114,42 @@ func (o *mobileAppOptions) run(cmd *cobra.Command, args []string) error {
 	log.Printf("Starting mobile-app server on %s:%d using folder %s", o.bindAddress, o.port, o.folder)
 	eng := engine.New(store)
 	r := mobileapp.NewRouter(store, eng, GetResources(), verifier)
-	return r.Run(o.bindAddress + ":" + strconv.Itoa(o.port))
+
+	addr := o.bindAddress + ":" + strconv.Itoa(o.port)
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: r,
+		// Prevent Slowloris: header must arrive within 10 s.
+		ReadHeaderTimeout: 10 * time.Second,
+		// Individual request body read deadline (not SSE — streaming
+		// connections upgrade WriteTimeout via ResponseController).
+		ReadTimeout: 30 * time.Second,
+		// WriteTimeout=0 leaves SSE connections open indefinitely.
+		// gin.Default()'s Recovery middleware still caps panics on the
+		// non-streaming path; the safeGo helpers protect viewer goroutines.
+		WriteTimeout: 0,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("mobile-app server error: %v", err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	log.Println("Shutting down mobile-app server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("mobile-app server forced shutdown: %v", err)
+		return err
+	}
+	log.Println("mobile-app server exited cleanly")
+	return nil
 }
 
 func init() {

--- a/internal/mobileapp/handlers_viewer.go
+++ b/internal/mobileapp/handlers_viewer.go
@@ -33,11 +33,12 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 		// wg.Wait() provides the happens-before for reads below.
 		results := make([]any, len(ids))
 		var wg sync.WaitGroup
+		errCh := make(chan error, len(ids))
 
 		for i, id := range ids {
 			wg.Add(1)
-			go func(idx int, compID string) {
-				defer wg.Done()
+			idx, compID := i, id
+			safeGo(&wg, errCh, func() {
 				comp, _ := store.LoadCompetition(compID)
 				if comp == nil {
 					return
@@ -73,9 +74,14 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 					"poolMatches": poolMatches,
 					"bracket":     bracket,
 				}
-			}(i, id)
+			})
 		}
 		wg.Wait()
+
+		if len(errCh) > 0 {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			return
+		}
 
 		comps := make([]any, 0, len(ids))
 		for _, comp := range results {
@@ -120,10 +126,11 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 			playersErr, poolsErr, poolMatchesErr, standingsErr, bracketErr, scheduleErr, reservedSlotsErr error
 		)
 
+		const goroutineCount = 7
 		var wg sync.WaitGroup
-		wg.Add(7)
-		go func() {
-			defer wg.Done()
+		errCh := make(chan error, goroutineCount)
+		wg.Add(goroutineCount)
+		safeGo(&wg, errCh, func() {
 			// Only pass HasIDs=true hint; false means unset so auto-detect
 			// still runs for competitions created before the flag existed.
 			var hasIDsHint *bool
@@ -137,32 +144,31 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 			})
 			comp.Players = p
 			playersErr = e
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		safeGo(&wg, errCh, func() {
 			pools, poolsErr = store.LoadPools(id)
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		safeGo(&wg, errCh, func() {
 			poolMatches, poolMatchesErr = store.LoadPoolMatches(id)
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		safeGo(&wg, errCh, func() {
 			standings, standingsErr = eng.CalculatePoolStandings(id)
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		safeGo(&wg, errCh, func() {
 			bracket, bracketErr = store.LoadBracket(id)
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		safeGo(&wg, errCh, func() {
 			schedule, scheduleErr = store.LoadSchedule(id)
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		safeGo(&wg, errCh, func() {
 			reservedSlots, reservedSlotsErr = store.LoadReservedSlots(id)
-		}()
+		})
 		wg.Wait()
+
+		if len(errCh) > 0 {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			return
+		}
 
 		for _, e := range []error{playersErr, poolsErr, poolMatchesErr, standingsErr, bracketErr, scheduleErr, reservedSlotsErr} {
 			if e != nil {
@@ -193,15 +199,22 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 		// the reads below.
 		perComp := make([][]state.ScheduleEntry, len(ids))
 		var wg sync.WaitGroup
+		errCh := make(chan error, len(ids))
 		for i, id := range ids {
 			wg.Add(1)
-			go func(idx int, compID string) {
-				defer wg.Done()
+			idx, compID := i, id
+			safeGo(&wg, errCh, func() {
 				s, _ := store.LoadSchedule(compID)
 				perComp[idx] = s
-			}(i, id)
+			})
 		}
 		wg.Wait()
+
+		if len(errCh) > 0 {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+			return
+		}
+
 		allEntries := []state.ScheduleEntry{}
 		for _, s := range perComp {
 			allEntries = append(allEntries, s...)

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -119,6 +119,11 @@ type Hub struct {
 	// take the write lock.
 	history     []historyEntry
 	HistorySize int
+
+	// maxClients caps concurrent SSE connections. Subscribe returns nil
+	// when the cap is reached; HandleEvents responds with 503 in that case.
+	// 0 means unlimited (default for NewHub).
+	maxClients int
 }
 
 func NewHub() *Hub {
@@ -139,10 +144,23 @@ func NewHubWithHistory(historySize int) *Hub {
 	}
 }
 
-// Subscribe adds a new client channel to the hub
+// NewHubWithOptions constructs a Hub with custom history and client cap.
+// maxClients=0 means unlimited.
+func NewHubWithOptions(historySize, maxClients int) *Hub {
+	h := NewHubWithHistory(historySize)
+	h.maxClients = maxClients
+	return h
+}
+
+// Subscribe adds a new client channel to the hub.
+// Returns nil when the maxClients cap is reached; the caller (HandleEvents)
+// must treat nil as a 503.
 func (h *Hub) Subscribe() chan string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if h.maxClients > 0 && len(h.clients) >= h.maxClients {
+		return nil
+	}
 	// Buffer absorbs short bursts (bulk-score and schedule updates) for ~300
 	// concurrent SSE clients; truly stalled clients are detected via the
 	// non-blocking send in Broadcast and unsubscribed.
@@ -289,6 +307,10 @@ func (h *Hub) HandleEvents() gin.HandlerFunc {
 		}
 
 		ch := h.Subscribe()
+		if ch == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "too many SSE connections"})
+			return
+		}
 		defer h.Unsubscribe(ch)
 
 		// Set SSE headers

--- a/internal/mobileapp/hub_test.go
+++ b/internal/mobileapp/hub_test.go
@@ -422,3 +422,58 @@ Subscribed:
 		t.Fatal("HandleEvents did not exit after channel closure")
 	}
 }
+
+func TestHub_MaxClients(t *testing.T) {
+	t.Run("subscribe returns nil at cap", func(t *testing.T) {
+		h := NewHubWithOptions(DefaultHistorySize, 2)
+		ch1 := h.Subscribe()
+		require.NotNil(t, ch1)
+		ch2 := h.Subscribe()
+		require.NotNil(t, ch2)
+		ch3 := h.Subscribe()
+		assert.Nil(t, ch3, "Subscribe should return nil when maxClients reached")
+		h.Unsubscribe(ch1)
+		h.Unsubscribe(ch2)
+	})
+
+	t.Run("subscribe succeeds after slot freed", func(t *testing.T) {
+		h := NewHubWithOptions(DefaultHistorySize, 1)
+		ch1 := h.Subscribe()
+		require.NotNil(t, ch1)
+		h.Unsubscribe(ch1)
+		ch2 := h.Subscribe()
+		assert.NotNil(t, ch2, "Subscribe should succeed after a slot is freed")
+		h.Unsubscribe(ch2)
+	})
+
+	t.Run("HandleEvents returns 503 at cap", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		h := NewHubWithOptions(DefaultHistorySize, 1)
+
+		// Fill the cap
+		occupied := h.Subscribe()
+		require.NotNil(t, occupied)
+		defer h.Unsubscribe(occupied)
+
+		router := gin.New()
+		router.GET("/events", h.HandleEvents())
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/events", nil)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	})
+
+	t.Run("zero maxClients means unlimited", func(t *testing.T) {
+		h := NewHubWithOptions(DefaultHistorySize, 0)
+		channels := make([]chan string, 10)
+		for i := range channels {
+			ch := h.Subscribe()
+			require.NotNil(t, ch, "Subscribe should never return nil when maxClients=0")
+			channels[i] = ch
+		}
+		for _, ch := range channels {
+			h.Unsubscribe(ch)
+		}
+	})
+}

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -7,6 +7,18 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
+// MaxBodyBytes returns middleware that caps the request body at n bytes.
+// Requests exceeding the limit receive 413 Request Entity Too Large.
+// Apply to all write routes to prevent memory exhaustion from oversized
+// payloads. Do not apply to SSE (GET, no body) or file-import endpoints
+// whose payloads may legitimately exceed the default cap.
+func MaxBodyBytes(n int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, n)
+		c.Next()
+	}
+}
+
 // requireValidCompID extracts the `:id` URL parameter and validates it
 // via state.ValidateCompetitionID. Rejects:
 //   - empty

--- a/internal/mobileapp/safego.go
+++ b/internal/mobileapp/safego.go
@@ -1,0 +1,37 @@
+package mobileapp
+
+import (
+	"fmt"
+	"log"
+	"runtime/debug"
+	"sync"
+)
+
+// safeGo runs fn in a goroutine. If fn panics, the panic is recovered:
+// the value is logged with a full stack trace, and a generic error is
+// written to errCh. wg.Done() is called in all paths so the WaitGroup
+// is never leaked.
+//
+// The panic value itself is NOT forwarded to errCh or to HTTP responses —
+// it may contain internal state (file paths, memory addresses) that must
+// not be surfaced to unauthenticated callers on the viewer endpoints.
+//
+// Convention: every goroutine spawned inside a request handler MUST use
+// safeGo. A panic in a bare goroutine bypasses gin.Default()'s Recovery
+// middleware and crashes the process. safeGo closes that gap for
+// handler-spawned goroutines.
+func safeGo(wg *sync.WaitGroup, errCh chan<- error, fn func()) {
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("safeGo: recovered panic in viewer goroutine: %v\n%s", r, debug.Stack())
+				select {
+				case errCh <- fmt.Errorf("internal error"):
+				default:
+				}
+			}
+		}()
+		fn()
+	}()
+}

--- a/internal/mobileapp/safego_test.go
+++ b/internal/mobileapp/safego_test.go
@@ -1,0 +1,92 @@
+package mobileapp
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeGo_NormalExecution(t *testing.T) {
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+	called := false
+
+	wg.Add(1)
+	safeGo(&wg, errCh, func() {
+		called = true
+	})
+	wg.Wait()
+
+	assert.True(t, called)
+	assert.Empty(t, errCh, "no error expected on normal execution")
+}
+
+func TestSafeGo_PanicRecovery(t *testing.T) {
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+
+	wg.Add(1)
+	safeGo(&wg, errCh, func() {
+		panic("test panic")
+	})
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		assert.ErrorContains(t, err, "internal error")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected error in errCh after panic")
+	}
+}
+
+func TestSafeGo_WaitGroupAlwaysDone(t *testing.T) {
+	// Even when the goroutine panics, wg.Done() must be called exactly once
+	// so wg.Wait() does not block forever.
+	var wg sync.WaitGroup
+	errCh := make(chan error, 1)
+
+	wg.Add(1)
+	safeGo(&wg, errCh, func() {
+		panic("unexpected panic")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// WaitGroup unblocked — wg.Done() was called despite the panic.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("wg.Wait() blocked after panic in safeGo — wg.Done() not called")
+	}
+}
+
+func TestSafeGo_ErrorChannelFullDoesNotBlock(t *testing.T) {
+	// When errCh is full (capacity 0 / already filled), safeGo must not
+	// block — the select default path must fire.
+	var wg sync.WaitGroup
+	errCh := make(chan error, 0) // zero-capacity: send will always fail default
+
+	wg.Add(1)
+	safeGo(&wg, errCh, func() {
+		panic("overflow panic")
+	})
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// safeGo did not block on the full channel.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("safeGo blocked on full errCh instead of using select default")
+	}
+}

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -4,7 +4,9 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -34,7 +36,13 @@ func NewRouter(store *state.Store, eng *engine.Engine, res *resources.Resources,
 		c.Next()
 	})
 
-	hub := NewHub()
+	maxClients := 0
+	if raw := os.Getenv("SSE_MAX_CLIENTS"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			maxClients = n
+		}
+	}
+	hub := NewHubWithOptions(DefaultHistorySize, maxClients)
 
 	// Health check
 	r.GET("/health", func(c *gin.Context) {
@@ -84,6 +92,10 @@ func NewRouter(store *state.Store, eng *engine.Engine, res *resources.Resources,
 
 	// Admin API endpoints (protected)
 	admin := r.Group("/api")
+	// Cap request bodies at 4 MiB before auth runs so oversized payloads
+	// don't tie up the bcrypt/file-read in AuthMiddleware. Import endpoints
+	// (participant CSV) are well under 4 MiB in practice.
+	admin.Use(MaxBodyBytes(4 * 1024 * 1024))
 	admin.Use(AuthMiddleware(verifier, store))
 	{
 		RegisterTournamentHandlers(admin, store, hub, verifier)


### PR DESCRIPTION
## Summary

- **Phase 1 — safeGo**: Viewer goroutines in `GET /viewer/competitions`, `GET /viewer/competitions/:id`, and `GET /viewer/schedule` now use `safeGo(&wg, errCh, fn)`. A panic on a corrupt file returns HTTP 500 instead of crashing the process. `wg.Done()` is always called even on panic.
- **Phase 2 — server timeouts**: `cmd/mobile_app.go` replaces `gin.Engine.Run()` with an `http.Server` (ReadHeaderTimeout=10s, ReadTimeout=30s, WriteTimeout=0 for SSE, IdleTimeout=120s) and adds SIGTERM/SIGINT graceful shutdown with a 30s drain window.
- **Phase 3 — body cap**: `MaxBodyBytes(4 MiB)` middleware applied to the admin group before `AuthMiddleware` so oversized payloads are rejected before bcrypt runs.
- **Phase 4 — SSE client cap**: `Hub.maxClients` field + `NewHubWithOptions`; `Subscribe()` returns nil when cap reached; `HandleEvents` returns 503. Configurable via `SSE_MAX_CLIENTS` env var (0 = unlimited, the default).

## Test plan

- [ ] `make go/test` passes
- [ ] `make go/build` succeeds
- [ ] Start server with `make run-mobile`, confirm `GET /api/viewer/competitions` returns correct data
- [ ] Confirm `POST /api/…` with a 5 MB body receives 413 (use `curl -X POST ... -d @5mb.bin`)
- [ ] Set `SSE_MAX_CLIENTS=1`, open two SSE connections, confirm second gets 503
- [ ] Send `SIGTERM` to the process, confirm clean shutdown log appears
- [ ] TestSafeGo_* and TestHub_MaxClients tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)