### PR TITLE
fix(mobile-app): improve startup diagnostics for data-folder permission failures

### DIFF
--- a/cmd/diag_unix.go
+++ b/cmd/diag_unix.go
@@ -42,6 +42,16 @@ func diagnoseFolderErrorForProcess(folder string, uid, gid int) string {
 	target := folder
 	info, err := os.Stat(folder)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			// EACCES or other non-NotExist errors mean the folder exists but we
+			// can't inspect it — report that directly rather than silently falling
+			// back to the parent, which could have different ownership and mislead
+			// the operator about what's wrong.
+			hint += fmt.Sprintf("  %s: could not stat (%v)", folder, err)
+			return hint
+		}
+		// Folder doesn't exist yet (common: data dir was never created on this
+		// host). Stat the parent to show who owns the volume root.
 		parent := filepath.Dir(folder)
 		info, err = os.Stat(parent)
 		if err != nil {

--- a/cmd/diag_unix.go
+++ b/cmd/diag_unix.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// diagnoseFolderError returns an actionable Hint block when data-folder
+// initialisation fails at startup. It reports the effective UID/GID of the
+// running process alongside the ownership and mode bits of the folder (or its
+// parent when the folder doesn't exist yet), so operators running in Docker
+// with bind-mounted volumes can immediately identify a UID/GID mismatch
+// without having to read source code.
+//
+// The typical failure chain is:
+//
+//	host bind mount /tournament-data owned by uid=1000
+//	container USER directive → uid=999
+//	→ os.MkdirAll("/tournament-data/competitions") → EACCES
+//
+// On POSIX, syscall.Stat_t carries Uid/Gid; on Windows this file is excluded
+// by the build tag and the stub in diag_windows.go returns "".
+func diagnoseFolderError(folder string) string {
+	uid := os.Geteuid()
+	gid := os.Getegid()
+
+	hint := fmt.Sprintf("Hint: process running as uid=%d gid=%d\n", uid, gid)
+
+	// Prefer statting the folder itself — it often exists as the bind-mount
+	// root even when a sub-directory (competitions/, .wal/) can't be created.
+	// Fall back to the parent when the folder itself doesn't exist yet.
+	target := folder
+	info, err := os.Stat(folder)
+	if err != nil {
+		parent := filepath.Dir(folder)
+		info, err = os.Stat(parent)
+		if err != nil {
+			hint += fmt.Sprintf("  %s: could not stat (%v)", parent, err)
+			return hint
+		}
+		target = parent
+	}
+
+	mode := info.Mode().Perm()
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		hint += fmt.Sprintf("  %s exists, mode=%04o", target, mode)
+		return hint
+	}
+
+	ownerUID := stat.Uid
+	ownerGID := stat.Gid
+
+	hint += fmt.Sprintf("  %s exists, mode=%04o, owner=%d:%d", target, mode, ownerUID, ownerGID)
+
+	if uint32(uid) != ownerUID { // #nosec G115 — POSIX Geteuid() is always >= 0 and fits in uint32
+		hint += fmt.Sprintf("\n  → %s is owned by uid %d but the container runs as uid %d", target, ownerUID, uid)
+		hint += fmt.Sprintf("\n  → docker-compose: add `user: \"%d:%d\"` to the mobile-app service,", ownerUID, ownerGID)
+		hint += "\n    OR chown the host folder to match the container's USER"
+	}
+
+	return hint
+}

--- a/cmd/diag_unix.go
+++ b/cmd/diag_unix.go
@@ -51,8 +51,10 @@ func diagnoseFolderErrorForProcess(folder string, uid, gid int) string {
 			return hint
 		}
 		// Folder doesn't exist yet (common: data dir was never created on this
