### PR TITLE
chore(embed): exclude unserved JSX sources from binary (mp-6dw)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,14 @@ square_prep/*
 # !square_prep/lc2026/*
 # Universal and Go added by speckit
 vendor/
+# Go embed placeholders — these files ensure web-mobile/dist and
+# web-mobile/vendor exist on clean checkouts so the embed directive compiles.
+!web-mobile/dist/
+web-mobile/dist/*
+!web-mobile/dist/keep
+!web-mobile/vendor/
+web-mobile/vendor/*
+!web-mobile/vendor/keep
 Thumbs.db
 *.tmp
 *.swp

--- a/main.go
+++ b/main.go
@@ -20,16 +20,16 @@ import (
 //go:embed web/css web/js
 var webFiles embed.FS
 
-// Mobile-app assets. The glob embeds all files present at build time.
-// After `make go/build` runs esbuild, this includes css, js, dist and vendor.
-// Explicit paths are not used here because dist/ and vendor/ are generated
-// by esbuild and absent in a clean checkout — listing them would break
-// `go test ./...` before a build has run. The trade-off: a local binary
-// built after `npm install` will also embed node_modules/, making it
-// larger. Production Docker builds and CI run in clean envs where
-// node_modules/ is absent, so the artifact size is not affected there.
+// Mobile-app assets — only the files the HTTP server actually serves.
+// web-mobile/js (JSX sources) and dev tooling are excluded; the browser
+// loads compiled output from dist/ and vendor libraries from vendor/.
+// Tracked "keep" placeholders in dist/ and vendor/ ensure the directories
+// exist on clean checkouts so this directive compiles before esbuild runs.
 //
-//go:embed web-mobile/*
+//go:embed web-mobile/index.html
+//go:embed web-mobile/css
+//go:embed web-mobile/dist
+//go:embed web-mobile/vendor
 var mobileWebFiles embed.FS
 
 func main() {

--- a/web-mobile/dist/keep
+++ b/web-mobile/dist/keep
@@ -1,0 +1,1 @@
+Placeholder so the directory exists in clean checkouts for go:embed.

--- a/web-mobile/vendor/keep
+++ b/web-mobile/vendor/keep
@@ -1,0 +1,1 @@
+Placeholder so the directory exists in clean checkouts for go:embed.


### PR DESCRIPTION
## Summary
- Replace `//go:embed web-mobile/*` wildcard with explicit paths for only runtime-served files (`index.html`, `css/`, `dist/`, `vendor/`)
- Drops ~900KB of dead weight: `.jsx` source files, `package-lock.json`, eslint/vitest configs that were embedded but never served
- Tracked `keep` placeholder files in `dist/` and `vendor/` ensure the embed compiles on clean checkouts before esbuild runs

## Test plan
- [x] `make go/build` succeeds — binary is ~900KB smaller (36.7MB vs 37.6MB)
- [x] `go test -cover . ./cmd/... ./internal/... ./tests/...` — all pass
- [x] `make run-mobile` — verify no 404s on any JS/CSS path in browser (37 requests, all 200)
- [x] Clean checkout test: removed generated files from dist/vendor (keeping only `keep`), ran `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)