### PR TITLE
fix(mobileapp): promote body-size caps to group middleware for all admin routes (mp-3sm)

### DIFF
--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -21,7 +21,7 @@ var validAnnouncementDurations = map[int]bool{5: true, 10: true, 15: true, 30: t
 
 func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
 	// POST /api/tournament/announce is protected (requires admin credentials).
-	// Body cap enforced by adminTinyBody in server.go (AnnouncementMaxBodyBytes), before AuthMiddleware.
+	// MaxBodyBytes(AnnouncementMaxBodyBytes) is applied before AuthMiddleware on the route group wiring this handler.
 	r.POST("/tournament/announce", func(c *gin.Context) {
 		var req announcementRequest
 		if err := c.ShouldBindJSON(&req); err != nil {

--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -19,23 +19,11 @@ type announcementRequest struct {
 // reallocated on every POST /api/tournament/announce.
 var validAnnouncementDurations = map[int]bool{5: true, 10: true, 15: true, 30: true}
 
-// maxAnnounceBodyBytes caps the POST /api/tournament/announce request
-// body. Worst-case JSON encoding of a valid payload:
-//
-//	message         200 chars × 6 chars/escape = 1200 bytes (full \uXXXX)
-//	durationMinutes 2 digits                    =    2 bytes
-//	JSON overhead (keys, braces, quotes)        =   ~40 bytes
-//	Total                                       = ~1242 bytes
-//
-// 4096 bytes gives a ~3x safety margin while still bounding malicious
-// or accidental large-body uploads. Mirrors the pattern established in
-// handlers_reset.go for body-bounded admin endpoints.
-const maxAnnounceBodyBytes = 4096
-
 func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
-	// POST /api/tournament/announce is protected (requires admin credentials)
+	// POST /api/tournament/announce is protected (requires admin credentials).
+	// Body cap is enforced by the adminTinyBody group middleware in server.go
+	// (AnnouncementMaxBodyBytes = 4 KB), which fires before AuthMiddleware.
 	r.POST("/tournament/announce", func(c *gin.Context) {
-		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxAnnounceBodyBytes)
 		var req announcementRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})

--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -21,8 +21,7 @@ var validAnnouncementDurations = map[int]bool{5: true, 10: true, 15: true, 30: t
 
 func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
 	// POST /api/tournament/announce is protected (requires admin credentials).
-	// Body cap is enforced by the adminTinyBody group middleware in server.go
-	// (AnnouncementMaxBodyBytes = 4 KB), which fires before AuthMiddleware.
+	// Body cap enforced by adminTinyBody in server.go (AnnouncementMaxBodyBytes), before AuthMiddleware.
 	r.POST("/tournament/announce", func(c *gin.Context) {
 		var req announcementRequest
 		if err := c.ShouldBindJSON(&req); err != nil {

--- a/internal/mobileapp/handlers_announcement_test.go
+++ b/internal/mobileapp/handlers_announcement_test.go
@@ -106,12 +106,10 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "Duration must be 5, 10, 15, or 30 minutes")
 
-	// 7. POST /api/tournament/announce - oversized body (>maxAnnounceBodyBytes)
-	// returns 400 from MaxBytesReader unwinding through ShouldBindJSON.
-	// Build a JSON body whose `message` field alone exceeds the 4096-byte
-	// cap so we exercise the body-cap path (not the post-bind 200-char
-	// validation).
-	hugeMsg := strings.Repeat("A", maxAnnounceBodyBytes+10)
+	// 7. POST /api/tournament/announce - oversized body (>AnnouncementMaxBodyBytes)
+	// returns 413 from the adminTinyBody group middleware (Content-Length fast
+	// path fires before AuthMiddleware and before ShouldBindJSON).
+	hugeMsg := strings.Repeat("A", int(AnnouncementMaxBodyBytes)+10)
 	hugePayload := announcementRequest{
 		Message:         hugeMsg,
 		DurationMinutes: 30,
@@ -121,7 +119,7 @@ func TestAnnouncementHandlers(t *testing.T) {
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
 	req.Header.Set("X-Tournament-Password", "secret-password")
 	router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code, "expected 400 for body over %d bytes", maxAnnounceBodyBytes)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "expected 413 for body over %d bytes", AnnouncementMaxBodyBytes)
 
 	// 8. POST /api/tournament/announce - happy path (200 OK)
 	body, _ = json.Marshal(payload)

--- a/internal/mobileapp/handlers_announcement_test.go
+++ b/internal/mobileapp/handlers_announcement_test.go
@@ -107,8 +107,8 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Duration must be 5, 10, 15, or 30 minutes")
 
 	// 7. POST /api/tournament/announce - oversized body (>AnnouncementMaxBodyBytes)
-	// returns 413 from the adminTinyBody group middleware (Content-Length fast
-	// path fires before AuthMiddleware and before ShouldBindJSON).
+	// returns 413: MaxBodyBytes fires before AuthMiddleware (Content-Length fast
+	// path) and before ShouldBindJSON can run.
 	hugeMsg := strings.Repeat("A", int(AnnouncementMaxBodyBytes)+10)
 	hugePayload := announcementRequest{
 		Message:         hugeMsg,

--- a/internal/mobileapp/handlers_reset.go
+++ b/internal/mobileapp/handlers_reset.go
@@ -149,22 +149,12 @@ func RegisterResetHandlers(r *gin.RouterGroup, store *state.Store, verifier Pass
 			return
 		}
 
-		// Cap the request body before parsing so an attacker cannot
-		// send an arbitrarily large payload and force the server to
-		// allocate memory for it.
-		//
-		// Worst-case JSON encoding (all characters become \uXXXX escapes):
-		//   password    256 bytes × 6 chars/escape = 1536 chars
-		//   originatorId 128 bytes × 6 chars/escape =  768 chars
-		//   JSON overhead (keys, braces, quotes)    =   ~40 chars
-		//   Total                                   = ~2344 chars
-		//
-		// 4096 bytes gives a ×1.7 safety margin while still forming a
-		// meaningful per-request limit. MaxBytesReader wraps the body
-		// and causes ShouldBindJSON to return an error if the body
-		// exceeds the cap.
-		const maxResetBodyBytes = 4096
-		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxResetBodyBytes)
+		// Cap the request body before parsing. Applied here (not as group
+		// middleware) so that locked-mode deployments return 404 before any
+		// body is read — a group-level cap would return 413 for large bodies
+		// even in locked mode, leaking that the route exists. Size rationale
+		// is in ResetMaxBodyBytes in middleware.go.
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, ResetMaxBodyBytes)
 
 		var req resetPasswordRequest
 		if err := c.ShouldBindJSON(&req); err != nil {

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -18,8 +18,8 @@ import (
 const (
 	// AnnouncementMaxBodyBytes caps POST /api/tournament/announce.
 	// Worst-case JSON encoding: 200-char message × 6 bytes/escape + keys
-	// ≈ 1242 bytes; 4096 gives ≈3× headroom. Used by adminTinyBody in
-	// server.go so the cap fires before AuthMiddleware.
+	// ≈ 1242 bytes; 4096 gives ≈3× headroom. Applied via MaxBodyBytes
+	// before AuthMiddleware on the /api announce route group in server.go.
 	AnnouncementMaxBodyBytes int64 = 4096
 
 	// ResetMaxBodyBytes caps POST /api/tournament/reset.

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -81,6 +81,18 @@ func MaxBodyBytes(n int64) gin.HandlerFunc {
 	}
 }
 
+// adminGroup creates an /api route group with MaxBodyBytes(capBytes) wired
+// BEFORE AuthMiddleware, enforcing the cap→auth ordering that prevents an
+// unauthenticated attacker from consuming auth overhead before hitting 413.
+// Use this for every protected admin sub-group so the ordering can't be
+// accidentally reversed when adding new groups.
+func adminGroup(r *gin.Engine, capBytes int64, verifier PasswordVerifier, store *state.Store) *gin.RouterGroup {
+	g := r.Group("/api")
+	g.Use(MaxBodyBytes(capBytes))
+	g.Use(AuthMiddleware(verifier, store))
+	return g
+}
+
 // requireValidCompID extracts the `:id` URL parameter and validates it
 // via state.ValidateCompetitionID. Rejects:
 //   - empty

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -16,6 +16,20 @@ import (
 // "64 MB" consistently — but the request-size cap lives here, in the
 // MaxBodyBytes middleware applied to the import group in server.go.
 const (
+	// AnnouncementMaxBodyBytes caps POST /api/tournament/announce.
+	// Worst-case JSON encoding: 200-char message × 6 bytes/escape + keys
+	// ≈ 1242 bytes; 4096 gives ≈3× headroom. Used by adminTinyBody in
+	// server.go so the cap fires before AuthMiddleware.
+	AnnouncementMaxBodyBytes int64 = 4096
+
+	// ResetMaxBodyBytes caps POST /api/tournament/reset.
+	// Worst-case JSON: password 256 chars × 6 bytes/escape + originatorId
+	// 128 × 6 + overhead ≈ 2344 bytes; 4096 gives ≈1.7× headroom. Applied
+	// inside the handler (not as group middleware) to preserve the locked-mode
+	// 404 response before any body is read — a per-group cap would reveal the
+	// route's existence via 413 vs 404 on locked deployments.
+	ResetMaxBodyBytes int64 = 4096
+
 	// DefaultMaxBodyBytes caps non-import admin request bodies. 1 MB is
 	// far above any legitimate JSON payload on this server (the largest
 	// is a competition with embedded roster ~ a few KB per player ×

--- a/internal/mobileapp/middleware_body_size_test.go
+++ b/internal/mobileapp/middleware_body_size_test.go
@@ -4,11 +4,17 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/engine"
+	"github.com/gitrgoliveira/bracket-creator/internal/resources"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newBodySizeTestRouter(limit int64) *gin.Engine {
@@ -122,31 +128,41 @@ func TestMaxBodyBytes_FiresBeforeAuth(t *testing.T) {
 		"oversized body must be rejected before auth runs; got %d (body: %s)", w.Code, w.Body.String())
 }
 
-// TestMaxBodyBytes_TinyBodyGroup_FiresBeforeAuth pins the adminTinyBody
-// group wiring from server.go: POST /api/tournament/announce uses a 4 KB
-// cap that fires before AuthMiddleware, so an unauthenticated request with
-// a body larger than AnnouncementMaxBodyBytes gets 413, not 401.
+// TestMaxBodyBytes_TinyBodyGroup_FiresBeforeAuth exercises the real NewRouter
+// to confirm POST /api/tournament/announce rejects oversized bodies with 413
+// before AuthMiddleware runs (which would return 401). This pins the actual
+// server.go wiring rather than a hand-rolled stub.
 func TestMaxBodyBytes_TinyBodyGroup_FiresBeforeAuth(t *testing.T) {
-	gin.SetMode(gin.ReleaseMode)
-	r := gin.New()
+	tempDir, err := os.MkdirTemp("", "announce-cap-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
 
-	// Mirrors adminTinyBody setup in server.go.
-	g := r.Group("/api")
-	g.Use(MaxBodyBytes(AnnouncementMaxBodyBytes))
-	g.Use(func(c *gin.Context) {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-	})
-	g.POST("/tournament/announce", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"ok": true})
-	})
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
 
-	// Body just over 4 KB — exceeds announce cap but well under 1 MB default cap.
+	// Tournament must exist so AuthMiddleware returns 401 (not 403), letting
+	// the test distinguish "cap fired first → 413" from "auth fired first → 401".
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:     "Test",
+		Password: "secret",
+	}))
+
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{
+		"web-mobile/index.html": {Data: []byte("<html></html>")},
+	}
+	res := resources.NewResources(nil, mockFS)
+	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
+
+	// Body just over AnnouncementMaxBodyBytes — no auth header intentionally:
+	// if the body cap fires first (correct), we get 413; if auth fires first
+	// (regression), we get 401.
 	body := strings.Repeat("x", int(AnnouncementMaxBodyBytes)+1)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/api/tournament/announce", bytes.NewBufferString(body))
 	req.ContentLength = int64(len(body))
-	r.ServeHTTP(w, req)
+	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code,
-		"4 KB announce cap must fire before auth; got %d", w.Code)
+		"body cap must fire before auth on /api/tournament/announce; got %d", w.Code)
 }

--- a/internal/mobileapp/middleware_body_size_test.go
+++ b/internal/mobileapp/middleware_body_size_test.go
@@ -121,3 +121,32 @@ func TestMaxBodyBytes_FiresBeforeAuth(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code,
 		"oversized body must be rejected before auth runs; got %d (body: %s)", w.Code, w.Body.String())
 }
+
+// TestMaxBodyBytes_TinyBodyGroup_FiresBeforeAuth pins the adminTinyBody
+// group wiring from server.go: POST /api/tournament/announce uses a 4 KB
+// cap that fires before AuthMiddleware, so an unauthenticated request with
+// a body larger than AnnouncementMaxBodyBytes gets 413, not 401.
+func TestMaxBodyBytes_TinyBodyGroup_FiresBeforeAuth(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+
+	// Mirrors adminTinyBody setup in server.go.
+	g := r.Group("/api")
+	g.Use(MaxBodyBytes(AnnouncementMaxBodyBytes))
+	g.Use(func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	})
+	g.POST("/tournament/announce", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// Body just over 4 KB — exceeds announce cap but well under 1 MB default cap.
+	body := strings.Repeat("x", int(AnnouncementMaxBodyBytes)+1)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/tournament/announce", bytes.NewBufferString(body))
+	req.ContentLength = int64(len(body))
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code,
+		"4 KB announce cap must fire before auth; got %d", w.Code)
+}

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -102,42 +102,25 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	//   adminSmallBody (1 MB)  — all other admin JSON endpoints
 	//   adminLargeBody (64 MB) — /tournament/import (CSV upload)
 	//
-	// Middleware ordering: MaxBodyBytes runs BEFORE AuthMiddleware on
-	// purpose (mp-663 Phase 3). An unauthenticated attacker who streams
-	// a huge Content-Length should hit 413 immediately, not get a
-	// chance to consume an auth roundtrip first. The Content-Length
-	// fast path inside MaxBodyBytes is constant-time and reads no body
-	// bytes, so the order doesn't add measurable cost to the happy
-	// path either.
-	adminTinyBody := r.Group("/api")
-	adminTinyBody.Use(MaxBodyBytes(AnnouncementMaxBodyBytes))
-	adminTinyBody.Use(AuthMiddleware(verifier, store))
-	{
-		RegisterAnnouncementHandlers(adminTinyBody, store, hub)
-	}
+	// Use adminGroup() to wire each group: it enforces the cap→auth ordering
+	// so new groups can't accidentally reverse it.
+	adminTinyBody := adminGroup(r, AnnouncementMaxBodyBytes, verifier, store)
+	RegisterAnnouncementHandlers(adminTinyBody, store, hub)
 
-	adminSmallBody := r.Group("/api")
-	adminSmallBody.Use(MaxBodyBytes(DefaultMaxBodyBytes))
-	adminSmallBody.Use(AuthMiddleware(verifier, store))
-	{
-		RegisterTournamentHandlers(adminSmallBody, store, hub, verifier)
-		RegisterCompetitionHandlers(adminSmallBody, store, eng, hub)
-		RegisterParticipantHandlers(adminSmallBody, store, hub)
-		RegisterMatchHandlers(adminSmallBody, eng, store, store, hub)
-		RegisterDecisionHandlers(adminSmallBody, eng, store, store, hub)
-		RegisterEligibilityHandlers(adminSmallBody, store, hub)
-		RegisterReinstateHandler(adminSmallBody, eng, hub)
-		RegisterLineupHandlers(adminSmallBody, store, store, store)
-		RegisterDaihyosenHandlers(adminSmallBody, eng, store, hub)
-		RegisterSwissHandlers(adminSmallBody, store, eng, hub)
-	}
+	adminSmallBody := adminGroup(r, DefaultMaxBodyBytes, verifier, store)
+	RegisterTournamentHandlers(adminSmallBody, store, hub, verifier)
+	RegisterCompetitionHandlers(adminSmallBody, store, eng, hub)
+	RegisterParticipantHandlers(adminSmallBody, store, hub)
+	RegisterMatchHandlers(adminSmallBody, eng, store, store, hub)
+	RegisterDecisionHandlers(adminSmallBody, eng, store, store, hub)
+	RegisterEligibilityHandlers(adminSmallBody, store, hub)
+	RegisterReinstateHandler(adminSmallBody, eng, hub)
+	RegisterLineupHandlers(adminSmallBody, store, store, store)
+	RegisterDaihyosenHandlers(adminSmallBody, eng, store, hub)
+	RegisterSwissHandlers(adminSmallBody, store, eng, hub)
 
-	adminLargeBody := r.Group("/api")
-	adminLargeBody.Use(MaxBodyBytes(MaxImportBodyBytes))
-	adminLargeBody.Use(AuthMiddleware(verifier, store))
-	{
-		RegisterImportHandlers(adminLargeBody, store, hub)
-	}
+	adminLargeBody := adminGroup(r, MaxImportBodyBytes, verifier, store)
+	RegisterImportHandlers(adminLargeBody, store, hub)
 
 	// Static files & SPA Fallback
 	mobileFS := res.GetMobileWebFS()

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -94,10 +94,13 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	RegisterResetHandlers(api, store, verifier, hub)
 	RegisterAuthConfigHandlers(api, verifier)
 
-	// Admin API endpoints (protected). Split into two sub-groups so the
-	// CSV-import route gets a larger body cap than the rest — every
-	// other admin endpoint takes small JSON, while /tournament/import
-	// legitimately uploads multi-MB CSVs.
+	// Admin API endpoints (protected). Split into three sub-groups by
+	// expected body size so the body cap fires BEFORE AuthMiddleware at
+	// the right granularity for each endpoint tier:
+	//
+	//   adminTinyBody  (4 KB)  — /tournament/announce
+	//   adminSmallBody (1 MB)  — all other admin JSON endpoints
+	//   adminLargeBody (64 MB) — /tournament/import (CSV upload)
 	//
 	// Middleware ordering: MaxBodyBytes runs BEFORE AuthMiddleware on
 	// purpose (mp-663 Phase 3). An unauthenticated attacker who streams
@@ -106,6 +109,13 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	// fast path inside MaxBodyBytes is constant-time and reads no body
 	// bytes, so the order doesn't add measurable cost to the happy
 	// path either.
+	adminTinyBody := r.Group("/api")
+	adminTinyBody.Use(MaxBodyBytes(AnnouncementMaxBodyBytes))
+	adminTinyBody.Use(AuthMiddleware(verifier, store))
+	{
+		RegisterAnnouncementHandlers(adminTinyBody, store, hub)
+	}
+
 	adminSmallBody := r.Group("/api")
 	adminSmallBody.Use(MaxBodyBytes(DefaultMaxBodyBytes))
 	adminSmallBody.Use(AuthMiddleware(verifier, store))
@@ -120,11 +130,6 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 		RegisterLineupHandlers(adminSmallBody, store, store, store)
 		RegisterDaihyosenHandlers(adminSmallBody, eng, store, hub)
 		RegisterSwissHandlers(adminSmallBody, store, eng, hub)
-		// Announcement send is a small JSON payload (already further
-		// capped at 4 KB inside the handler via http.MaxBytesReader,
-		// per the earlier security review). Belongs in the small-body
-		// group with the rest of the admin JSON endpoints.
-		RegisterAnnouncementHandlers(adminSmallBody, store, hub)
 	}
 
 	adminLargeBody := r.Group("/api")