-		// host). Stat the parent to show who owns the volume root.
-		parent := filepath.Dir(folder)
+		// host). Stat the parent to show who owns the volume root. Clean first
+		// so a trailing separator (e.g. "/tournament-data/") doesn't make
+		// filepath.Dir return the folder itself instead of its parent.
+		parent := filepath.Dir(filepath.Clean(folder))
 		info, err = os.Stat(parent)
 		if err != nil {
 			hint += fmt.Sprintf("  %s: could not stat (%v)", parent, err)

--- a/cmd/diag_unix.go
+++ b/cmd/diag_unix.go
@@ -25,9 +25,15 @@ import (
 // On POSIX, syscall.Stat_t carries Uid/Gid; on Windows this file is excluded
 // by the build tag and the stub in diag_windows.go returns "".
 func diagnoseFolderError(folder string) string {
-	uid := os.Geteuid()
-	gid := os.Getegid()
+	return diagnoseFolderErrorForProcess(folder, os.Geteuid(), os.Getegid())
+}
 
+// diagnoseFolderErrorForProcess is the testable core of diagnoseFolderError.
+// uid and gid are the effective credentials of the running process; callers
+// other than diagnoseFolderError should only use this in tests where
+// injecting a synthetic uid/gid is needed to exercise the mismatch path
+// without requiring root or a real foreign-owned directory.
+func diagnoseFolderErrorForProcess(folder string, uid, gid int) string {
 	hint := fmt.Sprintf("Hint: process running as uid=%d gid=%d\n", uid, gid)
 
 	// Prefer statting the folder itself — it often exists as the bind-mount

--- a/cmd/diag_unix_test.go
+++ b/cmd/diag_unix_test.go
@@ -52,16 +52,6 @@ func TestDiagnoseFolderError_OwnerInfo(t *testing.T) {
 	}
 }
 
-func TestDiagnoseFolderError_NoMismatchWarningWhenSameUID(t *testing.T) {
-	dir := t.TempDir()
-	result := diagnoseFolderError(dir)
-
-	// When the process uid matches the dir owner there should be no arrow warning.
-	if strings.Contains(result, "→") {
-		t.Errorf("expected no mismatch arrow when uid matches, got:\n%s", result)
-	}
-}
-
 func TestDiagnoseFolderError_MismatchArrowWhenUIDDiffers(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root — UID mismatch against root-owned dir not testable")
@@ -90,9 +80,10 @@ func TestDiagnoseFolderError_NoArrowWhenUIDMatches(t *testing.T) {
 }
 
 func TestDiagnoseFolderError_BothParentsMissing(t *testing.T) {
-	// Deeply nested path that doesn't exist at all — both folder and its
-	// immediate parent are absent. diagnoseFolderError must not panic.
-	result := diagnoseFolderError("/nonexistent-bc-diag-test/sub/deeper")
+	// Construct a guaranteed-missing nested path under t.TempDir() so that
+	// both the target folder and its immediate parent are absent regardless
+	// of the environment. diagnoseFolderError must not panic.
+	result := diagnoseFolderError(filepath.Join(t.TempDir(), "a", "b"))
 
 	if !strings.Contains(result, "uid=") {
 		t.Errorf("expected uid= in output even when both paths missing, got:\n%s", result)

--- a/cmd/diag_unix_test.go
+++ b/cmd/diag_unix_test.go
@@ -79,6 +79,24 @@ func TestDiagnoseFolderError_NoArrowWhenUIDMatches(t *testing.T) {
 	}
 }
 
+// TestDiagnoseFolderError_TrailingSeparatorFallsBackToTrueParent guards against
+// the filepath.Dir quirk where Dir("/x/") returns "/x" rather than "/" — the
+// fallback must Clean before computing the parent, otherwise it would stat the
+// folder itself again.
+func TestDiagnoseFolderError_TrailingSeparatorFallsBackToTrueParent(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist")
+	// Append trailing slash to the missing path; the parent must still be `dir`.
+	result := diagnoseFolderError(missing + string(filepath.Separator))
+
+	if !strings.Contains(result, dir) {
+		t.Errorf("expected true parent %s in output (not the path itself), got:\n%s", dir, result)
+	}
+	if !strings.Contains(result, "exists, mode=") {
+		t.Errorf("expected parent's mode info in output, got:\n%s", result)
+	}
+}
+
 func TestDiagnoseFolderError_TargetAndParentMissing(t *testing.T) {
 	// Construct a guaranteed-missing nested path under t.TempDir() so that
 	// both the target folder and its immediate parent are absent regardless

--- a/cmd/diag_unix_test.go
+++ b/cmd/diag_unix_test.go
@@ -1,0 +1,76 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiagnoseFolderError_ExistingFolder(t *testing.T) {
+	dir := t.TempDir()
+	result := diagnoseFolderError(dir)
+
+	// Must include process UID in the Hint: header
+	if !strings.Contains(result, fmt.Sprintf("uid=%d", os.Geteuid())) {
+		t.Errorf("expected effective uid=%d in output, got:\n%s", os.Geteuid(), result)
+	}
+	// Must include mode and owner info for an existing dir
+	if !strings.Contains(result, "exists, mode=") {
+		t.Errorf("expected mode info in output, got:\n%s", result)
+	}
+}
+
+func TestDiagnoseFolderError_NonexistentFolderFallsBackToParent(t *testing.T) {
+	dir := t.TempDir()
+	// Pass a path whose direct stat will fail; diagnoseFolderError
+	// must fall back to statting the parent (dir).
+	target := filepath.Join(dir, "does-not-exist")
+	result := diagnoseFolderError(target)
+
+	// Process UID must still be present
+	if !strings.Contains(result, fmt.Sprintf("uid=%d", os.Geteuid())) {
+		t.Errorf("expected effective uid=%d in output, got:\n%s", os.Geteuid(), result)
+	}
+	// The parent dir path should appear in the output
+	if !strings.Contains(result, dir) {
+		t.Errorf("expected parent dir %s in output, got:\n%s", dir, result)
+	}
+}
+
+func TestDiagnoseFolderError_OwnerInfo(t *testing.T) {
+	dir := t.TempDir()
+	result := diagnoseFolderError(dir)
+
+	// t.TempDir() is owned by the current user, so owner= must match Geteuid:Getegid
+	expected := fmt.Sprintf("owner=%d:%d", os.Geteuid(), os.Getegid())
+	if !strings.Contains(result, expected) {
+		t.Errorf("expected %q in output, got:\n%s", expected, result)
+	}
+}
+
+func TestDiagnoseFolderError_NoMismatchWarningWhenSameUID(t *testing.T) {
+	dir := t.TempDir()
+	result := diagnoseFolderError(dir)
+
+	// When the process uid matches the dir owner there should be no arrow warning.
+	if strings.Contains(result, "→") {
+		t.Errorf("expected no mismatch arrow when uid matches, got:\n%s", result)
+	}
+}
+
+func TestDiagnoseFolderError_BothParentsMissing(t *testing.T) {
+	// Deeply nested path that doesn't exist at all — both folder and its
+	// immediate parent are absent. diagnoseFolderError must not panic.
+	result := diagnoseFolderError("/nonexistent-bc-diag-test/sub/deeper")
+
+	if !strings.Contains(result, "uid=") {
+		t.Errorf("expected uid= in output even when both paths missing, got:\n%s", result)
+	}
+	if !strings.Contains(result, "could not stat") {
+		t.Errorf("expected 'could not stat' message, got:\n%s", result)
+	}
+}

--- a/cmd/diag_unix_test.go
+++ b/cmd/diag_unix_test.go
@@ -66,10 +66,10 @@ func TestDiagnoseFolderError_MismatchArrowWhenUIDDiffers(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root — UID mismatch against root-owned dir not testable")
 	}
-	// /usr/bin exists on macOS and Linux and is always owned by root (uid=0).
+	// "/" is always present on any Unix system and owned by root (uid=0).
 	// Inject uid=999 (≠ 0) to trigger the mismatch arrow without needing Docker
 	// or elevated privileges.
-	result := diagnoseFolderErrorForProcess("/usr/bin", 999, 999)
+	result := diagnoseFolderErrorForProcess("/", 999, 999)
 
 	if !strings.Contains(result, "→") {
 		t.Errorf("expected UID mismatch arrow when uid=999 != owner(0), got:\n%s", result)

--- a/cmd/diag_unix_test.go
+++ b/cmd/diag_unix_test.go
@@ -79,7 +79,7 @@ func TestDiagnoseFolderError_NoArrowWhenUIDMatches(t *testing.T) {
 	}
 }
 
-func TestDiagnoseFolderError_BothParentsMissing(t *testing.T) {
+func TestDiagnoseFolderError_TargetAndParentMissing(t *testing.T) {
 	// Construct a guaranteed-missing nested path under t.TempDir() so that
 	// both the target folder and its immediate parent are absent regardless
 	// of the environment. diagnoseFolderError must not panic.
@@ -90,5 +90,38 @@ func TestDiagnoseFolderError_BothParentsMissing(t *testing.T) {
 	}
 	if !strings.Contains(result, "could not stat") {
 		t.Errorf("expected 'could not stat' message, got:\n%s", result)
+	}
+}
+
+// TestDiagnoseFolderError_StatErrorReportedDirectly covers the non-IsNotExist
+// branch: when os.Stat returns EACCES (folder exists but is unreadable due to
+// a parent dir we can't traverse), the diagnostic must report the failure on
+// the original folder rather than silently falling back to the parent — the
+// parent's ownership would be misleading in this case.
+func TestDiagnoseFolderError_StatErrorReportedDirectly(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses POSIX permission checks; EACCES branch not reachable")
+	}
+	parent := t.TempDir()
+	child := filepath.Join(parent, "child")
+	if err := os.Mkdir(child, 0o700); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	// Strip search permission on parent. stat(parent/child) now returns EACCES
+	// (not IsNotExist). Restore in cleanup so t.TempDir() can remove the tree.
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("chmod parent 000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	result := diagnoseFolderError(child)
+
+	if !strings.Contains(result, "could not stat") {
+		t.Errorf("expected 'could not stat' for EACCES, got:\n%s", result)
+	}
+	// The hint must reference the target itself, not its parent — falling back
+	// to the parent would tell the operator about a different directory's owner.
+	if !strings.Contains(result, child) {
+		t.Errorf("expected target %s in output, got:\n%s", child, result)
 	}
 }

--- a/cmd/diag_unix_test.go
+++ b/cmd/diag_unix_test.go
@@ -62,6 +62,33 @@ func TestDiagnoseFolderError_NoMismatchWarningWhenSameUID(t *testing.T) {
 	}
 }
 
+func TestDiagnoseFolderError_MismatchArrowWhenUIDDiffers(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — UID mismatch against root-owned dir not testable")
+	}
+	// /usr/bin exists on macOS and Linux and is always owned by root (uid=0).
+	// Inject uid=999 (≠ 0) to trigger the mismatch arrow without needing Docker
+	// or elevated privileges.
+	result := diagnoseFolderErrorForProcess("/usr/bin", 999, 999)
+
+	if !strings.Contains(result, "→") {
+		t.Errorf("expected UID mismatch arrow when uid=999 != owner(0), got:\n%s", result)
+	}
+	if !strings.Contains(result, "uid 999") {
+		t.Errorf("expected injected uid 999 in mismatch message, got:\n%s", result)
+	}
+}
+
+func TestDiagnoseFolderError_NoArrowWhenUIDMatches(t *testing.T) {
+	dir := t.TempDir()
+	// Inject the actual process uid/gid — they match the t.TempDir() owner.
+	result := diagnoseFolderErrorForProcess(dir, os.Geteuid(), os.Getegid())
+
+	if strings.Contains(result, "→") {
+		t.Errorf("expected no mismatch arrow when uid matches dir owner, got:\n%s", result)
+	}
+}
+
 func TestDiagnoseFolderError_BothParentsMissing(t *testing.T) {
 	// Deeply nested path that doesn't exist at all — both folder and its
 	// immediate parent are absent. diagnoseFolderError must not panic.

--- a/cmd/diag_windows.go
+++ b/cmd/diag_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cmd
+
+// diagnoseFolderError is a no-op on Windows: syscall.Stat_t doesn't carry
+// Uid/Gid fields there, and Docker bind-mount UID mismatches are a
+// Linux/macOS concern. The empty string tells the caller to omit the hint
+// block from the error message.
+func diagnoseFolderError(_ string) string { return "" }

--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -114,7 +114,7 @@ func (o *mobileAppOptions) run(cmd *cobra.Command, args []string) error {
 		verifier = mobileapp.NewFileVerifier(store)
 	}
 
-	slog.Info("mobile-app: starting", "bind", o.bindAddress, "port", o.port, "folder", o.folder)
+	slog.Info("mobile-app: starting", "bind", o.bindAddress, "port", o.port, "tournamentDataDir", o.folder)
 	eng := engine.New(store)
 	r := mobileapp.NewRouter(store, eng, GetResources(), verifier)
 	return r.Run(o.bindAddress + ":" + strconv.Itoa(o.port))

--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strconv"
 
@@ -82,9 +82,18 @@ func (o *mobileAppOptions) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	slog.Info("mobile-app: initializing",
+		"tournamentDataDir", o.folder,
+		"bind", o.bindAddress,
+		"port", o.port,
+		"lockPassword", o.lockPassword,
+	)
 	store, err := state.NewStore(o.folder)
 	if err != nil {
-		return fmt.Errorf("failed to initialize state store: %w", err)
+		if hint := diagnoseFolderError(o.folder); hint != "" {
+			return fmt.Errorf("failed to initialize state store at %q: %w\n%s", o.folder, err, hint)
+		}
+		return fmt.Errorf("failed to initialize state store at %q: %w", o.folder, err)
 	}
 
 	// Select the auth source. Fail-closed: when --lock-password is set
@@ -100,12 +109,12 @@ func (o *mobileAppOptions) run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("--lock-password set but TOURNAMENT_PASSWORD_HASH invalid: %w", err)
 		}
 		verifier = v
-		log.Printf("Starting mobile-app server in LOCKED mode (auth from TOURNAMENT_PASSWORD_HASH; POST /api/tournament/reset disabled)")
+		slog.Info("mobile-app: locked mode", "authSource", "TOURNAMENT_PASSWORD_HASH", "resetDisabled", true)
 	} else {
 		verifier = mobileapp.NewFileVerifier(store)
 	}
 
-	log.Printf("Starting mobile-app server on %s:%d using folder %s", o.bindAddress, o.port, o.folder)
+	slog.Info("mobile-app: starting", "bind", o.bindAddress, "port", o.port, "folder", o.folder)
 	eng := engine.New(store)
 	r := mobileapp.NewRouter(store, eng, GetResources(), verifier)
 	return r.Run(o.bindAddress + ":" + strconv.Itoa(o.port))


### PR DESCRIPTION
## Summary

- Adds `diagnoseFolderError` (POSIX-only, `//go:build !windows`) that captures effective uid/gid, the target dir's mode/owner via `syscall.Stat_t`, and emits an actionable `Hint:` block when the process uid doesn't match the directory owner — the most common Docker bind-mount misconfiguration
- Augments the `NewStore` error in `cmd/mobile_app.go` with that hint block so operators get an immediately actionable message instead of a bare `permission denied`
- Adds `slog.Info("mobile-app: initializing", ...)` before `NewStore` so tournamentDataDir, bind, port, and lockPassword mode are always logged at startup
- Converts the two remaining `log.Printf` calls to `slog.Info` for consistency
- Adds 8 unit tests covering: existing folder, IsNotExist fallback to parent, owner info, UID-mismatch arrow (via injected uid via testable `diagnoseFolderErrorForProcess`), no-arrow-when-uid-matches, trailing-separator parent resolution, target+parent both missing, and the non-IsNotExist (EACCES) stat-error branch

Closes mp-0d3

## Example output (before)

```
Error: failed to initialize state store: mkdir /tournament-data/competitions: permission denied
```

## Example output (after)

```
time=2026-05-20T20:00:00Z level=INFO msg="mobile-app: initializing" tournamentDataDir=/tournament-data bind=0.0.0.0 port=8080 lockPassword=false
Error: failed to initialize state store at "/tournament-data": mkdir /tournament-data/competitions: permission denied
Hint: process running as uid=999 gid=999
  /tournament-data exists, mode=0755, owner=1000:1000
  → /tournament-data is owned by uid 1000 but the container runs as uid 999
  → docker-compose: add `user: "1000:1000"` to the mobile-app service,
    OR chown the host folder to match the container's USER
```

## Test plan

- [x] `make go/lint` passes (0 issues)
- [x] `go test ./cmd/ -run TestDiagnoseFolderError -v` — all 8 tests pass
- [x] `go test -cover ./cmd/... ./internal/...` — all packages pass
- [x] Manual: `docker run -v /tmp/ro:/tournament-data:ro bracket-creator mobile-app` produces the new Hint: block
- [x] Manual: `docker run -v /tmp/owned-by-1000:/tournament-data bracket-creator mobile-app` (container as uid≠1000) shows the → mismatch arrow and docker-compose suggestion
- [x] Normal start (correct permissions) emits `slog.Info("mobile-app: initializing", ...)` line with all config fields

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
