### PR TITLE
chore(gitignore): replace specific worktree dirs with mp-*/ glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,11 +74,4 @@ bracket-creator-webapp*
 # bd worktree
 bracket-creator-*
 bracket-creator-*/*
-# bd worktree
-bracket-creator-lvh/
-# bd worktree
-mp-h60/
-# bd worktree
-mp-k8x/
-# bd worktree
-mp-t3h/
+mp-*/


### PR DESCRIPTION
## Summary
- Replaced 4 specific bead worktree directory names (`bracket-creator-lvh/`, `mp-h60/`, `mp-k8x/`, `mp-t3h/`) with a single `mp-*/` glob pattern
- Consolidated duplicate `# bd worktree` comment blocks
- Prevents `.gitignore` from growing a new line per bead worktree

Closes mp-g5o.

## Test plan
- [x] `git ls-files | grep '^mp-'` returns nothing — no legitimate tracked files match the glob
- [x] `git status` shows no newly untracked files after the change
- [x] `make go/lint` passes
- [x] `go test ./...` passes — all packages OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)