### PR TITLE
fix(build): add -buildvcs=false (mp-j5j)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ $(BIN_PATH)/$(BIN_NAME): vendor-frontend esbuild-jsx $(GO_SOURCES) $(EMBEDDED_AS
 	@echo "Building $(BIN_NAME) version $(VERSION)..."
 	@mkdir -p $(BIN_PATH)
 	go generate ./...
-	# -buildvcs=false: version/commit/build-date are already embedded via `go generate`
-	# (internal/cmd/version/get_build_info.sh writes commit.txt/version.txt/build_date.txt
-	# consumed by //go:embed), so Go's auto VCS stamp is redundant. Go 1.26's default
-	# -buildvcs=auto fails in git worktrees with "error obtaining VCS status: exit status 128".
+	@# -buildvcs=false: version/commit/build-date are already embedded via `go generate`
+	@# (internal/cmd/version/get_build_info.sh writes commit.txt/version.txt/build_date.txt
+	@# consumed by //go:embed), so Go's auto VCS stamp is redundant. Go 1.26's default
+	@# -buildvcs=auto fails in git worktrees with "error obtaining VCS status: exit status 128".
 	go build -buildvcs=false $(LDFLAGS) -o $(BIN_PATH)/$(BIN_NAME) .
 
 examples: go/build ## Build locally and create example files

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,11 @@ $(BIN_PATH)/$(BIN_NAME): vendor-frontend esbuild-jsx $(GO_SOURCES) $(EMBEDDED_AS
 	@echo "Building $(BIN_NAME) version $(VERSION)..."
 	@mkdir -p $(BIN_PATH)
 	go generate ./...
-	go build $(LDFLAGS) -o $(BIN_PATH)/$(BIN_NAME) .
+	# -buildvcs=false: version/commit/build-date are already embedded via `go generate`
+	# (internal/cmd/version/get_build_info.sh writes commit.txt/version.txt/build_date.txt
+	# consumed by //go:embed), so Go's auto VCS stamp is redundant. Go 1.26's default
+	# -buildvcs=auto fails in git worktrees with "error obtaining VCS status: exit status 128".
+	go build -buildvcs=false $(LDFLAGS) -o $(BIN_PATH)/$(BIN_NAME) .
 
 examples: go/build ## Build locally and create example files
 	@echo "Cleaning previous examples..."


### PR DESCRIPTION
## Summary

`make go/build` fails in git worktrees on Go 1.26 because the default `-buildvcs=auto` cannot collect VCS metadata from the worktree git layout. Three separate review agents (on PRs #124, #126, #125) hit this and worked around it with `GOFLAGS=-buildvcs=false`. This makes the workaround the default.

## Reproduced error

In `/Users/ricardo/repos/bracket-creator-bw2` (an existing worktree):

```
$ go build -o /tmp/test . 
error obtaining VCS status: exit status 128
        Use -buildvcs=false to disable VCS stamping.
```

After fix (worktree `claude/mp-j5j`):

```
$ make go/build
... go build -buildvcs=false -ldflags "..." -o ./bin/bracket-creator .
$ ls -la bin/bracket-creator
-rwxr-xr-x  37M ... bin/bracket-creator
```

## Why `-buildvcs=false` is safe

The binary's version/commit/build-date come from `go generate ./...` (which runs `internal/cmd/version/get_build_info.sh`) writing `commit.txt` / `version.txt` / `build_date.txt`, consumed by `//go:embed` in `internal/cmd/version/version.go`. Go's auto VCS stamp is redundant — disabling it loses nothing user-visible.

(Note: the Makefile's `LDFLAGS` actually target `version.Version`/`version.Commit`/`version.BuildDate`, but the embedded variables in that package are lowercase `version`/`gitCommit`/`buildDate`, so the LDFLAGS are silent no-ops today. The embed-based path is the real source. That's a separate pre-existing cleanup, not changed here.)

## Files changed

- `Makefile` — single `go build` invocation now passes `-buildvcs=false`, with an inline comment pointing to the embed-based version stamping.
- No Go source changes.
- No `.goreleaser.yaml` change — goreleaser runs from the main checkout where the bug doesn't manifest; speculative additions would broaden scope without evidence.
- No CI workflow change — CI invokes the Make targets, so it inherits the fix.

## Test plan

- [x] `make go/build` succeeds in fresh worktree (`.claude/worktrees/mp-j5j`)
- [x] `make go/build` still succeeds in main checkout (`/Users/ricardo/repos/bracket-creator`)
- [x] Direct `go build -buildvcs=false .` succeeds in previously-broken worktree (`bracket-creator-bw2`)
- [x] `make go/test` passes (lint + gosec + govulncheck + js eslint + 23 web-mobile vitest files / 649 tests + 4 web vitest files / 56 tests + full Go test suite, all green)
- [x] `./bin/bracket-creator version` reports version + commit + build date populated (not empty)
- [x] `make examples` runs end-to-end and produces all 12 example xlsx files

Closes mp-j5j

🤖 Generated with [Claude Code](https://claude.com/claude-code)