### PR TITLE
fix(admin_participants): correct seed-row grid columns when check-in is disabled

### DIFF
--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -1024,9 +1024,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     }}
                     style={{
                       cursor: reorderDisabled ? "default" : "grab",
-                      gridTemplateColumns: c.checkInEnabled
-                        ? "24px 20px 36px 1fr 32px 64px"
-                        : "20px 36px 1fr 32px 64px",
+                      gridTemplateColumns: c.checkInEnabled ? undefined : "20px 36px 1fr 32px 64px",
                     }}
                   >
                     {c.checkInEnabled && (

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -1022,7 +1022,12 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                       dragIdxRef.current = null;
                       setDragOverIdx(null);
                     }}
-                    style={{ cursor: reorderDisabled ? "default" : "grab" }}
+                    style={{
+                      cursor: reorderDisabled ? "default" : "grab",
+                      gridTemplateColumns: c.checkInEnabled
+                        ? "24px 20px 36px 1fr 32px 64px"
+                        : "20px 36px 1fr 32px 64px",
+                    }}
                   >
                     {c.checkInEnabled && (
                       <div style={{ display: "flex", alignItems: "center", gap: 8, marginRight: 4 }}>


### PR DESCRIPTION
## Summary

- `.seed-row` has a 6-column CSS grid (`24px 20px 36px 1fr 32px 64px`) that includes a checkbox column at position 1
- When `checkInEnabled=false` the checkbox child is not rendered, so only 5 children fill the 6-column template — names landed in the 36px rank column (truncated) and buttons expanded into the 1fr name column
- Fix: set `gridTemplateColumns` as an inline style only when `checkInEnabled=false`, omitting the 24px checkbox column; the CSS rule stays authoritative for the default (check-in enabled) path

## Test plan

- [x] Competition with `check_in_enabled: false` → seed list shows full names, compact buttons, correct seed input width
- [x] Competition with `check_in_enabled: true` → layout unchanged (no inline override, CSS 6-column rule applies)
- [x] Reorder buttons (↑↓↔) render in correct column and respond to clicks
- [x] Seed input (—) visible and correctly sized at 64px

🤖 Generated with [Claude Code](https://claude.com/claude-code)