### PR DESCRIPTION
## Summary

- Adds a new `adminTinyBody` (4 KB) route group in `server.go` for `POST /api/tournament/announce`, so the body cap fires **before** `AuthMiddleware` — matching the pre-auth ordering already established by `adminSmallBody` (1 MB) and `adminLargeBody` (64 MB) in mp-663 Phase 3.
- Centralises the per-endpoint body-size constants (`AnnouncementMaxBodyBytes`, `ResetMaxBodyBytes`) in `middleware.go` alongside the existing `DefaultMaxBodyBytes` / `MaxImportBodyBytes`.
- Removes the redundant `http.MaxBytesReader` per-handler wrap from `handlers_announcement.go`; the group middleware now owns enforcement.
- Keeps the per-handler `MaxBytesReader` wrap in `handlers_reset.go` **intentionally**: moving it to a group-level cap would make a locked-mode server return 413 (instead of 404) for oversized bodies, leaking the route's existence to scanners.

## Details

| Group | Cap | Routes |
|---|---|---|
| `adminTinyBody` | 4 KB | `POST /tournament/announce` |
| `adminSmallBody` | 1 MB | all other admin JSON endpoints |
| `adminLargeBody` | 64 MB | `POST /tournament/import` |
| public (reset handler) | 4 KB (per-handler) | `POST /tournament/reset` |

## Test plan

- [x] `go test -run TestMaxBodyBytes ./internal/mobileapp/...` — all pass
- [x] `go test -run TestAnnouncement ./internal/mobileapp/...` — all pass, oversized body now returns 413 (was 400 from ShouldBindJSON)
- [x] `go test -run TestReset ./internal/mobileapp/...` — all pass
- [x] `make go/lint` — 0 issues
- [x] `go test ./internal/... ./cmd/...` — all pass
- [x] New test `TestMaxBodyBytes_TinyBodyGroup_FiresBeforeAuth` pins the pre-auth ordering for the 4 KB announce group

## Checklist

- [x] Every admin POST/PUT/PATCH route has a body cap (group-level or per-handler for locked-mode preservation)
- [x] No redundant per-handler `MaxBytesReader` wraps after middleware coverage
- [x] `MaxBodyBytes` applied BEFORE `AuthMiddleware` on every admin group
- [x] Per-cap regression test mirrors `TestMaxBodyBytes_FiresBeforeAuth`
- [x] `make go/test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)