### PR TITLE
feat(mp-708): remove format="pools" — migrate to format="mixed" everywhere

### DIFF
--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -156,7 +156,7 @@ func (e *Engine) MaybeAutoCompletePools(compID string) (AutoCompleteOutcome, err
 
 	// No ties (or ties already resolved). Transition to complete.
 	changed, err := e.store.UpdateCompetitionChanged(compID, func(comp *state.Competition) (*state.Competition, error) {
-		if comp == nil || (comp.Format != state.CompFormatPools && comp.Format != state.CompFormatLeague) || comp.Status != state.CompStatusPools {
+		if comp == nil || (comp.Format != state.CompFormatMixed && comp.Format != state.CompFormatLeague) || comp.Status != state.CompStatusPools {
 			return nil, nil
 		}
 		// Re-check under the lock.
@@ -399,7 +399,7 @@ func (e *Engine) StartCompetition(id string) error {
 	// skips the redundant write (the HasParticipantIDs flip still runs).
 	earlyParticipantsSaved := false
 	switch comp.Format {
-	case state.CompFormatPools, state.CompFormatLeague:
+	case state.CompFormatMixed, state.CompFormatLeague:
 		if err := e.generatePools(comp, players, seeds); err != nil {
 			return err
 		}
@@ -480,7 +480,7 @@ func (e *Engine) StartCompetition(id string) error {
 	// save changed any of those between our outer Load (the basis
 	// for the pools/playoffs files we just generated) and this atomic
 	// commit, the generated artifacts no longer match the new config
-	// — e.g. a Format change from "pools" to "playoffs" would leave
+	// — e.g. a Format change from "mixed" to "playoffs" would leave
 	// pools.csv on disk while Status committed to "playoffs". Better
 	// to abort with a 409-style conflict than to commit inconsistent
 	// state. Note: TeamSize and PoolWinners are deliberately NOT in

--- a/internal/engine/competition_test.go
+++ b/internal/engine/competition_test.go
@@ -47,7 +47,7 @@ func TestMaybeAutoCompletePools_AllComplete(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Auto Complete Test",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -76,7 +76,7 @@ func TestMaybeAutoCompletePools_OnePending(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Pending Test",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -132,7 +132,7 @@ func TestMaybeAutoCompletePools_AlreadyComplete(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Already Done",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusComplete,
 		Courts: []string{"A"},
 	}))

--- a/internal/engine/eligibility_test.go
+++ b/internal/engine/eligibility_test.go
@@ -21,7 +21,7 @@ func TestStartMatchBlockedByIneligibleCompetitor(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "elig-blocked"
 
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	// Seed participants with explicit UUIDs — state.LoadParticipants
 	// only treats the first column as an ID when it parses as UUID v4.
@@ -70,7 +70,7 @@ func TestRecordDecision_KikenUndo(t *testing.T) {
 		t.Helper()
 		eng, store, _ := setupTestEngine(t)
 		compID := "undo-test"
-		createTestCompetition(t, store, compID, "pools", 3)
+		createTestCompetition(t, store, compID, "mixed", 3)
 
 		aliceID := helper.NewUUID4()
 		bobID := helper.NewUUID4()
@@ -181,7 +181,7 @@ func TestRecordDecision_KikenUndo(t *testing.T) {
 func TestRecordDecision_ConcurrentKiken(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "concurrent-kiken"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -234,7 +234,7 @@ func TestRecordDecision_ConcurrentKiken(t *testing.T) {
 func TestRecordDecision_ConcurrentKikenRace(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "race-kiken"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -299,7 +299,7 @@ func TestRecordDecision_ConcurrentKikenRace(t *testing.T) {
 func TestRecordDecision_FusenshoSkipsConcurrentCheck(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "fusensho-bypass"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -329,7 +329,7 @@ func TestRecordDecision_FusenshoSkipsConcurrentCheck(t *testing.T) {
 func TestCheckEligibility_AllEligible(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "elig-all"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	err := eng.CheckEligibility(compID, []string{"pid1", "pid2", ""})
 	assert.NoError(t, err)
@@ -341,7 +341,7 @@ func TestCheckEligibility_AllEligible(t *testing.T) {
 func TestCheckEligibility_OneIneligible(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "elig-one"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	require.NoError(t, store.SetCompetitorStatus(compID, domain.CompetitorStatus{
 		PlayerID: "ineligible-pid",
@@ -364,7 +364,7 @@ func TestCheckEligibility_OneIneligible(t *testing.T) {
 func TestCheckEligibility_EmptyIDsSkipped(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "elig-empty"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	err := eng.CheckEligibility(compID, []string{"", ""})
 	assert.NoError(t, err)
@@ -703,7 +703,7 @@ func TestRecordDecision_KikenReinstateable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			eng, store, _ := setupTestEngine(t)
 			compID := "reinstateable-test-" + tc.decision
-			createTestCompetition(t, store, compID, "pools", 2)
+			createTestCompetition(t, store, compID, "mixed", 2)
 
 			aliceID := helper.NewUUID4()
 			require.NoError(t, store.SaveParticipants(compID, []domain.Player{
@@ -731,7 +731,7 @@ func TestRecordDecision_KikenReinstateable(t *testing.T) {
 func TestReinstateCompetitor(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "reinstate-test"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	playerID := helper.NewUUID4()
 	require.NoError(t, store.SaveParticipants(compID, []domain.Player{

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -53,7 +53,7 @@ func saveTestParticipants(t *testing.T, store *state.Store, compID string, names
 
 // --- Pool Generation Tests ---
 
-func TestStartCompetition_PoolsFormat_BasicGeneration(t *testing.T) {
+func TestStartCompetition_MixedFormat_BasicGeneration(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "mens-individual"
 
@@ -101,7 +101,7 @@ func TestStartCompetition_PoolsFormat_BasicGeneration(t *testing.T) {
 	}
 }
 
-func TestStartCompetition_PoolsFormat_WithSeeds(t *testing.T) {
+func TestStartCompetition_MixedFormat_WithSeeds(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "seeded-pools"
 
@@ -152,7 +152,7 @@ func TestStartCompetition_PoolsFormat_WithSeeds(t *testing.T) {
 	assert.Equal(t, 3, totalSeeds, "all seeds should be placed in pools")
 }
 
-func TestStartCompetition_PoolsFormat_DojoConflictAvoidance(t *testing.T) {
+func TestStartCompetition_MixedFormat_DojoConflictAvoidance(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "dojo-conflict"
 
@@ -191,7 +191,7 @@ func TestStartCompetition_PoolsFormat_DojoConflictAvoidance(t *testing.T) {
 	}
 }
 
-func TestStartCompetition_PoolsFormat_MaxMode(t *testing.T) {
+func TestStartCompetition_MixedFormat_MaxMode(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "max-mode"
 
@@ -229,7 +229,7 @@ func TestStartCompetition_PoolsFormat_MaxMode(t *testing.T) {
 	assert.Equal(t, 7, totalPlayers)
 }
 
-func TestStartCompetition_PoolsFormat_NonRoundRobin(t *testing.T) {
+func TestStartCompetition_MixedFormat_NonRoundRobin(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "non-rr"
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -57,7 +57,7 @@ func TestStartCompetition_PoolsFormat_BasicGeneration(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "mens-individual"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank",
 	})
@@ -105,7 +105,7 @@ func TestStartCompetition_PoolsFormat_WithSeeds(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "seeded-pools"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank",
 		"Grace", "Hank", "Ivy",
@@ -156,7 +156,7 @@ func TestStartCompetition_PoolsFormat_DojoConflictAvoidance(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "dojo-conflict"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 
 	// Create players with same-dojo groups
 	players := []domain.Player{
@@ -199,7 +199,7 @@ func TestStartCompetition_PoolsFormat_MaxMode(t *testing.T) {
 		ID:           compID,
 		Name:         "Max Mode Test",
 		Kind:         "individual",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     4,
 		PoolSizeMode: "max",
 		PoolWinners:  2,
@@ -237,7 +237,7 @@ func TestStartCompetition_PoolsFormat_NonRoundRobin(t *testing.T) {
 		ID:           compID,
 		Name:         "Non RR Test",
 		Kind:         "individual",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     4,
 		PoolSizeMode: "min",
 		PoolWinners:  2,
@@ -528,7 +528,7 @@ func TestStartCompetition_NoParticipants(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "empty"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	// Don't save any participants file
 
 	err := eng.StartCompetition(compID)
@@ -540,7 +540,7 @@ func TestStartCompetition_InvalidSeedName(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "bad-seed"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
 
 	seeds := []domain.SeedAssignment{
@@ -721,7 +721,7 @@ func TestRecordPoolMatchResult(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "pool-score"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie",
 	})
@@ -764,7 +764,7 @@ func TestRecordPoolMatchResult_NotFound(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "pool-not-found"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -783,7 +783,7 @@ func TestCalculatePoolStandings_Basic(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "standings"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie",
 	})
@@ -830,7 +830,7 @@ func TestCalculatePoolStandings_AllDraws(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "all-draws"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie",
 	})
@@ -863,7 +863,7 @@ func TestCalculatePoolStandings_IpponDifferentialTiebreak(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tiebreak"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie",
 	})
@@ -917,7 +917,7 @@ func TestCalculatePoolStandings_IncompleteMatches(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "incomplete"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie",
 	})
@@ -940,7 +940,7 @@ func TestCalculatePoolStandings_WeightedScore(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "weighted-score"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie",
 	})
@@ -1016,7 +1016,7 @@ func TestCalculatePoolStandings_TeamScoring(t *testing.T) {
 		ID:           compID,
 		Name:         "Team Competition",
 		Kind:         "team",
-		Format:       "pools",
+		Format:       "mixed",
 		TeamSize:     3,
 		PoolSize:     3,
 		PoolSizeMode: "min",
@@ -1117,7 +1117,7 @@ func TestGenerateSchedule_Pools(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "schedule-pools"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"A", "B", "C", "D", "E", "F"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1244,7 +1244,7 @@ func TestPoolMatchIDs_AreUnique(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "unique-pool-ids"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{
 		"A", "B", "C", "D", "E", "F",
 	})
@@ -1266,7 +1266,7 @@ func TestExportCompetitionXlsx(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "export-test"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1290,7 +1290,7 @@ func TestUpdateMatchCourt_Pool(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "court-pool"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1365,7 +1365,7 @@ func TestUpdateMatchCourt_Bracket(t *testing.T) {
 func TestUpdateMatchCourt_NotFound(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "court-not-found"
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"A", "B", "C"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1468,7 +1468,7 @@ func TestCalculatePoolStandings_WithManualOverrides(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "standings-override"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1557,7 +1557,7 @@ func TestCalculatePoolStandings_EdgeCases(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "standings-edges"
 
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob"}) // Pool of 2
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1608,7 +1608,7 @@ func TestStartCompetition_NumberPrefix_Pools(t *testing.T) {
 	compID := "prefix-pools"
 
 	comp := &state.Competition{
-		ID: compID, Name: "Prefix Test", Kind: "individual", Format: "pools",
+		ID: compID, Name: "Prefix Test", Kind: "individual", Format: "mixed",
 		PoolSize: 3, PoolSizeMode: "min", PoolWinners: 2, RoundRobin: true,
 		Courts: []string{"A"}, StartTime: "09:00", Status: "setup",
 		NumberPrefix: "K",
@@ -1662,7 +1662,7 @@ func TestUpdateMatchTime_Pool(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "time-pool"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1711,7 +1711,7 @@ func TestUpdateMatchTime_Bracket(t *testing.T) {
 func TestUpdateMatchTime_NotFound(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "time-not-found"
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	saveTestParticipants(t, store, compID, []string{"A", "B", "C"})
 	require.NoError(t, eng.StartCompetition(compID))
 
@@ -1727,7 +1727,7 @@ func TestStartCompetition_TeamSizeFallback(t *testing.T) {
 		ID:       compID,
 		Name:     "Team Competition",
 		Kind:     "team",
-		Format:   "pools",
+		Format:   "mixed",
 		PoolSize: 3,
 		Status:   "setup",
 		Courts:   []string{"A"},
@@ -1749,7 +1749,7 @@ func TestRecordMatchResult_PreservesSides(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "preservation-test"
 
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	// Create pool matches
 	matchID := "Pool A-0"
 	matches := []state.MatchResult{
@@ -1796,7 +1796,7 @@ func TestStartCompetition_PoolCourtDistribution(t *testing.T) {
 	compID := "court-dist-pools"
 
 	// createTestCompetition uses Courts: []string{"A", "B"}
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 	// 6 players → 2 pools. AssignPoolsToCourts(2, 2) → [0, 1]
 	saveTestParticipants(t, store, compID, []string{
 		"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank",
@@ -1873,7 +1873,7 @@ func TestStartCompetition_SingleCourtFallback(t *testing.T) {
 		ID:           compID,
 		Name:         "Single Court",
 		Kind:         "individual",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     3,
 		PoolSizeMode: "min",
 		PoolWinners:  2,
@@ -1919,7 +1919,7 @@ func TestStartCompetition_AutoDefaultsTeamSize(t *testing.T) {
 		ID:           compID,
 		Name:         "Team Test",
 		Kind:         "team",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     2,
 		PoolSizeMode: "min",
 		PoolWinners:  1,
@@ -1962,7 +1962,7 @@ func TestStartCompetition_PreservesExplicitTeamSize(t *testing.T) {
 		ID:           compID,
 		Name:         "Team Preserve Test",
 		Kind:         "team",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     2,
 		PoolSizeMode: "min",
 		PoolWinners:  1,
@@ -2000,7 +2000,7 @@ func TestStartCompetition_PreservesNumberPrefix(t *testing.T) {
 		ID:           compID,
 		Name:         "Prefix Test",
 		Kind:         "individual",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     3,
 		PoolSizeMode: "min",
 		PoolWinners:  2,

--- a/internal/engine/kachinuki_export_test.go
+++ b/internal/engine/kachinuki_export_test.go
@@ -180,7 +180,7 @@ func TestCollectKachinukiMatches_PoolMatchesWithBouts(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:            compID,
 		Name:          "Kachinuki Collect",
-		Format:        state.CompFormatPools,
+		Format:        state.CompFormatMixed,
 		TeamMatchType: state.TeamMatchTypeKachinuki,
 		TeamSize:      5,
 		Status:        state.CompStatusPools,

--- a/internal/engine/kachinuki_test.go
+++ b/internal/engine/kachinuki_test.go
@@ -414,7 +414,7 @@ func TestMaybeAdvanceKachinuki_NoOutcome(t *testing.T) {
 		ID:            compID,
 		TeamMatchType: state.TeamMatchTypeKachinuki,
 		TeamSize:      5,
-		Format:        state.CompFormatPools,
+		Format:        state.CompFormatMixed,
 	}))
 	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
 		{
@@ -449,7 +449,7 @@ func TestMaybeAdvanceKachinuki_HikiwakeBothExhausted(t *testing.T) {
 		ID:            compID,
 		TeamMatchType: state.TeamMatchTypeKachinuki,
 		TeamSize:      5,
-		Format:        state.CompFormatPools,
+		Format:        state.CompFormatMixed,
 	}))
 	// Single hikiwake bout — both players are retired; remaining rosters empty.
 	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
@@ -484,7 +484,7 @@ func TestMaybeAdvanceKachinuki_MatchEndedPoolUpdate(t *testing.T) {
 		ID:            compID,
 		TeamMatchType: state.TeamMatchTypeKachinuki,
 		TeamSize:      5,
-		Format:        state.CompFormatPools,
+		Format:        state.CompFormatMixed,
 	}))
 	// After B-Senpo beats A-Senpo, A's remaining roster is empty → match ends.
 	// With kachinukiRemainingRoster: knownA={A-Senpo}, retiredA={A-Senpo},

--- a/internal/engine/pool_daihyosen_test.go
+++ b/internal/engine/pool_daihyosen_test.go
@@ -126,7 +126,7 @@ func setupTeamPoolComp(t *testing.T, compID string, tieAll bool) (*Engine, *stat
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:       compID,
 		Name:     "Team Pool Test",
-		Format:   state.CompFormatPools,
+		Format:   state.CompFormatMixed,
 		Status:   state.CompStatusPools,
 		Courts:   []string{"A"},
 		TeamSize: 2, // 2-person teams keeps the SubResults simple
@@ -562,7 +562,7 @@ func TestInjectPoolDaihyosenMatches_PreservesExistingScheduledAt(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:        compID,
 		Name:      "DH Preserves Time",
-		Format:    state.CompFormatPools,
+		Format:    state.CompFormatMixed,
 		Status:    state.CompStatusPools,
 		Courts:    []string{"A"},
 		TeamSize:  2,

--- a/internal/engine/ranking.go
+++ b/internal/engine/ranking.go
@@ -151,7 +151,7 @@ func (e *Engine) resolveReservedSlots(compID string, players []domain.Player) ([
 		}
 
 		var real *domain.Player
-		if srcComp.Format == state.CompFormatPools || srcComp.Format == state.CompFormatLeague {
+		if srcComp.Format == state.CompFormatMixed || srcComp.Format == state.CompFormatLeague {
 			if srcComp.Status != state.CompStatusComplete && srcComp.Status != state.CompStatusPlayoffs {
 				return nil, false, validationErrorf("reserved slot source %q pool results are not final yet (status: %s)", srcComp.Name, srcComp.Status)
 			}

--- a/internal/engine/ranking_test.go
+++ b/internal/engine/ranking_test.go
@@ -262,7 +262,7 @@ func TestGetPoolRanking_Basic(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Pool Ranking",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusComplete,
 	}))
 
@@ -313,7 +313,7 @@ func TestGetPoolRanking_NotFound(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Empty",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 	}))
 
 	_, err := eng.GetPoolRanking(compID, 1)
@@ -329,7 +329,7 @@ func TestGetPoolRanking_OutOfRange(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "OOB",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusComplete,
 	}))
 
@@ -432,7 +432,7 @@ func TestCalculatePoolStandings_TeamSubDraw(t *testing.T) {
 		ID:       compID,
 		Name:     "Team Sub Draw",
 		Kind:     "team",
-		Format:   state.CompFormatPools,
+		Format:   state.CompFormatMixed,
 		Status:   state.CompStatusPools,
 		TeamSize: 3,
 	}))

--- a/internal/engine/schedule.go
+++ b/internal/engine/schedule.go
@@ -125,7 +125,7 @@ func (e *Engine) GenerateSchedule(compID string) error {
 
 	var entries []state.ScheduleEntry
 
-	if comp.Format == state.CompFormatPools || comp.Format == state.CompFormatLeague || comp.Format == state.CompFormatSwiss {
+	if comp.Format == state.CompFormatMixed || comp.Format == state.CompFormatLeague || comp.Format == state.CompFormatSwiss {
 		matches, err := e.store.LoadPoolMatches(compID)
 		if err != nil {
 			return err

--- a/internal/engine/schedule_test.go
+++ b/internal/engine/schedule_test.go
@@ -123,7 +123,7 @@ func TestEstimateScheduleCourtsClampedToOne(t *testing.T) {
 }
 
 // TestGenerateSchedule_MixedFormat verifies that GenerateSchedule produces
-// "pool" type entries for a mixed (pools + knockout) competition.
+// "pool" type entries for a mixed (Pools + Knockout) competition.
 func TestGenerateSchedule_MixedFormat(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "gen-sched-pools"

--- a/internal/engine/schedule_test.go
+++ b/internal/engine/schedule_test.go
@@ -123,7 +123,7 @@ func TestEstimateScheduleCourtsClampedToOne(t *testing.T) {
 }
 
 // TestGenerateSchedule_MixedFormat verifies that GenerateSchedule produces
-// "pool" type entries for a pools competition.
+// "pool" type entries for a mixed (pools + knockout) competition.
 func TestGenerateSchedule_MixedFormat(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "gen-sched-pools"

--- a/internal/engine/schedule_test.go
+++ b/internal/engine/schedule_test.go
@@ -122,9 +122,9 @@ func TestEstimateScheduleCourtsClampedToOne(t *testing.T) {
 	assert.Greater(t, result.TotalDurationMinutes, 0)
 }
 
-// TestGenerateSchedule_PoolsFormat verifies that GenerateSchedule produces
+// TestGenerateSchedule_MixedFormat verifies that GenerateSchedule produces
 // "pool" type entries for a pools competition.
-func TestGenerateSchedule_PoolsFormat(t *testing.T) {
+func TestGenerateSchedule_MixedFormat(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "gen-sched-pools"
 

--- a/internal/engine/schedule_test.go
+++ b/internal/engine/schedule_test.go
@@ -130,7 +130,7 @@ func TestGenerateSchedule_PoolsFormat(t *testing.T) {
 
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 	}))
 	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
 		{ID: "P1-0", Court: "A", Status: state.MatchStatusScheduled},

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -226,7 +226,7 @@ func TestMaybeAutoCompletePools(t *testing.T) {
 
 	compID := "auto-complete"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: compID, Name: "Auto", Format: state.CompFormatPools, Status: state.CompStatusPools,
+		ID: compID, Name: "Auto", Format: state.CompFormatMixed, Status: state.CompStatusPools,
 	}))
 
 	t.Run("no transition while a pool match is still scheduled", func(t *testing.T) {
@@ -279,7 +279,7 @@ func TestMaybeAutoCompletePools(t *testing.T) {
 		// Without this branch the competition would be stuck in `pools` forever.
 		emptyID := "auto-complete-empty"
 		require.NoError(t, store.SaveCompetition(&state.Competition{
-			ID: emptyID, Name: "Empty", Format: state.CompFormatPools, Status: state.CompStatusPools,
+			ID: emptyID, Name: "Empty", Format: state.CompFormatMixed, Status: state.CompStatusPools,
 		}))
 		require.NoError(t, store.SavePoolMatches(emptyID, []state.MatchResult{}))
 		outcome, err := eng.MaybeAutoCompletePools(emptyID)
@@ -558,7 +558,7 @@ func TestMaybeAutoCompletePools_ConcurrentInvalidateNotLost(t *testing.T) {
 		compID := "auto-vs-invalidate"
 		require.NoError(t, store.SaveCompetition(&state.Competition{
 			ID: compID, Name: "Auto vs Invalidate",
-			Format: state.CompFormatPools, Status: state.CompStatusPools,
+			Format: state.CompFormatMixed, Status: state.CompStatusPools,
 		}))
 		// All matches already completed — auto-complete is eligible.
 		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
@@ -661,7 +661,7 @@ func TestMaybeLockTeamLineupsForRound_TeamComp(t *testing.T) {
 		ID:       compID,
 		Name:     "Team Lock",
 		Kind:     "team",
-		Format:   state.CompFormatPools,
+		Format:   state.CompFormatMixed,
 		TeamSize: 3,
 		Status:   state.CompStatusPools,
 		Courts:   []string{"A"},

--- a/internal/engine/scoring_tx_test.go
+++ b/internal/engine/scoring_tx_test.go
@@ -19,7 +19,7 @@ import (
 func TestRecordDecisionTx_BasicEquivalence(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-basic"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -71,7 +71,7 @@ func TestRecordDecisionTx_BasicEquivalence(t *testing.T) {
 func TestRecordDecisionTx_ConcurrentDoesNotDeadlock(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-deadlock"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -167,7 +167,7 @@ func TestRecordDecisionTx_ConcurrentDoesNotDeadlock(t *testing.T) {
 func TestRecordDecisionTx_KikenUndoSucceeds(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-undo"
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -215,7 +215,7 @@ func TestRecordDecisionTx_KikenUndoSucceeds(t *testing.T) {
 func TestRecordDecisionTx_DownstreamLockReturnsErr(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-lock"
-	createTestCompetition(t, store, compID, "pools", 3)
+	createTestCompetition(t, store, compID, "mixed", 3)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -250,7 +250,7 @@ func TestRecordDecisionTx_DownstreamLockReturnsErr(t *testing.T) {
 func TestRecordMatchResultWithIneligibilityTx_Basic(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-score"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -294,7 +294,7 @@ func TestRecordMatchResultWithIneligibilityTx_Basic(t *testing.T) {
 func TestStartMatchTx_BlocksIneligibleParticipant(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "fr035-block"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	aliceID := helper.NewUUID4()
 	bobID := helper.NewUUID4()
@@ -341,7 +341,7 @@ func TestStartMatchTx_BlocksIneligibleParticipant(t *testing.T) {
 func TestStoreTxUpdatePoolMatchByIDLockFree(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-pool-update"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
 		{ID: "Pool A-0", SideA: "X", SideB: "Y", Status: state.MatchStatusScheduled},
 	}))
@@ -377,7 +377,7 @@ func TestStoreTxUpdatePoolMatchByIDLockFree(t *testing.T) {
 func TestRecordMatchResultWithIneligibilityTx_HansokuAutoAward(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "tx-hansoku"
-	createTestCompetition(t, store, compID, "pools", 2)
+	createTestCompetition(t, store, compID, "mixed", 2)
 
 	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
 		{ID: "Pool A-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled},

--- a/internal/engine/swiss_test.go
+++ b/internal/engine/swiss_test.go
@@ -571,7 +571,7 @@ func TestAdvanceSwissRound(t *testing.T) {
 	t.Run("non-swiss format returns validation error", func(t *testing.T) {
 		eng, store, _ := setupTestEngine(t)
 		require.NoError(t, store.SaveCompetition(&state.Competition{
-			ID: "pools-comp", Format: state.CompFormatPools, Status: state.CompStatusPools,
+			ID: "pools-comp", Format: state.CompFormatMixed, Status: state.CompStatusPools,
 		}))
 		_, _, err := eng.AdvanceSwissRound("pools-comp")
 		assert.Error(t, err)
@@ -791,7 +791,7 @@ func TestMaybeLockTeamLineupsForRoundViaRecordResult(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	compID := "mlttr-nonteam-team"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: compID, TeamSize: 5, Format: "pools",
+		ID: compID, TeamSize: 5, Format: "mixed",
 	}))
 	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
 		{ID: "Pool A-0", SideA: "RedTeam", SideB: "WhiteTeam", Status: state.MatchStatusScheduled},

--- a/internal/engine/tiebreaker_test.go
+++ b/internal/engine/tiebreaker_test.go
@@ -139,7 +139,7 @@ func TestInjectTiebreakerMatches_NoTie(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "No Tie",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -167,7 +167,7 @@ func TestInjectTiebreakerMatches_TwoWayTie(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Two-way Tie",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -202,7 +202,7 @@ func TestInjectTiebreakerMatches_Idempotent(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Idempotent Test",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -243,7 +243,7 @@ func TestMaybeAutoCompletePools_TiesDetected(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Tie Detect",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -286,7 +286,7 @@ func TestMaybeAutoCompletePools_TiebreakersIncomplete(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "TB Pending",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -313,7 +313,7 @@ func TestMaybeAutoCompletePools_TiebreakersComplete(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "TB Done",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -344,7 +344,7 @@ func TestComputeStandings_TBExcludedFromStats(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "TB Excluded",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -384,7 +384,7 @@ func TestInjectTiebreakerMatches_PreservesExistingScheduledAt(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:        compID,
 		Name:      "Preserves Time",
-		Format:    state.CompFormatPools,
+		Format:    state.CompFormatMixed,
 		Status:    state.CompStatusPools,
 		Courts:    []string{"A"},
 		StartTime: "09:00",
@@ -434,7 +434,7 @@ func TestMaybeAutoCompletePools_NoTies(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "No Ties",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -479,7 +479,7 @@ func TestComputeStandings_MultiGroupTBSortIsolation(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "Multi-Group Isolation",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))
@@ -535,7 +535,7 @@ func TestComputeStandings_TBSecondarySort(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
 		Name:   "TB Secondary Sort",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 		Courts: []string{"A"},
 	}))

--- a/internal/mobileapp/concurrency_test.go
+++ b/internal/mobileapp/concurrency_test.go
@@ -55,7 +55,7 @@ func TestConcurrentScoresPreserveOrder(t *testing.T) {
 	compID := "concurrent-order"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}))
 	const N = 10

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -110,7 +110,7 @@ func validateCompetitionDurations(comp *state.Competition) error {
 
 func validateCompetitionFormat(format, poolFormat string) (int, error) {
 	switch format {
-	case "", state.CompFormatPools, state.CompFormatPlayoffs,
+	case "", state.CompFormatPlayoffs,
 		state.CompFormatMixed, state.CompFormatLeague, state.CompFormatSwiss:
 		// ok
 	default:
@@ -123,6 +123,13 @@ func validateCompetitionFormat(format, poolFormat string) (int, error) {
 		return http.StatusBadRequest, fmt.Errorf("unknown poolFormat %q", poolFormat)
 	}
 	return 0, nil
+}
+
+func migratePoolsFormat(format string) string {
+	if format == "pools" {
+		return state.CompFormatMixed
+	}
+	return format
 }
 
 // validateSwissConfig enforces FR-050a: when Format == swiss, SwissRounds
@@ -1126,7 +1133,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 
-		if src.Format != state.CompFormatPools {
+		if src.Format != state.CompFormatMixed {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "source competition must use pools format"})
 			return
 		}

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -125,12 +125,6 @@ func validateCompetitionFormat(format, poolFormat string) (int, error) {
 	return 0, nil
 }
 
-func migratePoolsFormat(format string) string {
-	if format == "pools" {
-		return state.CompFormatMixed
-	}
-	return format
-}
 
 // validateSwissConfig enforces FR-050a: when Format == swiss, SwissRounds
 // must be at least 1. Returns nil for non-swiss competitions. The caller

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -1128,7 +1128,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		}
 
 		if src.Format != state.CompFormatMixed {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "source competition must use pools format"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "source competition must use mixed (Pools + Knockout) format"})
 			return
 		}
 

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -125,7 +125,6 @@ func validateCompetitionFormat(format, poolFormat string) (int, error) {
 	return 0, nil
 }
 
-
 // validateSwissConfig enforces FR-050a: when Format == swiss, SwissRounds
 // must be at least 1. Returns nil for non-swiss competitions. The caller
 // surfaces the error as HTTP 400.

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -366,7 +366,7 @@ func TestCompetitionHandlers_Extended(t *testing.T) {
 	t.Run("All String Fields Trimmed On Create", func(t *testing.T) {
 		comp := state.Competition{
 			ID: "trim-fields-create", Name: "Trim Fields Create",
-			Kind: "  individual  ", Format: "  pools  ",
+			Kind: "  individual  ", Format: "  mixed  ",
 			PoolSizeMode: "  min  ", StartTime: "  09:00  ", Date: "  12-05-2026  ",
 		}
 		body, _ := json.Marshal(comp)
@@ -379,14 +379,14 @@ func TestCompetitionHandlers_Extended(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, stored)
 		assert.Equal(t, "individual", stored.Kind, "Kind should be trimmed on POST")
-		assert.Equal(t, "pools", stored.Format, "Format should be trimmed on POST")
+		assert.Equal(t, "mixed", stored.Format, "Format should be trimmed on POST")
 		assert.Equal(t, "min", stored.PoolSizeMode, "PoolSizeMode should be trimmed on POST")
 		assert.Equal(t, "09:00", stored.StartTime, "StartTime should be trimmed on POST")
 		assert.Equal(t, "12-05-2026", stored.Date, "Date should be trimmed on POST")
 	})
 
 	t.Run("All String Fields Trimmed On Update", func(t *testing.T) {
-		seed := state.Competition{ID: "trim-fields-update", Name: "Trim Fields Update", Kind: "individual", Format: "pools"}
+		seed := state.Competition{ID: "trim-fields-update", Name: "Trim Fields Update", Kind: "individual", Format: "mixed"}
 		require.NoError(t, store.SaveCompetition(&seed))
 
 		update := state.Competition{
@@ -1028,7 +1028,7 @@ func TestPlayoff_ResponseIncludesPlayers(t *testing.T) {
 	src := state.Competition{
 		ID:          "src",
 		Name:        "Source",
-		Format:      state.CompFormatPools,
+		Format:      state.CompFormatMixed,
 		Status:      state.CompStatusPools,
 		PoolSize:    3,
 		PoolWinners: 2,

--- a/internal/mobileapp/handlers_import.go
+++ b/internal/mobileapp/handlers_import.go
@@ -21,7 +21,7 @@ type ImportManifestComp struct {
 	ID             string   `yaml:"id"`
 	Name           string   `yaml:"name"`
 	Kind           string   `yaml:"kind"`   // "individual" or "team"
-	Format         string   `yaml:"format"` // "pools" or "playoffs" or "swiss"
+	Format         string   `yaml:"format"` // "mixed" or "playoffs" or "swiss"
 	Courts         []string `yaml:"courts"`
 	PoolSize       int      `yaml:"pool_size"`
 	PoolSizeMode   string   `yaml:"pool_size_mode"` // "max" or "min"
@@ -148,7 +148,7 @@ func importCompetition(store *state.Store, entry ImportManifestComp, files map[s
 		ID:             entry.ID,
 		Name:           trimmedName,
 		Kind:           strings.TrimSpace(entry.Kind),
-		Format:         strings.TrimSpace(entry.Format),
+		Format:         migratePoolsFormat(strings.TrimSpace(entry.Format)),
 		Courts:         entry.Courts,
 		PoolSize:       entry.PoolSize,
 		PoolSizeMode:   strings.TrimSpace(entry.PoolSizeMode),

--- a/internal/mobileapp/handlers_import.go
+++ b/internal/mobileapp/handlers_import.go
@@ -21,7 +21,7 @@ type ImportManifestComp struct {
 	ID             string   `yaml:"id"`
 	Name           string   `yaml:"name"`
 	Kind           string   `yaml:"kind"`   // "individual" or "team"
-	Format         string   `yaml:"format"` // "mixed", "playoffs", "league", or "swiss"
+	Format         string   `yaml:"format"` // "mixed", "playoffs", "league", or "swiss"; omit/empty for default (playoffs)
 	Courts         []string `yaml:"courts"`
 	PoolSize       int      `yaml:"pool_size"`
 	PoolSizeMode   string   `yaml:"pool_size_mode"` // "max" or "min"

--- a/internal/mobileapp/handlers_import.go
+++ b/internal/mobileapp/handlers_import.go
@@ -21,7 +21,7 @@ type ImportManifestComp struct {
 	ID             string   `yaml:"id"`
 	Name           string   `yaml:"name"`
 	Kind           string   `yaml:"kind"`   // "individual" or "team"
-	Format         string   `yaml:"format"` // "mixed" or "playoffs" or "swiss"
+	Format         string   `yaml:"format"` // "mixed", "playoffs", "league", or "swiss"
 	Courts         []string `yaml:"courts"`
 	PoolSize       int      `yaml:"pool_size"`
 	PoolSizeMode   string   `yaml:"pool_size_mode"` // "max" or "min"

--- a/internal/mobileapp/handlers_import.go
+++ b/internal/mobileapp/handlers_import.go
@@ -148,7 +148,7 @@ func importCompetition(store *state.Store, entry ImportManifestComp, files map[s
 		ID:             entry.ID,
 		Name:           trimmedName,
 		Kind:           strings.TrimSpace(entry.Kind),
-		Format:         migratePoolsFormat(strings.TrimSpace(entry.Format)),
+		Format:         strings.TrimSpace(entry.Format),
 		Courts:         entry.Courts,
 		PoolSize:       entry.PoolSize,
 		PoolSizeMode:   strings.TrimSpace(entry.PoolSizeMode),

--- a/internal/mobileapp/handlers_import_test.go
+++ b/internal/mobileapp/handlers_import_test.go
@@ -401,7 +401,7 @@ competitions:
   - id: "comp-trim"
     name: "  Padded Cup  "
     kind: "  individual  "
-    format: "  pools  "
+    format: "  mixed  "
     pool_size_mode: "  min  "
     number_prefix: "  A  "
     start_time: "  09:00  "

--- a/internal/mobileapp/handlers_import_test.go
+++ b/internal/mobileapp/handlers_import_test.go
@@ -31,7 +31,7 @@ competitions:
   - id: "comp-1"
     name: "Competition 1"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["A", "B"]
     participants: "players.csv"
     seeds: "seeds.csv"
@@ -424,7 +424,7 @@ competitions:
 		require.NotNil(t, stored)
 		assert.Equal(t, "Padded Cup", stored.Name, "Name should be trimmed")
 		assert.Equal(t, "individual", stored.Kind, "Kind should be trimmed")
-		assert.Equal(t, "pools", stored.Format, "Format should be trimmed")
+		assert.Equal(t, "mixed", stored.Format, "Format should be trimmed")
 		assert.Equal(t, "min", stored.PoolSizeMode, "PoolSizeMode should be trimmed")
 		assert.Equal(t, "A", stored.NumberPrefix, "NumberPrefix should be trimmed")
 		assert.Equal(t, "09:00", stored.StartTime, "StartTime should be trimmed")
@@ -460,7 +460,7 @@ competitions:
   - id: "blank-name-import"
     name: "   "
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["A"]
 `))
 		writer.Close()
@@ -505,7 +505,7 @@ competitions:
   - id: "duplicate-cup"
     name: "Cup Name"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["A"]
 `))
 		writer.Close()
@@ -554,7 +554,7 @@ competitions:
   - id: "id-collide"
     name: "Different Name"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["A"]
 `))
 		writer.Close()
@@ -592,7 +592,7 @@ competitions:
   - id: "iso-date-import"
     name: "ISO Date Import"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     date: "2026-05-12"
     courts: ["A"]
 `))
@@ -633,7 +633,7 @@ competitions:
   - id: "bad-court-label"
     name: "Bad Court Label"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["AA"]
 `))
 		writer.Close()
@@ -662,7 +662,7 @@ competitions:
   - id: "too-many-courts"
     name: "Too Many Courts"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z","AA"]
 `))
 		writer2.Close()
@@ -694,7 +694,7 @@ competitions:
   - id: "dup-courts-import"
     name: "Dup Courts Import"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     courts: ["A", "A"]
 `))
 		writerDup.Close()
@@ -793,7 +793,7 @@ competitions:
   - id: "year-out-of-range-import"
     name: "Year Out Of Range Import"
     kind: "individual"
-    format: "pools"
+    format: "mixed"
     date: "01-01-1800"
     courts: ["A"]
 `))

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -303,7 +303,7 @@ func TestScoreHandler_CompletionBroadcastContract(t *testing.T) {
 
 	comp := state.Competition{
 		ID:     "pools1",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}
 	require.NoError(t, store.SaveCompetition(&comp))
@@ -390,7 +390,7 @@ func TestBulkScoreHandler_CompletionBroadcastContract(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: "bulk1", Format: state.CompFormatPools, Status: state.CompStatusPools,
+		ID: "bulk1", Format: state.CompFormatMixed, Status: state.CompStatusPools,
 	}))
 	require.NoError(t, store.SaveParticipants("bulk1", []domain.Player{
 		{Name: "P1"}, {Name: "P2"}, {Name: "P3"},
@@ -439,7 +439,7 @@ func TestQuickScoreHandler_CompletionBroadcastContract(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: "qs1", Format: state.CompFormatPools, Status: state.CompStatusPools, TeamSize: 3,
+		ID: "qs1", Format: state.CompFormatMixed, Status: state.CompStatusPools, TeamSize: 3,
 	}))
 	require.NoError(t, store.SavePools("qs1", []helper.Pool{
 		{PoolName: "PoolA", Players: []helper.Player{{Name: "TeamA"}, {Name: "TeamB"}, {Name: "TeamC"}}},
@@ -514,7 +514,7 @@ func TestPostScoreKikenAutoFillsRegulation(t *testing.T) {
 
 	compID := "kiken-reg"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: compID, Format: state.CompFormatPools, Status: state.CompStatusPools,
+		ID: compID, Format: state.CompFormatMixed, Status: state.CompStatusPools,
 	}))
 	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
 		{Name: "Alice"}, {Name: "Bob"},
@@ -555,7 +555,7 @@ func TestPostScoreKikenInEncho(t *testing.T) {
 
 	compID := "kiken-encho"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: compID, Format: state.CompFormatPools, Status: state.CompStatusPools,
+		ID: compID, Format: state.CompFormatMixed, Status: state.CompStatusPools,
 	}))
 	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
 		{Name: "Alice"}, {Name: "Bob"},
@@ -595,7 +595,7 @@ func TestPostScoreKikenInvalidScoreline(t *testing.T) {
 
 	compID := "kiken-bad"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID: compID, Format: state.CompFormatPools, Status: state.CompStatusPools,
+		ID: compID, Format: state.CompFormatMixed, Status: state.CompStatusPools,
 	}))
 	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
 		{Name: "Alice"}, {Name: "Bob"},
@@ -673,7 +673,7 @@ func TestEnforceEnchoCap_ScoreHandler(t *testing.T) {
 
 	compID := "encho-cap-test"
 	require.NoError(t, realStore.SaveCompetition(&state.Competition{
-		ID: compID, Format: state.CompFormatPools, Status: state.CompStatusPools,
+		ID: compID, Format: state.CompFormatMixed, Status: state.CompStatusPools,
 		MaxEnchoPeriods: 2,
 	}))
 	require.NoError(t, realStore.SaveParticipants(compID, []domain.Player{

--- a/internal/mobileapp/handlers_match_tx_test.go
+++ b/internal/mobileapp/handlers_match_tx_test.go
@@ -44,7 +44,7 @@ func TestScoreHandler_NoDeadlockUnderConcurrentLoad(t *testing.T) {
 	compID := "concurrent-score"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}))
 	const N = 8
@@ -133,7 +133,7 @@ func TestDecisionHandler_NoDeadlockOnConcurrentKiken(t *testing.T) {
 	compID := "concurrent-kiken-handler"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     compID,
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}))
 	aliceID := helper.NewUUID4()

--- a/internal/mobileapp/handlers_swiss_test.go
+++ b/internal/mobileapp/handlers_swiss_test.go
@@ -189,7 +189,7 @@ func TestSwissGenerateRound_NonSwissFormat(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     "pools-comp",
 		Name:   "Pools",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 	}))
 
 	w := httptest.NewRecorder()

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -1375,7 +1375,7 @@ func TestCreatePlayoff_RejectsNameCollision(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     "source",
 		Name:   "Source",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}))
 	// Pre-existing competition with the same name the playoff would
@@ -1477,7 +1477,7 @@ func TestPlayoff_RejectsDerivedIDCollision(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     "source",
 		Name:   "Source",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}))
 
@@ -1536,7 +1536,7 @@ func TestPOSTCompetition_RollbackOnSaveParticipantsFailure(t *testing.T) {
 		"id":     cid,
 		"name":   "Rollback Test",
 		"kind":   "individual",
-		"format": "pools",
+		"format": "mixed",
 		"date":   "12-05-2026",
 		"courts": []string{"A"},
 		// Populated Players triggers the saveCompetitionWithPlayers
@@ -1583,7 +1583,7 @@ func TestCreatePlayoff_RollbackOnReservedSlotFailure(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{
 		ID:     "rollback-src",
 		Name:   "Rollback Src",
-		Format: state.CompFormatPools,
+		Format: state.CompFormatMixed,
 		Status: state.CompStatusPools,
 	}))
 	require.NoError(t, store.SaveParticipants("rollback-src", []domain.Player{

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -39,7 +39,11 @@ func (s *Store) LoadCompetition(id string) (*Competition, error) {
 	if data == nil {
 		return nil, nil
 	}
-	return s.copyCompetition(data.(*Competition)), nil
+	c := s.copyCompetition(data.(*Competition))
+	if c.Format == "pools" {
+		c.Format = CompFormatMixed
+	}
+	return c, nil
 }
 
 func parseCompetitionFile(path string) (any, error) {
@@ -53,6 +57,9 @@ func parseCompetitionFile(path string) (any, error) {
 	var c Competition
 	if err := parseFrontMatter(raw, &c); err != nil {
 		return nil, err
+	}
+	if c.Format == "pools" {
+		c.Format = CompFormatMixed
 	}
 	return &c, nil
 }

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -39,11 +39,7 @@ func (s *Store) LoadCompetition(id string) (*Competition, error) {
 	if data == nil {
 		return nil, nil
 	}
-	c := s.copyCompetition(data.(*Competition))
-	if c.Format == "pools" {
-		c.Format = CompFormatMixed
-	}
-	return c, nil
+	return s.copyCompetition(data.(*Competition)), nil
 }
 
 func parseCompetitionFile(path string) (any, error) {
@@ -57,9 +53,6 @@ func parseCompetitionFile(path string) (any, error) {
 	var c Competition
 	if err := parseFrontMatter(raw, &c); err != nil {
 		return nil, err
-	}
-	if c.Format == "pools" {
-		c.Format = CompFormatMixed
 	}
 	return &c, nil
 }

--- a/internal/state/competition_test.go
+++ b/internal/state/competition_test.go
@@ -110,27 +110,6 @@ func TestLeagueFormatHidesPlayoffs(t *testing.T) {
 	}
 }
 
-func TestLoadCompetition_MigratesPoolsToMixed(t *testing.T) {
-	dir, err := os.MkdirTemp("", "pools-migration-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	store, err := NewStore(dir)
-	require.NoError(t, err)
-
-	comp := &Competition{
-		ID: "legacy-pools", Name: "Legacy", Kind: "individual",
-		Format: "pools", PoolSize: 3, Status: "setup",
-		Courts: []string{"A"},
-	}
-	require.NoError(t, store.SaveCompetition(comp))
-
-	loaded, loadErr := store.LoadCompetition("legacy-pools")
-	require.NoError(t, loadErr)
-	require.NotNil(t, loaded)
-	assert.Equal(t, CompFormatMixed, loaded.Format, "legacy format=pools should migrate to mixed on load")
-}
-
 // TestCopyCompetition_WithPlayersAndCourts exercises the Players and
 // Courts slice-copy branches in copyCompetition so mutations to the
 // copy don't alias back to the original.

--- a/internal/state/competition_test.go
+++ b/internal/state/competition_test.go
@@ -91,15 +91,13 @@ func TestSwissRoundsFieldPersists(t *testing.T) {
 
 // TestLeagueFormatHidesPlayoffs verifies FR-050 / FR-051:
 // IsPlayoffEnabled() reports whether the competition's format includes a
-// playoff phase. League and pure-pools formats return false; playoffs and
-// mixed return true.
+// playoff phase. League returns false; playoffs and mixed return true.
 func TestLeagueFormatHidesPlayoffs(t *testing.T) {
 	cases := []struct {
 		format string
 		want   bool
 	}{
 		{format: "league", want: false},
-		{format: "pools", want: false},
 		{format: "playoffs", want: true},
 		{format: "mixed", want: true},
 	}
@@ -110,6 +108,27 @@ func TestLeagueFormatHidesPlayoffs(t *testing.T) {
 			assert.Equal(t, tc.want, c.IsPlayoffEnabled(), "format=%q", tc.format)
 		})
 	}
+}
+
+func TestLoadCompetition_MigratesPoolsToMixed(t *testing.T) {
+	dir, err := os.MkdirTemp("", "pools-migration-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	comp := &Competition{
+		ID: "legacy-pools", Name: "Legacy", Kind: "individual",
+		Format: "pools", PoolSize: 3, Status: "setup",
+		Courts: []string{"A"},
+	}
+	require.NoError(t, store.SaveCompetition(comp))
+
+	loaded, loadErr := store.LoadCompetition("legacy-pools")
+	require.NoError(t, loadErr)
+	require.NotNil(t, loaded)
+	assert.Equal(t, CompFormatMixed, loaded.Format, "legacy format=pools should migrate to mixed on load")
 }
 
 // TestCopyCompetition_WithPlayersAndCourts exercises the Players and

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -172,7 +172,6 @@ const (
 
 // Competition.Format values.
 const (
-	CompFormatPools    = "pools"
 	CompFormatPlayoffs = "playoffs"
 	CompFormatMixed    = "mixed"  // FR-050
 	CompFormatLeague   = "league" // FR-050

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -617,7 +617,7 @@ func TestStore_Competition_CRUD(t *testing.T) {
 		ID:           "mens-individual",
 		Name:         "Men's Individual",
 		Kind:         "individual",
-		Format:       "pools",
+		Format:       "mixed",
 		PoolSize:     3,
 		PoolSizeMode: "min",
 		PoolWinners:  2,
@@ -635,7 +635,7 @@ func TestStore_Competition_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	assert.Equal(t, "Men's Individual", loaded.Name)
-	assert.Equal(t, "pools", loaded.Format)
+	assert.Equal(t, "mixed", loaded.Format)
 	assert.Equal(t, 3, loaded.PoolSize)
 	assert.Equal(t, true, loaded.RoundRobin)
 	assert.Equal(t, []string{"A", "B"}, loaded.Courts)

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -727,7 +727,7 @@ describe('canGenerateNextSwissRound', () => {
   });
 
   it('false when format !== swiss', () => {
-    expect(canGenerateNextSwissRound(mkComp({ format: 'pools' }), completedR1)).toBe(false);
+    expect(canGenerateNextSwissRound(mkComp({ format: 'mixed' }), completedR1)).toBe(false);
     expect(canGenerateNextSwissRound(mkComp({ format: 'playoffs' }), completedR1)).toBe(false);
   });
 
@@ -785,6 +785,6 @@ describe('isSwissCompetitionComplete', () => {
   });
 
   it('false when format !== swiss', () => {
-    expect(isSwissCompetitionComplete(mkComp({ format: 'pools' }), completedR4)).toBe(false);
+    expect(isSwissCompetitionComplete(mkComp({ format: 'mixed' }), completedR4)).toBe(false);
   });
 });

--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -104,60 +104,60 @@ describe('validatePoolSettings', () => {
     });
   });
 
-  describe('format=pools, valid inputs pass', () => {
+  describe('format=mixed, valid inputs pass', () => {
     it('boundary: poolSize=3, winners=1 (smallest legal pool)', () => {
-      expect(validatePoolSettings('pools', 3, 1)).toEqual({ ok: true, error: null });
+      expect(validatePoolSettings('mixed', 3, 1)).toEqual({ ok: true, error: null });
     });
 
     it('typical: poolSize=4, winners=2', () => {
-      expect(validatePoolSettings('pools', 4, 2)).toEqual({ ok: true, error: null });
+      expect(validatePoolSettings('mixed', 4, 2)).toEqual({ ok: true, error: null });
     });
 
     it('large: poolSize=10, winners=4', () => {
-      expect(validatePoolSettings('pools', 10, 4)).toEqual({ ok: true, error: null });
+      expect(validatePoolSettings('mixed', 10, 4)).toEqual({ ok: true, error: null });
     });
   });
 
-  describe('format=pools, poolSize invalid (the Copilot finding)', () => {
+  describe('format=mixed, poolSize invalid (the Copilot finding)', () => {
     it('NaN poolSize (cleared input) → blocked', () => {
-      const r = validatePoolSettings('pools', NaN, 2);
+      const r = validatePoolSettings('mixed', NaN, 2);
       expect(r.ok).toBe(false);
       expect(r.error).toMatch(/Players per pool/);
     });
 
     it('fractional poolSize=2.5 → blocked (Number.isInteger guard)', () => {
-      const r = validatePoolSettings('pools', 2.5, 2);
+      const r = validatePoolSettings('mixed', 2.5, 2);
       expect(r.ok).toBe(false);
       expect(r.error).toMatch(/whole number/);
     });
 
     it('poolSize=2 below min → blocked', () => {
-      const r = validatePoolSettings('pools', 2, 2);
+      const r = validatePoolSettings('mixed', 2, 2);
       expect(r.ok).toBe(false);
       expect(r.error).toMatch(/≥ 3/);
     });
 
     it('negative poolSize → blocked', () => {
-      const r = validatePoolSettings('pools', -1, 2);
+      const r = validatePoolSettings('mixed', -1, 2);
       expect(r.ok).toBe(false);
     });
   });
 
-  describe('format=pools, winners invalid', () => {
+  describe('format=mixed, winners invalid', () => {
     it('NaN winners (cleared input) → blocked', () => {
-      const r = validatePoolSettings('pools', 4, NaN);
+      const r = validatePoolSettings('mixed', 4, NaN);
       expect(r.ok).toBe(false);
       expect(r.error).toMatch(/Winners per pool/);
     });
 
     it('fractional winners=1.5 → blocked', () => {
-      const r = validatePoolSettings('pools', 4, 1.5);
+      const r = validatePoolSettings('mixed', 4, 1.5);
       expect(r.ok).toBe(false);
       expect(r.error).toMatch(/whole number/);
     });
 
     it('winners=0 below min → blocked', () => {
-      const r = validatePoolSettings('pools', 4, 0);
+      const r = validatePoolSettings('mixed', 4, 0);
       expect(r.ok).toBe(false);
       expect(r.error).toMatch(/≥ 1/);
     });
@@ -169,7 +169,7 @@ describe('validatePoolSettings', () => {
       // the poolSize error first so the user fixes the higher-priority
       // field first. Pin the order so a refactor that flips the checks
       // doesn't silently change UX.
-      const r = validatePoolSettings('pools', NaN, NaN);
+      const r = validatePoolSettings('mixed', NaN, NaN);
       expect(r.error).toMatch(/Players per pool/);
     });
   });
@@ -187,8 +187,7 @@ describe('validateSwissSettings (T190 / FR-050a)', () => {
       expect(validateSwissSettings('playoffs', 0)).toEqual({ ok: true, error: null });
     });
 
-    it('format=pools / mixed / league all skip the guard', () => {
-      expect(validateSwissSettings('pools', NaN)).toEqual({ ok: true, error: null });
+    it('format=mixed / league all skip the guard', () => {
       expect(validateSwissSettings('mixed', NaN)).toEqual({ ok: true, error: null });
       expect(validateSwissSettings('league', NaN)).toEqual({ ok: true, error: null });
     });

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -110,7 +110,7 @@ describe('Viewer Utils', () => {
     });
 
     it('false when format !== swiss', () => {
-      expect(isSwissFinalStandings(mkComp({ format: 'pools' }), completedR4)).toBe(false);
+      expect(isSwissFinalStandings(mkComp({ format: 'mixed' }), completedR4)).toBe(false);
       expect(isSwissFinalStandings(mkComp({ format: 'playoffs' }), completedR4)).toBe(false);
     });
 

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -649,12 +649,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
         </div>
         <div className="field__hint">Concurrency = number of shiaijo (courts) assigned. Schedule prevents double-booking with other competitions.</div>
       </div>
-      {/* Pool-size controls apply to formats that run multiple pools: */}
-      {/* legacy "pools" (back-compat: pools-then-playoff in the old */}
-      {/* taxonomy) and the new "mixed" (pools + knockout). "league" */}
-      {/* uses a single round-robin and so doesn't expose pool-size; */}
-      {/* "playoffs" has no pool phase. FR-050 / T044. */}
-      {(local.format === "pools" || local.format === "mixed") && (
+      {local.format === "mixed" && (
         <>
           <div className="field">
             <label className="field__label">Pool size is a</label>
@@ -686,21 +681,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       )}
       {/* FR-052..FR-054 / T047: per-phase match-duration inputs. */}
       {/* Render rules: */}
-      {/*   - poolMatchDuration: any format that runs pool play */}
-      {/*     ("pools", "mixed", "league", "swiss") — swiss rounds */}
-      {/*     reuse the pool-match-duration knob since each round is */}
-      {/*     a flat set of matches. */}
-      {/*   - playoffMatchDuration: any format with a knockout phase */}
-      {/*     ("playoffs", "mixed"). */}
-      {/* Both fields use the NaN-as-"" + updateNumber pattern; */}
-      {/* zero/empty means "fall through to the legacy matchDuration */}
-      {/* default" per backend ApplyCompetitionDefaults. The legacy */}
-      {/* `matchDuration` field is no longer exposed in the UI — it */}
-      {/* round-trips invisibly via the mirror/safeInt path so existing */}
-      {/* on-disk values are preserved. */}
-      {(local.format === "pools" || local.format === "mixed" || local.format === "league" || local.format === "playoffs" || local.format === "swiss") && (
+      {(local.format === "mixed" || local.format === "league" || local.format === "playoffs" || local.format === "swiss") && (
         <div className="row">
-          {(local.format === "pools" || local.format === "mixed" || local.format === "league" || local.format === "swiss") && (
+          {(local.format === "mixed" || local.format === "league" || local.format === "swiss") && (
             <div className="field">
               <label className="field__label">{local.format === "swiss" ? "Round match duration (min)" : "Pool match duration (min)"}</label>
               <input
@@ -1230,15 +1213,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 )}
               </>
             )}
-            {/* FR-050 / FR-051 / T045: the create-playoff affordance */}
-            {/* is gated by format. Legacy "pools" rows kept their old */}
-            {/* pools-then-playoff semantics, so they still show the */}
-            {/* button. "league" runs standings-only — show an inline */}
-            {/* note instead of the button so operators know the */}
-            {/* competition completes via pool standings. Other formats */}
-            {/* ("playoffs", "mixed") build their bracket up front and */}
-            {/* don't need the create-playoff button at all. */}
-            {(c.format === "pools" || c.format === "league") && c.status !== "setup" && onCreatePlayoff && (() => {
+            {(c.format === "mixed" || c.format === "league") && c.status !== "setup" && onCreatePlayoff && (() => {
               if (c.format === "league") {
                 return <div style={{ fontSize: 11, color: "var(--ink-3)", fontWeight: 600 }}>League: standings determine the winner</div>;
               }

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -55,18 +55,12 @@ function deriveCompetitionName(rawName, kind, gender) {
 // playoffs-only and league-only competitions don't use pool-size
 // settings (knockout has no pools; league runs a single round-robin
 // without user-configured size), so the guard short-circuits for those
-// formats. "pools" (pool-only) and "mixed" (pools + knockout) both
-// require valid pool size + winners-per-pool.
-//
-// FR-050 / T044: the format taxonomy split "pools" into two distinct
-// values — "pools" (legacy meaning in the old wire format kept for
-// back-compat) and "mixed" (new: pools followed by knockout in the new
-// taxonomy). Pool-size validation applies to both since both run pool
-// play; the difference is whether a knockout stage follows.
+// formats. "mixed" (pools + knockout) requires valid pool size +
+// winners-per-pool.
 //
 // Exported for vitest at __tests__/admin_setup.test.jsx.
 function validatePoolSettings(format, poolSize, winners) {
-  if (format !== "pools" && format !== "mixed") return { ok: true, error: null };
+  if (format !== "mixed") return { ok: true, error: null };
   if (!Number.isInteger(poolSize) || poolSize < 3) {
     return { ok: false, error: "Players per pool must be a whole number ≥ 3." };
   }
@@ -286,7 +280,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   const [gender, setGender] = useStateA("M"); // for individual: M/F/X
   const [format, setFormat] = useStateA("playoffs");
   // FR-050 / T044: per-phase round-robin shape selector. Only meaningful
-  // when the format runs pool play ("pools", "mixed", "league"); default
+  // when the format runs pool play ("mixed", "league"); default
   // "full" (every-vs-every) matches the historical behaviour. "partial"
   // (neighbour-only) is the new option for league-sized fields where a
   // full round-robin would not fit in the day's schedule.
@@ -409,7 +403,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     // signature unchanged and lets the backend's JSON binding pick up
     // the camelCase key directly. Only emit for formats that run pool
     // play — knockout-only competitions have no pool phase.
-    if (format === "pools" || format === "mixed" || format === "league") {
+    if (format === "mixed" || format === "league") {
       c.poolFormat = poolFormat;
     }
     // T190 (FR-050a): persist swissRounds when format=swiss. Same
@@ -491,38 +485,21 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
 
           <div className="field">
             <label className="field__label">Format</label>
-            {/* FR-050 / T044 / T190: five-option format taxonomy. */}
-            {/* - "playoffs" — knockout only (no pools). */}
-            {/* - "mixed"    — pools followed by knockout (the new */}
-            {/*               canonical value for what the old UI labelled */}
-            {/*               "Pools + Knockout"; old "pools" rows remain */}
-            {/*               readable but new competitions use "mixed"). */}
-            {/* - "pools"    — pool play only, no knockout phase. */}
-            {/* - "league"   — single round-robin, standings final, no */}
-            {/*               playoff phase. IsPlayoffEnabled returns */}
-            {/*               false on the backend, so the create-playoff */}
-            {/*               affordance is hidden for these (T045). */}
-            {/* - "swiss"    — Swiss-system pairing across N rounds */}
-            {/*               (FR-050a); no pools or bracket. The */}
-            {/*               swissRounds field below configures the */}
-            {/*               round count. */}
             <div className="radio-group">
               <button className={`radio-pill ${format === "playoffs" ? "is-active" : ""}`} type="button" onClick={() => setFormat("playoffs")}>Knockout only</button>
               <button className={`radio-pill ${format === "mixed" ? "is-active" : ""}`} type="button" onClick={() => setFormat("mixed")}>Pools + Knockout</button>
-              <button className={`radio-pill ${format === "pools" ? "is-active" : ""}`} type="button" onClick={() => setFormat("pools")}>Pools only</button>
               <button className={`radio-pill ${format === "league" ? "is-active" : ""}`} type="button" onClick={() => setFormat("league")}>League</button>
               <button className={`radio-pill ${format === "swiss" ? "is-active" : ""}`} type="button" onClick={() => setFormat("swiss")}>Swiss</button>
             </div>
             <div className="field__hint">
               {format === "playoffs" && "Direct single-elimination knockout."}
               {format === "mixed" && "Round-robin pools first, then top finishers advance to a knockout bracket."}
-              {format === "pools" && "Round-robin pool play; standings within each pool decide placements (no knockout)."}
               {format === "league" && "Single round-robin across all participants; final standings determine the winner (no knockout)."}
               {format === "swiss" && "Swiss-system: fixed number of rounds, pairing players with equal win counts; cumulative standings decide the winner."}
             </div>
           </div>
 
-          {(format === "pools" || format === "league") && (
+          {format === "league" && (
             <div className="field">
               <label className="field__label">Round-robin shape</label>
               <div className="radio-group">
@@ -580,7 +557,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
             <div className="field__hint">Concurrency for this competition equals the number of shiaijo (courts) assigned. Different competitions can share shiaijo (courts); the schedule prevents conflicts.</div>
           </div>
 
-          {(format === "pools" || format === "mixed") && (
+          {format === "mixed" && (
             <>
               <div className="field">
                 <label className="field__label">Pool size is a</label>
@@ -809,7 +786,7 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
                     <tr key={comp.id || comp.name}>
                       <td>{comp.id || "—"}</td>
                       <td>{comp.name || "—"}</td>
-                      <td>{comp.format || "pools"}</td>
+                      <td>{comp.format || "mixed"}</td>
                       <td className={!comp.participants ? "cell--missing" : ""}>{comp.participants || "—"}</td>
                       <td>{comp.seeds || "—"}</td>
                     </tr>

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -786,7 +786,7 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
                     <tr key={comp.id || comp.name}>
                       <td>{comp.id || "—"}</td>
                       <td>{comp.name || "—"}</td>
-                      <td>{comp.format || "mixed"}</td>
+                      <td>{comp.format || "—"}</td>
                       <td className={!comp.participants ? "cell--missing" : ""}>{comp.participants || "—"}</td>
                       <td>{comp.seeds || "—"}</td>
                     </tr>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -11,6 +11,7 @@ const compMatchStats = window.compMatchStats;
 const pluralize = window.pluralize;
 const StatusBadge = window.StatusBadge;
 const formatDate = window.formatDate;
+const formatLabelShort = window.formatLabelShort;
 
 // Maximum live-match chips rendered in the topbar status strip before the
 // "+N more" overflow indicator kicks in.
@@ -270,7 +271,7 @@ function CompCard({ c, onOpen, onStart }) {
       <div className="tcard__stats">
         <div className="tcard__stat"><div className="v">{playerCount}</div><div className="l">{pluralize(playerCount, c.kind === "team" ? "Team" : "Player")}</div></div>
         <div className="tcard__stat"><div className="v">{c.courts.length}</div><div className="l">{pluralize(c.courts.length, "Shiaijo", "Shiaijo")}</div></div>
-        <div className="tcard__stat"><div className="v">{c.format === "mixed" ? "P+KO" : c.format === "league" ? "League" : c.format === "swiss" ? "Swiss" : "KO"}</div><div className="l">Format</div></div>
+        <div className="tcard__stat"><div className="v">{formatLabelShort(c.format)}</div><div className="l">Format</div></div>
         {liveCount > 0 && <div className="tcard__stat"><div className="v" style={{ color: "var(--red)" }}>{liveCount}</div><div className="l">Live</div></div>}
       </div>
       <div className="tcard__actions">

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -270,7 +270,7 @@ function CompCard({ c, onOpen, onStart }) {
       <div className="tcard__stats">
         <div className="tcard__stat"><div className="v">{playerCount}</div><div className="l">{pluralize(playerCount, c.kind === "team" ? "Team" : "Player")}</div></div>
         <div className="tcard__stat"><div className="v">{c.courts.length}</div><div className="l">{pluralize(c.courts.length, "Shiaijo", "Shiaijo")}</div></div>
-        <div className="tcard__stat"><div className="v">{c.format === "pools" ? "Pools" : "KO"}</div><div className="l">Format</div></div>
+        <div className="tcard__stat"><div className="v">{c.format === "mixed" ? "P+KO" : c.format === "league" ? "League" : c.format === "swiss" ? "Swiss" : "KO"}</div><div className="l">Format</div></div>
         {liveCount > 0 && <div className="tcard__stat"><div className="v" style={{ color: "var(--red)" }}>{liveCount}</div><div className="l">Live</div></div>}
       </div>
       <div className="tcard__actions">

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -22,6 +22,8 @@
 // Competition: one event within a tournament (e.g., "Men's Individual", "Women's Teams").
 //   - kind: "individual" | "team"  (only two kinds — gender/age tags are metadata)
 //   - format: "playoffs" (knockout only) | "mixed" (pools + knockout) | "league" | "swiss"
+//     Note: the sample generator (applyFormat) only simulates "mixed" fully;
+//     "league" and "swiss" fall back to bracket-only display in demo data.
 //   - has its own list of competitors (players or teams).
 //   - has pools (optional) AND a bracket (optional). Both can coexist.
 //   - assigned to a subset of tournament courts.

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -250,6 +250,7 @@ function applyFormat(c) {
       simulateRounds(c.bracket, c.bracket.length);
     }
   } else {
+    // "playoffs", "league", and "swiss" all use a knockout bracket for sample data.
     c.bracket = buildBracket(c.players, c.courts); advanceByes(c.bracket);
     if (c.status === "playoffs") simulateRounds(c.bracket, Math.max(1, Math.floor(c.bracket.length / 2)), true);
     if (c.status === "completed") simulateRounds(c.bracket, c.bracket.length);

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -21,7 +21,7 @@
 //
 // Competition: one event within a tournament (e.g., "Men's Individual", "Women's Teams").
 //   - kind: "individual" | "team"  (only two kinds — gender/age tags are metadata)
-//   - format: "playoffs" (knockout only) | "pools" (pools + knockout) | "pools_only"
+//   - format: "playoffs" (knockout only) | "mixed" (pools + knockout) | "league" | "swiss"
 //   - has its own list of competitors (players or teams).
 //   - has pools (optional) AND a bracket (optional). Both can coexist.
 //   - assigned to a subset of tournament courts.
@@ -203,7 +203,7 @@ function poolWinners(pools) {
 
 // ---------- Competition ----------
 // kind: "individual" | "team"
-// format: "playoffs" | "pools"  (pools format always implies pools followed by a bracket)
+// format: "playoffs" | "mixed" | "league" | "swiss"
 function buildEmptyCompetition(args) {
   if (!args) { console.error("buildEmptyCompetition: args is undefined!"); return null; }
   const { id, name, kind, gender = "X", format, sampleRoster = "medium", courts, seedCount, status, startTime, date, teamSize, poolMode, poolSize, winnersPerPool, withZekkenName, numberPrefix, checkInEnabled } = args;
@@ -232,7 +232,7 @@ function buildEmptyCompetition(args) {
 function applyFormat(c) {
   if (c.status === "setup") return c;
   console.log("buildCompetition: c before pools/bracket", c);
-  if (c.format === "pools") {
+  if (c.format === "mixed") {
     c.pools = buildPools(c.players, { poolMode: c.poolSizeMode, poolSize: c.poolSize, winnersPerPool: c.poolWinners, courts: c.courts });
     if (c.status === "pools") {
       simulatePools(c.pools, 0.6);
@@ -282,17 +282,17 @@ const SAMPLE_TOURNAMENTS = [
     const comps = [
       buildCompetition({ id: "lc26-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "playoffs", sampleRoster: "medium", seedCount: 4, status: "playoffs", startTime: "09:00", courts: ["A","B"] }),
       buildCompetition({ id: "lc26-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "playoffs", sampleRoster: "small", seedCount: 2, status: "playoffs", startTime: "09:00", courts: ["C"] }),
-      buildCompetition({ id: "lc26-mt", name: "Men's Teams", kind: "team", format: "pools", sampleRoster: "small", seedCount: 0, status: "setup", startTime: "14:00", teamSize: 5, courts: ["A","B"] }),
+      buildCompetition({ id: "lc26-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "setup", startTime: "14:00", teamSize: 5, courts: ["A","B"] }),
     ];
     return buildTournament({ id: "lc2026", name: "London Cup 2026", date: "2026-05-12", venue: "Crystal Palace Sports Centre", courts, status: competitionStatus(comps), competitions: comps });
   })(),
   (() => {
     const courts = ["A", "B", "C", "D"];
     const comps = [
-      buildCompetition({ id: "ko-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "pools", sampleRoster: "large", seedCount: 4, status: "pools", startTime: "09:00", courts: ["A","B"] }),
-      buildCompetition({ id: "ko-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "pools", sampleRoster: "medium", seedCount: 4, status: "pools", startTime: "09:00", courts: ["C","D"] }),
-      buildCompetition({ id: "ko-mt", name: "Men's Teams", kind: "team", format: "pools", sampleRoster: "medium", seedCount: 0, status: "setup", startTime: "14:00", teamSize: 5, courts: ["A","B","C","D"] }),
-      buildCompetition({ id: "ko-wt", name: "Women's Teams", kind: "team", format: "pools", sampleRoster: "small", seedCount: 0, status: "setup", startTime: "16:00", teamSize: 5, courts: ["A","B"] }),
+      buildCompetition({ id: "ko-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "mixed", sampleRoster: "large", seedCount: 4, status: "pools", startTime: "09:00", courts: ["A","B"] }),
+      buildCompetition({ id: "ko-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "pools", startTime: "09:00", courts: ["C","D"] }),
+      buildCompetition({ id: "ko-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "medium", seedCount: 0, status: "setup", startTime: "14:00", teamSize: 5, courts: ["A","B","C","D"] }),
+      buildCompetition({ id: "ko-wt", name: "Women's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "setup", startTime: "16:00", teamSize: 5, courts: ["A","B"] }),
     ];
     return buildTournament({ id: "kanto-open", name: "Kanto Open Spring Shiai", date: "2026-04-28", venue: "Tokyo Budokan", courts, status: competitionStatus(comps), competitions: comps });
   })(),
@@ -307,9 +307,9 @@ const SAMPLE_TOURNAMENTS = [
   (() => {
     const courts = ["A", "B", "C"];
     const comps = [
-      buildCompetition({ id: "ek25-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "pools", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
-      buildCompetition({ id: "ek25-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "pools", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
-      buildCompetition({ id: "ek25-mt", name: "Men's Teams", kind: "team", format: "pools", sampleRoster: "small", seedCount: 0, status: "completed", teamSize: 5, courts: ["A","B","C"] }),
+      buildCompetition({ id: "ek25-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
+      buildCompetition({ id: "ek25-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
+      buildCompetition({ id: "ek25-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "completed", teamSize: 5, courts: ["A","B","C"] }),
     ];
     return buildTournament({ id: "european-2025", name: "European Kendo Championships 2025", date: "2025-11-08", venue: "Paris Bercy", courts, status: "completed", competitions: comps });
   })(),

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -128,6 +128,20 @@ function pluralize(count, singular, plural) {
   return count === 1 ? `${count} ${singular}` : `${count} ${plural || singular + 's'}`;
 }
 
+function formatLabel(format) {
+  if (format === "mixed")   return "Pools + Knockout";
+  if (format === "league")  return "League";
+  if (format === "swiss")   return "Swiss";
+  return "Knockout";
+}
+
+function formatLabelShort(format) {
+  if (format === "mixed")   return "P+KO";
+  if (format === "league")  return "League";
+  if (format === "swiss")   return "Swiss";
+  return "KO";
+}
+
 // Hook: register an Escape key listener that always calls the latest onClose
 // without re-registering on every render (listener registered once, ref kept fresh).
 function useEscapeToClose(onClose) {
@@ -170,6 +184,8 @@ if (typeof window !== "undefined") {
   window.Toast = Toast;
   window.StableInput = StableInput;
   window.pluralize = pluralize;
+  window.formatLabel = formatLabel;
+  window.formatLabelShort = formatLabelShort;
   window.useEscapeToClose = useEscapeToClose;
   window.isTextEntry = isTextEntry;
   window.isInteractiveTarget = isInteractiveTarget;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -450,7 +450,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                           <div className="vlist-item__eyebrow">{competitionKindLabel(c)}{c.teamSize ? ` · ${c.teamSize}-person` : ""}</div>
                           <div className="vlist-item__name">{c.name}</div>
                           <div className="vlist-item__meta">
-                            {c.players.length} {c.kind === "team" ? "teams" : "players"} · {c.format === "pools" ? "Pools + Knockout" : "Knockout"} · Starts {c.startTime}
+                            {c.players.length} {c.kind === "team" ? "teams" : "players"} · {c.format === "mixed" ? "Pools + Knockout" : c.format === "league" ? "League" : c.format === "swiss" ? "Swiss" : "Knockout"} · Starts {c.startTime}
                           </div>
                         </div>
                         <StatusBadge status={c.status} showLiveDot />
@@ -1139,7 +1139,7 @@ function ViewerCompetition({ _tournament, competition, pools, poolMatches, stand
 
   const derivedBracket = useMemo(() => {
     if (bracket && bracket.rounds && bracket.rounds.length > 0) return bracket;
-    if (c.format === "pools" && pools && pools.length > 0) {
+    if (c.format === "mixed" && pools && pools.length > 0) {
       const placeholders = [];
       const winners = c.poolWinners || 2;
       pools.forEach(p => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -4,6 +4,7 @@
 const { useState, useMemo, useRef: useRefV, useEffect } = React;
 const StatusBadge = window.StatusBadge;
 const formatDate = window.formatDate;
+const formatLabel = window.formatLabel;
 
 // TermV — kendo-glossary tooltip wrapper. Lazy lookup so the script
 // load order between glossary.jsx and viewer.jsx doesn't matter.
@@ -450,7 +451,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                           <div className="vlist-item__eyebrow">{competitionKindLabel(c)}{c.teamSize ? ` · ${c.teamSize}-person` : ""}</div>
                           <div className="vlist-item__name">{c.name}</div>
                           <div className="vlist-item__meta">
-                            {c.players.length} {c.kind === "team" ? "teams" : "players"} · {c.format === "mixed" ? "Pools + Knockout" : c.format === "league" ? "League" : c.format === "swiss" ? "Swiss" : "Knockout"} · Starts {c.startTime}
+                            {c.players.length} {c.kind === "team" ? "teams" : "players"} · {formatLabel(c.format)} · Starts {c.startTime}
                           </div>
                         </div>
                         <StatusBadge status={c.status} showLiveDot />


### PR DESCRIPTION
## Summary

- Removes the invalid \`format="pools"\` wire value throughout the stack — it was never a real kendo format, only an artifact of how mixed-pool competitions were stored
- Fixes a latent engine bug: \`StartCompetition\` was routing \`mixed\` to the \`default\` (playoffs-only) branch instead of the pool-generation branch
- Removes "Pools only" UI button and all \`format === "pools"\` guards in the frontend; updates demo data, format labels, and all test fixtures
- A manifest with \`format: pools\` is now rejected by \`validateCompetitionFormat\` like any other unknown format value

## Test plan

- [x] All JS tests pass (\`npm test\`)
- [x] All Go tests pass (\`go test ./internal/... ./cmd/...\`)
- [x] \`TestValidateCompetitionFormat\` — \`"pools"\` is no longer accepted
- [x] \`TestImportCompetition\` — import manifest with \`format: pools\` is rejected (invalid format)
- [x] Manual: create a new competition — "Pools only" button is gone; four valid formats present: Knockout only, Pools + Knockout, League, Swiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)