### PR TITLE
fix(state): CSV quoting for participant & seed files (mp-4oq)

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -3,7 +3,9 @@ package helper
 import (
 	"bufio"
 	"embed"
+	"encoding/csv"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -171,6 +173,45 @@ func ReadEntriesFromFile(filePath string) ([]string, error) {
 	}
 
 	return entries, nil
+}
+
+// ReadCSVFile reads a CSV file using encoding/csv, properly handling
+// RFC 4180 quoting (fields with commas, double-quotes, or newlines).
+func ReadCSVFile(filePath string) ([][]string, error) {
+	cleanPath := filepath.Clean(filePath)
+	if strings.Contains(cleanPath, "..") {
+		return nil, fmt.Errorf("invalid file path: %s", filePath)
+	}
+
+	// #nosec G304 - file path is validated above
+	file, err := os.Open(cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
+		}
+	}()
+
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+	reader.LazyQuotes = true
+	reader.TrimLeadingSpace = true
+
+	var records [][]string
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+
+	return records, nil
 }
 
 // AssignPoolsToCourts distributes numPools pools across numCourts courts using

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -208,7 +208,16 @@ func ReadCSVFile(filePath string) ([][]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		records = append(records, record)
+		allEmpty := true
+		for _, f := range record {
+			if strings.TrimSpace(f) != "" {
+				allEmpty = false
+				break
+			}
+		}
+		if !allEmpty {
+			records = append(records, record)
+		}
 	}
 
 	return records, nil

