### PR TITLE
feat(admin-participants): add search/filter to Check-in & Seeding list (mp-edx)

### DIFF
--- a/web-mobile/js/__tests__/admin_participants.test.jsx
+++ b/web-mobile/js/__tests__/admin_participants.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mintParticipantIds, findSeedMatchIndex } from '../admin_participants.jsx';
+import { mintParticipantIds, findSeedMatchIndex, participantSearchTarget } from '../admin_participants.jsx';
 
 // Helper: parsed rows arrive from parseParticipantLines as
 // { name, displayName, dojo, danGrade, tag } objects. Test rows omit the
@@ -230,5 +230,40 @@ describe('findSeedMatchIndex', () => {
 
   it('handles empty roster without throwing', () => {
     expect(findSeedMatchIndex([], 'Alice')).toBe(-1);
+  });
+});
+
+describe('participantSearchTarget', () => {
+  const p = (name, displayName, dojo) => ({ name, displayName, dojo });
+
+  it('returns a lowercase string combining name, displayName, and dojo', () => {
+    const target = participantSearchTarget(p('Alice', 'ALI', 'Tokyo Dojo'));
+    expect(target).toBe('alice ali tokyo dojo');
+  });
+
+  it('matches by name substring (case-insensitive)', () => {
+    const target = participantSearchTarget(p('Alice Yamamoto', null, 'Shinjuku'));
+    expect(target.includes('alice')).toBe(true);
+    expect(target.includes('yamamoto')).toBe(true);
+  });
+
+  it('matches by dojo substring', () => {
+    const target = participantSearchTarget(p('Bob', null, 'Osaka Kendo Club'));
+    expect(target.includes('osaka')).toBe(true);
+  });
+
+  it('matches by displayName/zekken substring', () => {
+    const target = participantSearchTarget(p('Bob Tanaka', 'TANAKA', 'Shinjuku'));
+    expect(target.includes('tanaka')).toBe(true);
+  });
+
+  it('handles null/undefined fields without throwing', () => {
+    expect(() => participantSearchTarget(p(null, null, null))).not.toThrow();
+    expect(participantSearchTarget(p(null, null, null))).toBe('  ');
+  });
+
+  it('does not match a query that is not a substring of any field', () => {
+    const target = participantSearchTarget(p('Alice', null, 'Tokyo'));
+    expect(target.includes('bob')).toBe(false);
   });
 });

