### PR TITLE
feat(competition): draw preview workflow (mp-sn5)

### DIFF
--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -306,7 +306,21 @@ func (e *Engine) GenerateDraw(id string) error {
 // DiscardDraw discards the generated draw for a draw-ready competition,
 // deleting the draw artifacts and resetting the competition to Setup.
 // Returns an error when the competition is not in draw-ready state.
+//
+// Ordering rationale: files are deleted BEFORE the status flip. While the
+// competition is still draw-ready, GenerateDraw rejects new requests, so no
+// concurrent caller can generate fresh artifacts during the deletion window.
+// If we flipped to Setup first, a concurrent GenerateDraw could start,
+// write new artifacts, commit draw-ready — and then our deferred deletes
+// would erase the freshly generated files, leaving draw-ready with no
+// artifacts.
 func (e *Engine) DiscardDraw(id string) error {
+	// Delete draw artifacts first while status is still draw-ready.
+	// GenerateDraw rejects requests in draw-ready state, so no concurrent
+	// caller can write new artifacts during this window.
+	_ = e.store.DeleteCompetitionFile(id, "pools.csv")
+	_ = e.store.DeleteCompetitionFile(id, "pool-matches.csv")
+	_ = e.store.DeleteCompetitionFile(id, "bracket.json")
 	_, err := e.store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
 		if current == nil {
 			return nil, notFoundErrorf("competition %s not found", id)
@@ -317,17 +331,7 @@ func (e *Engine) DiscardDraw(id string) error {
 		current.Status = state.CompStatusSetup
 		return current, nil
 	})
-	if err != nil {
-		return err
-	}
-	// Delete draw artifacts so the next GenerateDraw starts clean.
-	// Ignore individual file errors — the competition config is already
-	// reset to Setup, so orphaned files are safe to leave (next
-	// GenerateDraw overwrites them).
-	_ = e.store.DeleteCompetitionFile(id, "pools.csv")
-	_ = e.store.DeleteCompetitionFile(id, "pool-matches.csv")
-	_ = e.store.DeleteCompetitionFile(id, "bracket.json")
-	return nil
+	return err
 }
 
 // transitionDrawToRunning atomically moves a draw-ready competition to
@@ -580,7 +584,7 @@ func (e *Engine) runDrawPipeline(id string) error {
 		if current == nil {
 			return nil, notFoundErrorf("competition %s not found (deleted during start)", id)
 		}
-		if current.Status != state.CompStatusSetup && current.Status != "" && current.Status != state.CompStatusDrawReady {
+		if current.Status != state.CompStatusSetup && current.Status != "" {
 			return nil, validationErrorf("competition %s started concurrently by another writer", id)
 		}
 		// Generation-relevant fields must match the SNAPSHOT we

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -329,6 +329,7 @@ func (e *Engine) DiscardDraw(id string) error {
 			return nil, validationErrorf("competition %s is not in draw-ready state (status: %s)", id, current.Status)
 		}
 		current.Status = state.CompStatusSetup
+		current.SwissCurrentRound = 0 // reset so a fresh GenerateDraw can re-initialise it
 		return current, nil
 	})
 	return err

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -293,13 +293,14 @@ func (e *Engine) GenerateDraw(id string) error {
 	if comp == nil {
 		return notFoundErrorf("competition %s not found", id)
 	}
-	if comp.Status != state.CompStatusSetup && comp.Status != "" {
-		if comp.Status == state.CompStatusDrawReady {
-			return validationErrorf("competition %s draw already generated; discard it first to regenerate", id)
-		}
+	switch comp.Status {
+	case state.CompStatusSetup, "":
+		return e.runDrawPipeline(id)
+	case state.CompStatusDrawReady:
+		return validationErrorf("competition %s draw already generated; discard it first to regenerate", id)
+	default:
 		return validationErrorf("competition %s cannot generate draw (status: %s)", id, comp.Status)
 	}
-	return e.runDrawPipeline(id)
 }
 
 // DiscardDraw discards the generated draw for a draw-ready competition,

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -318,9 +318,11 @@ func (e *Engine) DiscardDraw(id string) error {
 	// Delete draw artifacts first while status is still draw-ready.
 	// GenerateDraw rejects requests in draw-ready state, so no concurrent
 	// caller can write new artifacts during this window.
-	_ = e.store.DeleteCompetitionFile(id, "pools.csv")
-	_ = e.store.DeleteCompetitionFile(id, "pool-matches.csv")
-	_ = e.store.DeleteCompetitionFile(id, "bracket.json")
+	for _, f := range []string{"pools.csv", "pool-matches.csv", "bracket.json"} {
+		if err := e.store.DeleteCompetitionFile(id, f); err != nil {
+			return fmt.Errorf("DiscardDraw: failed to delete %s: %w", f, err)
+		}
+	}
 	_, err := e.store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
 		if current == nil {
 			return nil, notFoundErrorf("competition %s not found", id)

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -315,15 +315,31 @@ func (e *Engine) GenerateDraw(id string) error {
 // would erase the freshly generated files, leaving draw-ready with no
 // artifacts.
 func (e *Engine) DiscardDraw(id string) error {
-	// Delete draw artifacts first while status is still draw-ready.
-	// GenerateDraw rejects requests in draw-ready state, so no concurrent
-	// caller can write new artifacts during this window.
+	// Pre-check: verify draw-ready status before touching the filesystem.
+	// This prevents deleting artifacts from a running competition when the
+	// caller is wrong. The authoritative check is the status CAS below; this
+	// early return is the common-case guard.
+	comp, err := e.store.LoadCompetition(id)
+	if err != nil {
+		return err
+	}
+	if comp == nil {
+		return notFoundErrorf("competition %s not found", id)
+	}
+	if comp.Status != state.CompStatusDrawReady {
+		return validationErrorf("competition %s is not in draw-ready state (status: %s)", id, comp.Status)
+	}
+
+	// Delete draw artifacts while status is still draw-ready (verified above).
+	// GenerateDraw rejects draw-ready state, so no concurrent GenerateDraw can
+	// write new artifacts here. The final status CAS below is the authoritative
+	// guard.
 	for _, f := range []string{"pools.csv", "pool-matches.csv", "bracket.json"} {
 		if err := e.store.DeleteCompetitionFile(id, f); err != nil {
 			return fmt.Errorf("DiscardDraw: failed to delete %s: %w", f, err)
 		}
 	}
-	_, err := e.store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
+	_, err = e.store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
 		if current == nil {
 			return nil, notFoundErrorf("competition %s not found", id)
 		}

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -246,33 +246,12 @@ func dhCycleExists(standings map[string][]state.PlayerStanding, allMatches []sta
 	return false
 }
 
-// StartCompetition runs the competition-start pipeline: validate
-// status, load participants/seeds, generate pools or bracket, commit
-// the new Status atomically, save participants, generate schedule.
+// StartCompetition starts a competition. When called on a draw-ready
+// competition it transitions directly to running (no regeneration).
+// When called on a setup competition it generates the draw first then
+// transitions — preserving the single-click "Start" UX.
 //
-// The final comp-status commit is wrapped in
-// state.Store.UpdateCompetitionChanged so two concurrent
-// StartCompetition calls can't both write the new Status (or, more
-// importantly, one's "start" can't clobber the other's already-applied
-// status change). The status re-check inside the transform aborts if
-// another writer moved Status off Setup between our outer Load and
-// the atomic commit.
-//
-// Pipeline limitations (pre-existing, NOT addressed by this fix):
-//   - Pool/bracket generation (writes pools.csv / bracket.json) runs
-//     OUTSIDE the comp-config lock. Two concurrent starts could each
-//     generate and overwrite each other's pools.csv before the
-//     atomic Status commit serializes them. The later start's
-//     pools.csv wins; users see the second start's player ordering.
-//     A full fix would require holding the comp lock across the
-//     entire pipeline, which would conflict with the generator's
-//     internal use of the same lock for pools.csv / bracket.json
-//     writes. Left as a follow-up — needs a deeper refactor that
-//     either threads "lock already held" through the generators or
-//     restructures the lock granularity.
-//   - SaveParticipants + GenerateSchedule (steps after the comp
-//     commit) also have their own lock acquisitions. A failure
-//     mid-pipeline leaves partial state on disk. Pre-existing.
+// See runDrawPipeline for pipeline limitations (pre-existing).
 func (e *Engine) StartCompetition(id string) error {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {
@@ -281,12 +260,115 @@ func (e *Engine) StartCompetition(id string) error {
 	if comp == nil {
 		return notFoundErrorf("competition %s not found", id)
 	}
-
-	// Best-effort early validation outside the lock — fast-fails the
-	// obviously-not-startable case (admin clicks start twice). The
-	// authoritative re-check is inside the atomic commit below.
-	if comp.Status != state.CompStatusSetup && comp.Status != "" {
+	switch comp.Status {
+	case state.CompStatusDrawReady:
+		// Draw already exists; only flip status and generate schedule.
+		if err := e.transitionDrawToRunning(id); err != nil {
+			return err
+		}
+		return e.GenerateSchedule(id)
+	case state.CompStatusSetup, "":
+		// One-click path: generate draw then transition.
+		if err := e.runDrawPipeline(id); err != nil {
+			return err
+		}
+		if err := e.transitionDrawToRunning(id); err != nil {
+			return err
+		}
+		return e.GenerateSchedule(id)
+	default:
 		return validationErrorf("competition %s already started", id)
+	}
+}
+
+// GenerateDraw generates pools/bracket/Swiss-r1 for a Setup competition
+// and transitions it to CompStatusDrawReady without starting the competition.
+// The operator can preview, discard, and regenerate the draw before calling
+// StartCompetition to enter the running state.
+func (e *Engine) GenerateDraw(id string) error {
+	comp, err := e.store.LoadCompetition(id)
+	if err != nil {
+		return err
+	}
+	if comp == nil {
+		return notFoundErrorf("competition %s not found", id)
+	}
+	if comp.Status != state.CompStatusSetup && comp.Status != "" {
+		if comp.Status == state.CompStatusDrawReady {
+			return validationErrorf("competition %s draw already generated; discard it first to regenerate", id)
+		}
+		return validationErrorf("competition %s cannot generate draw (status: %s)", id, comp.Status)
+	}
+	return e.runDrawPipeline(id)
+}
+
+// DiscardDraw discards the generated draw for a draw-ready competition,
+// deleting the draw artifacts and resetting the competition to Setup.
+// Returns an error when the competition is not in draw-ready state.
+func (e *Engine) DiscardDraw(id string) error {
+	_, err := e.store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
+		if current == nil {
+			return nil, notFoundErrorf("competition %s not found", id)
+		}
+		if current.Status != state.CompStatusDrawReady {
+			return nil, validationErrorf("competition %s is not in draw-ready state (status: %s)", id, current.Status)
+		}
+		current.Status = state.CompStatusSetup
+		return current, nil
+	})
+	if err != nil {
+		return err
+	}
+	// Delete draw artifacts so the next GenerateDraw starts clean.
+	// Ignore individual file errors — the competition config is already
+	// reset to Setup, so orphaned files are safe to leave (next
+	// GenerateDraw overwrites them).
+	_ = e.store.DeleteCompetitionFile(id, "pools.csv")
+	_ = e.store.DeleteCompetitionFile(id, "pool-matches.csv")
+	_ = e.store.DeleteCompetitionFile(id, "bracket.json")
+	return nil
+}
+
+// transitionDrawToRunning atomically moves a draw-ready competition to
+// the appropriate running status (Pools or Playoffs) based on its format.
+func (e *Engine) transitionDrawToRunning(id string) error {
+	_, err := e.store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
+		if current == nil {
+			return nil, notFoundErrorf("competition %s not found (deleted during start)", id)
+		}
+		if current.Status != state.CompStatusDrawReady {
+			return nil, validationErrorf("competition %s not in draw-ready state (status: %s); concurrent modification?", id, current.Status)
+		}
+		switch current.Format {
+		case state.CompFormatPools, state.CompFormatLeague, state.CompFormatSwiss:
+			current.Status = state.CompStatusPools
+		default:
+			current.Status = state.CompStatusPlayoffs
+		}
+		return current, nil
+	})
+	return err
+}
+
+// runDrawPipeline runs the full draw-generation pipeline for a Setup
+// competition and commits CompStatusDrawReady. It does NOT generate the
+// schedule; callers must call GenerateSchedule after transitioning to a
+// running status.
+//
+// Pipeline limitations (pre-existing):
+//   - Pool/bracket generation (writes pools.csv / bracket.json) runs
+//     OUTSIDE the comp-config lock. Two concurrent GenerateDraw calls
+//     could overwrite each other's pools.csv before the atomic Status
+//     commit serializes them. Left as a follow-up.
+//   - SaveParticipants (reserved-slot path) also has its own lock
+//     acquisition. A failure mid-pipeline leaves partial state on disk.
+func (e *Engine) runDrawPipeline(id string) error {
+	comp, err := e.store.LoadCompetition(id)
+	if err != nil {
+		return err
+	}
+	if comp == nil {
+		return notFoundErrorf("competition %s not found", id)
 	}
 
 	// Snapshot the loaded config BEFORE the pipeline mutates anything.
@@ -403,7 +485,7 @@ func (e *Engine) StartCompetition(id string) error {
 		if err := e.generatePools(comp, players, seeds); err != nil {
 			return err
 		}
-		comp.Status = state.CompStatusPools
+		comp.Status = state.CompStatusDrawReady
 	case state.CompFormatSwiss:
 		// Guard 1: SwissCurrentRound already bumped — AdvanceSwissRound ran to
 		// completion before StartCompetition was called.
@@ -459,12 +541,12 @@ func (e *Engine) StartCompetition(id string) error {
 			return err
 		}
 		comp.SwissCurrentRound = 1
-		comp.Status = state.CompStatusPools
+		comp.Status = state.CompStatusDrawReady
 	default:
 		if err := e.generatePlayoffs(comp, players, seeds); err != nil {
 			return err
 		}
-		comp.Status = state.CompStatusPlayoffs
+		comp.Status = state.CompStatusDrawReady
 	}
 
 	// Atomic commit of the modified competition. The transform
@@ -497,7 +579,7 @@ func (e *Engine) StartCompetition(id string) error {
 		if current == nil {
 			return nil, notFoundErrorf("competition %s not found (deleted during start)", id)
 		}
-		if current.Status != state.CompStatusSetup && current.Status != "" {
+		if current.Status != state.CompStatusSetup && current.Status != "" && current.Status != state.CompStatusDrawReady {
 			return nil, validationErrorf("competition %s started concurrently by another writer", id)
 		}
 		// Generation-relevant fields must match the SNAPSHOT we
@@ -667,5 +749,5 @@ func (e *Engine) StartCompetition(id string) error {
 		}
 	}
 
-	return e.GenerateSchedule(id)
+	return nil
 }

--- a/internal/engine/competition_test.go
+++ b/internal/engine/competition_test.go
@@ -397,6 +397,7 @@ func TestDiscardDraw_ResetsToSetup(t *testing.T) {
 	comp, err = store.LoadCompetition(compID)
 	require.NoError(t, err)
 	assert.Equal(t, state.CompStatusSetup, comp.Status, "DiscardDraw must reset status to setup")
+	assert.Equal(t, 0, comp.SwissCurrentRound, "DiscardDraw must reset SwissCurrentRound to 0")
 
 	// Draw artifacts should be deleted.
 	compDir := filepath.Join(dir, "competitions", compID)

--- a/internal/engine/competition_test.go
+++ b/internal/engine/competition_test.go
@@ -320,3 +320,155 @@ func TestStartCompetition_SwissMatchesOnDiskRoundZero_AllScheduled(t *testing.T)
 	assert.Equal(t, state.CompStatusPools, comp.Status)
 	assert.Equal(t, 1, comp.SwissCurrentRound)
 }
+
+// TestGenerateDraw_PoolsFormat verifies that GenerateDraw transitions a pools
+// competition from Setup to DrawReady and writes pools/pool-matches artifacts.
+func TestGenerateDraw_PoolsFormat(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "generate-draw-pools"
+
+	createTestCompetition(t, store, compID, state.CompFormatPools, 3)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"})
+
+	require.NoError(t, eng.GenerateDraw(compID))
+
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	assert.Equal(t, state.CompStatusDrawReady, comp.Status, "GenerateDraw must set status to draw-ready")
+
+	pools, err := store.LoadPools(compID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, pools, "pools must be written on GenerateDraw")
+}
+
+// TestGenerateDraw_PlayoffsFormat verifies GenerateDraw on a playoffs
+// competition writes bracket.json and sets draw-ready.
+func TestGenerateDraw_PlayoffsFormat(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "generate-draw-playoffs"
+
+	createTestCompetition(t, store, compID, state.CompFormatPlayoffs, 0)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave"})
+
+	require.NoError(t, eng.GenerateDraw(compID))
+
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	assert.Equal(t, state.CompStatusDrawReady, comp.Status)
+
+	bracket, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	assert.NotNil(t, bracket, "bracket must be written on GenerateDraw for playoffs")
+}
+
+// TestGenerateDraw_RejectsDrawReady ensures GenerateDraw returns an error
+// when the competition is already in draw-ready state.
+func TestGenerateDraw_RejectsDrawReady(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "generate-draw-already-ready"
+
+	createTestCompetition(t, store, compID, state.CompFormatPools, 3)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
+
+	require.NoError(t, eng.GenerateDraw(compID))
+
+	err := eng.GenerateDraw(compID)
+	require.Error(t, err)
+	var ve *ValidationError
+	assert.ErrorAs(t, err, &ve, "second GenerateDraw must return a ValidationError")
+}
+
+// TestDiscardDraw verifies that DiscardDraw resets status to Setup and
+// removes draw artifacts.
+func TestDiscardDraw_ResetsToSetup(t *testing.T) {
+	eng, store, dir := setupTestEngine(t)
+	compID := "discard-draw"
+
+	createTestCompetition(t, store, compID, state.CompFormatPools, 3)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"})
+
+	require.NoError(t, eng.GenerateDraw(compID))
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	require.Equal(t, state.CompStatusDrawReady, comp.Status)
+
+	require.NoError(t, eng.DiscardDraw(compID))
+
+	comp, err = store.LoadCompetition(compID)
+	require.NoError(t, err)
+	assert.Equal(t, state.CompStatusSetup, comp.Status, "DiscardDraw must reset status to setup")
+
+	// Draw artifacts should be deleted.
+	_, poolsErr := os.Stat(filepath.Join(dir, "competitions", compID, "pool-matches.csv"))
+	assert.True(t, os.IsNotExist(poolsErr), "pool-matches.csv must be deleted after DiscardDraw")
+}
+
+// TestDiscardDraw_RejectsNonDrawReady ensures DiscardDraw errors when not in
+// draw-ready state.
+func TestDiscardDraw_RejectsNonDrawReady(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "discard-draw-guard"
+
+	createTestCompetition(t, store, compID, state.CompFormatPools, 3)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie"})
+
+	err := eng.DiscardDraw(compID)
+	require.Error(t, err)
+	var ve *ValidationError
+	assert.ErrorAs(t, err, &ve, "DiscardDraw on setup competition must return ValidationError")
+}
+
+// TestStartCompetition_FromDrawReady verifies that StartCompetition on a
+// draw-ready competition transitions to running without regenerating the draw.
+func TestStartCompetition_FromDrawReady(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "start-from-draw-ready"
+
+	createTestCompetition(t, store, compID, state.CompFormatPools, 3)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"})
+
+	require.NoError(t, eng.GenerateDraw(compID))
+	comp, _ := store.LoadCompetition(compID)
+	require.Equal(t, state.CompStatusDrawReady, comp.Status)
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	assert.Equal(t, state.CompStatusPools, comp.Status, "StartCompetition from DrawReady must set status to pools")
+}
+
+// TestStartCompetition_BackwardCompatSetup verifies that StartCompetition
+// still works directly from Setup (one-click path, no explicit GenerateDraw).
+func TestStartCompetition_BackwardCompatSetup(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "start-backward-compat"
+
+	createTestCompetition(t, store, compID, state.CompFormatPlayoffs, 0)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave"})
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	assert.Equal(t, state.CompStatusPlayoffs, comp.Status, "StartCompetition from Setup must set status to playoffs for playoffs format")
+}
+
+// TestGenerateDraw_ThenDiscardThenRegenerateAndStart exercises the full
+// preview workflow: generate, discard, regenerate, then start.
+func TestGenerateDraw_ThenDiscardThenRegenerateAndStart(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "full-preview-flow"
+
+	createTestCompetition(t, store, compID, state.CompFormatPools, 3)
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"})
+
+	require.NoError(t, eng.GenerateDraw(compID))
+	require.NoError(t, eng.DiscardDraw(compID))
+	require.NoError(t, eng.GenerateDraw(compID))
+	require.NoError(t, eng.StartCompetition(compID))
+
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	assert.Equal(t, state.CompStatusPools, comp.Status)
+}

--- a/internal/engine/competition_test.go
+++ b/internal/engine/competition_test.go
@@ -399,8 +399,11 @@ func TestDiscardDraw_ResetsToSetup(t *testing.T) {
 	assert.Equal(t, state.CompStatusSetup, comp.Status, "DiscardDraw must reset status to setup")
 
 	// Draw artifacts should be deleted.
-	_, poolsErr := os.Stat(filepath.Join(dir, "competitions", compID, "pool-matches.csv"))
-	assert.True(t, os.IsNotExist(poolsErr), "pool-matches.csv must be deleted after DiscardDraw")
+	compDir := filepath.Join(dir, "competitions", compID)
+	for _, f := range []string{"pools.csv", "pool-matches.csv", "bracket.json"} {
+		_, ferr := os.Stat(filepath.Join(compDir, f))
+		assert.True(t, os.IsNotExist(ferr), "%s must be deleted after DiscardDraw", f)
+	}
 }
 
 // TestDiscardDraw_RejectsNonDrawReady ensures DiscardDraw errors when not in

--- a/internal/engine/competition_test.go
+++ b/internal/engine/competition_test.go
@@ -339,6 +339,10 @@ func TestGenerateDraw_PoolsFormat(t *testing.T) {
 	pools, err := store.LoadPools(compID)
 	require.NoError(t, err)
 	assert.NotEmpty(t, pools, "pools must be written on GenerateDraw")
+
+	poolMatches, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, poolMatches, "pool-matches must be written on GenerateDraw")
 }
 
 // TestGenerateDraw_PlayoffsFormat verifies GenerateDraw on a playoffs

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -935,6 +935,55 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.JSON(http.StatusOK, comp)
 	})
 
+	r.POST("/competitions/:id/generate-draw", func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+		if err := eng.GenerateDraw(id); err != nil {
+			var notFound *engine.NotFoundError
+			var validation *engine.ValidationError
+			switch {
+			case errors.As(err, &notFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			case errors.As(err, &validation):
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		comp, err := store.LoadCompetition(id)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "draw generated but failed to load updated state: " + err.Error()})
+			return
+		}
+		hub.Broadcast(EventDrawGenerated, gin.H{"competitionId": id})
+		c.JSON(http.StatusOK, comp)
+	})
+
+	r.DELETE("/competitions/:id/draw", func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+		if err := eng.DiscardDraw(id); err != nil {
+			var notFound *engine.NotFoundError
+			var validation *engine.ValidationError
+			switch {
+			case errors.As(err, &notFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			case errors.As(err, &validation):
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
+			return
+		}
+		hub.Broadcast(EventDrawDiscarded, gin.H{"competitionId": id})
+		c.Status(http.StatusNoContent)
+	})
+
 	r.POST("/competitions/:id/complete", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -545,6 +545,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// set HasParticipantIDs=true (saveParticipants writes UUID rows).
 		var nameErr error
 		var notFoundFlag bool
+		var drawReadyFlag bool
 		var changed bool
 		err := store.WithCompetitionRenameLock(func() error {
 			var updateErr error
@@ -573,6 +574,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				// settings-PUT and roster-PUT no longer step on each
 				// other's writes.
 				if comp.Players != nil {
+					if current.Status == state.CompStatusDrawReady {
+						drawReadyFlag = true
+						return nil, nil
+					}
 					// Roster-only PUT — do NOT flip HasParticipantIDs
 					// here. Pre-fix, the transform committed the flag
 					// (HasParticipantIDs=true) BEFORE the post-transform
@@ -654,6 +659,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// either flag escapes the transform unexpectedly.
 		if notFoundFlag {
 			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+		if drawReadyFlag {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants while a draw is pending; discard the draw first"})
 			return
 		}
 		if nameErr != nil {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -595,6 +595,15 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				}
 
 				// Settings-only PUT (Players field absent in body).
+				// Block settings changes while a draw is pending — the
+				// draw artifacts (pools.csv / bracket.json) were generated
+				// from the current config; mutating PoolSize, Courts, or
+				// Format while draw-ready would leave config.md inconsistent
+				// with those artifacts when StartCompetition runs.
+				if current.Status == state.CompStatusDrawReady {
+					drawReadyFlag = true
+					return nil, nil
+				}
 				// Existence first, uniqueness second. Pre-fix order ran
 				// checkUniqueCompName BEFORE the transform, so a PUT to
 				// a missing :id whose body Name happened to collide with
@@ -871,6 +880,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
 			return
 		}
+		if comp.Status == state.CompStatusDrawReady {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants while a draw is pending; discard the draw first"})
+			return
+		}
 		slot, err := store.AddReservedSlot(id, req.SourceCompID, req.SourceRank, comp.WithZekkenName)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -889,6 +902,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		comp, err := store.LoadCompetition(id)
 		if err != nil || comp == nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+		if comp.Status == state.CompStatusDrawReady {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants while a draw is pending; discard the draw first"})
 			return
 		}
 		if err := store.RemoveReservedSlot(id, slotID, comp.WithZekkenName); err != nil {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -671,7 +671,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		if drawReadyFlag {
-			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants while a draw is pending; discard the draw first"})
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify competition while a draw is pending; discard the draw first"})
 			return
 		}
 		if nameErr != nil {
@@ -982,6 +982,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		comp, err := store.LoadCompetition(id)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "draw generated but failed to load updated state: " + err.Error()})
+			return
+		}
+		if comp == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "draw generated but competition no longer exists"})
 			return
 		}
 		hub.Broadcast(EventDrawGenerated, gin.H{"competitionId": id})

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -711,6 +711,8 @@ func TestCompetitionHandlers_Extended(t *testing.T) {
 			{"POST", "/api/competitions/%s/participants"},
 			{"GET", "/api/competitions/%s/seeds"},
 			{"PUT", "/api/competitions/%s/seeds"},
+			{"POST", "/api/competitions/%s/generate-draw"},
+			{"DELETE", "/api/competitions/%s/draw"},
 			// Match endpoints from handlers_match.go. Without a match
 			// route in this set, a regression that drops requireValidCompID
 			// from match.go would still ship green.
@@ -1246,4 +1248,88 @@ func TestPUTCompetition_CheckInEnabledPersists(t *testing.T) {
 	saved, err = store.LoadCompetition(cid)
 	require.NoError(t, err)
 	assert.False(t, saved.CheckInEnabled, "checkInEnabled=false must also persist")
+}
+
+func TestGenerateDrawHandler(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	// Seed 8 players in a playoffs competition so GenerateDraw can succeed.
+	players := make([]domain.Player, 8)
+	for i := range players {
+		players[i] = domain.Player{Name: fmt.Sprintf("P%d", i+1), Dojo: "Dojo"}
+	}
+	cid := "gen-draw-comp"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     cid,
+		Name:   "Gen Draw",
+		Format: state.CompFormatPlayoffs,
+		Courts: []string{"A"},
+		Status: state.CompStatusSetup,
+	}))
+	require.NoError(t, store.SaveParticipants(cid, players))
+
+	t.Run("Success: setup → draw-ready", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/"+cid+"/generate-draw", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+		saved, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		assert.Equal(t, state.CompStatusDrawReady, saved.Status)
+	})
+
+	t.Run("Reject: already draw-ready", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/"+cid+"/generate-draw", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Not found: unknown competition", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/no-such-comp/generate-draw", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
+func TestDiscardDrawHandler(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	cid := "discard-draw-comp"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     cid,
+		Name:   "Discard Draw",
+		Format: state.CompFormatPlayoffs,
+		Courts: []string{"A"},
+		Status: state.CompStatusDrawReady,
+	}))
+
+	t.Run("Success: draw-ready → setup", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/competitions/"+cid+"/draw", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNoContent, w.Code, "response: %s", w.Body.String())
+
+		saved, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		assert.Equal(t, state.CompStatusSetup, saved.Status)
+	})
+
+	t.Run("Reject: not draw-ready (setup)", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/competitions/"+cid+"/draw", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Not found: unknown competition", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("DELETE", "/api/competitions/no-such-comp/draw", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
 }

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -42,6 +42,10 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
+		if comp.Status == state.CompStatusDrawReady {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants while a draw is pending; discard the draw first"})
+			return
+		}
 		if comp.Status != state.CompStatusSetup && comp.Status != "" {
 			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants after competition has started"})
 			return
@@ -217,6 +221,10 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
+		if comp.Status == state.CompStatusDrawReady {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants while a draw is pending; discard the draw first"})
+			return
+		}
 		if comp.Status != state.CompStatusSetup && comp.Status != "" {
 			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify participants after competition has started"})
 			return

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -317,6 +317,15 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		if !ok {
 			return
 		}
+		comp, err := store.LoadCompetition(id)
+		if err != nil || comp == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+		if comp.Status == state.CompStatusDrawReady {
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify seeds while a draw is pending; discard the draw first"})
+			return
+		}
 		var assignments []domain.SeedAssignment
 		if err := c.ShouldBindJSON(&assignments); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -278,6 +278,11 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 				httpMsg = "competition not found"
 				return fmt.Errorf("competition not found")
 			}
+			if comp.Status == state.CompStatusDrawReady {
+				httpStatus = http.StatusConflict
+				httpMsg = "cannot modify participants while a draw is pending; discard the draw first"
+				return state.ErrCompetitionNotInSetup
+			}
 			if comp.Status != state.CompStatusSetup && comp.Status != "" {
 				httpStatus = http.StatusConflict
 				httpMsg = "cannot modify participants after competition has started"

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -131,8 +131,19 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 
 			addedPlayer, err := store.AddParticipant(id, player, comp.WithZekkenName)
 			if err != nil {
-				if errors.Is(err, state.ErrDuplicateName) || errors.Is(err, state.ErrCompetitionNotInSetup) {
+				if errors.Is(err, state.ErrDuplicateName) {
 					c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+					return
+				}
+				if errors.Is(err, state.ErrCompetitionNotInSetup) {
+					// Reload to distinguish draw-ready from a fully-started competition
+					// under TOCTOU: status could have flipped between our check above
+					// and AddParticipant acquiring the per-comp lock.
+					msg := "cannot modify participants after competition has started"
+					if reloaded, _ := store.LoadCompetition(id); reloaded != nil && reloaded.Status == state.CompStatusDrawReady {
+						msg = "cannot modify participants while a draw is pending; discard the draw first"
+					}
+					c.JSON(http.StatusConflict, gin.H{"error": msg})
 					return
 				}
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to add participant: " + err.Error()})

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -41,6 +41,8 @@ const (
 	// ignore the event — their flow doesn't depend on the admin password.
 	EventPasswordReset EventType = "password_reset"
 	EventAnnouncement  EventType = "announcement"
+	EventDrawGenerated EventType = "draw_generated"
+	EventDrawDiscarded EventType = "draw_discarded"
 )
 
 // AutoCompleteErrorHeader is set on score/start responses when the

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -262,6 +262,13 @@ func (s *Store) DeleteCompetitionFile(id, filename string) error {
 	if err := ValidateCompetitionID(id); err != nil {
 		return fmt.Errorf("invalid competition ID: %w", err)
 	}
+	// Validate filename to prevent path traversal. The allowedDrawFiles
+	// allowlist below is the primary guard; this check is a belt-and-
+	// suspenders defence that also catches empty strings and dotdot segments
+	// before reaching the map lookup.
+	if filename == "" || filepath.Base(filename) != filename {
+		return fmt.Errorf("invalid filename: %q", filename)
+	}
 	if _, ok := allowedDrawFiles[filename]; !ok {
 		return fmt.Errorf("DeleteCompetitionFile: filename %q is not an allowed draw artifact", filename)
 	}

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -245,11 +245,25 @@ func (s *Store) UpdateCompetitionChanged(id string, transform func(current *Comp
 	return s.saveCompetitionChangedLocked(desired, s.directWrite)
 }
 
-// DeleteCompetitionFile removes a single file from a competition directory.
-// Returns nil when the file does not exist (idempotent delete).
+// allowedDrawFiles is the set of artifact filenames that DiscardDraw may
+// delete. The allowlist prevents a future caller from passing a user-
+// controlled value and gaining an arbitrary-file-deletion primitive inside
+// the data directory.
+var allowedDrawFiles = map[string]struct{}{
+	"pools.csv":        {},
+	"pool-matches.csv": {},
+	"bracket.json":     {},
+}
+
+// DeleteCompetitionFile removes a single draw artifact from a competition
+// directory. Returns nil when the file does not exist (idempotent delete).
+// Only filenames in the allowedDrawFiles set are accepted.
 func (s *Store) DeleteCompetitionFile(id, filename string) error {
 	if err := ValidateCompetitionID(id); err != nil {
 		return fmt.Errorf("invalid competition ID: %w", err)
+	}
+	if _, ok := allowedDrawFiles[filename]; !ok {
+		return fmt.Errorf("DeleteCompetitionFile: filename %q is not an allowed draw artifact", filename)
 	}
 	mu := s.getCompLock(id)
 	mu.Lock()

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -245,6 +245,22 @@ func (s *Store) UpdateCompetitionChanged(id string, transform func(current *Comp
 	return s.saveCompetitionChangedLocked(desired, s.directWrite)
 }
 
+// DeleteCompetitionFile removes a single file from a competition directory.
+// Returns nil when the file does not exist (idempotent delete).
+func (s *Store) DeleteCompetitionFile(id, filename string) error {
+	if err := ValidateCompetitionID(id); err != nil {
+		return fmt.Errorf("invalid competition ID: %w", err)
+	}
+	mu := s.getCompLock(id)
+	mu.Lock()
+	defer mu.Unlock()
+	path := s.compPath(id, filename)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func (s *Store) DeleteCompetition(id string) error {
 	if err := ValidateCompetitionID(id); err != nil {
 		return fmt.Errorf("invalid competition ID: %w", err)

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -155,11 +155,12 @@ func (c Competition) IsPlayoffEnabled() bool {
 type CompetitionStatus string
 
 const (
-	CompStatusSetup    CompetitionStatus = "setup"
-	CompStatusPools    CompetitionStatus = "pools"
-	CompStatusPlayoffs CompetitionStatus = "playoffs"
-	CompStatusComplete CompetitionStatus = "completed"
-	CompStatusInvalid  CompetitionStatus = "invalid"
+	CompStatusSetup     CompetitionStatus = "setup"
+	CompStatusDrawReady CompetitionStatus = "draw-ready"
+	CompStatusPools     CompetitionStatus = "pools"
+	CompStatusPlayoffs  CompetitionStatus = "playoffs"
+	CompStatusComplete  CompetitionStatus = "completed"
+	CompStatusInvalid   CompetitionStatus = "invalid"
 )
 
 type MatchStatus string

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -786,11 +786,65 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/competitions/{id}/generate-draw:
+    post:
+      tags: [competitions]
+      summary: Generate draw (preview)
+      description: |
+        Generates pools/bracket/Swiss-r1 from the saved participant list and seeds and
+        transitions the competition to `draw-ready` status without starting it.
+        The operator can inspect the draw, discard it, and regenerate before calling
+        `/start`. Participant edits are blocked while a draw is pending.
+      security:
+        - TournamentPassword: []
+      parameters:
+        - $ref: '#/components/parameters/CompetitionId'
+      responses:
+        '200':
+          description: Draw generated; competition is now in `draw-ready` status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Competition'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/competitions/{id}/draw:
+    delete:
+      tags: [competitions]
+      summary: Discard draw
+      description: |
+        Discards the generated draw for a `draw-ready` competition, deletes draw
+        artifacts (pools.csv, pool-matches.csv, bracket.json), and resets the
+        competition to `setup`. Returns 400 if the competition is not in `draw-ready`
+        state.
+      security:
+        - TournamentPassword: []
+      parameters:
+        - $ref: '#/components/parameters/CompetitionId'
+      responses:
+        '204':
+          description: Draw discarded; competition reset to setup.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/competitions/{id}/start:
     post:
       tags: [competitions]
       summary: Start competition
-      description: Generates pools/bracket from the saved participant list and seeds.
+      description: |
+        Starts the competition. When in `draw-ready` status the existing draw is reused
+        and the competition transitions directly to `pools` or `playoffs`. When in
+        `setup` status the draw is generated first then the competition transitions
+        (backward-compatible one-click path).
       security:
         - TournamentPassword: []
       parameters:
@@ -2013,7 +2067,7 @@ components:
             `playoffs` → knockout phase active; `completed` → finished;
             `invalid` → operator-declared invalid, prerequisite for deleting
             an already-started competition.
-          enum: [setup, pools, playoffs, completed, invalid, ""]
+          enum: [setup, draw-ready, pools, playoffs, completed, invalid, ""]
         mirror:
           type: boolean
         withZekkenName:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2063,7 +2063,8 @@ components:
           type: string
           description: >
             Lifecycle state. Set by the server — do not supply on create/update.
-            `setup` → not yet started; `pools` → pools phase active;
+            `setup` → not yet started; `draw-ready` → draw generated and available
+            for preview, not yet started; `pools` → pools phase active;
             `playoffs` → knockout phase active; `completed` → finished;
             `invalid` → operator-declared invalid, prerequisite for deleting
             an already-started competition.

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -681,6 +681,12 @@ a:hover {
   border-color: var(--line);
 }
 
+.badge--draw-ready {
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-color: #bfdbfe;
+}
+
 .badge--pools {
   background: #fff7ed;
   color: #9a3412;

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -618,6 +618,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       onBack={() => setView({ kind: "dashboard" })}
       onOpenCompetition={(id, section) => setView({ kind: "competition", id, section: section || "overview" })}
       onUpdate={(next) => updateCompetition(c.id, next)}
+      onRefreshCompetition={() => window.API.fetchCompetitionDetails(c.id).then(setAdminCompData).catch(err => console.error("refresh failed:", err))}
       onCreatePlayoff={createPlayoff}
       onMoveCourt={moveMatchCourt}
       onEditScore={editMatchScore}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1343,7 +1343,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {/* onViewStandings is wired to the public viewer URL so the */}
             {/* operator can navigate into the viewer-mode standings */}
             {/* page when the competition completes. */}
-            {section === "swiss" && c.format === "swiss" && (
+            {section === "swiss" && c.format === "swiss" && !isDrawReady && (
               <AdminSwissRounds
                 c={c}
                 poolMatches={poolMatches}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1288,7 +1288,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {isDrawReady && (
               <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
                 <div style={{ display: "flex", gap: 8 }}>
-                  <button className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting}>
+                  <button className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting || generating}>
                     {discarding && <span className="spinner" />}
                     {discarding ? "Discarding…" : "Discard draw"}
                   </button>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1347,7 +1347,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             )}
             {section === "pools" && <AdminPools c={c} pools={pools} poolMatches={poolMatches} standings={standings} tweaks={tweaks} onEditScore={onEditScore} password={password} />}
             {section === "bracket" && <AdminBracket c={c} t={t} bracket={bracket} onMoveCourt={onMoveCourt} tweaks={tweaks} password={password} showToast={showToast} />}
-            {section === "scores" && <AdminScoreEditor c={c} t={t} onEditScore={onEditScore} onMoveCourt={onMoveCourt} restrictToCompId={c.id} password={password} />}
+            {section === "scores" && !isDrawReady && <AdminScoreEditor c={c} t={t} onEditScore={onEditScore} onMoveCourt={onMoveCourt} restrictToCompId={c.id} password={password} />}
             {section === "export" && <AdminExport c={c} t={t} password={password} />}
           </div>
         </div>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1127,7 +1127,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       // waiting for SSE (which may be slow or temporarily disconnected).
       onRefreshCompetition?.();
       showToast(`Draw generated for ${c.name}`);
-      onSection(c.format === "playoffs" ? "bracket" : "pools");
+      onSection(c.format === "playoffs" ? "bracket" : c.format === "swiss" ? "overview" : "pools");
     } catch (e) {
       console.error("Generate draw failed:", e);
       if (mountedRef.current) showToast(e.message, "error");
@@ -1165,7 +1165,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       if (!mountedRef.current) return;
       onRefreshCompetition?.();
       showToast(`Draw regenerated for ${c.name}`);
-      onSection(c.format === "playoffs" ? "bracket" : "pools");
+      onSection(c.format === "playoffs" ? "bracket" : c.format === "swiss" ? "overview" : "pools");
     } catch (e) {
       console.error("Regenerate draw failed:", e);
       if (mountedRef.current) {

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1157,6 +1157,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     setGenerating(true);
     try {
       await window.API.discardDraw(c.id, password);
+      if (!mountedRef.current) return;
+      // Refresh after discard so the UI reflects setup status immediately;
+      // if generateDraw then fails the UI is consistent with the server.
+      onRefreshCompetition?.();
       await window.API.generateDraw(c.id, password);
       if (!mountedRef.current) return;
       onRefreshCompetition?.();
@@ -1164,7 +1168,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
     } catch (e) {
       console.error("Regenerate draw failed:", e);
-      if (mountedRef.current) showToast(e.message, "error");
+      if (mountedRef.current) {
+        onRefreshCompetition?.();
+        showToast(e.message, "error");
+      }
     } finally {
       if (mountedRef.current) setGenerating(false);
     }

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1235,11 +1235,13 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     {
       sec: "Run", items: [
         // Show pools/bracket in nav when draw is ready (preview) or running.
-        (pools || isDrawReady) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
+        // Use .length checks: the state store returns [] / {rounds:[]} (never null)
+        // when files are absent, so plain truthiness would always show the items.
+        (pools?.length || isDrawReady) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
         // T191 (FR-050d): Swiss competitions surface a dedicated round
         // management panel for the "Generate next round" workflow.
         c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds — manage" } : null,
-        (bracket || isDrawReady) ? { id: "bracket", label: isDrawReady ? "Bracket — preview" : "Bracket — live" } : null,
+        (bracket?.rounds?.length || isDrawReady) ? { id: "bracket", label: isDrawReady ? "Bracket — preview" : "Bracket — live" } : null,
         !isDrawReady ? { id: "scores", label: "Scores — edit" } : null,
       ].filter(Boolean)
     },

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1168,6 +1168,22 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     }
   };
 
+  const regenerateDraw = async () => {
+    setGenerating(true);
+    try {
+      await window.API.discardDraw(c.id, password);
+      await window.API.generateDraw(c.id, password);
+      if (!mountedRef.current) return;
+      showToast(`Draw regenerated for ${c.name}`);
+      onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
+    } catch (e) {
+      console.error("Regenerate draw failed:", e);
+      if (mountedRef.current) showToast(e.message, "error");
+    } finally {
+      if (mountedRef.current) setGenerating(false);
+    }
+  };
+
   const start = async () => {
     showToast(`Starting ${c.name}…`);
 
@@ -1281,7 +1297,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                     {discarding && <span className="spinner" />}
                     {discarding ? "Discarding…" : "Discard draw"}
                   </button>
-                  <button className="btn btn--ghost" onClick={generateDraw} disabled={generating || starting || discarding}>
+                  <button className="btn btn--ghost" onClick={regenerateDraw} disabled={generating || starting || discarding}>
                     {generating && <span className="spinner" />}
                     {generating ? "Regenerating…" : "Regenerate draw"}
                   </button>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1227,7 +1227,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         // Show pools/bracket in nav when draw is ready (preview) or running.
         // Use .length checks: the state store returns [] / {rounds:[]} (never null)
         // when files are absent, so plain truthiness would always show the items.
-        (pools?.length || (isDrawReady && c.format !== "playoffs")) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
+        (pools?.length || (isDrawReady && c.format !== "playoffs" && c.format !== "swiss")) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
         // T191 (FR-050d): Swiss competitions surface a dedicated round
         // management panel for the "Generate next round" workflow.
         c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds — manage" } : null,
@@ -1266,7 +1266,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             </div>
           </div>
           <div className="page-head__actions" style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
-            {c.status === "setup" && c.players.length >= 2 && (
+            {(!c.status || c.status === "setup") && c.players.length >= 2 && (
               <>
                 <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
                   <button className="btn btn--ghost" onClick={generateDraw} disabled={!isDateValid(c.date) || generating || starting}>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1127,7 +1127,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       // waiting for SSE (which may be slow or temporarily disconnected).
       onRefreshCompetition?.();
       showToast(`Draw generated for ${c.name}`);
-      onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
+      onSection(c.format === "playoffs" ? "bracket" : "pools");
     } catch (e) {
       console.error("Generate draw failed:", e);
       if (mountedRef.current) showToast(e.message, "error");
@@ -1165,7 +1165,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       if (!mountedRef.current) return;
       onRefreshCompetition?.();
       showToast(`Draw regenerated for ${c.name}`);
-      onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
+      onSection(c.format === "playoffs" ? "bracket" : "pools");
     } catch (e) {
       console.error("Regenerate draw failed:", e);
       if (mountedRef.current) {
@@ -1227,11 +1227,11 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         // Show pools/bracket in nav when draw is ready (preview) or running.
         // Use .length checks: the state store returns [] / {rounds:[]} (never null)
         // when files are absent, so plain truthiness would always show the items.
-        (pools?.length || isDrawReady) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
+        (pools?.length || (isDrawReady && c.format !== "playoffs")) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
         // T191 (FR-050d): Swiss competitions surface a dedicated round
         // management panel for the "Generate next round" workflow.
         c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds — manage" } : null,
-        (bracket?.rounds?.length || isDrawReady) ? { id: "bracket", label: isDrawReady ? "Bracket — preview" : "Bracket — live" } : null,
+        (bracket?.rounds?.length || (isDrawReady && c.format === "playoffs")) ? { id: "bracket", label: isDrawReady ? "Bracket — preview" : "Bracket — live" } : null,
         !isDrawReady ? { id: "scores", label: "Scores — edit" } : null,
       ].filter(Boolean)
     },

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -852,7 +852,8 @@ function AdminBracket({ c, t, bracket, onMoveCourt, tweaks, password, showToast 
   }, [runningMatchId]);
 
   if (!bracket || !bracket.rounds) {
-    return <div className="empty"><div className="icon">⚙</div><h3>Bracket not generated yet</h3><div>Start the competition to build the bracket.</div></div>;
+    const previewMode = c && c.status === "draw-ready";
+    return <div className="empty"><div className="icon">⚙</div><h3>Bracket not generated yet</h3><div>{previewMode ? "Bracket not available for this format preview." : "Start the competition to build the bracket."}</div></div>;
   }
   const select = (m, ri, mi) => setSelected({ matchId: m.id, ri, mi });
   // Look up the selected match by ID rather than [ri][mi] index. The
@@ -1113,6 +1114,8 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   const c = competition;
   const t = tournament;
   const [starting, setStarting] = useStateA(false);
+  const [generating, setGenerating] = useStateA(false);
+  const [discarding, setDiscarding] = useStateA(false);
   // localStatus lets AdminSettings report an invalidation immediately so the
   // page-header StatusBadge flips without waiting for the SSE refresh.
   // Cleared automatically when the prop status changes (SSE arrives).
@@ -1131,6 +1134,39 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   // stricter check would reject — letting the operator start a competition
   // with a date that can't be saved back.
   const isDateValid = isValidDate;
+
+  const generateDraw = async () => {
+    setGenerating(true);
+    try {
+      await window.API.generateDraw(c.id, password);
+      // SSE draw_generated triggers a tournament reload; navigate to the
+      // bracket/pools preview so the operator can inspect the draw.
+      if (!mountedRef.current) return;
+      showToast(`Draw generated for ${c.name}`);
+      onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
+    } catch (e) {
+      console.error("Generate draw failed:", e);
+      if (mountedRef.current) showToast(e.message, "error");
+    } finally {
+      if (mountedRef.current) setGenerating(false);
+    }
+  };
+
+  const discardDraw = async () => {
+    if (!confirm(`Discard the generated draw for "${c.name}"? The pools/bracket will be removed and you can regenerate.`)) return;
+    setDiscarding(true);
+    try {
+      await window.API.discardDraw(c.id, password);
+      if (!mountedRef.current) return;
+      showToast(`Draw discarded for ${c.name}`);
+      onSection("overview");
+    } catch (e) {
+      console.error("Discard draw failed:", e);
+      if (mountedRef.current) showToast(e.message, "error");
+    } finally {
+      if (mountedRef.current) setDiscarding(false);
+    }
+  };
 
   const start = async () => {
     showToast(`Starting ${c.name}…`);
@@ -1165,6 +1201,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     }
   };
 
+  const isDrawReady = c.status === "draw-ready";
   const sections = [
     {
       sec: "Preparation", items: [
@@ -1178,12 +1215,13 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     },
     {
       sec: "Run", items: [
-        pools ? { id: "pools", label: "Pools — live" } : null,
+        // Show pools/bracket in nav when draw is ready (preview) or running.
+        (pools || isDrawReady) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
         // T191 (FR-050d): Swiss competitions surface a dedicated round
         // management panel for the "Generate next round" workflow.
-        c.format === "swiss" ? { id: "swiss", label: "Swiss rounds — manage" } : null,
-        bracket ? { id: "bracket", label: "Bracket — live" } : null,
-        { id: "scores", label: "Scores — edit" },
+        c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds — manage" } : null,
+        (bracket || isDrawReady) ? { id: "bracket", label: isDrawReady ? "Bracket — preview" : "Bracket — live" } : null,
+        !isDrawReady ? { id: "scores", label: "Scores — edit" } : null,
       ].filter(Boolean)
     },
     {
@@ -1219,16 +1257,41 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
           <div className="page-head__actions" style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
             {c.status === "setup" && c.players.length >= 2 && (
               <>
-                <button className="btn btn--primary" onClick={start} disabled={!isDateValid(c.date) || starting}>
-                  {starting && <span className="spinner" />}
-                  {starting ? "Starting…" : "Start competition →"}
-                </button>
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                  <button className="btn btn--ghost" onClick={generateDraw} disabled={!isDateValid(c.date) || generating || starting}>
+                    {generating && <span className="spinner" />}
+                    {generating ? "Generating…" : "Preview draw"}
+                  </button>
+                  <button className="btn btn--primary" onClick={start} disabled={!isDateValid(c.date) || starting || generating}>
+                    {starting && <span className="spinner" />}
+                    {starting ? "Starting…" : "Start competition →"}
+                  </button>
+                </div>
                 {!isDateValid(c.date) && (
                   <div style={{ color: "var(--red)", fontSize: 11, fontWeight: 600 }}>
                     ⚠ Cannot start: invalid date in Settings tab (e.g. "{c.date}")
                   </div>
                 )}
               </>
+            )}
+            {isDrawReady && (
+              <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting}>
+                    {discarding && <span className="spinner" />}
+                    {discarding ? "Discarding…" : "Discard draw"}
+                  </button>
+                  <button className="btn btn--ghost" onClick={generateDraw} disabled={generating || starting || discarding}>
+                    {generating && <span className="spinner" />}
+                    {generating ? "Regenerating…" : "Regenerate draw"}
+                  </button>
+                  <button className="btn btn--primary" onClick={start} disabled={starting || generating || discarding}>
+                    {starting && <span className="spinner" />}
+                    {starting ? "Starting…" : "Start competition →"}
+                  </button>
+                </div>
+                <div style={{ fontSize: 11, color: "var(--ink-3)" }}>Draw generated — preview below, then start when ready</div>
+              </div>
             )}
             {/* FR-050 / FR-051 / T045: the create-playoff affordance */}
             {/* is gated by format. Legacy "pools" rows kept their old */}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -790,7 +790,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           </div>
         )}
         <button className="btn btn--danger btn--ghost" disabled={deleting || invalidating} onClick={async () => {
-          const started = local.status && local.status !== "setup";
+          const started = local.status && local.status !== "setup" && local.status !== "draw-ready";
           const msg = started
             ? `"${local.name}" has already started. Deleting it will remove ALL matches and results. This cannot be undone. Continue?`
             : `Are you sure you want to delete "${local.name}"? This action cannot be undone.`;
@@ -1304,7 +1304,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 <div style={{ fontSize: 11, color: "var(--ink-3)" }}>Draw generated — preview below, then start when ready</div>
               </div>
             )}
-            {(c.format === "mixed" || c.format === "league") && c.status !== "setup" && onCreatePlayoff && (() => {
+            {(c.format === "mixed" || c.format === "league") && c.status !== "setup" && c.status !== "draw-ready" && onCreatePlayoff && (() => {
               if (c.format === "league") {
                 return <div style={{ fontSize: 11, color: "var(--ink-3)", fontWeight: 600 }}>League: standings determine the winner</div>;
               }

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1110,7 +1110,7 @@ function AdminSwissRounds({ c, poolMatches, password, onViewStandings, showToast
   );
 }
 
-function AdminCompetition({ tournament, competition, pools, poolMatches, standings, bracket, reservedSlots, section, onSection, onBack, onOpenCompetition, onUpdate, onCreatePlayoff, onMoveCourt, onEditScore, onLogout, onViewerMode, tweaks, password, showToast }) {
+function AdminCompetition({ tournament, competition, pools, poolMatches, standings, bracket, reservedSlots, section, onSection, onBack, onOpenCompetition, onUpdate, onRefreshCompetition, onCreatePlayoff, onMoveCourt, onEditScore, onLogout, onViewerMode, tweaks, password, showToast }) {
   const c = competition;
   const t = tournament;
   const [starting, setStarting] = useStateA(false);
@@ -1139,9 +1139,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     setGenerating(true);
     try {
       await window.API.generateDraw(c.id, password);
-      // SSE draw_generated triggers a tournament reload; navigate to the
-      // bracket/pools preview so the operator can inspect the draw.
       if (!mountedRef.current) return;
+      // Refresh immediately so the UI reflects draw-ready status without
+      // waiting for SSE (which may be slow or temporarily disconnected).
+      onRefreshCompetition?.();
       showToast(`Draw generated for ${c.name}`);
       onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
     } catch (e) {
@@ -1158,6 +1159,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     try {
       await window.API.discardDraw(c.id, password);
       if (!mountedRef.current) return;
+      onRefreshCompetition?.();
       showToast(`Draw discarded for ${c.name}`);
       onSection("overview");
     } catch (e) {
@@ -1174,6 +1176,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       await window.API.discardDraw(c.id, password);
       await window.API.generateDraw(c.id, password);
       if (!mountedRef.current) return;
+      onRefreshCompetition?.();
       showToast(`Draw regenerated for ${c.name}`);
       onSection(c.format === "playoffs" || c.format === "mixed" ? "bracket" : "pools");
     } catch (e) {

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -734,7 +734,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
     URL.revokeObjectURL(url);
   };
 
-  const isSetup = !c.status || c.status === "setup";
+  const isSetup = !c.status || c.status === "setup" || c.status === "draw-ready";
   const isStarted = !isSetup;
   const hasReservedSlotsContext = otherComps.length > 0 || (reservedSlots != null && reservedSlots.length > 0);
 

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -734,13 +734,19 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
     URL.revokeObjectURL(url);
   };
 
-  const isSetup = !c.status || c.status === "setup" || c.status === "draw-ready";
-  const isStarted = !isSetup;
+  const isSetup = !c.status || c.status === "setup";
+  const isDrawReady = c.status === "draw-ready";
+  const isStarted = !isSetup && !isDrawReady;
   const hasReservedSlotsContext = otherComps.length > 0 || (reservedSlots != null && reservedSlots.length > 0);
 
   return (
     <>
       {c.checkInEnabled && <CheckInBanner tournament={tournament} players={players} />}
+      {isDrawReady && (
+        <div className="notice notice--info" style={{ marginBottom: 12 }}>
+          Draw pending — participant edits are locked. Discard the draw to make changes.
+        </div>
+      )}
       {isStarted && (
         <div style={{ marginBottom: 16, display: "flex", justifyContent: "flex-end" }}>
           <button className="btn btn--primary" onClick={() => onSection("scores")}>Go to Scoring →</button>

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -214,6 +214,28 @@ const API = {
         const data = await res.json();
         return normalizeCompetitionDetail(data);
     },
+    async generateDraw(id, password) {
+        const res = await fetch(`/api/competitions/${id}/generate-draw`, {
+            method: 'POST',
+            headers: { 'X-Tournament-Password': password }
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || "Failed to generate draw");
+        }
+        const data = await res.json();
+        return normalizeCompetitionDetail(data);
+    },
+    async discardDraw(id, password) {
+        const res = await fetch(`/api/competitions/${id}/draw`, {
+            method: 'DELETE',
+            headers: { 'X-Tournament-Password': password }
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || "Failed to discard draw");
+        }
+    },
     // Subscribe to the server's SSE event stream. `callback` is fired
     // for each parsed event. `onStatus` (optional) is fired with
     // 'open' when the EventSource transitions to open and 'error' when

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -453,6 +453,14 @@ function App() {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), jitter);
             }
             jitteredTimeout(load, jitter);
+        } else if (event.type === "draw_generated" || event.type === "draw_discarded") {
+            // Draw generated/discarded: refresh the selected competition's
+            // details (new pools/bracket data or cleared state) and the
+            // tournament list so status badges update.
+            if (viewerCompId === event.data?.competitionId) {
+                jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), jitter);
+            }
+            jitteredTimeout(load, jitter);
         } else if (event.type === "swiss_round_generated") {
             // T192 (US13 — FR-050d): a new Swiss round's matches have been
             // generated. The payload carries competitionId + swissCurrentRound

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -3,6 +3,7 @@
 function StatusBadge({ status, showLiveDot }) {
   const map = {
     setup: ["badge--setup", "Pending"],
+    "draw-ready": ["badge--draw-ready", "Draw ready"],
     pools: ["badge--pools", "Pools"],
     playoffs: ["badge--playoffs", "Playoffs"],
     completed: ["badge--completed", "Completed"],

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -8,7 +8,7 @@ function StatusBadge({ status, showLiveDot }) {
     playoffs: ["badge--playoffs", "Playoffs"],
     completed: ["badge--completed", "Completed"],
   };
-  const [cls, label] = map[status] || ["badge--setup", status];
+  const [cls, label] = map[status || "setup"] || ["badge--setup", status];
   const showLive = showLiveDot && (status === "pools" || status === "playoffs");
   return (
     <span className={`badge ${cls}`}>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -64,8 +64,8 @@ const isPoolDaihyosenID = id => id.includes('-DH-');
 function compMatches(c) {
   const out = [];
 
-  // Setup/draw-ready: no public data yet — draw is an admin-only preview
-  if (c.status === "setup" || c.status === "draw-ready") return out;
+  // Setup/draw-ready/empty status: no public data yet — draw is admin-only preview
+  if (!c.status || c.status === "setup" || c.status === "draw-ready") return out;
 
   const POOL_ID_RE = /^(.+?)(?:-DH-\d+|-TB-\d+|-\d+)$/;
   const rawPoolMatches = c.poolMatches || (c.pools ? c.pools.flatMap(p => p.matches.map(m => ({ ...m, phase: "pool", poolName: p.name, phaseName: p.name }))) : []);
@@ -97,7 +97,7 @@ function compMatches(c) {
 
 function tournamentMatches(t) {
   return (t.competitions || [])
-    .filter(c => c.status !== "setup" && c.status !== "draw-ready")
+    .filter(c => c.status && c.status !== "setup" && c.status !== "draw-ready")
     .flatMap(compMatches);
 }
 
@@ -334,7 +334,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
 
   // global "across-all-competitions" lists for the home page
   const allMatches = useMemo(() => tournamentMatches(t), [t]);
-  const liveCompIds = useMemo(() => new Set((t.competitions || []).filter(c => c.status !== "setup" && c.status !== "draw-ready").map(c => c.id)), [t.competitions]);
+  const liveCompIds = useMemo(() => new Set((t.competitions || []).filter(c => c.status && c.status !== "setup" && c.status !== "draw-ready").map(c => c.id)), [t.competitions]);
   // Apply hasBothSides here too — pre-fix, a bracket match marked
   // `running` while one side was still an unresolved "Winner of rX-mY"
   // placeholder would appear in the public LIVE NOW strip, even though
@@ -468,7 +468,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                         </div>
                         <StatusBadge status={c.status} showLiveDot />
                       </div>
-                      {c.status !== "setup" && c.status !== "draw-ready" && total > 0 && (
+                      {c.status && c.status !== "setup" && c.status !== "draw-ready" && total > 0 && (
                         <div className="vlist-item__progress">
                           <div className="vlist-item__bar"><div style={{ width: pct + "%" }}></div></div>
                           <div className="vlist-item__pct">
@@ -1160,8 +1160,9 @@ function ViewerCompetition({ _tournament, competition, pools, poolMatches, stand
     return null;
   }, [bracket, c, pools]);
 
-  const hasPools = !!pools && pools.length > 0;
-  const hasBracket = !!derivedBracket && derivedBracket.rounds && derivedBracket.rounds.length > 0;
+  const isPreStart = !c.status || c.status === "setup" || c.status === "draw-ready";
+  const hasPools = !isPreStart && !!pools && pools.length > 0;
+  const hasBracket = !isPreStart && !!derivedBracket && derivedBracket.rounds && derivedBracket.rounds.length > 0;
   // T192 (FR-050e): Swiss competitions surface a dedicated standings
   // tab in place of pools/bracket. The standings tab fetches its own
   // data via /swiss/standings (it's not part of the competition-detail
@@ -1354,7 +1355,7 @@ function MatchDetailCard({ match, onClose }) {
 function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks }) {
   const [expandedMatchId, setExpandedMatchId] = useState(null);
 
-  if (c.status === "setup" || c.status === "draw-ready") {
+  if (!c.status || c.status === "setup" || c.status === "draw-ready") {
     return (
       <div className="empty" style={{ padding: 32 }}>
         <div className="icon">⏳</div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -64,8 +64,8 @@ const isPoolDaihyosenID = id => id.includes('-DH-');
 function compMatches(c) {
   const out = [];
 
-  // Setup-mode: no backend data yet, return empty (no client-side preview)
-  if (c.status === "setup") return out;
+  // Setup/draw-ready: no public data yet — draw is an admin-only preview
+  if (c.status === "setup" || c.status === "draw-ready") return out;
 
   const POOL_ID_RE = /^(.+?)(?:-DH-\d+|-TB-\d+|-\d+)$/;
   const rawPoolMatches = c.poolMatches || (c.pools ? c.pools.flatMap(p => p.matches.map(m => ({ ...m, phase: "pool", poolName: p.name, phaseName: p.name }))) : []);
@@ -97,7 +97,7 @@ function compMatches(c) {
 
 function tournamentMatches(t) {
   return (t.competitions || [])
-    .filter(c => c.status !== "setup")
+    .filter(c => c.status !== "setup" && c.status !== "draw-ready")
     .flatMap(compMatches);
 }
 
@@ -334,7 +334,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
 
   // global "across-all-competitions" lists for the home page
   const allMatches = useMemo(() => tournamentMatches(t), [t]);
-  const liveCompIds = useMemo(() => new Set((t.competitions || []).filter(c => c.status !== "setup").map(c => c.id)), [t.competitions]);
+  const liveCompIds = useMemo(() => new Set((t.competitions || []).filter(c => c.status !== "setup" && c.status !== "draw-ready").map(c => c.id)), [t.competitions]);
   // Apply hasBothSides here too — pre-fix, a bracket match marked
   // `running` while one side was still an unresolved "Winner of rX-mY"
   // placeholder would appear in the public LIVE NOW strip, even though
@@ -468,7 +468,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                         </div>
                         <StatusBadge status={c.status} showLiveDot />
                       </div>
-                      {c.status !== "setup" && total > 0 && (
+                      {c.status !== "setup" && c.status !== "draw-ready" && total > 0 && (
                         <div className="vlist-item__progress">
                           <div className="vlist-item__bar"><div style={{ width: pct + "%" }}></div></div>
                           <div className="vlist-item__pct">
@@ -1354,7 +1354,7 @@ function MatchDetailCard({ match, onClose }) {
 function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks }) {
   const [expandedMatchId, setExpandedMatchId] = useState(null);
 
-  if (c.status === "setup") {
+  if (c.status === "setup" || c.status === "draw-ready") {
     return (
       <div className="empty" style={{ padding: 32 }}>
         <div className="icon">⏳</div>


### PR DESCRIPTION
# Description

Adds a `draw-ready` status so operators can generate and inspect pools/bracket before starting a competition.

**New endpoints:**
- `POST /api/competitions/:id/generate-draw` → builds draw, sets status to `draw-ready`
- `DELETE /api/competitions/:id/draw` → discards draw artifacts, resets to `setup`
- `POST /api/competitions/:id/start` now accepts `draw-ready` (reuses existing draw) OR `setup` (one-click backward-compat path)

**UI changes:**
- "Preview draw" button alongside Start in Setup (also shown for legacy competitions with empty/falsy status)
- Three-button bar (Regenerate / Discard / Start) in DrawReady; all three buttons are mutually disabled while any operation is in flight
- Format-aware post-generation navigation: `playoffs → bracket`, `swiss → overview`, others → `pools`
- Pools preview nav item hidden for `playoffs` and `swiss` formats in draw-ready (neither produces pools data during preview)
- Bracket preview nav item shown in draw-ready only for `playoffs` format
- Swiss rounds management nav and section render suppressed during draw-ready to prevent stale deep-link exposure
- Public viewer hides pools/bracket tabs for `draw-ready`, `setup`, and empty-status competitions (admin-only preview); all pre-start status guards treat falsy/empty status as setup-equivalent
- `admin_participants`: split `isSetup`/`isDrawReady`/`isStarted` flags so mutation controls remain hidden in draw-ready; "draw pending — edits locked" notice shown to operators

**Architecture changes:**
- New `CompStatusDrawReady = "draw-ready"` in `internal/state/models.go`
- `engine.StartCompetition` refactored to dispatch: `DrawReady → transitionDrawToRunning + GenerateSchedule`, `Setup → runDrawPipeline + transitionDrawToRunning + GenerateSchedule`
- `state.Store.DeleteCompetitionFile` added for idempotent per-file removal (allowlist-restricted)
- `DiscardDraw` validates competition status before deleting any artifacts — non-draw-ready calls return 4xx immediately without touching the filesystem
- Participant add/update/seeds blocked with "discard first" 409 message when draw is pending; explicit `CompStatusDrawReady` branch inside `WithTransaction` ensures correct error message even under TOCTOU races; check-in intentionally allowed (does not affect draw composition)
- `regenerateDraw` refreshes UI immediately after discard step and in the catch block so partial failures leave the UI in sync with server state
- `onRefreshCompetition` prop added to `AdminCompetition` for immediate UI refresh without waiting for SSE
- `TestGenerateDrawHandler` and `TestDiscardDrawHandler` added covering success path, invalid-status 4xx, and not-found 404; both endpoints added to path-traversal ID sweep

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have read the [CONTRIBUTING](https://github.com/gitrgoliveira/bracket-creator/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works