### PR TITLE
test(web-mobile): extract shared reactive React harness (mp-wrp)

### DIFF
--- a/web-mobile/js/__tests__/admin_schedule.test.jsx
+++ b/web-mobile/js/__tests__/admin_schedule.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { timeEdited, timeToMinutes, clampMatchDuration, filterMatchesByCourt, suggestRebalances, computeCourtPaceStats, allMatchesCompleted } from '../admin_schedule.jsx';
+import { makeReactive } from './helpers/reactive_react.js';
 
 describe('timeEdited', () => {
   // Copilot round-9 finding: AdminTWMatch.submitTime() used
@@ -499,81 +500,6 @@ describe('CourtPacePanel timer', () => {
   let realReact;
   let runtime;
   let CourtPacePanel;
-
-  function makeReactive() {
-    let hookSlots = [];
-    let hookIndex = 0;
-    let scheduledRender = null;
-    let rootProps = null;
-    let rootFactory = null;
-    let effectCleanups = [];
-    let renderCount = 0;
-
-    function rerender() {
-      hookIndex = 0;
-      renderCount++;
-      scheduledRender = rootFactory(rootProps);
-      return scheduledRender;
-    }
-
-    const reactive = {
-      createElement: (type, props, ...children) => ({ type, props, children }),
-      useState: (initial) => {
-        const i = hookIndex++;
-        if (hookSlots.length <= i) {
-          hookSlots[i] = typeof initial === 'function' ? initial() : initial;
-        }
-        const setter = (v) => {
-          hookSlots[i] = typeof v === 'function' ? v(hookSlots[i]) : v;
-          rerender();
-        };
-        return [hookSlots[i], setter];
-      },
-      useEffect: (effect, deps) => {
-        const i = hookIndex++;
-        if (hookSlots.length <= i) {
-          hookSlots[i] = deps;
-          const cleanup = effect();
-          if (typeof cleanup === 'function') {
-            effectCleanups.push(cleanup);
-          }
-        }
-      },
-      // useMemo runs eagerly without dependency tracking — the test runtime
-      // intentionally simplifies hooks for render isolation. This means tests
-      // can't catch "tick missing from deps" regressions; that contract is
-      // enforced by code review instead.
-      useMemo: (fn) => fn(),
-      useRef: (initial) => {
-        const i = hookIndex++;
-        if (hookSlots.length <= i) {
-          hookSlots[i] = { current: initial };
-        }
-        return hookSlots[i];
-      },
-      useLayoutEffect: () => {},
-      memo: (c) => c,
-    };
-
-    return {
-      React: reactive,
-      mount: (factory, props) => {
-        hookSlots = [];
-        hookIndex = 0;
-        rootFactory = factory;
-        rootProps = props;
-        effectCleanups = [];
-        renderCount = 0;
-        return rerender();
-      },
-      unmount: () => {
-        effectCleanups.forEach(c => c());
-        effectCleanups = [];
-      },
-      currentTree: () => scheduledRender,
-      renderCount: () => renderCount,
-    };
-  }
 
   beforeEach(async () => {
     realReact = global.React;

--- a/web-mobile/js/__tests__/helpers/reactive_react.js
+++ b/web-mobile/js/__tests__/helpers/reactive_react.js
@@ -1,0 +1,96 @@
+// Reactive React stub for vitest.
+//
+// The global React stub in vitest.setup.js is non-reactive (useState
+// returns [val, vi.fn()]), which is fine for asserting a single static
+// render but useless for tests that need to exercise interactions
+// (typing into an input, ticking a timer, then re-reading the tree).
+//
+// makeReactive() returns a single-component reactive shim with:
+//   - useState that re-renders on setter
+//   - useEffect that runs once, with cleanup capture (fired on unmount)
+//   - useRef, useMemo (eager), useLayoutEffect (no-op), memo
+//   - render counter and unmount() for tests that care about either
+//
+// Install per test:
+//   const runtime = makeReactive();
+//   global.React = runtime.React;
+//   vi.resetModules();
+//   const { MyComponent } = await import('../my_component.jsx');
+//   runtime.mount(MyComponent, { ...props });
+//
+// Restore the original React in afterEach.
+
+export function makeReactive() {
+  let hookSlots = [];
+  let hookIndex = 0;
+  let scheduledRender = null;
+  let rootProps = null;
+  let rootFactory = null;
+  let effectCleanups = [];
+  let renderCount = 0;
+
+  function rerender() {
+    hookIndex = 0;
+    renderCount++;
+    scheduledRender = rootFactory(rootProps);
+    return scheduledRender;
+  }
+
+  const reactive = {
+    createElement: (type, props, ...children) => ({ type, props, children }),
+    useState: (initial) => {
+      const i = hookIndex++;
+      if (hookSlots.length <= i) {
+        hookSlots[i] = typeof initial === 'function' ? initial() : initial;
+      }
+      const setter = (v) => {
+        hookSlots[i] = typeof v === 'function' ? v(hookSlots[i]) : v;
+        rerender();
+      };
+      return [hookSlots[i], setter];
+    },
+    useEffect: (effect, deps) => {
+      const i = hookIndex++;
+      if (hookSlots.length <= i) {
+        hookSlots[i] = deps;
+        const cleanup = effect();
+        if (typeof cleanup === 'function') {
+          effectCleanups.push(cleanup);
+        }
+      }
+    },
+    // useMemo runs eagerly without dependency tracking — the test runtime
+    // intentionally simplifies hooks for render isolation. This means tests
+    // can't catch "tick missing from deps" regressions; that contract is
+    // enforced by code review instead.
+    useMemo: (fn) => fn(),
+    useRef: (initial) => {
+      const i = hookIndex++;
+      if (hookSlots.length <= i) {
+        hookSlots[i] = { current: initial };
+      }
+      return hookSlots[i];
+    },
+    useLayoutEffect: () => {},
+    memo: (c) => c,
+  };
+
+  return {
+    React: reactive,
+    mount: (factory, props) => {
+      hookSlots = [];
+      hookIndex = 0;
+      rootFactory = factory;
+      rootProps = props;
+      effectCleanups = [];
+      renderCount = 0;
+      return rerender();
+    },
+    unmount: () => {
+      effectCleanups.forEach((c) => c());
+      effectCleanups = [];
+    },
+    currentTree: () => scheduledRender,
+    renderCount: () => renderCount,
+  };
+}

--- a/web-mobile/js/__tests__/helpers/reactive_react.js
+++ b/web-mobile/js/__tests__/helpers/reactive_react.js
@@ -18,7 +18,10 @@
 //   const { MyComponent } = await import('../my_component.jsx');
 //   runtime.mount(MyComponent, { ...props });
 //
-// Restore the original React in afterEach.
+// In afterEach, call runtime.unmount() to fire captured effect cleanups
+// (intervals, listeners, etc.) before restoring the original React. If
+// the component under test uses no effects with cleanups, the unmount
+// call is a no-op but still safe to include.
 
 export function makeReactive() {
   let hookSlots = [];
@@ -37,7 +40,17 @@ export function makeReactive() {
   }
 
   const reactive = {
-    createElement: (type, props, ...children) => ({ type, props, children }),
+    // Mirror React's element shape: children are exposed on props.children
+    // (single child vs array, matching how JSX-compiled components read
+    // them) and also kept as a top-level alias so simple tree-traversal
+    // helpers can walk node.children directly.
+    createElement: (type, props, ...children) => {
+      const merged = { ...(props || {}) };
+      if (children.length > 0) {
+        merged.children = children.length === 1 ? children[0] : children;
+      }
+      return { type, props: merged, children };
+    },
     useState: (initial) => {
       const i = hookIndex++;
       if (hookSlots.length <= i) {

--- a/web-mobile/js/__tests__/reset.test.jsx
+++ b/web-mobile/js/__tests__/reset.test.jsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
 
 // reset.jsx ships:
 //   - ResetPasswordForm: the /reset SPA page. Renders either the
@@ -11,71 +12,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // returns [val, vi.fn()]) which is fine for asserting the static
 // render tree but useless for exercising the submit handler — that's
 // where the new password is sent, errors mapped, localStorage
-// updated, and onSuccess invoked. To cover submit-time behavior we
-// install a small per-test reactive React shim before importing
-// reset.jsx and restore the original stub afterwards.
-//
-// The shim is deliberately minimal (single-component, no diffing,
-// no batching) — just enough to make useState/useEffect/useRef
-// reactive so the onSubmit closure sees current input values.
+// updated, and onSuccess invoked. The shared makeReactive helper
+// installs a minimal reactive shim so useState mutations are
+// observable across renders.
 
 const realReact = global.React;
-
-// reactiveReact: a single-component stand-in that mimics the parts of
-// React the component actually uses. Each render call creates a fresh
-// per-component "instance" record holding hook slots; subsequent calls
-// reuse the slots so setState mutations are observable across renders.
-function makeReactive() {
-  let hookSlots = [];
-  let hookIndex = 0;
-  let scheduledRender = null;
-  let rootProps = null;
-  let rootFactory = null;
-
-  function rerender() {
-    hookIndex = 0;
-    scheduledRender = rootFactory(rootProps);
-    return scheduledRender;
-  }
-
-  const reactive = {
-    createElement: (type, props, ...children) => ({ type, props, children }),
-    useState: (initial) => {
-      const i = hookIndex++;
-      if (hookSlots.length <= i) {
-        hookSlots[i] = typeof initial === 'function' ? initial() : initial;
-      }
-      const setter = (v) => {
-        hookSlots[i] = typeof v === 'function' ? v(hookSlots[i]) : v;
-        rerender();
-      };
-      return [hookSlots[i], setter];
-    },
-    useEffect: () => {}, // ignore effects in tests — submit handler doesn't depend on them
-    useMemo: (fn) => fn(),
-    useRef: (initial) => {
-      const i = hookIndex++;
-      if (hookSlots.length <= i) {
-        hookSlots[i] = { current: initial };
-      }
-      return hookSlots[i];
-    },
-    useLayoutEffect: () => {},
-    memo: (c) => c,
-  };
-
-  return {
-    React: reactive,
-    mount: (factory, props) => {
-      hookSlots = [];
-      hookIndex = 0;
-      rootFactory = factory;
-      rootProps = props;
-      return rerender();
-    },
-    currentTree: () => scheduledRender,
-  };
-}
 
 function findInTree(node, predicate) {
   if (!node || typeof node !== 'object') return null;

--- a/web-mobile/js/__tests__/reset.test.jsx
+++ b/web-mobile/js/__tests__/reset.test.jsx
@@ -67,6 +67,10 @@ describe('ResetPasswordForm', () => {
   });
 
   afterEach(() => {
+    // Fire captured effect cleanups (e.g. ResetPasswordForm's mountedRef
+    // unmount path) before swapping React back, so the cleanup runs against
+    // the same React the effect was registered with.
+    runtime.unmount();
     global.React = realReact;
     vi.resetModules();
   });


### PR DESCRIPTION
## Summary
- Extract the reactive React test shim from `reset.test.jsx` and `admin_schedule.test.jsx` into a shared `web-mobile/js/__tests__/helpers/reactive_react.js`.
- The unified harness is the superset of the two: effect-cleanup tracking, render counter, mount/unmount accessors.
- Closes [mp-wrp](#).

## Why
Pre-existing duplication flagged by `/review` on [PR #149](https://github.com/gitrgoliveira/bracket-creator/pull/149) (mp-pb1). Both test files maintained near-identical reactive shims that were already drifting (admin schedule added `renderCount` + `effectCleanups`). A shared helper stops further drift and lets future component-logic tests (e.g., the RankInput DOM-event tests blocked on vitest infra) reuse the harness.

## Test plan
- [x] `npx vitest run js/__tests__/reset.test.jsx js/__tests__/admin_schedule.test.jsx` — 78/78 green
- [x] `npx vitest run` — full suite 805/805 green
- [x] `npx eslint js/__tests__/helpers/reactive_react.js js/__tests__/reset.test.jsx js/__tests__/admin_schedule.test.jsx` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)