### PR TITLE
feat(admin): add Naginata checkbox to create-competition form (mp-05o)

### DIFF
--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -237,6 +237,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   const [teamSize, setTeamSize] = useStateA(5);
   const [numberPrefix, setNumberPrefix] = useStateA("");
   const [withZekken, setWithZekken] = useStateA(false);
+  const [naginata, setNaginata] = useStateA(false);
   const [selectedCourts, setSelectedCourts] = useStateA(tournament.courts.slice(0, Math.min(2, tournament.courts.length)));
   const [error, setError] = useStateA("");
 
@@ -350,6 +351,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     if (format === "swiss") {
       c.swissRounds = swissRounds;
     }
+    c.naginata = naginata;
     onCreate(c);
   };
 
@@ -576,6 +578,11 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
               <div className="field__hint" style={{ marginTop: 4 }}>When enabled, participant CSV uses three columns: Name, Zekken, Dojo.</div>
             </div>
           )}
+
+          <div className="field">
+            <label className="checkbox"><input type="checkbox" checked={naginata} onChange={(e) => setNaginata(e.target.checked)} /> Naginata competition</label>
+            <div className="field__hint" style={{ marginTop: 4 }}>Adds the Sune (S) ippon button to the score editor. Use for Naginata divisions.</div>
+          </div>
 
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
             <button className="btn" onClick={onCancel}>Cancel</button>


### PR DESCRIPTION
## Summary
- Adds a **Naginata competition** checkbox to the **+ Add competition** form in the admin UI.
- The flag already existed in the per-competition Settings panel (and the backend, scoring modal, glossary, etc. all already understand it). It was just missing at creation time, so users had to create a competition and then immediately go into Settings to flip it on.
- The new checkbox writes \`naginata: true/false\` into the POST payload — the backend's \`POST /api/competitions\` already binds \`comp.Naginata\` via the existing \`state.Competition\` JSON tag, so no server-side change is needed.

## Test plan
- [x] \`make go/build\` (rebuilds esbuild dist with the new JSX)
- [x] \`make go/test\` — Go lint, gosec, govulncheck, JS lint all clean. JS tests 649/649 pass. (Final \`make js/test\` step fails on \`cd web && npm test\` because \`web/\` has no package.json in a fresh worktree — pre-existing, tracked in mp-bjy, unrelated to this change.)
- [x] **Manual browser walkthrough** (via preview server):
  - [x] Open create-competition form → scroll down → see **Naginata competition** checkbox with hint *"Adds the Sune (S) ippon button to the score editor."*
  - [x] Tick the checkbox, name the competition "Naginata Open", click **Create & continue →**
  - [x] Confirm on disk: \`/tmp/bc-naginata-test/competitions/naginata-open/config.md\` contains \`naginata: true\`
  - [x] Open the new competition's **Settings** panel → confirm the existing Naginata checkbox is rendered checked (round-trips correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)