### PR TITLE
fix(participants): close TOCTOU race on replace via WithTransaction (mp-0lc)

### DIFF
--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -211,17 +211,6 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		}
 		pid := c.Param("pid")
 
-		comp, err := store.LoadCompetition(id)
-		if err != nil || comp == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
-			return
-		}
-
-		if comp.Status != state.CompStatusSetup && comp.Status != "" {
-			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants after competition has started"})
-			return
-		}
-
 		var req struct {
 			Name        string   `json:"name"`
 			DisplayName string   `json:"displayName"`
@@ -251,39 +240,69 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			metadata = []string{req.DanGrade}
 		}
 
-		// Strip displayName for non-zekken competitions — same CSV-corruption
-		// guard as the single-add path: a 3-column row written here would be
-		// mis-parsed on the next LoadParticipants(withZekkenName=false) read,
-		// shifting Dojo into Metadata. Empty DisplayName triggers SanitizeName
-		// re-derivation in saveParticipantsNoLock.
-		displayName := req.DisplayName
-		if !comp.WithZekkenName {
-			displayName = ""
-		}
+		// Run the status check and participant write under one lock acquire so
+		// a concurrent start-competition cannot flip status between the check
+		// and the file write (TOCTOU, mp-0lc).
+		var (
+			updatedPlayer *domain.Player
+			httpStatus    = http.StatusInternalServerError
+			httpMsg       string
+		)
+		txErr := store.WithTransaction(id, func(tx state.StoreTx) error {
+			comp, err := tx.LoadCompetition(id)
+			if err != nil {
+				return err
+			}
+			if comp == nil {
+				httpStatus = http.StatusNotFound
+				httpMsg = "competition not found"
+				return fmt.Errorf("competition not found")
+			}
+			if comp.Status != state.CompStatusSetup && comp.Status != "" {
+				httpStatus = http.StatusConflict
+				httpMsg = "cannot modify participants after competition has started"
+				return state.ErrCompetitionNotInSetup
+			}
 
-		if err := validatePlayerLengths(name, displayName, dojo, req.Tag, metadata); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
+			// Strip displayName for non-zekken competitions — same CSV-corruption
+			// guard as the single-add path: a 3-column row written here would be
+			// mis-parsed on the next LoadParticipants(withZekkenName=false) read,
+			// shifting Dojo into Metadata. Empty DisplayName triggers SanitizeName
+			// re-derivation in saveParticipantsNoLock.
+			displayName := req.DisplayName
+			if !comp.WithZekkenName {
+				displayName = ""
+			}
 
-		updatedPlayer, err := store.ReplaceParticipant(id, pid, comp.WithZekkenName, func(p *domain.Player) error {
-			p.Name = name
-			p.DisplayName = displayName
-			p.Dojo = dojo
-			p.Metadata = metadata
-			p.Tag = req.Tag
+			if err := validatePlayerLengths(name, displayName, dojo, req.Tag, metadata); err != nil {
+				httpStatus = http.StatusBadRequest
+				httpMsg = err.Error()
+				return err
+			}
+
+			p, err := tx.UpdateParticipant(id, pid, comp.WithZekkenName, func(p *domain.Player) error {
+				p.Name = name
+				p.DisplayName = displayName
+				p.Dojo = dojo
+				p.Metadata = metadata
+				p.Tag = req.Tag
+				return nil
+			})
+			if err != nil {
+				switch {
+				case errors.Is(err, state.ErrParticipantNotFound):
+					httpStatus = http.StatusNotFound
+				case errors.Is(err, state.ErrDuplicateName), errors.Is(err, state.ErrCompetitionNotInSetup):
+					httpStatus = http.StatusConflict
+				}
+				httpMsg = err.Error()
+				return err
+			}
+			updatedPlayer = p
 			return nil
 		})
-
-		if err != nil {
-			status := http.StatusInternalServerError
-			switch {
-			case errors.Is(err, state.ErrParticipantNotFound):
-				status = http.StatusNotFound
-			case errors.Is(err, state.ErrDuplicateName), errors.Is(err, state.ErrCompetitionNotInSetup):
-				status = http.StatusConflict
-			}
-			c.JSON(status, gin.H{"error": err.Error()})
+		if txErr != nil {
+			c.JSON(httpStatus, gin.H{"error": httpMsg})
 			return
 		}
 

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -251,6 +251,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		txErr := store.WithTransaction(id, func(tx state.StoreTx) error {
 			comp, err := tx.LoadCompetition(id)
 			if err != nil {
+				httpMsg = err.Error()
 				return err
 			}
 			if comp == nil {
@@ -302,7 +303,11 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return nil
 		})
 		if txErr != nil {
-			c.JSON(httpStatus, gin.H{"error": httpMsg})
+			msg := httpMsg
+			if msg == "" {
+				msg = txErr.Error()
+			}
+			c.JSON(httpStatus, gin.H{"error": msg})
 			return
 		}
 

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -293,7 +293,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 				switch {
 				case errors.Is(err, state.ErrParticipantNotFound):
 					httpStatus = http.StatusNotFound
-				case errors.Is(err, state.ErrDuplicateName), errors.Is(err, state.ErrCompetitionNotInSetup):
+				case errors.Is(err, state.ErrDuplicateName):
 					httpStatus = http.StatusConflict
 				}
 				httpMsg = err.Error()

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -551,6 +551,7 @@ func TestReplaceParticipant_ConcurrentStartRace(t *testing.T) {
 		wg.Add(2)
 
 		var replCode int
+		var replBody []byte
 		go func() {
 			defer wg.Done()
 			body, _ := json.Marshal(map[string]interface{}{
@@ -561,17 +562,43 @@ func TestReplaceParticipant_ConcurrentStartRace(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 			r.ServeHTTP(rec, req)
 			replCode = rec.Code
+			replBody = rec.Body.Bytes()
 		}()
 
+		startErrCh := make(chan error, 1)
 		go func() {
 			defer wg.Done()
-			_ = store.SaveCompetition(&state.Competition{
+			startErrCh <- store.SaveCompetition(&state.Competition{
 				ID: compID, Name: "Race", Status: state.CompStatusPools,
 			})
 		}()
 
 		wg.Wait()
+		assert.NoError(t, <-startErrCh, "iteration %d: status-flip goroutine must not error", i)
 		assert.True(t, replCode == http.StatusOK || replCode == http.StatusConflict,
 			"iteration %d: replace must return 200 or 409, got %d", i, replCode)
+
+		// When replace succeeded, verify the persisted roster is readable
+		// and the returned player name matches what was requested.
+		if replCode == http.StatusOK {
+			var returned domain.Player
+			require.NoError(t, json.Unmarshal(replBody, &returned),
+				"iteration %d: 200 body must be a valid Player JSON", i)
+			assert.Equal(t, "Alice Renamed", returned.Name,
+				"iteration %d: returned player name must match request", i)
+
+			reloaded, err := store.LoadParticipants(compID, false)
+			require.NoError(t, err, "iteration %d: must be able to reload participants after 200", i)
+			found := false
+			for _, p := range reloaded {
+				if p.ID == player.ID {
+					assert.Equal(t, "Alice Renamed", p.Name,
+						"iteration %d: persisted participant name must match request", i)
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "iteration %d: replaced participant must still exist in roster", i)
+		}
 	}
 }

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -511,4 +512,66 @@ func TestZekkenAddAndReplace(t *testing.T) {
 	assert.Equal(t, helper.SanitizeName("Kenji Sato"), loaded[0].DisplayName,
 		"empty displayName must be re-derived from the new name, not inherited")
 	assert.NotEqual(t, "YAMAMOTO", loaded[0].DisplayName)
+}
+
+// TestReplaceParticipant_ConcurrentStartRace verifies that the PUT replace
+// handler serialises the status check and the participant write under one
+// lock acquire (mp-0lc). A goroutine that concurrently flips status to
+// CompStatusPools must produce either a 200 (replace won the race) or a 409
+// (start-competition won the race) — never a 500 or a data-corrupt 200.
+func TestReplaceParticipant_ConcurrentStartRace(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	const compID = "race-replace"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: compID, Name: "Race", Status: state.CompStatusSetup,
+	}))
+
+	addBody, _ := json.Marshal(map[string]interface{}{
+		"name": "Alice Smith", "dojo": "Dojo A",
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants", bytes.NewBuffer(addBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var player domain.Player
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &player))
+
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
+		// Reset competition to setup before each iteration.
+		require.NoError(t, store.SaveCompetition(&state.Competition{
+			ID: compID, Name: "Race", Status: state.CompStatusSetup,
+		}))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		var replCode int
+		go func() {
+			defer wg.Done()
+			body, _ := json.Marshal(map[string]interface{}{
+				"name": "Alice Renamed", "dojo": "Dojo A",
+			})
+			rec := httptest.NewRecorder()
+			req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/participants/"+player.ID, bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(rec, req)
+			replCode = rec.Code
+		}()
+
+		go func() {
+			defer wg.Done()
+			_ = store.SaveCompetition(&state.Competition{
+				ID: compID, Name: "Race", Status: state.CompStatusPools,
+			})
+		}()
+
+		wg.Wait()
+		assert.True(t, replCode == http.StatusOK || replCode == http.StatusConflict,
+			"iteration %d: replace must return 200 or 409, got %d", i, replCode)
+	}
 }

--- a/internal/state/transactions.go
+++ b/internal/state/transactions.go
@@ -119,6 +119,16 @@ type StoreTx interface {
 	// (T128 / T156) so the lineup freeze happens under the same lock
 	// acquire as the score write.
 	LockTeamLineupsForRound(compID string, round int, lockedAt time.Time) error
+	// UpdateParticipant is the tx-aware twin of
+	// Store.updateParticipantNoLock. Applies transform to the target
+	// participant while the transaction lock is held, so the caller
+	// can serialise a competition-status pre-check (via LoadCompetition
+	// in the same tx body) and the participant write under one lock
+	// acquire. Participants.csv and seeds.csv are written directly via
+	// atomic rename — they are not staged through the WAL — but each
+	// write is individually crash-safe, and no other WAL-staged file
+	// is touched by this path, so cross-file atomicity is not required.
+	UpdateParticipant(compID, pid string, withZekkenName bool, transform func(*domain.Player) error) (*domain.Player, error)
 }
 
 // WithTransaction runs fn under the per-competition write lock for
@@ -517,6 +527,13 @@ func (t *storeTx) LoadParticipants(compID string, withZekkenName bool) ([]domain
 		return nil, err
 	}
 	return t.store.loadParticipantsLocked(compID, withZekkenName)
+}
+
+func (t *storeTx) UpdateParticipant(compID, pid string, withZekkenName bool, transform func(*domain.Player) error) (*domain.Player, error) {
+	if err := t.checkCompID(compID); err != nil {
+		return nil, err
+	}
+	return t.store.updateParticipantNoLock(compID, pid, withZekkenName, transform)
 }
 
 // UpdatePoolMatchByID dispatches to a lock-free body that mirrors

--- a/internal/state/transactions.go
+++ b/internal/state/transactions.go
@@ -158,6 +158,13 @@ type StoreTx interface {
 // The per-comp mutex is a non-recursive sync.RWMutex; a direct
 // s.Save* call from inside fn would re-acquire and deadlock.
 //
+// WAL caveat. StoreTx.UpdateParticipant writes directly via atomic
+// rename (not through the WAL). It is crash-safe per-file but is NOT
+// rolled back by a WAL replay. Do not mix UpdateParticipant with
+// WAL-staged tx saves (e.g. tx.SaveCompetition) and expect cross-file
+// crash-atomicity — each participant write and each WAL-staged write
+// land independently.
+//
 // fn read-after-write within the same tx. Tx-internal reads
 // (tx.LoadCompetition, tx.LoadBracket, etc.) read from disk via the
 // *Locked helpers and DO NOT see the WAL-staged writes — the on-disk

--- a/internal/state/transactions.go
+++ b/internal/state/transactions.go
@@ -137,7 +137,7 @@ type StoreTx interface {
 // entire fn body and released exactly once on return (success OR
 // error).
 //
-// Crash-atomicity. Every save invoked through tx is STAGED into a
+// Crash-atomicity. Most saves invoked through tx are STAGED into a
 // per-transaction write-ahead log (see internal/state/wal) instead
 // of going straight to disk. After fn returns nil, this method
 // Commits the WAL (atomic-renames the intent file into <data>/.wal/),
@@ -149,6 +149,8 @@ type StoreTx interface {
 // Multi-file transactions that previously could land file A but not
 // file B now either land both or replay both — cross-file atomicity
 // across a process crash (closing the v3 review A1 finding).
+// Exception: UpdateParticipant is NOT WAL-staged (see WAL caveat
+// below); it writes immediately and is not rolled back on error.
 //
 // Lock semantics. Per-comp lock is held for the entire fn body AND
 // across Commit + Apply, so other writers see the WAL transition
@@ -160,10 +162,11 @@ type StoreTx interface {
 //
 // WAL caveat. StoreTx.UpdateParticipant writes directly via atomic
 // rename (not through the WAL). It is crash-safe per-file but is NOT
-// rolled back by a WAL replay. Do not mix UpdateParticipant with
-// WAL-staged tx saves (e.g. tx.SaveCompetition) and expect cross-file
-// crash-atomicity — each participant write and each WAL-staged write
-// land independently.
+// staged, so if fn returns an error after calling UpdateParticipant
+// the participant write is NOT rolled back. Do not mix
+// UpdateParticipant with WAL-staged tx saves (e.g. tx.SaveCompetition)
+// and expect cross-file crash-atomicity — each write lands
+// independently.
 //
 // fn read-after-write within the same tx. Tx-internal reads
 // (tx.LoadCompetition, tx.LoadBracket, etc.) read from disk via the

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -725,7 +725,8 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
     URL.revokeObjectURL(url);
   };
 
-  const isStarted = c.status !== "setup";
+  const isSetup = !c.status || c.status === "setup";
+  const isStarted = !isSetup;
 
   return (
     <>
@@ -922,7 +923,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
               ))}
             </div>
           )}
-          {c.status === "setup" && (
+          {isSetup && (
             <div style={{ padding: "0 16px 12px" }}>
               {!showAddForm ? (
                 <button className="btn btn--sm" type="button" onClick={() => setShowAddForm(true)}>+ Add participant</button>
@@ -1055,7 +1056,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                       <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0 || reorderDisabled} aria-label="Move up">↑</button>
                       <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1 || reorderDisabled} aria-label="Move down">↓</button>
-                      {c.status === "setup" && (
+                      {isSetup && (
                         <button className="btn btn--sm btn--icon-sm" style={{ fontSize: 9 }} title={`Replace ${p.name}`} onClick={() => { setReplaceTarget(p); setReplaceName(p.name); setReplaceDojo(p.dojo); setReplaceDanGrade(p.danGrade || ""); setReplaceZekken(c.withZekkenName ? (p.displayName || "") : ""); }} aria-label={`Replace ${p.name}`}>↔</button>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

- Extends `StoreTx` with `UpdateParticipant` (delegates to `updateParticipantNoLock`) so the tx-aware path can mutate participants while the transaction lock is held
- Wraps the `PUT /competitions/:id/participants/:pid` handler in `Store.WithTransaction` so the competition-status pre-check (`CompStatusSetup`) and the participant file write share **one** per-comp write-lock acquire — closing the TOCTOU window identified in mp-0lc
- Adds `TestReplaceParticipant_ConcurrentStartRace`: fires 30 concurrent `replace` + `SaveCompetition(status=pools)` pairs and asserts every result is `200` or `409`, never `500` or a corrupt success

## Why a separate `StoreTx.UpdateParticipant`

`ReplaceParticipant` (the previous store-side helper) acquired its own lock and re-checked status, but that was a second lock acquire after the handler's first `LoadCompetition` call. `WithTransaction` holds the write lock for the entire fn body, so `tx.UpdateParticipant` runs without releasing and re-acquiring — true single-lock serialisation. `participants.csv` and `seeds.csv` writes use atomic rename (not WAL staging), which is already per-file crash-safe and no multi-file cross-atomicity is needed for this path.

## Test plan

- [x] `go test -race ./internal/mobileapp/... ./internal/state/...` — clean, no races reported
- [x] All 15 Go packages pass `go test ./...`
- [x] Zero lint issues after `make go/build` (build_date.txt generated)
- [x] Manual: start `make run-mobile`, add a participant in admin, replace participant, confirm 200 and updated name in UI
- [x] Manual: start competition, attempt replace, confirm 409 in UI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)