--- a/web-mobile/js/__tests__/admin_participants.test.jsx
+++ b/web-mobile/js/__tests__/admin_participants.test.jsx
@@ -259,7 +259,13 @@ describe('participantSearchTarget', () => {
 
   it('handles null/undefined fields without throwing', () => {
     expect(() => participantSearchTarget(p(null, null, null))).not.toThrow();
-    expect(participantSearchTarget(p(null, null, null))).toBe('  ');
+    expect(participantSearchTarget(p(null, null, null))).toBe('');
+  });
+
+  it('omits empty displayName — no double-space in search target', () => {
+    const target = participantSearchTarget(p('Alice', null, 'Tokyo'));
+    expect(target).toBe('alice tokyo');
+    expect(target.includes('  ')).toBe(false);
   });
 
   it('does not match a query that is not a substring of any field', () => {

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -904,6 +904,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                 <input
                   className="input"
                   type="search"
+                  aria-label="Search participants"
                   value={searchQuery}
                   onChange={e => setSearchQuery(e.target.value)}
                   onKeyDown={e => e.key === "Escape" && setSearchQuery("")}
@@ -1038,7 +1039,9 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
               )}
               {visiblePlayers.length === 0 && trimmedSearch && (
                 <div className="empty" style={{ padding: "16px 24px" }}>
-                  No match for "{trimmedSearch}".
+                  {(tagFilter || showOnlyUnchecked)
+                    ? "No participants match current filters."
+                    : `No match for "${trimmedSearch}".`}
                 </div>
               )}
               {visiblePlayers.map((p) => {
@@ -1147,7 +1150,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
 }
 
 function participantSearchTarget(p) {
-  return `${p.name || ""} ${p.displayName || ""} ${p.dojo || ""}`.toLowerCase();
+  return [p.name, p.displayName, p.dojo].filter(Boolean).join(" ").toLowerCase();
 }
 
 window.AdminParticipants = AdminParticipants;

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -359,15 +359,22 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   };
 
   const [tagFilter, setTagFilter] = useStateA(null);
+  const [searchQuery, setSearchQuery] = useStateA("");
   const lines = useMemoA(() => text.split("\n").filter((l) => l.trim()), [text]);
   const players = useMemoA(() => c.players || [], [c.players]);
   const allTags = useMemoA(() => [...new Set(players.map(p => p.tag).filter(Boolean))], [players]);
   const visiblePlayers = useMemoA(() => {
+    const q = searchQuery.trim().toLowerCase();
     let out = players;
     if (tagFilter) out = out.filter(p => p.tag === tagFilter);
     if (showOnlyUnchecked) out = out.filter(p => !p.checkedIn);
+    if (q) out = out.filter(p =>
+      (p.name || "").toLowerCase().includes(q) ||
+      (p.displayName || "").toLowerCase().includes(q) ||
+      (p.dojo || "").toLowerCase().includes(q)
+    );
     return out;
-  }, [players, tagFilter, showOnlyUnchecked]);
+  }, [players, tagFilter, showOnlyUnchecked, searchQuery]);
   const dojoFirstRowSet = useMemoA(() => {
     const seen = new Set();
     const first = new Set();
@@ -890,6 +897,27 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
               Assign seed ranks (1, 2, 3…) to separate top players. Seeds 1 and 2 will be placed on opposite sides of the bracket.
               Drag rows to change order.
             </div>
+            {players.length > 0 && (
+              <div style={{ position: "relative", marginBottom: 8 }}>
+                <input
+                  className="input"
+                  type="search"
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  onKeyDown={e => e.key === "Escape" && setSearchQuery("")}
+                  placeholder="Search name, dojo…"
+                  style={{ width: "100%", paddingRight: searchQuery ? 28 : undefined }}
+                />
+                {searchQuery && (
+                  <button
+                    type="button"
+                    onClick={() => setSearchQuery("")}
+                    style={{ position: "absolute", right: 6, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", color: "var(--ink-3)", fontSize: 14, padding: 2 }}
+                    aria-label="Clear search"
+                  >×</button>
+                )}
+              </div>
+            )}
           </div>
           {hasGaps && (
             <div className="alert alert--error" style={{ margin: "0 16px 16px" }}>
@@ -1000,14 +1028,20 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
               {/* When a tag filter is active, reorder controls would operate on */}
               {/* full-list indices but rows are filtered — so they'd swap with hidden */}
               {/* neighbours. Disable reordering until the filter is cleared. */}
-              {(tagFilter || showOnlyUnchecked) && (
+              {(tagFilter || showOnlyUnchecked || searchQuery.trim()) && (
                 <div className="field__hint" style={{ padding: "0 16px 8px" }}>
+                  {visiblePlayers.length < players.length && `Showing ${visiblePlayers.length} of ${players.length}. `}
                   Reordering disabled while a filter is active. Clear all filters to drag rows or use the arrows.
+                </div>
+              )}
+              {visiblePlayers.length === 0 && searchQuery.trim() && (
+                <div className="empty" style={{ padding: "16px 24px" }}>
+                  No match for "{searchQuery.trim()}".
                 </div>
               )}
               {visiblePlayers.map((p) => {
                 const i = players.indexOf(p);
-                const reorderDisabled = !!tagFilter || showOnlyUnchecked;
+                const reorderDisabled = !!tagFilter || showOnlyUnchecked || !!searchQuery.trim();
                 return (
                   <div
                     key={p.id}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -366,9 +366,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   const allTags = useMemoA(() => [...new Set(players.map(p => p.tag).filter(Boolean))], [players]);
   const playerSearchTargets = useMemoA(() => {
     const map = new Map();
-    players.forEach(p => {
-      map.set(p.id, `${p.name || ""} ${p.displayName || ""} ${p.dojo || ""}`.toLowerCase());
-    });
+    players.forEach(p => { map.set(p.id, participantSearchTarget(p)); });
     return map;
   }, [players]);
   const visiblePlayers = useMemoA(() => {
@@ -910,9 +908,9 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                   onChange={e => setSearchQuery(e.target.value)}
                   onKeyDown={e => e.key === "Escape" && setSearchQuery("")}
                   placeholder="Search name, dojo…"
-                  style={{ width: "100%", paddingRight: searchQuery ? 28 : undefined }}
+                  style={{ width: "100%", paddingRight: trimmedSearch ? 28 : undefined }}
                 />
-                {searchQuery && (
+                {trimmedSearch && (
                   <button
                     type="button"
                     onClick={() => setSearchQuery("")}
@@ -1148,8 +1146,12 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
   );
 }
 
+function participantSearchTarget(p) {
+  return `${p.name || ""} ${p.displayName || ""} ${p.dojo || ""}`.toLowerCase();
+}
+
 window.AdminParticipants = AdminParticipants;
 
 // ES export for the vitest suite — pure helpers only. Components remain
 // behind the window.* global pattern to match the rest of admin_*.jsx.
-export { mintParticipantIds, findSeedMatchIndex };
+export { mintParticipantIds, findSeedMatchIndex, participantSearchTarget };

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -360,21 +360,25 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
 
   const [tagFilter, setTagFilter] = useStateA(null);
   const [searchQuery, setSearchQuery] = useStateA("");
+  const trimmedSearch = useMemoA(() => searchQuery.trim(), [searchQuery]);
   const lines = useMemoA(() => text.split("\n").filter((l) => l.trim()), [text]);
   const players = useMemoA(() => c.players || [], [c.players]);
   const allTags = useMemoA(() => [...new Set(players.map(p => p.tag).filter(Boolean))], [players]);
+  const playerSearchTargets = useMemoA(() => {
+    const map = new Map();
+    players.forEach(p => {
+      map.set(p.id, `${p.name || ""} ${p.displayName || ""} ${p.dojo || ""}`.toLowerCase());
+    });
+    return map;
+  }, [players]);
   const visiblePlayers = useMemoA(() => {
-    const q = searchQuery.trim().toLowerCase();
+    const q = trimmedSearch.toLowerCase();
     let out = players;
     if (tagFilter) out = out.filter(p => p.tag === tagFilter);
     if (showOnlyUnchecked) out = out.filter(p => !p.checkedIn);
-    if (q) out = out.filter(p =>
-      (p.name || "").toLowerCase().includes(q) ||
-      (p.displayName || "").toLowerCase().includes(q) ||
-      (p.dojo || "").toLowerCase().includes(q)
-    );
+    if (q) out = out.filter(p => playerSearchTargets.get(p.id)?.includes(q));
     return out;
-  }, [players, tagFilter, showOnlyUnchecked, searchQuery]);
+  }, [players, tagFilter, showOnlyUnchecked, trimmedSearch, playerSearchTargets]);
   const dojoFirstRowSet = useMemoA(() => {
     const seen = new Set();
     const first = new Set();
@@ -1028,20 +1032,20 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
               {/* When a tag filter is active, reorder controls would operate on */}
               {/* full-list indices but rows are filtered — so they'd swap with hidden */}
               {/* neighbours. Disable reordering until the filter is cleared. */}
-              {(tagFilter || showOnlyUnchecked || searchQuery.trim()) && (
+              {(tagFilter || showOnlyUnchecked || trimmedSearch) && (
                 <div className="field__hint" style={{ padding: "0 16px 8px" }}>
                   {visiblePlayers.length < players.length && `Showing ${visiblePlayers.length} of ${players.length}. `}
                   Reordering disabled while a filter is active. Clear all filters to drag rows or use the arrows.
                 </div>
               )}
-              {visiblePlayers.length === 0 && searchQuery.trim() && (
+              {visiblePlayers.length === 0 && trimmedSearch && (
                 <div className="empty" style={{ padding: "16px 24px" }}>
-                  No match for "{searchQuery.trim()}".
+                  No match for "{trimmedSearch}".
                 </div>
               )}
               {visiblePlayers.map((p) => {
                 const i = players.indexOf(p);
-                const reorderDisabled = !!tagFilter || showOnlyUnchecked || !!searchQuery.trim();
+                const reorderDisabled = !!tagFilter || showOnlyUnchecked || !!trimmedSearch;
                 return (
                   <div
                     key={p.id}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -1037,7 +1037,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                   Reordering disabled while a filter is active. Clear all filters to drag rows or use the arrows.
                 </div>
               )}
-              {visiblePlayers.length === 0 && trimmedSearch && (
+              {visiblePlayers.length === 0 && (trimmedSearch || tagFilter || showOnlyUnchecked) && (
                 <div className="empty" style={{ padding: "16px 24px" }}>
                   {(tagFilter || showOnlyUnchecked)
                     ? "No participants match current filters."


### PR DESCRIPTION
## Summary

- Adds a real-time text search box to the Check-in & Seeding participant list
- Filters by name, zekken/displayName, and dojo (case-insensitive substring match)
- Composes with the existing tag filter and Show-unchecked toggle
- Shows N-of-M count and empty-state message when no rows match
- ESC and × button clear the input; reordering disabled while filter is active

## Implementation notes

- Player search targets are pre-normalized (one combined lowercase string per player) when the `players` list changes, so per-keystroke filtering is O(n) substring scan with no per-player `.toLowerCase()` allocation
- `trimmedSearch` is memoized to avoid repeated `.trim()` calls across the render

## Test plan

- [ ] Open a competition with 20+ participants
- [ ] Type a partial name → list narrows in real time
- [ ] Type a partial dojo name → list narrows correctly
- [ ] Type a zekken/display name fragment (if withZekkenName enabled) → filters correctly
- [ ] Case-insensitive: "ALICE" matches "Alice"
- [ ] ESC clears the search box and restores the full list
- [ ] × button clears the search box
- [ ] Search composes with tag filter: activate a tag, then type → both filters apply
- [ ] Search composes with Show-unchecked toggle: activate toggle, then type → both apply
- [ ] N-of-M count appears in the hint banner when filter is active
- [ ] "No match for X" empty state appears when nothing matches
- [ ] Reordering arrows and drag are disabled while search is active
- [ ] Clearing the search box re-enables reordering

Closes mp-edx

🤖 Generated with [Claude Code](https://claude.com/claude-code)