--- a/internal/helper/tournament.go
+++ b/internal/helper/tournament.go
@@ -54,6 +54,10 @@ func CreatePlayers(entries []string, withZekkenName bool) ([]Player, error) {
 		if entry == "" {
 			continue
 		}
+		if !strings.Contains(entry, `"`) {
+			records = append(records, strings.Split(entry, ","))
+			continue
+		}
 		r := csv.NewReader(strings.NewReader(entry))
 		r.LazyQuotes = true
 		r.TrimLeadingSpace = true

--- a/internal/helper/tournament.go
+++ b/internal/helper/tournament.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"encoding/csv"
 	"fmt"
 	"strings"
 
@@ -47,17 +48,45 @@ type Match struct {
 }
 
 func CreatePlayers(entries []string, withZekkenName bool) ([]Player, error) {
-	players := make([]Player, 0, len(entries))
-	var errors []string
-	seenNames := make(map[string]int) // tracks composite key Name|DisplayName|Dojo -> line number
-	c := cases.Title(language.Und, cases.NoLower)
-
-	for i, entry := range entries {
+	records := make([][]string, 0, len(entries))
+	for _, entry := range entries {
 		entry = strings.TrimSpace(entry)
 		if entry == "" {
 			continue
 		}
-		line := strings.Split(entry, ",")
+		r := csv.NewReader(strings.NewReader(entry))
+		r.LazyQuotes = true
+		r.TrimLeadingSpace = true
+		fields, err := r.Read()
+		if err != nil {
+			records = append(records, strings.Split(entry, ","))
+			continue
+		}
+		records = append(records, fields)
+	}
+	return CreatePlayersFromRecords(records, withZekkenName)
+}
+
+// CreatePlayersFromRecords builds players from pre-parsed CSV records
+// (each record is a slice of fields). Use this when the CSV has already
+// been parsed by encoding/csv so that quoted commas are handled correctly.
+func CreatePlayersFromRecords(records [][]string, withZekkenName bool) ([]Player, error) {
+	players := make([]Player, 0, len(records))
+	var errors []string
+	seenNames := make(map[string]int)
+	c := cases.Title(language.Und, cases.NoLower)
+
+	for i, line := range records {
+		allEmpty := true
+		for _, f := range line {
+			if strings.TrimSpace(f) != "" {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			continue
+		}
 		for j := range line {
 			line[j] = strings.TrimSpace(line[j])
 		}
@@ -73,7 +102,6 @@ func CreatePlayers(entries []string, withZekkenName bool) ([]Player, error) {
 			}
 			player.Name = c.String(line[0])
 			if len(line) == 2 {
-				// Tolerate 2-column rows (Name, Dojo) written without a distinct display name.
 				player.DisplayName = SanitizeName(line[0])
 				player.Dojo = line[1]
 				if player.Dojo == "" {
@@ -81,7 +109,6 @@ func CreatePlayers(entries []string, withZekkenName bool) ([]Player, error) {
 					continue
 				}
 			} else {
-				// 3+ columns: Name, DisplayName, Dojo
 				if line[2] == "" {
 					errors = append(errors, fmt.Sprintf("entry %d: missing dojo", i+1))
 					continue
@@ -103,7 +130,6 @@ func CreatePlayers(entries []string, withZekkenName bool) ([]Player, error) {
 				}
 			}
 		} else {
-			// backward compatibility: Name, Dojo
 			player.Name = c.String(line[0])
 			player.DisplayName = SanitizeName(line[0])
 			player.Dojo = "NA"

--- a/internal/helper/tournament.go
+++ b/internal/helper/tournament.go
@@ -101,7 +101,7 @@ func CreatePlayersFromRecords(records [][]string, withZekkenName bool) ([]Player
 
 		if withZekkenName {
 			if len(line) < 2 {
-				errors = append(errors, fmt.Sprintf("entry %d: invalid format: expected at least 'Name, DisplayName, Dojo'", i+1))
+				errors = append(errors, fmt.Sprintf("entry %d: invalid format: expected 'Name, Dojo' or 'Name, DisplayName, Dojo'", i+1))
 				continue
 			}
 			player.Name = c.String(line[0])

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -105,6 +105,20 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 		}
 		dataFields := record[dataStart:]
 
+		// Skip records that are empty after UUID stripping (e.g. a
+		// UUID-only row) — CreatePlayersFromRecords would skip these
+		// too, and the metadata slices must stay aligned.
+		allEmpty := true
+		for _, f := range dataFields {
+			if strings.TrimSpace(f) != "" {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			continue
+		}
+
 		// Detect and strip checked_in marker from the last data field.
 		// Minimum valid data row is "Name,Dojo" (2 parts), so checked_in
 		// is only treated as a marker when at least 3 data parts are present.

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -105,20 +105,6 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 		}
 		dataFields := record[dataStart:]
 
-		// Skip all-empty records (e.g. blank CSV lines) before
-		// appending to metadata slices — CreatePlayersFromRecords
-		// also skips these, so the slices must stay aligned.
-		allEmpty := true
-		for _, f := range dataFields {
-			if strings.TrimSpace(f) != "" {
-				allEmpty = false
-				break
-			}
-		}
-		if allEmpty {
-			continue
-		}
-
 		// Detect and strip checked_in marker from the last data field.
 		// Minimum valid data row is "Name,Dojo" (2 parts), so checked_in
 		// is only treated as a marker when at least 3 data parts are present.

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"os"
@@ -70,7 +71,7 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 	}
 
 	path := s.compPath(compID, "participants.csv")
-	lines, err := helper.ReadEntriesFromFile(path)
+	records, err := helper.ReadCSVFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			cache.data = []domain.Player{}
@@ -85,70 +86,51 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 	if opts.HasIDs != nil {
 		hasIDs = *opts.HasIDs
 	} else {
-		hasIDs = len(lines) > 0 && uuidRE(strings.TrimSpace(strings.SplitN(lines[0], ",", 2)[0]))
+		hasIDs = len(records) > 0 && len(records[0]) > 0 && uuidRE(strings.TrimSpace(records[0][0]))
 	}
 
 	var ids []string
 	var checkedInFlags []bool
-	var plainLines []string
+	var playerRecords [][]string
 
-	for _, line := range lines {
+	for _, record := range records {
 		isCheckedIn := false
 
-		// Robust column-based detection: strip the UUID prefix first so
-		// the threshold is applied to the data columns only (per Copilot
-		// review). After stripping the ID the minimum valid data row is
-		// "Name,Dojo" (2 parts), so checked_in is only treated as a
-		// marker when at least 3 data parts are present (Name, Dojo,
-		// checked_in).
-		//
-		// Known limitation: a dojo literally named "checked_in" in a
-		// zekken competition that also has a distinct DisplayName column
-		// produces "Name, DisplayName, checked_in" (3 data parts) after
-		// UUID strip, which the threshold cannot distinguish from the
-		// legitimate "Name, Dojo, checked_in" row. Resolving this
-		// ambiguity without a format version or column header is not
-		// possible; in practice no real dojo uses this name.
-		line = strings.TrimSpace(line)
-
-		// Strip UUID prefix for threshold calculation only (idLine is
-		// what remains after the ID field).
-		idLine := line
+		// Determine data fields (everything after UUID if present).
+		// If hasIDs but this record's first field is not a UUID (mixed-
+		// format file, e.g. plain "Bob" line), treat the whole record as
+		// data with an empty ID.
+		dataStart := 0
 		if hasIDs {
-			if _, rest, ok := strings.Cut(line, ","); ok {
-				idLine = strings.TrimSpace(rest)
+			if len(record) > 1 || (len(record) == 1 && uuidRE(strings.TrimSpace(record[0]))) {
+				dataStart = 1
 			}
 		}
-		dataParts := strings.Split(idLine, ",")
-		if len(dataParts) > 2 {
-			last := strings.TrimSpace(dataParts[len(dataParts)-1])
+		dataFields := record[dataStart:]
+
+		// Detect and strip checked_in marker from the last data field.
+		// Minimum valid data row is "Name,Dojo" (2 parts), so checked_in
+		// is only treated as a marker when at least 3 data parts are present.
+		if len(dataFields) > 2 {
+			last := strings.TrimSpace(dataFields[len(dataFields)-1])
 			if strings.ToLower(last) == "checked_in" {
 				isCheckedIn = true
-				// Strip from the full original line (preserves UUID prefix).
-				if li := strings.LastIndex(line, ","); li >= 0 {
-					line = strings.TrimRight(line[:li], " ")
-				}
+				dataFields = dataFields[:len(dataFields)-1]
 			}
 		}
 
 		if hasIDs {
-			id, rest, ok := strings.Cut(line, ",")
-			if !ok {
-				plainLines = append(plainLines, line)
-				ids = append(ids, "")
-				checkedInFlags = append(checkedInFlags, isCheckedIn)
-				continue
+			id := ""
+			if dataStart > 0 && len(record) > 0 {
+				id = strings.TrimSpace(record[0])
 			}
-			ids = append(ids, strings.TrimSpace(id))
-			plainLines = append(plainLines, rest)
-			checkedInFlags = append(checkedInFlags, isCheckedIn)
-		} else {
-			plainLines = append(plainLines, line)
-			checkedInFlags = append(checkedInFlags, isCheckedIn)
+			ids = append(ids, id)
 		}
+		playerRecords = append(playerRecords, dataFields)
+		checkedInFlags = append(checkedInFlags, isCheckedIn)
 	}
 
-	players, err := helper.CreatePlayers(plainLines, withZekkenName)
+	players, err := helper.CreatePlayersFromRecords(playerRecords, withZekkenName)
 	if err != nil {
 		return nil, err
 	}
@@ -235,6 +217,7 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) e
 	path := s.compPath(compID, "participants.csv")
 
 	var sb strings.Builder
+	w := csv.NewWriter(&sb)
 	for _, p := range players {
 		id := p.ID
 		if id == "" {
@@ -246,19 +229,25 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) e
 		// LoadParticipants(_, withZekkenName=false) reads column 2 as Dojo
 		// and pushes the real Dojo into Metadata. See the round-trip
 		// regression test in participants_test.go.
-		var row string
+		var record []string
 		if p.DisplayName != "" && p.DisplayName != helper.SanitizeName(p.Name) {
-			row = fmt.Sprintf("%s, %s, %s", p.Name, p.DisplayName, p.Dojo)
+			record = []string{id, p.Name, p.DisplayName, p.Dojo}
 		} else {
-			row = fmt.Sprintf("%s, %s", p.Name, p.Dojo)
+			record = []string{id, p.Name, p.Dojo}
 		}
 		if p.Tag != "" {
-			row += ", " + p.Tag
+			record = append(record, p.Tag)
 		}
 		if p.CheckedIn {
-			row += ", checked_in"
+			record = append(record, "checked_in")
 		}
-		sb.WriteString(id + ", " + row + "\n")
+		if err := w.Write(record); err != nil {
+			return fmt.Errorf("writing participant CSV record: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("flushing participant CSV: %w", err)
 	}
 
 	if err := s.atomicWrite(path, []byte(sb.String()), 0600); err != nil {

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -97,16 +97,27 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 		isCheckedIn := false
 
 		// Determine data fields (everything after UUID if present).
-		// If hasIDs but this record's first field is not a UUID (mixed-
-		// format file, e.g. plain "Bob" line), treat the whole record as
-		// data with an empty ID.
+		// Per-record UUID check: only strip the first field as an ID
+		// when it actually matches the UUID pattern.
 		dataStart := 0
-		if hasIDs {
-			if len(record) > 1 || (len(record) == 1 && uuidRE(strings.TrimSpace(record[0]))) {
-				dataStart = 1
-			}
+		if hasIDs && len(record) > 0 && uuidRE(strings.TrimSpace(record[0])) {
+			dataStart = 1
 		}
 		dataFields := record[dataStart:]
+
+		// Skip all-empty records (e.g. blank CSV lines) before
+		// appending to metadata slices — CreatePlayersFromRecords
+		// also skips these, so the slices must stay aligned.
+		allEmpty := true
+		for _, f := range dataFields {
+			if strings.TrimSpace(f) != "" {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			continue
+		}
 
 		// Detect and strip checked_in marker from the last data field.
 		// Minimum valid data row is "Name,Dojo" (2 parts), so checked_in
@@ -121,7 +132,7 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 
 		if hasIDs {
 			id := ""
-			if dataStart > 0 && len(record) > 0 {
+			if dataStart > 0 {
 				id = strings.TrimSpace(record[0])
 			}
 			ids = append(ids, id)

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -213,9 +213,10 @@ func (s *Store) UpdateParticipant(compID string, pid string, withZekkenName bool
 	return &players[foundIdx], nil
 }
 
-func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) error {
-	path := s.compPath(compID, "participants.csv")
-
+// marshalParticipantsCSV serialises players into RFC 4180 CSV bytes.
+// Shared by saveParticipantsNoLock and saveParticipantsLocked so the
+// display-name and checked_in logic is defined once.
+func marshalParticipantsCSV(players []domain.Player) ([]byte, error) {
 	var sb strings.Builder
 	w := csv.NewWriter(&sb)
 	for _, p := range players {
@@ -227,8 +228,7 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) e
 		// beyond what helper.SanitizeName would derive from Name on load.
 		// Writing the auto-derived form would corrupt non-zekken loads:
 		// LoadParticipants(_, withZekkenName=false) reads column 2 as Dojo
-		// and pushes the real Dojo into Metadata. See the round-trip
-		// regression test in participants_test.go.
+		// and pushes the real Dojo into Metadata.
 		var record []string
 		if p.DisplayName != "" && p.DisplayName != helper.SanitizeName(p.Name) {
 			record = []string{id, p.Name, p.DisplayName, p.Dojo}
@@ -242,15 +242,25 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) e
 			record = append(record, "checked_in")
 		}
 		if err := w.Write(record); err != nil {
-			return fmt.Errorf("writing participant CSV record: %w", err)
+			return nil, fmt.Errorf("writing participant CSV record: %w", err)
 		}
 	}
 	w.Flush()
 	if err := w.Error(); err != nil {
-		return fmt.Errorf("flushing participant CSV: %w", err)
+		return nil, fmt.Errorf("flushing participant CSV: %w", err)
+	}
+	return []byte(sb.String()), nil
+}
+
+func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player) error {
+	path := s.compPath(compID, "participants.csv")
+
+	data, err := marshalParticipantsCSV(players)
+	if err != nil {
+		return err
 	}
 
-	if err := s.atomicWrite(path, []byte(sb.String()), 0600); err != nil {
+	if err := s.atomicWrite(path, data, 0600); err != nil {
 		return err
 	}
 

--- a/internal/state/reservedslots.go
+++ b/internal/state/reservedslots.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -107,22 +106,35 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 	hasIDs := len(records) > 0 && len(records[0]) > 0 && uuidRE(strings.TrimSpace(records[0][0]))
 
 	var ids []string
+	var checkedInFlags []bool
 	var playerRecords [][]string
 	for _, record := range records {
+		isCheckedIn := false
+		dataStart := 0
+		if hasIDs {
+			if len(record) > 1 || (len(record) == 1 && uuidRE(strings.TrimSpace(record[0]))) {
+				dataStart = 1
+			}
+		}
+		dataFields := record[dataStart:]
+
+		if len(dataFields) > 2 {
+			last := strings.TrimSpace(dataFields[len(dataFields)-1])
+			if strings.ToLower(last) == "checked_in" {
+				isCheckedIn = true
+				dataFields = dataFields[:len(dataFields)-1]
+			}
+		}
+
 		if hasIDs {
 			id := ""
-			if len(record) > 0 {
+			if dataStart > 0 && len(record) > 0 {
 				id = strings.TrimSpace(record[0])
 			}
 			ids = append(ids, id)
-			if len(record) > 1 {
-				playerRecords = append(playerRecords, record[1:])
-			} else {
-				playerRecords = append(playerRecords, nil)
-			}
-		} else {
-			playerRecords = append(playerRecords, record)
 		}
+		playerRecords = append(playerRecords, dataFields)
+		checkedInFlags = append(checkedInFlags, isCheckedIn)
 	}
 
 	players, err := helper.CreatePlayersFromRecords(playerRecords, withZekkenName)
@@ -130,11 +142,12 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 		return nil, err
 	}
 
-	if hasIDs {
-		for i := range players {
-			if i < len(ids) {
-				players[i].ID = ids[i]
-			}
+	for i := range players {
+		if hasIDs && i < len(ids) {
+			players[i].ID = ids[i]
+		}
+		if i < len(checkedInFlags) {
+			players[i].CheckedIn = checkedInFlags[i]
 		}
 	}
 
@@ -161,31 +174,11 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 // for compID. Mirrors SaveParticipants.
 func (s *Store) saveParticipantsLocked(compID string, players []domain.Player) error {
 	path := s.compPath(compID, "participants.csv")
-	var sb strings.Builder
-	w := csv.NewWriter(&sb)
-	for _, p := range players {
-		id := p.ID
-		if id == "" {
-			id = newParticipantID()
-		}
-		var record []string
-		if p.DisplayName != "" && p.DisplayName != p.Name {
-			record = []string{id, p.Name, p.DisplayName, p.Dojo}
-		} else {
-			record = []string{id, p.Name, p.Dojo}
-		}
-		if p.Tag != "" {
-			record = append(record, p.Tag)
-		}
-		if err := w.Write(record); err != nil {
-			return fmt.Errorf("writing participant CSV record: %w", err)
-		}
+	data, err := marshalParticipantsCSV(players)
+	if err != nil {
+		return err
 	}
-	w.Flush()
-	if err := w.Error(); err != nil {
-		return fmt.Errorf("flushing participant CSV: %w", err)
-	}
-	if err := s.atomicWrite(path, []byte(sb.String()), 0600); err != nil {
+	if err := s.atomicWrite(path, data, 0600); err != nil {
 		return err
 	}
 	for _, key := range []string{"participants.csv", "participants_with_seeds.csv"} {

--- a/internal/state/reservedslots.go
+++ b/internal/state/reservedslots.go
@@ -116,17 +116,6 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 		}
 		dataFields := record[dataStart:]
 
-		allEmpty := true
-		for _, f := range dataFields {
-			if strings.TrimSpace(f) != "" {
-				allEmpty = false
-				break
-			}
-		}
-		if allEmpty {
-			continue
-		}
-
 		if len(dataFields) > 2 {
 			last := strings.TrimSpace(dataFields[len(dataFields)-1])
 			if strings.ToLower(last) == "checked_in" {

--- a/internal/state/reservedslots.go
+++ b/internal/state/reservedslots.go
@@ -116,6 +116,17 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 		}
 		dataFields := record[dataStart:]
 
+		allEmpty := true
+		for _, f := range dataFields {
+			if strings.TrimSpace(f) != "" {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			continue
+		}
+
 		if len(dataFields) > 2 {
 			last := strings.TrimSpace(dataFields[len(dataFields)-1])
 			if strings.ToLower(last) == "checked_in" {

--- a/internal/state/reservedslots.go
+++ b/internal/state/reservedslots.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -98,31 +99,33 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 		return []domain.Player{}, nil
 	}
 
-	lines, err := helper.ReadEntriesFromFile(path)
+	records, err := helper.ReadCSVFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	hasIDs := len(lines) > 0 && uuidRE(strings.TrimSpace(strings.SplitN(lines[0], ",", 2)[0]))
+	hasIDs := len(records) > 0 && len(records[0]) > 0 && uuidRE(strings.TrimSpace(records[0][0]))
 
 	var ids []string
-	var plainLines []string
-	if hasIDs {
-		for _, line := range lines {
-			id, rest, ok := strings.Cut(line, ",")
-			if !ok {
-				plainLines = append(plainLines, line)
-				ids = append(ids, "")
-				continue
+	var playerRecords [][]string
+	for _, record := range records {
+		if hasIDs {
+			id := ""
+			if len(record) > 0 {
+				id = strings.TrimSpace(record[0])
 			}
-			ids = append(ids, strings.TrimSpace(id))
-			plainLines = append(plainLines, rest)
+			ids = append(ids, id)
+			if len(record) > 1 {
+				playerRecords = append(playerRecords, record[1:])
+			} else {
+				playerRecords = append(playerRecords, nil)
+			}
+		} else {
+			playerRecords = append(playerRecords, record)
 		}
-	} else {
-		plainLines = lines
 	}
 
-	players, err := helper.CreatePlayers(plainLines, withZekkenName)
+	players, err := helper.CreatePlayersFromRecords(playerRecords, withZekkenName)
 	if err != nil {
 		return nil, err
 	}
@@ -159,21 +162,28 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 func (s *Store) saveParticipantsLocked(compID string, players []domain.Player) error {
 	path := s.compPath(compID, "participants.csv")
 	var sb strings.Builder
+	w := csv.NewWriter(&sb)
 	for _, p := range players {
 		id := p.ID
 		if id == "" {
 			id = newParticipantID()
 		}
-		var row string
+		var record []string
 		if p.DisplayName != "" && p.DisplayName != p.Name {
-			row = fmt.Sprintf("%s, %s, %s", p.Name, p.DisplayName, p.Dojo)
+			record = []string{id, p.Name, p.DisplayName, p.Dojo}
 		} else {
-			row = fmt.Sprintf("%s, %s", p.Name, p.Dojo)
+			record = []string{id, p.Name, p.Dojo}
 		}
 		if p.Tag != "" {
-			row += ", " + p.Tag
+			record = append(record, p.Tag)
 		}
-		sb.WriteString(id + ", " + row + "\n")
+		if err := w.Write(record); err != nil {
+			return fmt.Errorf("writing participant CSV record: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("flushing participant CSV: %w", err)
 	}
 	if err := s.atomicWrite(path, []byte(sb.String()), 0600); err != nil {
 		return err

--- a/internal/state/reservedslots.go
+++ b/internal/state/reservedslots.go
@@ -111,12 +111,21 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 	for _, record := range records {
 		isCheckedIn := false
 		dataStart := 0
-		if hasIDs {
-			if len(record) > 1 || (len(record) == 1 && uuidRE(strings.TrimSpace(record[0]))) {
-				dataStart = 1
-			}
+		if hasIDs && len(record) > 0 && uuidRE(strings.TrimSpace(record[0])) {
+			dataStart = 1
 		}
 		dataFields := record[dataStart:]
+
+		allEmpty := true
+		for _, f := range dataFields {
+			if strings.TrimSpace(f) != "" {
+				allEmpty = false
+				break
+			}
+		}
+		if allEmpty {
+			continue
+		}
 
 		if len(dataFields) > 2 {
 			last := strings.TrimSpace(dataFields[len(dataFields)-1])
@@ -128,7 +137,7 @@ func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]do
 
 		if hasIDs {
 			id := ""
-			if dataStart > 0 && len(record) > 0 {
+			if dataStart > 0 {
 				id = strings.TrimSpace(record[0])
 			}
 			ids = append(ids, id)

--- a/internal/state/seeds.go
+++ b/internal/state/seeds.go
@@ -1,9 +1,11 @@
 package state
 
 import (
+	"encoding/csv"
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -59,9 +61,18 @@ func (s *Store) SaveSeeds(compID string, assignments []domain.SeedAssignment) er
 	})
 
 	var sb strings.Builder
-	sb.WriteString("Rank,Name\n")
+	w := csv.NewWriter(&sb)
+	if err := w.Write([]string{"Rank", "Name"}); err != nil {
+		return fmt.Errorf("writing seeds CSV header: %w", err)
+	}
 	for _, a := range assignments {
-		fmt.Fprintf(&sb, "%d,%s\n", a.SeedRank, a.Name)
+		if err := w.Write([]string{strconv.Itoa(a.SeedRank), a.Name}); err != nil {
+			return fmt.Errorf("writing seeds CSV record: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("flushing seeds CSV: %w", err)
 	}
 
 	return s.atomicWrite(path, []byte(sb.String()), 0600)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -265,6 +265,31 @@ func TestStore_ParticipantsCSV_Empty(t *testing.T) {
 	assert.Empty(t, loaded)
 }
 
+func TestStore_ParticipantsCSV_BlankLines(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "blank-lines"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID}))
+
+	path := filepath.Join(dir, "competitions", compID, "participants.csv")
+	content := "550e8400-e29b-41d4-a716-446655440000,Alice,DojoA\n\n660e8400-e29b-41d4-a716-446655440001,Bob,DojoB\n"
+	err = os.WriteFile(path, []byte(content), 0600)
+	require.NoError(t, err)
+
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", loaded[0].ID)
+	assert.Equal(t, "Alice", loaded[0].Name)
+	assert.Equal(t, "660e8400-e29b-41d4-a716-446655440001", loaded[1].ID)
+	assert.Equal(t, "Bob", loaded[1].Name)
+}
+
 func TestStore_ParticipantsCSV_CommaInNameAndDojo(t *testing.T) {
 	dir, err := os.MkdirTemp("", "state-test-*")
 	require.NoError(t, err)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -193,7 +193,7 @@ func TestStore_ParticipantsCSV(t *testing.T) {
 	path := filepath.Join(dir, "competitions", compID, "participants.csv")
 	data, err := os.ReadFile(path)
 	require.NoError(t, err)
-	assert.Contains(t, string(data), "Akira Tanaka, Mumeishi")
+	assert.Contains(t, string(data), "Akira Tanaka,Mumeishi")
 
 	loaded, err := store.LoadParticipants(compID, false)
 	require.NoError(t, err)
@@ -263,6 +263,58 @@ func TestStore_ParticipantsCSV_Empty(t *testing.T) {
 	loaded, err := store.LoadParticipants("nonexistent", false)
 	require.NoError(t, err)
 	assert.Empty(t, loaded)
+}
+
+func TestStore_ParticipantsCSV_CommaInNameAndDojo(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "comma-test"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID}))
+
+	players := []domain.Player{
+		{Name: "Smith, John", Dojo: "Kendo Club, Tokyo"},
+		{Name: "Yamada Taro", Dojo: "Plain Dojo"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.Equal(t, "Smith, John", loaded[0].Name)
+	assert.Equal(t, "Kendo Club, Tokyo", loaded[0].Dojo)
+	assert.Equal(t, "Yamada Taro", loaded[1].Name)
+	assert.Equal(t, "Plain Dojo", loaded[1].Dojo)
+}
+
+func TestStore_SeedsCSV_CommaInName(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "seed-comma"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID}))
+
+	seeds := []domain.SeedAssignment{
+		{Name: "Smith, John", SeedRank: 1},
+		{Name: "Yamada Taro", SeedRank: 2},
+	}
+	require.NoError(t, store.SaveSeeds(compID, seeds))
+
+	loaded, err := store.LoadSeeds(compID)
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.Equal(t, "Smith, John", loaded[0].Name)
+	assert.Equal(t, 1, loaded[0].SeedRank)
+	assert.Equal(t, "Yamada Taro", loaded[1].Name)
+	assert.Equal(t, 2, loaded[1].SeedRank)
 }
 
 // --- Pools CSV ---


### PR DESCRIPTION
## Summary
- Switch `saveParticipantsNoLock`, `saveParticipantsLocked`, and `SaveSeeds` from `fmt.Sprintf` to `encoding/csv.Writer` so fields containing commas or double-quotes are properly RFC 4180 quoted
- Switch the load paths (`loadParticipantsNoLock`, `loadParticipantsLocked`) from line-based `ReadEntriesFromFile` + `strings.Split` to new `ReadCSVFile` + `csv.Reader` so quoted fields parse correctly on reload
- Add `CreatePlayersFromRecords` for pre-parsed CSV records; `CreatePlayers` now parses each entry with `csv.Reader` before delegating, so web form / CLI callers also handle quoted input
- Backward compatible: `csv.Reader` with `TrimLeadingSpace=true` and `LazyQuotes=true` correctly parses old-format files that use `"name, dojo"` with spaces after commas

## Test plan
- [x] New `TestStore_ParticipantsCSV_CommaInNameAndDojo` — round-trips names/dojos with commas
- [x] New `TestStore_SeedsCSV_CommaInName` — round-trips seed names with commas
- [x] New `TestStore_ParticipantsCSV_BlankLines` — blank lines don't misalign IDs/checkedIn
- [x] Existing `TestStore_ParticipantsCSV` — basic round-trip still works (assertion updated for no-space format)
- [x] Existing `TestStore_ParticipantsCSV_MixedIDs` — mixed UUID/plain lines still parse correctly
- [x] Existing `TestStore_ParticipantsCSV_WithZekkenName` — zekken display name round-trip unchanged
- [x] Full `go test ./internal/state/... ./internal/helper/... ./internal/engine/... ./internal/mobileapp/... ./cmd/...` passes
- [x] `golangci-lint` and `gosec` pass with 0 issues
- [x] Manual: POST participants with commas in names via API, verify CSV on disk is properly quoted, verify GET round-trip returns correct names/dojos, verify dojo dropdown in viewer UI displays comma-containing dojos correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)