### PR TITLE
feat(viewer): cross-pool ranked podium during pool phase of mixed competitions (mp-arn)

### DIFF
--- a/internal/mobileapp/server_test.go
+++ b/internal/mobileapp/server_test.go
@@ -26,10 +26,10 @@ func TestNewRouter(t *testing.T) {
 
 	// Mock FS
 	mockFS := fstest.MapFS{
-		"web-mobile/index.html":    {Data: []byte("<html><body>Mobile</body></html>")},
-		"web-mobile/main.js":       {Data: []byte("console.log('hello')")},
-		"web-mobile/favicon.jpeg":  {Data: []byte("fake-jpeg-favicon")},
-		"web-mobile/logo.jpeg":     {Data: []byte("fake-jpeg-logo")},
+		"web-mobile/index.html":   {Data: []byte("<html><body>Mobile</body></html>")},
+		"web-mobile/main.js":      {Data: []byte("console.log('hello')")},
+		"web-mobile/favicon.jpeg": {Data: []byte("fake-jpeg-favicon")},
+		"web-mobile/logo.jpeg":    {Data: []byte("fake-jpeg-logo")},
 	}
 	res := resources.NewResources(nil, mockFS)
 

--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -282,7 +282,7 @@ describe('deriveAwards (multi-pool cross-pool ranking)', () => {
     const standings = {
       'Pool A': [
         mkRow('Alice', 'Aoyama', 3, 0, 0, 6, 1),
-        mkRow('Ash', 'Aoyama', 1, 2, 0, 2, 4),
+        mkRow('Ash', 'Aoyama', 1, 2, 0, 3, 4),
       ],
       'Pool B': [
         mkRow('Bob', 'Bunkyo', 3, 0, 0, 5, 1),

--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -1,7 +1,7 @@
 // Pure-logic tests for deriveAwards — the helper that maps bracket/standings
 // payloads into the 1/2/3/3 podium per FIK convention (no bronze match).
 import { describe, it, expect } from 'vitest';
-import { deriveAwards } from '../viewer.jsx';
+import { deriveAwards, crossPoolRank } from '../viewer.jsx';
 
 const playerMap = (...pairs) => {
   const m = new Map();
@@ -184,5 +184,131 @@ describe('deriveAwards (standings-based)', () => {
     const awards = deriveAwards(bracket, standings, pools, new Map());
     expect(awards.map((a) => a.name)).toEqual(['Alice', 'Bob', 'Carol', 'Dan']);
     expect(awards.map((a) => a.place)).toEqual([1, 2, 3, 3]);
+  });
+});
+
+// Helper to build a standings row for an individual player.
+const mkRow = (name, dojo, wins, losses, draws, ipponsGiven, ipponsTaken) => ({
+  player: { name, dojo },
+  wins, losses, draws, ipponsGiven, ipponsTaken,
+});
+
+// Helper to build a standings row for a team.
+const mkTeamRow = (name, dojo, wins, losses, draws, individualWins, individualLosses, individualDraws, pointsWon, pointsLost) => ({
+  player: { name, dojo },
+  wins, losses, draws, individualWins, individualLosses, individualDraws, pointsWon, pointsLost,
+});
+
+describe('crossPoolRank (individual)', () => {
+  it('merges 3 pools and sorts by canonical individual chain', () => {
+    const standings = {
+      'Pool A': [mkRow('Alice', 'Aoyama', 3, 0, 0, 6, 1)],
+      'Pool B': [mkRow('Bob', 'Bunkyo', 3, 0, 0, 5, 1)],
+      'Pool C': [mkRow('Carol', 'Chiba', 2, 1, 0, 4, 2)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }, { poolName: 'Pool C' }];
+    const result = crossPoolRank(standings, pools, false);
+    expect(result.map(r => r.player.name)).toEqual(['Alice', 'Bob', 'Carol']);
+  });
+
+  it('resolves W tie by losses asc', () => {
+    const standings = {
+      'Pool A': [mkRow('Alice', '', 2, 0, 0, 4, 0)],
+      'Pool B': [mkRow('Bob', '', 2, 1, 0, 4, 0)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const result = crossPoolRank(standings, pools, false);
+    expect(result.map(r => r.player.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('resolves W+L tie by draws desc', () => {
+    const standings = {
+      'Pool A': [mkRow('Alice', '', 2, 0, 1, 4, 0)],
+      'Pool B': [mkRow('Bob', '', 2, 0, 0, 4, 0)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const result = crossPoolRank(standings, pools, false);
+    expect(result.map(r => r.player.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('resolves W+L+T tie by ipponsGiven desc', () => {
+    const standings = {
+      'Pool A': [mkRow('Alice', '', 2, 0, 0, 5, 1)],
+      'Pool B': [mkRow('Bob', '', 2, 0, 0, 3, 1)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const result = crossPoolRank(standings, pools, false);
+    expect(result.map(r => r.player.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('resolves W+L+T+PW tie by ipponsTaken asc', () => {
+    const standings = {
+      'Pool A': [mkRow('Alice', '', 2, 0, 0, 4, 1)],
+      'Pool B': [mkRow('Bob', '', 2, 0, 0, 4, 2)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const result = crossPoolRank(standings, pools, false);
+    expect(result.map(r => r.player.name)).toEqual(['Alice', 'Bob']);
+  });
+});
+
+describe('crossPoolRank (team)', () => {
+  it('uses team tie-breaker chain: IV desc after W/L/T', () => {
+    const standings = {
+      'Pool A': [mkTeamRow('TeamA', '', 2, 0, 0, 5, 1, 0, 8, 2)],
+      'Pool B': [mkTeamRow('TeamB', '', 2, 0, 0, 3, 1, 0, 8, 2)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const result = crossPoolRank(standings, pools, true);
+    expect(result.map(r => r.player.name)).toEqual(['TeamA', 'TeamB']);
+  });
+
+  it('uses IL asc after IV tie', () => {
+    const standings = {
+      'Pool A': [mkTeamRow('TeamA', '', 2, 0, 0, 4, 1, 0, 8, 2)],
+      'Pool B': [mkTeamRow('TeamB', '', 2, 0, 0, 4, 2, 0, 8, 2)],
+    };
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const result = crossPoolRank(standings, pools, true);
+    expect(result.map(r => r.player.name)).toEqual(['TeamA', 'TeamB']);
+  });
+});
+
+describe('deriveAwards (multi-pool cross-pool ranking)', () => {
+  it('merges 3 pools for a pools-only format and returns top-4 podium', () => {
+    const pools = [
+      { poolName: 'Pool A' },
+      { poolName: 'Pool B' },
+      { poolName: 'Pool C' },
+    ];
+    const standings = {
+      'Pool A': [
+        mkRow('Alice', 'Aoyama', 3, 0, 0, 6, 1),
+        mkRow('Ash', 'Aoyama', 1, 2, 0, 2, 4),
+      ],
+      'Pool B': [
+        mkRow('Bob', 'Bunkyo', 3, 0, 0, 5, 1),
+        mkRow('Beth', 'Bunkyo', 1, 2, 0, 2, 4),
+      ],
+      'Pool C': [
+        mkRow('Carol', 'Chiba', 2, 1, 0, 4, 2),
+        mkRow('Chris', 'Chiba', 0, 3, 0, 1, 5),
+      ],
+    };
+    const awards = deriveAwards(null, standings, pools, new Map(), false);
+    expect(awards.map(a => a.name)).toEqual(['Alice', 'Bob', 'Carol', 'Ash']);
+    expect(awards.map(a => a.place)).toEqual([1, 2, 3, 3]);
+  });
+
+  it('still uses first-pool standings when only one pool exists (unchanged behaviour)', () => {
+    const pools = [{ poolName: 'Pool A' }];
+    const standings = {
+      'Pool A': [
+        { player: { name: 'Alice', dojo: 'Aoyama' } },
+        { player: { name: 'Bob', dojo: 'Bunkyo' } },
+      ],
+    };
+    const awards = deriveAwards(null, standings, pools, new Map(), false);
+    expect(awards.map(a => a.name)).toEqual(['Alice', 'Bob']);
   });
 });

--- a/web-mobile/js/__tests__/viewer_awards.test.jsx
+++ b/web-mobile/js/__tests__/viewer_awards.test.jsx
@@ -187,13 +187,11 @@ describe('deriveAwards (standings-based)', () => {
   });
 });
 
-// Helper to build a standings row for an individual player.
 const mkRow = (name, dojo, wins, losses, draws, ipponsGiven, ipponsTaken) => ({
   player: { name, dojo },
   wins, losses, draws, ipponsGiven, ipponsTaken,
 });
 
-// Helper to build a standings row for a team.
 const mkTeamRow = (name, dojo, wins, losses, draws, individualWins, individualLosses, individualDraws, pointsWon, pointsLost) => ({
   player: { name, dojo },
   wins, losses, draws, individualWins, individualLosses, individualDraws, pointsWon, pointsLost,
@@ -310,5 +308,22 @@ describe('deriveAwards (multi-pool cross-pool ranking)', () => {
     };
     const awards = deriveAwards(null, standings, pools, new Map(), false);
     expect(awards.map(a => a.name)).toEqual(['Alice', 'Bob']);
+  });
+
+  it('uses team chain (isTeam=true) for multi-pool team format', () => {
+    const pools = [{ poolName: 'Pool A' }, { poolName: 'Pool B' }];
+    const standings = {
+      'Pool A': [
+        mkTeamRow('TeamA', 'Dojo1', 3, 0, 0, 6, 2, 0, 10, 3),
+        mkTeamRow('TeamC', 'Dojo1', 1, 2, 0, 3, 5, 0,  4, 8),
+      ],
+      'Pool B': [
+        mkTeamRow('TeamB', 'Dojo2', 3, 0, 0, 4, 2, 0, 10, 3),
+        mkTeamRow('TeamD', 'Dojo2', 0, 3, 0, 1, 6, 0,  2, 9),
+      ],
+    };
+    const awards = deriveAwards(null, standings, pools, new Map(), true);
+    expect(awards.map(a => a.name)).toEqual(['TeamA', 'TeamB', 'TeamC', 'TeamD']);
+    expect(awards.map(a => a.place)).toEqual([1, 2, 3, 3]);
   });
 });

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2102,19 +2102,18 @@ function crossPoolRank(standings, pools, isTeam) {
       (a.losses || 0) - (b.losses || 0) ||
       (b.draws || 0) - (a.draws || 0);
     if (base !== 0) return base;
-    if (isTeam) {
-      return (
-        (b.individualWins || 0) - (a.individualWins || 0) ||
+    const tail = isTeam
+      ? (b.individualWins || 0) - (a.individualWins || 0) ||
         (a.individualLosses || 0) - (b.individualLosses || 0) ||
         (b.individualDraws || 0) - (a.individualDraws || 0) ||
         (b.pointsWon || 0) - (a.pointsWon || 0) ||
         (a.pointsLost || 0) - (b.pointsLost || 0)
-      );
-    }
-    return (
-      (b.ipponsGiven || 0) - (a.ipponsGiven || 0) ||
-      (a.ipponsTaken || 0) - (b.ipponsTaken || 0)
-    );
+      : (b.ipponsGiven || 0) - (a.ipponsGiven || 0) ||
+        (a.ipponsTaken || 0) - (b.ipponsTaken || 0);
+    if (tail !== 0) return tail;
+    const nameA = a.player?.name || "";
+    const nameB = b.player?.name || "";
+    return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
   });
   return merged;
 }
@@ -2180,9 +2179,8 @@ function deriveAwards(bracket, standings, pools, nameToPlayer, isTeam) {
   // Standings-based fallback. Two payload shapes are supported:
   //   - Swiss/`/swiss/standings`: a flat array of standings rows.
   //   - Pools/league: an object keyed by poolName → array of rows.
-  // We take the top four from the (single) leaderboard; for pools-only with
-  // multiple pools we use the first pool (consistent with PoolsViewer's
-  // leagueWinner pick).
+  // Single pool: use that pool's standings directly. Multiple pools: merge
+  // and re-rank via crossPoolRank using the canonical FIK tie-breaker chain.
   let list = null;
   if (Array.isArray(standings)) {
     list = standings;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1629,7 +1629,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
   if (!pools || pools.length === 0) {
     return <div className="empty"><div className="icon">⏳</div><h3>Pools not drawn yet</h3></div>;
   }
-  const isTeam = competition && (competition.kind === "team" || competition.teamSize > 0);
+  const isTeam = isTeamComp(competition);
   // FR-050 / FR-051: league competitions render Final standings instead of
   // pool standings, and surface a Winner badge once every match is complete.
   // Format check is value-based so older competitions without a Format
@@ -1869,7 +1869,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, crossPoolRank, addDojoToWatchlist };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, crossPoolRank, isTeamComp, addDojoToWatchlist };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -2087,17 +2087,23 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
   );
 }
 
+function isTeamComp(c) {
+  return !!(c && (c.kind === "team" || c.teamSize > 0));
+}
+
 // crossPoolRank merges all pools' standings into a single sorted list using
 // the canonical FIK tie-breaker chain. For individual: W→L→T→PW→PL.
 // For team: W→L→T→IV→IL→IT→PW→PL. Returns a new array (does not mutate).
 function crossPoolRank(standings, pools, isTeam) {
   const merged = pools.flatMap(pool => standings[pool.poolName] || []);
   merged.sort((a, b) => {
+    const base =
+      (b.wins || 0) - (a.wins || 0) ||
+      (a.losses || 0) - (b.losses || 0) ||
+      (b.draws || 0) - (a.draws || 0);
+    if (base !== 0) return base;
     if (isTeam) {
       return (
-        (b.wins || 0) - (a.wins || 0) ||
-        (a.losses || 0) - (b.losses || 0) ||
-        (b.draws || 0) - (a.draws || 0) ||
         (b.individualWins || 0) - (a.individualWins || 0) ||
         (a.individualLosses || 0) - (b.individualLosses || 0) ||
         (b.individualDraws || 0) - (a.individualDraws || 0) ||
@@ -2106,9 +2112,6 @@ function crossPoolRank(standings, pools, isTeam) {
       );
     }
     return (
-      (b.wins || 0) - (a.wins || 0) ||
-      (a.losses || 0) - (b.losses || 0) ||
-      (b.draws || 0) - (a.draws || 0) ||
       (b.ipponsGiven || 0) - (a.ipponsGiven || 0) ||
       (a.ipponsTaken || 0) - (b.ipponsTaken || 0)
     );
@@ -2237,7 +2240,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     return m;
   }, [players]);
 
-  const isTeam = (c?.kind === "team") || (c?.teamSize || 0) > 0;
+  const isTeam = isTeamComp(c);
   const effectiveStandings = c?.format === "swiss" ? swissStandings : standings;
   const isSwissLoading = c?.format === "swiss" && swissStandings === null;
   const awards = useMemo(
@@ -2327,10 +2330,13 @@ function AwardsView({ c, bracket, standings, pools, players }) {
 }
 
 function PoolWinnersTable({ pools, standings, poolWinners, isFs }) {
-  const rows = pools.map(pool => {
-    const top = (standings[pool.poolName] || []).slice(0, poolWinners);
-    return { poolName: pool.poolName, entries: top };
-  }).filter(r => r.entries.length > 0);
+  const rows = useMemo(() =>
+    pools.map(pool => {
+      const top = (standings[pool.poolName] || []).slice(0, poolWinners);
+      return { poolName: pool.poolName, entries: top };
+    }).filter(r => r.entries.length > 0),
+    [pools, standings, poolWinners]
+  );
 
   if (rows.length === 0) return null;
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1869,7 +1869,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, crossPoolRank, addDojoToWatchlist };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -2087,6 +2087,35 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
   );
 }
 
+// crossPoolRank merges all pools' standings into a single sorted list using
+// the canonical FIK tie-breaker chain. For individual: W→L→T→PW→PL.
+// For team: W→L→T→IV→IL→IT→PW→PL. Returns a new array (does not mutate).
+function crossPoolRank(standings, pools, isTeam) {
+  const merged = pools.flatMap(pool => standings[pool.poolName] || []);
+  merged.sort((a, b) => {
+    if (isTeam) {
+      return (
+        (b.wins || 0) - (a.wins || 0) ||
+        (a.losses || 0) - (b.losses || 0) ||
+        (b.draws || 0) - (a.draws || 0) ||
+        (b.individualWins || 0) - (a.individualWins || 0) ||
+        (a.individualLosses || 0) - (b.individualLosses || 0) ||
+        (b.individualDraws || 0) - (a.individualDraws || 0) ||
+        (b.pointsWon || 0) - (a.pointsWon || 0) ||
+        (a.pointsLost || 0) - (b.pointsLost || 0)
+      );
+    }
+    return (
+      (b.wins || 0) - (a.wins || 0) ||
+      (a.losses || 0) - (b.losses || 0) ||
+      (b.draws || 0) - (a.draws || 0) ||
+      (b.ipponsGiven || 0) - (a.ipponsGiven || 0) ||
+      (a.ipponsTaken || 0) - (b.ipponsTaken || 0)
+    );
+  });
+  return merged;
+}
+
 // deriveAwards returns up to four placements for the closing ceremony per
 // FIK convention: 1st, 2nd, and two 3rds (semi-final losers — no bronze match).
 // Returns [] when no podium data exists yet.
@@ -2097,7 +2126,8 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
 // normalizeMatch() in api_serializers.jsx — both shapes are handled.
 // `standings` may be either a flat array (Swiss-shape) or an object keyed by
 // pool name (pools/league shape).
-function deriveAwards(bracket, standings, pools, nameToPlayer) {
+// `isTeam` selects the team vs individual tie-breaker chain for cross-pool ranking.
+function deriveAwards(bracket, standings, pools, nameToPlayer, isTeam) {
   // Extract the name string from a match field that may be a string (raw
   // backend payload) or a normalized object ({id, name, dojo}) produced by
   // normalizeMatch() in api_serializers.jsx.
@@ -2154,7 +2184,9 @@ function deriveAwards(bracket, standings, pools, nameToPlayer) {
   if (Array.isArray(standings)) {
     list = standings;
   } else if (standings && pools && pools.length > 0) {
-    list = standings[pools[0].poolName] || [];
+    list = pools.length > 1
+      ? crossPoolRank(standings, pools, isTeam)
+      : (standings[pools[0].poolName] || []);
   }
   if (list && list.length > 0) {
     const slice = list.slice(0, 4).map((s, i) => ({
@@ -2205,11 +2237,12 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     return m;
   }, [players]);
 
+  const isTeam = (c?.kind === "team") || (c?.teamSize || 0) > 0;
   const effectiveStandings = c?.format === "swiss" ? swissStandings : standings;
   const isSwissLoading = c?.format === "swiss" && swissStandings === null;
   const awards = useMemo(
-    () => deriveAwards(bracket, effectiveStandings, pools, nameToPlayer),
-    [bracket, effectiveStandings, pools, nameToPlayer]
+    () => deriveAwards(bracket, effectiveStandings, pools, nameToPlayer, isTeam),
+    [bracket, effectiveStandings, pools, nameToPlayer, isTeam]
   );
 
   const toggleFs = () => {
@@ -2286,6 +2319,48 @@ function AwardsView({ c, bracket, standings, pools, players }) {
           );
         })}
       </div>
+      {c?.format === "pools" && pools?.length > 1 && effectiveStandings && (
+        <PoolWinnersTable pools={pools} standings={effectiveStandings} poolWinners={c.poolWinners || 1} isFs={isFs} />
+      )}
+    </div>
+  );
+}
+
+function PoolWinnersTable({ pools, standings, poolWinners, isFs }) {
+  const rows = pools.map(pool => {
+    const top = (standings[pool.poolName] || []).slice(0, poolWinners);
+    return { poolName: pool.poolName, entries: top };
+  }).filter(r => r.entries.length > 0);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div style={{ marginTop: 24 }} data-testid="pool-winners-table">
+      <div className="section-title" style={{ fontSize: isFs ? 20 : 14, marginBottom: 8 }}>
+        Pool Winners
+      </div>
+      <table className="pool__table">
+        <thead>
+          <tr>
+            <th>Pool</th>
+            <th>#</th>
+            <th>Player</th>
+            <th>Dojo</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.flatMap(r =>
+            r.entries.map((s, i) => (
+              <tr key={`${r.poolName}-${i}`} data-testid={`pool-winner-${r.poolName}-${i + 1}`}>
+                {i === 0 && <td rowSpan={r.entries.length} style={{ fontWeight: 600 }}>{r.poolName}</td>}
+                <td style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{i + 1}</td>
+                <td style={{ fontWeight: 500 }}>{s.player?.name || ""}</td>
+                <td style={{ fontSize: 12, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2322,51 +2322,6 @@ function AwardsView({ c, bracket, standings, pools, players }) {
           );
         })}
       </div>
-      {c?.format === "pools" && pools?.length > 1 && effectiveStandings && (
-        <PoolWinnersTable pools={pools} standings={effectiveStandings} poolWinners={c.poolWinners || 1} isFs={isFs} />
-      )}
-    </div>
-  );
-}
-
-function PoolWinnersTable({ pools, standings, poolWinners, isFs }) {
-  const rows = useMemo(() =>
-    pools.map(pool => {
-      const top = (standings[pool.poolName] || []).slice(0, poolWinners);
-      return { poolName: pool.poolName, entries: top };
-    }).filter(r => r.entries.length > 0),
-    [pools, standings, poolWinners]
-  );
-
-  if (rows.length === 0) return null;
-
-  return (
-    <div style={{ marginTop: 24 }} data-testid="pool-winners-table">
-      <div className="section-title" style={{ fontSize: isFs ? 20 : 14, marginBottom: 8 }}>
-        Pool Winners
-      </div>
-      <table className="pool__table">
-        <thead>
-          <tr>
-            <th>Pool</th>
-            <th>#</th>
-            <th>Player</th>
-            <th>Dojo</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.flatMap(r =>
-            r.entries.map((s, i) => (
-              <tr key={`${r.poolName}-${i}`} data-testid={`pool-winner-${r.poolName}-${i + 1}`}>
-                {i === 0 && <td rowSpan={r.entries.length} style={{ fontWeight: 600 }}>{r.poolName}</td>}
-                <td style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{i + 1}</td>
-                <td style={{ fontWeight: 500 }}>{s.player?.name || ""}</td>
-                <td style={{ fontSize: 12, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds `crossPoolRank()` helper that merges all pool standings and sorts by the canonical FIK tie-breaker chain (individual: W→L→T→PW→PL; team: W→L→T→IV→IL→IT→PW→PL)
- `deriveAwards` now calls `crossPoolRank` when multiple pools exist, producing a true cross-pool podium instead of showing only the first pool's standings
- Extracts `isTeamComp(c)` utility to deduplicate the competition kind check across `PoolsViewer` and `AwardsView`
- 10 new unit tests covering: individual/team comparator chain, tie-break scenarios, multi-pool `deriveAwards` integration for both individual and team formats

### When does this fire?

During the **pool phase** of Pools & Playoffs (`mixed`) competitions — before the bracket is created and has a decided winner, `deriveAwards` falls through to the standings-based path where `crossPoolRank` merges and ranks all pools. Once the bracket has a winner, the bracket path takes over.

## Test plan

- [x] `npm test` in `web-mobile/` — 815 tests pass (21 in `viewer_awards.test.jsx`)
- [x] `make go/build` succeeds (JS embedded, no build errors)
- [ ] Manual: start a Pools & Playoffs competition with 3+ pools, complete all pool matches, open the Awards/Results tab and confirm the cross-pool podium shows correct rank order before the bracket is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)