### PR TITLE
fix(viewer): tighten name-match to exact equality (mp-egl)

### DIFF
--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -39,9 +39,9 @@ describe('buildPlayerMatchHighlight', () => {
 
   it('falls back to case-insensitive exact name match when UUID misses', () => {
     const matches = [{ id: 'm1', sideA: 'John Doe', sideB: 'Jane Smith' }];
-    const result = buildPlayerMatchHighlight('unknown-uuid', matches, 'John Doe');
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('m1');
+    expect(buildPlayerMatchHighlight('unknown-uuid', matches, 'John Doe')).toHaveLength(1);
+    expect(buildPlayerMatchHighlight('unknown-uuid', matches, 'JOHN DOE')).toHaveLength(1);
+    expect(buildPlayerMatchHighlight('unknown-uuid', matches, 'john doe')).toHaveLength(1);
   });
 
   it('name fallback rejects substring-only matches', () => {

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -37,22 +37,30 @@ describe('buildPlayerMatchHighlight', () => {
     expect(result[0].id).toBe('m2');
   });
 
-  it('falls back to case-insensitive name match when UUID misses', () => {
+  it('falls back to case-insensitive exact name match when UUID misses', () => {
     const matches = [{ id: 'm1', sideA: 'John Doe', sideB: 'Jane Smith' }];
-    const result = buildPlayerMatchHighlight('unknown-uuid', matches, 'JOHN');
+    const result = buildPlayerMatchHighlight('unknown-uuid', matches, 'John Doe');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('m1');
   });
 
+  it('name fallback rejects substring-only matches (mp-egl)', () => {
+    const matches = [{ id: 'm1', sideA: 'Banana', sideB: 'Charlie' }];
+    expect(buildPlayerMatchHighlight('no-id', matches, 'Ana')).toEqual([]);
+  });
+
+  it('name fallback trims whitespace', () => {
+    const matches = [{ id: 'm1', sideA: '  Alice  ', sideB: 'Bob' }];
+    const result = buildPlayerMatchHighlight('no-id', matches, 'Alice');
+    expect(result).toHaveLength(1);
+  });
+
   it('does not fall back to name match when UUID hits at least once', () => {
-    // FR-020: a UUID hit means we have a definitive answer — do not widen
-    // the result set with name substrings that could pull in unrelated
-    // people sharing a common surname.
     const matches = [
       { id: 'm1', sideA: { id: 'p1', name: 'John Doe' }, sideB: { id: 'p2', name: 'Jane Smith' } },
       { id: 'm2', sideA: { id: 'p3', name: 'Johnny Apple' }, sideB: { id: 'p4', name: 'Kim Lee' } },
     ];
-    const result = buildPlayerMatchHighlight('p1', matches, 'john');
+    const result = buildPlayerMatchHighlight('p1', matches, 'John Doe');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('m1');
   });

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -44,15 +44,15 @@ describe('buildPlayerMatchHighlight', () => {
     expect(result[0].id).toBe('m1');
   });
 
-  it('name fallback rejects substring-only matches (mp-egl)', () => {
+  it('name fallback rejects substring-only matches', () => {
     const matches = [{ id: 'm1', sideA: 'Banana', sideB: 'Charlie' }];
     expect(buildPlayerMatchHighlight('no-id', matches, 'Ana')).toEqual([]);
   });
 
-  it('name fallback trims whitespace', () => {
+  it('name fallback trims whitespace on both sides', () => {
     const matches = [{ id: 'm1', sideA: '  Alice  ', sideB: 'Bob' }];
-    const result = buildPlayerMatchHighlight('no-id', matches, 'Alice');
-    expect(result).toHaveLength(1);
+    expect(buildPlayerMatchHighlight('no-id', matches, 'Alice')).toHaveLength(1);
+    expect(buildPlayerMatchHighlight('no-id', matches, '  Alice  ')).toHaveLength(1);
   });
 
   it('does not fall back to name match when UUID hits at least once', () => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -146,7 +146,7 @@ function isFollowedPlayer(p, followed) {
 // Return the subset of `matches` where the followed player participates.
 // Matching is by UUID first; if `fallbackName` is provided and no UUID hits
 // (e.g., legacy data that still keys by display name), fall back to a
-// case-insensitive substring match on either side's name.
+// case-insensitive exact match on either side's name.
 function buildPlayerMatchHighlight(playerId, matches, fallbackName) {
   const id = (playerId || "").toString();
   const list = Array.isArray(matches) ? matches : [];
@@ -159,8 +159,8 @@ function buildPlayerMatchHighlight(playerId, matches, fallbackName) {
   if (!needle) return byId;
   return list.filter((m) => {
     const [an, bn] = matchParticipantNames(m);
-    return (an && an.toLowerCase().includes(needle))
-        || (bn && bn.toLowerCase().includes(needle));
+    return (an && an.trim().toLowerCase() === needle)
+        || (bn && bn.trim().toLowerCase() === needle);
   });
 }
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -155,7 +155,7 @@ function buildPlayerMatchHighlight(playerId, matches, fallbackName) {
     return (a && a === id) || (b && b === id);
   }) : [];
   if (byId.length > 0 || !fallbackName) return byId;
-  const needle = String(fallbackName).toLowerCase();
+  const needle = String(fallbackName).trim().toLowerCase();
   if (!needle) return byId;
   return list.filter((m) => {
     const [an, bn] = matchParticipantNames(m);


### PR DESCRIPTION
## Summary
- Aligns `buildPlayerMatchHighlight` name fallback with `isFollowedPlayer`: both now use `trim().toLowerCase() ===` (exact) instead of `.includes()` (substring)
- Prevents false positives where short names match longer ones (e.g. "Ana" matching "Banana")
- Adds tests for substring rejection and whitespace trimming

## Test plan
- [x] `make go/test` — all Go tests pass
- [x] 804 JS vitest tests pass (27 suites)
- [x] New test: substring-only match returns empty array
- [x] New test: whitespace-trimmed names still match
- [x] Updated existing test to use exact name instead of substring
- [x] Manual: follow a player in the viewer and confirm highlighting works

🤖 Generated with [Claude Code](https://claude.com/claude-code)