### PR TITLE
feat(announcements): queue multiple concurrent announcements with rotate viewer

### DIFF
--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -20,7 +20,6 @@ type announcementRequest struct {
 var validAnnouncementDurations = map[int]bool{5: true, 10: true, 15: true, 30: true}
 
 func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
-	// POST /api/tournament/announce — add a new announcement to the queue.
 	r.POST("/tournament/announce", func(c *gin.Context) {
 		var req announcementRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -44,46 +43,35 @@ func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *H
 			return
 		}
 
-		duration := time.Duration(req.DurationMinutes) * time.Minute
-		ann := store.AnnouncementStore().Add(trimmedMsg, duration)
-
-		// Broadcast full list snapshot so all clients stay in sync.
-		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().List())
-
+		ann, list := store.AnnouncementStore().Add(trimmedMsg, time.Duration(req.DurationMinutes)*time.Minute)
+		hub.Broadcast(EventAnnouncement, list)
 		c.JSON(http.StatusOK, ann)
 	})
 
 	// DELETE /api/announcements/:id — dismiss a single announcement.
 	r.DELETE("/announcements/:id", func(c *gin.Context) {
-		id := c.Param("id")
-		if !store.AnnouncementStore().Remove(id) {
+		found, list := store.AnnouncementStore().Remove(c.Param("id"))
+		if !found {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Announcement not found"})
 			return
 		}
-		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().List())
+		hub.Broadcast(EventAnnouncement, list)
 		c.Status(http.StatusNoContent)
 	})
 
 	// DELETE /api/announcements — clear all announcements.
 	r.DELETE("/announcements", func(c *gin.Context) {
-		store.AnnouncementStore().Clear()
-		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().List())
+		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().Clear())
 		c.Status(http.StatusNoContent)
 	})
 }
 
 func RegisterPublicAnnouncementHandlers(r *gin.RouterGroup, store *state.Store) {
-	// GET /api/tournament/announcements — returns the full active list (public).
 	r.GET("/tournament/announcements", func(c *gin.Context) {
-		list := store.AnnouncementStore().List()
-		if list == nil {
-			list = []state.Announcement{}
-		}
-		c.JSON(http.StatusOK, list)
+		c.JSON(http.StatusOK, store.AnnouncementStore().List())
 	})
 
-	// GET /api/tournament/announcement — legacy single-slot endpoint; kept for
-	// any clients that haven't migrated to the list endpoint.
+	// GET /api/tournament/announcement — legacy single-slot endpoint.
 	r.GET("/tournament/announcement", func(c *gin.Context) {
 		ann := store.AnnouncementStore().Get()
 		if ann == nil {

--- a/internal/mobileapp/handlers_announcement.go
+++ b/internal/mobileapp/handlers_announcement.go
@@ -20,8 +20,7 @@ type announcementRequest struct {
 var validAnnouncementDurations = map[int]bool{5: true, 10: true, 15: true, 30: true}
 
 func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
-	// POST /api/tournament/announce is protected (requires admin credentials).
-	// MaxBodyBytes(AnnouncementMaxBodyBytes) is applied before AuthMiddleware on the route group wiring this handler.
+	// POST /api/tournament/announce — add a new announcement to the queue.
 	r.POST("/tournament/announce", func(c *gin.Context) {
 		var req announcementRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -46,17 +45,45 @@ func RegisterAnnouncementHandlers(r *gin.RouterGroup, store *state.Store, hub *H
 		}
 
 		duration := time.Duration(req.DurationMinutes) * time.Minute
-		ann := store.AnnouncementStore().Set(trimmedMsg, duration)
+		ann := store.AnnouncementStore().Add(trimmedMsg, duration)
 
-		// Broadcast new announcement to all connected SSE clients
-		hub.Broadcast(EventAnnouncement, ann)
+		// Broadcast full list snapshot so all clients stay in sync.
+		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().List())
 
 		c.JSON(http.StatusOK, ann)
+	})
+
+	// DELETE /api/announcements/:id — dismiss a single announcement.
+	r.DELETE("/announcements/:id", func(c *gin.Context) {
+		id := c.Param("id")
+		if !store.AnnouncementStore().Remove(id) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Announcement not found"})
+			return
+		}
+		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().List())
+		c.Status(http.StatusNoContent)
+	})
+
+	// DELETE /api/announcements — clear all announcements.
+	r.DELETE("/announcements", func(c *gin.Context) {
+		store.AnnouncementStore().Clear()
+		hub.Broadcast(EventAnnouncement, store.AnnouncementStore().List())
+		c.Status(http.StatusNoContent)
 	})
 }
 
 func RegisterPublicAnnouncementHandlers(r *gin.RouterGroup, store *state.Store) {
-	// GET /api/tournament/announcement is public
+	// GET /api/tournament/announcements — returns the full active list (public).
+	r.GET("/tournament/announcements", func(c *gin.Context) {
+		list := store.AnnouncementStore().List()
+		if list == nil {
+			list = []state.Announcement{}
+		}
+		c.JSON(http.StatusOK, list)
+	})
+
+	// GET /api/tournament/announcement — legacy single-slot endpoint; kept for
+	// any clients that haven't migrated to the list endpoint.
 	r.GET("/tournament/announcement", func(c *gin.Context) {
 		ann := store.AnnouncementStore().Get()
 		if ann == nil {

--- a/internal/mobileapp/handlers_announcement_test.go
+++ b/internal/mobileapp/handlers_announcement_test.go
@@ -31,7 +31,6 @@ func TestAnnouncementHandlers(t *testing.T) {
 	}
 	res := resources.NewResources(nil, mockFS)
 
-	// Save tournament config with a password so AuthMiddleware doesn't run in bootstrap mode
 	tourney := state.Tournament{
 		Name:     "Test Tournament",
 		Password: "secret-password",
@@ -39,7 +38,6 @@ func TestAnnouncementHandlers(t *testing.T) {
 	err = store.SaveTournament(&tourney)
 	require.NoError(t, err)
 
-	// Construct router using NewRouter so we test full middleware integration
 	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
 
 	// 1. GET /api/tournament/announcement - initially empty (204 No Content)
@@ -48,7 +46,16 @@ func TestAnnouncementHandlers(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNoContent, w.Code)
 
-	// 2. POST /api/tournament/announce - unauthorized without header
+	// 2. GET /api/tournament/announcements - initially empty list
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/tournament/announcements", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var emptyList []state.Announcement
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &emptyList))
+	assert.Empty(t, emptyList)
+
+	// 3. POST /api/tournament/announce - unauthorized without header
 	payload := announcementRequest{
 		Message:         "Lunch break for 30 minutes",
 		DurationMinutes: 30,
@@ -59,18 +66,15 @@ func TestAnnouncementHandlers(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
-	// 3. POST /api/tournament/announce - unauthorized with wrong password
+	// 4. POST /api/tournament/announce - wrong password
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
 	req.Header.Set("X-Tournament-Password", "wrong-password")
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
-	// 4. POST /api/tournament/announce - bad request with empty message
-	badPayload := announcementRequest{
-		Message:         "   ",
-		DurationMinutes: 30,
-	}
+	// 5. POST /api/tournament/announce - empty message
+	badPayload := announcementRequest{Message: "   ", DurationMinutes: 30}
 	body, _ = json.Marshal(badPayload)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
@@ -79,12 +83,8 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "cannot be empty")
 
-	// 5. POST /api/tournament/announce - bad request with too long message (>200 chars)
-	tooLongMsg := strings.Repeat("A", 201)
-	badPayload = announcementRequest{
-		Message:         tooLongMsg,
-		DurationMinutes: 30,
-	}
+	// 6. POST /api/tournament/announce - message too long (>200 chars)
+	badPayload = announcementRequest{Message: strings.Repeat("A", 201), DurationMinutes: 30}
 	body, _ = json.Marshal(badPayload)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
@@ -93,11 +93,8 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "cannot exceed 200 characters")
 
-	// 6. POST /api/tournament/announce - bad request with invalid duration (e.g. 7 minutes)
-	badPayload = announcementRequest{
-		Message:         "Valid message",
-		DurationMinutes: 7,
-	}
+	// 7. POST /api/tournament/announce - invalid duration
+	badPayload = announcementRequest{Message: "Valid message", DurationMinutes: 7}
 	body, _ = json.Marshal(badPayload)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
@@ -106,22 +103,16 @@ func TestAnnouncementHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "Duration must be 5, 10, 15, or 30 minutes")
 
-	// 7. POST /api/tournament/announce - oversized body (>AnnouncementMaxBodyBytes)
-	// returns 413: MaxBodyBytes fires before AuthMiddleware (Content-Length fast
-	// path) and before ShouldBindJSON can run.
+	// 8. POST /api/tournament/announce - oversized body (>AnnouncementMaxBodyBytes)
 	hugeMsg := strings.Repeat("A", int(AnnouncementMaxBodyBytes)+10)
-	hugePayload := announcementRequest{
-		Message:         hugeMsg,
-		DurationMinutes: 30,
-	}
-	body, _ = json.Marshal(hugePayload)
+	body, _ = json.Marshal(announcementRequest{Message: hugeMsg, DurationMinutes: 30})
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
 	req.Header.Set("X-Tournament-Password", "secret-password")
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "expected 413 for body over %d bytes", AnnouncementMaxBodyBytes)
 
-	// 8. POST /api/tournament/announce - happy path (200 OK)
+	// 9. POST first announcement — happy path
 	body, _ = json.Marshal(payload)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
@@ -129,22 +120,89 @@ func TestAnnouncementHandlers(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response state.Announcement
-	err = json.Unmarshal(w.Body.Bytes(), &response)
-	require.NoError(t, err)
-	assert.Equal(t, "Lunch break for 30 minutes", response.Message)
-	assert.False(t, response.SentAt.IsZero())
-	assert.False(t, response.ExpiresAt.IsZero())
-	assert.True(t, response.ExpiresAt.After(response.SentAt))
+	var first state.Announcement
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &first))
+	assert.Equal(t, "Lunch break for 30 minutes", first.Message)
+	assert.NotEmpty(t, first.ID)
+	assert.False(t, first.SentAt.IsZero())
+	assert.True(t, first.ExpiresAt.After(first.SentAt))
 
-	// 9. GET /api/tournament/announcement - should now return the active announcement (200 OK)
+	// 10. POST second announcement — both should coexist
+	body, _ = json.Marshal(announcementRequest{Message: "Court 3 paused", DurationMinutes: 5})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/tournament/announce", bytes.NewReader(body))
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var second state.Announcement
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &second))
+	assert.Equal(t, "Court 3 paused", second.Message)
+	assert.NotEmpty(t, second.ID)
+	assert.NotEqual(t, first.ID, second.ID)
+
+	// 11. GET /api/tournament/announcements — should list both
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/tournament/announcements", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var list []state.Announcement
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &list))
+	assert.Len(t, list, 2)
+	assert.Equal(t, first.ID, list[0].ID)
+	assert.Equal(t, second.ID, list[1].ID)
+
+	// 12. GET /api/tournament/announcement — legacy endpoint returns most recent
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/api/tournament/announcement", nil)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	var single state.Announcement
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &single))
+	assert.Equal(t, second.ID, single.ID)
 
-	var retrieved state.Announcement
-	err = json.Unmarshal(w.Body.Bytes(), &retrieved)
-	require.NoError(t, err)
-	assert.Equal(t, "Lunch break for 30 minutes", retrieved.Message)
+	// 13. DELETE /api/announcements/:id — dismiss first
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/announcements/"+first.ID, nil)
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/tournament/announcements", nil)
+	router.ServeHTTP(w, req)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &list))
+	assert.Len(t, list, 1)
+	assert.Equal(t, second.ID, list[0].ID)
+
+	// 14. DELETE /api/announcements/:id — not found
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/announcements/doesnotexist", nil)
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// 15. DELETE /api/announcements — clear all
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/announcements", nil)
+	req.Header.Set("X-Tournament-Password", "secret-password")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/tournament/announcements", nil)
+	router.ServeHTTP(w, req)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &list))
+	assert.Empty(t, list)
+
+	// 16. DELETE admin endpoints require auth
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/announcements/someid", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/announcements", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/internal/state/announcement_store.go
+++ b/internal/state/announcement_store.go
@@ -1,8 +1,6 @@
 package state
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"sync"
 	"time"
 )
@@ -18,28 +16,45 @@ func NewAnnouncementStore() *AnnouncementStore {
 	return &AnnouncementStore{}
 }
 
-// Add appends a new announcement and returns it. Expired entries are pruned
-// first; if still at capacity the oldest is evicted.
-func (s *AnnouncementStore) Add(msg string, dur time.Duration) Announcement {
+// Add appends a new announcement. Returns the new item and the updated list
+// snapshot under the same lock, eliminating any race between mutation and
+// broadcast.
+func (s *AnnouncementStore) Add(msg string, dur time.Duration) (Announcement, []Announcement) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
-	ann := Announcement{
-		ID:        newAnnouncementID(),
-		Message:   msg,
-		SentAt:    now,
-		ExpiresAt: now.Add(dur),
-	}
-
-	s.pruneExpiredLocked(now)
+	ann := makeAnnouncement(msg, dur)
+	s.pruneExpiredLocked(time.Now())
 
 	if len(s.active) >= maxActiveAnnouncements {
 		s.active = s.active[1:]
 	}
 
 	s.active = append(s.active, ann)
-	return ann
+	return ann, snapshotLocked(s.active)
+}
+
+// Remove dismisses the announcement with the given ID. Returns whether it was
+// found and the updated list snapshot under the same lock.
+func (s *AnnouncementStore) Remove(id string) (bool, []Announcement) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, a := range s.active {
+		if a.ID == id {
+			s.active = append(s.active[:i], s.active[i+1:]...)
+			return true, snapshotLocked(s.active)
+		}
+	}
+	return false, snapshotLocked(s.active)
+}
+
+// Clear removes all announcements and returns an empty snapshot.
+func (s *AnnouncementStore) Clear() []Announcement {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = nil
+	return []Announcement{}
 }
 
 // List returns a copy of all currently active (non-expired) announcements,
@@ -49,32 +64,7 @@ func (s *AnnouncementStore) List() []Announcement {
 	defer s.mu.Unlock()
 
 	s.pruneExpiredLocked(time.Now())
-	if len(s.active) == 0 {
-		return nil
-	}
-	out := make([]Announcement, len(s.active))
-	copy(out, s.active)
-	return out
-}
-
-// Remove dismisses the announcement with the given ID. Returns true if found.
-func (s *AnnouncementStore) Remove(id string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for i, a := range s.active {
-		if a.ID == id {
-			s.active = append(s.active[:i], s.active[i+1:]...)
-			return true
-		}
-	}
-	return false
-}
-
-func (s *AnnouncementStore) Clear() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.active = nil
+	return snapshotLocked(s.active)
 }
 
 // Get returns the most recent active announcement, or nil.
@@ -97,13 +87,7 @@ func (s *AnnouncementStore) Set(msg string, dur time.Duration) Announcement {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
-	ann := Announcement{
-		ID:        newAnnouncementID(),
-		Message:   msg,
-		SentAt:    now,
-		ExpiresAt: now.Add(dur),
-	}
+	ann := makeAnnouncement(msg, dur)
 	s.active = []Announcement{ann}
 	return ann
 }
@@ -119,8 +103,21 @@ func (s *AnnouncementStore) pruneExpiredLocked(now time.Time) {
 	s.active = kept
 }
 
-func newAnnouncementID() string {
-	b := make([]byte, 8)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
+func makeAnnouncement(msg string, dur time.Duration) Announcement {
+	now := time.Now()
+	return Announcement{
+		ID:        newParticipantID(),
+		Message:   msg,
+		SentAt:    now,
+		ExpiresAt: now.Add(dur),
+	}
+}
+
+func snapshotLocked(active []Announcement) []Announcement {
+	if len(active) == 0 {
+		return []Announcement{}
+	}
+	out := make([]Announcement, len(active))
+	copy(out, active)
+	return out
 }

--- a/internal/state/announcement_store.go
+++ b/internal/state/announcement_store.go
@@ -1,68 +1,126 @@
 package state
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"sync"
 	"time"
 )
 
+const maxActiveAnnouncements = 10
+
 type AnnouncementStore struct {
-	mu      sync.RWMutex
-	current *Announcement
+	mu     sync.Mutex
+	active []Announcement
 }
 
 func NewAnnouncementStore() *AnnouncementStore {
 	return &AnnouncementStore{}
 }
 
+// Add appends a new announcement and returns it. Expired entries are pruned
+// first; if still at capacity the oldest is evicted.
+func (s *AnnouncementStore) Add(msg string, dur time.Duration) Announcement {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	ann := Announcement{
+		ID:        newAnnouncementID(),
+		Message:   msg,
+		SentAt:    now,
+		ExpiresAt: now.Add(dur),
+	}
+
+	s.pruneExpiredLocked(now)
+
+	if len(s.active) >= maxActiveAnnouncements {
+		s.active = s.active[1:]
+	}
+
+	s.active = append(s.active, ann)
+	return ann
+}
+
+// List returns a copy of all currently active (non-expired) announcements,
+// oldest first.
+func (s *AnnouncementStore) List() []Announcement {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(time.Now())
+	if len(s.active) == 0 {
+		return nil
+	}
+	out := make([]Announcement, len(s.active))
+	copy(out, s.active)
+	return out
+}
+
+// Remove dismisses the announcement with the given ID. Returns true if found.
+func (s *AnnouncementStore) Remove(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, a := range s.active {
+		if a.ID == id {
+			s.active = append(s.active[:i], s.active[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func (s *AnnouncementStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = nil
+}
+
+// Get returns the most recent active announcement, or nil.
+// Kept for backward-compat with callers expecting the single-slot API.
+func (s *AnnouncementStore) Get() *Announcement {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(time.Now())
+	if len(s.active) == 0 {
+		return nil
+	}
+	c := s.active[len(s.active)-1]
+	return &c
+}
+
+// Set adds a single announcement and clears all prior ones.
+// Kept for backward-compat; new callers should prefer Add.
 func (s *AnnouncementStore) Set(msg string, dur time.Duration) Announcement {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	now := time.Now()
 	ann := Announcement{
+		ID:        newAnnouncementID(),
 		Message:   msg,
 		SentAt:    now,
 		ExpiresAt: now.Add(dur),
 	}
-	s.current = &Announcement{
-		Message:   ann.Message,
-		SentAt:    ann.SentAt,
-		ExpiresAt: ann.ExpiresAt,
-	}
+	s.active = []Announcement{ann}
 	return ann
 }
 
-func (s *AnnouncementStore) Get() *Announcement {
-	s.mu.RLock()
-	if s.current == nil {
-		s.mu.RUnlock()
-		return nil
+// pruneExpiredLocked removes expired entries. Must be called with mu held.
+func (s *AnnouncementStore) pruneExpiredLocked(now time.Time) {
+	kept := s.active[:0]
+	for _, a := range s.active {
+		if now.Before(a.ExpiresAt) {
+			kept = append(kept, a)
+		}
 	}
-	if time.Now().Before(s.current.ExpiresAt) {
-		annCopy := *s.current
-		s.mu.RUnlock()
-		return &annCopy
-	}
-	s.mu.RUnlock()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	// Double-check under write lock: a concurrent Set() may have replaced
-	// the expired announcement with a fresh one between our RUnlock and
-	// Lock above. Only clear if still expired; if fresh, return a copy.
-	if s.current == nil {
-		return nil
-	}
-	if !time.Now().Before(s.current.ExpiresAt) {
-		s.current = nil
-		return nil
-	}
-	annCopy := *s.current
-	return &annCopy
+	s.active = kept
 }
 
-func (s *AnnouncementStore) Clear() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.current = nil
+func newAnnouncementID() string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }

--- a/internal/state/announcement_store.go
+++ b/internal/state/announcement_store.go
@@ -40,6 +40,7 @@ func (s *AnnouncementStore) Remove(id string) (bool, []Announcement) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.pruneExpiredLocked(time.Now())
 	for i, a := range s.active {
 		if a.ID == id {
 			s.active = append(s.active[:i], s.active[i+1:]...)

--- a/internal/state/announcement_store_test.go
+++ b/internal/state/announcement_store_test.go
@@ -115,6 +115,23 @@ func TestAnnouncementStoreRemove(t *testing.T) {
 	}
 }
 
+func TestAnnouncementStoreRemovePrunesExpired(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	_, _ = store.Add("expires soon", 10*time.Millisecond)
+	a2, _ := store.Add("long-lived", 30*time.Minute)
+	time.Sleep(20 * time.Millisecond)
+
+	// Remove the long-lived item; snapshot must not include the expired one.
+	found, list := store.Remove(a2.ID)
+	if !found {
+		t.Fatal("expected Remove to find a2")
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty snapshot after remove + prune, got %d items: %v", len(list), list)
+	}
+}
+
 func TestAnnouncementStoreCapEvictsOldest(t *testing.T) {
 	store := NewAnnouncementStore()
 

--- a/internal/state/announcement_store_test.go
+++ b/internal/state/announcement_store_test.go
@@ -12,8 +12,8 @@ func TestAnnouncementStore(t *testing.T) {
 	if ann := store.Get(); ann != nil {
 		t.Errorf("expected initial announcement to be nil, got: %v", ann)
 	}
-	if list := store.List(); list != nil {
-		t.Errorf("expected initial list to be nil, got: %v", list)
+	if list := store.List(); len(list) != 0 {
+		t.Errorf("expected initial list to be empty, got: %v", list)
 	}
 
 	// Set replaces all prior.
@@ -66,8 +66,8 @@ func TestAnnouncementStore(t *testing.T) {
 func TestAnnouncementStoreAdd(t *testing.T) {
 	store := NewAnnouncementStore()
 
-	a1 := store.Add("first", 30*time.Minute)
-	a2 := store.Add("second", 30*time.Minute)
+	a1, _ := store.Add("first", 30*time.Minute)
+	a2, _ := store.Add("second", 30*time.Minute)
 
 	if a1.ID == a2.ID {
 		t.Error("IDs should be unique")
@@ -94,16 +94,14 @@ func TestAnnouncementStoreAdd(t *testing.T) {
 func TestAnnouncementStoreRemove(t *testing.T) {
 	store := NewAnnouncementStore()
 
-	a1 := store.Add("msg1", 30*time.Minute)
-	a2 := store.Add("msg2", 30*time.Minute)
-	_ = a2
+	a1, _ := store.Add("msg1", 30*time.Minute)
+	_, _ = store.Add("msg2", 30*time.Minute)
 
-	removed := store.Remove(a1.ID)
+	removed, list := store.Remove(a1.ID)
 	if !removed {
 		t.Error("expected Remove to return true for existing ID")
 	}
 
-	list := store.List()
 	if len(list) != 1 {
 		t.Fatalf("expected 1 remaining, got %d", len(list))
 	}
@@ -111,7 +109,8 @@ func TestAnnouncementStoreRemove(t *testing.T) {
 		t.Errorf("expected msg2 to remain, got %q", list[0].Message)
 	}
 
-	if store.Remove("nonexistent") {
+	notFound, _ := store.Remove("nonexistent")
+	if notFound {
 		t.Error("expected Remove to return false for missing ID")
 	}
 }
@@ -120,10 +119,9 @@ func TestAnnouncementStoreCapEvictsOldest(t *testing.T) {
 	store := NewAnnouncementStore()
 
 	for range maxActiveAnnouncements {
-		store.Add("msg", 30*time.Minute)
+		_, _ = store.Add("msg", 30*time.Minute)
 	}
-	// One more should evict the oldest.
-	newest := store.Add("newest", 30*time.Minute)
+	newest, _ := store.Add("newest", 30*time.Minute)
 	list := store.List()
 	if len(list) != maxActiveAnnouncements {
 		t.Fatalf("expected cap %d, got %d", maxActiveAnnouncements, len(list))
@@ -173,7 +171,7 @@ func TestAnnouncementStoreConcurrentAddList(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			store.Add("concurrent", 30*time.Minute)
+			_, _ = store.Add("concurrent", 30*time.Minute)
 		}()
 		go func() {
 			defer wg.Done()

--- a/internal/state/announcement_store_test.go
+++ b/internal/state/announcement_store_test.go
@@ -9,21 +9,23 @@ import (
 func TestAnnouncementStore(t *testing.T) {
 	store := NewAnnouncementStore()
 
-	// Initial state: should be nil
 	if ann := store.Get(); ann != nil {
 		t.Errorf("expected initial announcement to be nil, got: %v", ann)
 	}
+	if list := store.List(); list != nil {
+		t.Errorf("expected initial list to be nil, got: %v", list)
+	}
 
-	// Set active announcement
+	// Set replaces all prior.
 	msg := "Lunch break for 30 minutes"
-	dur := 30 * time.Minute
-	ann := store.Set(msg, dur)
-
+	ann := store.Set(msg, 30*time.Minute)
 	if ann.Message != msg {
 		t.Errorf("expected message %q, got %q", msg, ann.Message)
 	}
+	if ann.ID == "" {
+		t.Error("expected non-empty ID")
+	}
 
-	// Retrieve active announcement
 	retrieved := store.Get()
 	if retrieved == nil {
 		t.Fatal("expected retrieved announcement to be non-nil")
@@ -32,15 +34,12 @@ func TestAnnouncementStore(t *testing.T) {
 		t.Errorf("expected retrieved message %q, got %q", msg, retrieved.Message)
 	}
 
-	// Set replaces previous
+	// Set replaces previous.
 	newMsg := "Delay on court B"
-	newDur := 5 * time.Minute
-	newAnn := store.Set(newMsg, newDur)
-
+	newAnn := store.Set(newMsg, 5*time.Minute)
 	if newAnn.Message != newMsg {
 		t.Errorf("expected new message %q, got %q", newMsg, newAnn.Message)
 	}
-
 	retrievedNew := store.Get()
 	if retrievedNew == nil {
 		t.Fatal("expected retrieved new announcement to be non-nil")
@@ -49,35 +48,112 @@ func TestAnnouncementStore(t *testing.T) {
 		t.Errorf("expected retrieved new message %q, got %q", newMsg, retrievedNew.Message)
 	}
 
-	// Expiration test: set an announcement with very short duration
+	// Expiry.
 	store.Set("Short notice", 10*time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
-
 	if expired := store.Get(); expired != nil {
 		t.Errorf("expected announcement to be expired (nil), got: %v", expired)
 	}
 
-	// Clear test
+	// Clear.
 	store.Set("Clear me", 10*time.Minute)
-	if retrieved := store.Get(); retrieved == nil {
-		t.Fatal("expected announcement to be set before clear")
-	}
 	store.Clear()
 	if cleared := store.Get(); cleared != nil {
 		t.Errorf("expected announcement to be cleared (nil), got: %v", cleared)
 	}
 }
 
-// TestAnnouncementStoreGetAfterSetReplacesExpired verifies the sequential
-// contract: after Set() replaces an expired announcement, Get() returns the
-// fresh value rather than the expired one or nil. (See the concurrent
-// variant below for the read-lock/write-lock race guard.)
+func TestAnnouncementStoreAdd(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	a1 := store.Add("first", 30*time.Minute)
+	a2 := store.Add("second", 30*time.Minute)
+
+	if a1.ID == a2.ID {
+		t.Error("IDs should be unique")
+	}
+
+	list := store.List()
+	if len(list) != 2 {
+		t.Fatalf("expected 2 announcements, got %d", len(list))
+	}
+	if list[0].Message != "first" {
+		t.Errorf("expected oldest first, got %q", list[0].Message)
+	}
+	if list[1].Message != "second" {
+		t.Errorf("expected newest last, got %q", list[1].Message)
+	}
+
+	// Get returns most recent.
+	got := store.Get()
+	if got == nil || got.Message != "second" {
+		t.Errorf("Get() should return most recent, got %v", got)
+	}
+}
+
+func TestAnnouncementStoreRemove(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	a1 := store.Add("msg1", 30*time.Minute)
+	a2 := store.Add("msg2", 30*time.Minute)
+	_ = a2
+
+	removed := store.Remove(a1.ID)
+	if !removed {
+		t.Error("expected Remove to return true for existing ID")
+	}
+
+	list := store.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 remaining, got %d", len(list))
+	}
+	if list[0].Message != "msg2" {
+		t.Errorf("expected msg2 to remain, got %q", list[0].Message)
+	}
+
+	if store.Remove("nonexistent") {
+		t.Error("expected Remove to return false for missing ID")
+	}
+}
+
+func TestAnnouncementStoreCapEvictsOldest(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	for range maxActiveAnnouncements {
+		store.Add("msg", 30*time.Minute)
+	}
+	// One more should evict the oldest.
+	newest := store.Add("newest", 30*time.Minute)
+	list := store.List()
+	if len(list) != maxActiveAnnouncements {
+		t.Fatalf("expected cap %d, got %d", maxActiveAnnouncements, len(list))
+	}
+	if list[len(list)-1].ID != newest.ID {
+		t.Error("newest should be last in list")
+	}
+}
+
+func TestAnnouncementStoreListPrunesExpired(t *testing.T) {
+	store := NewAnnouncementStore()
+
+	store.Add("expires soon", 10*time.Millisecond)
+	store.Add("long-lived", 30*time.Minute)
+	time.Sleep(20 * time.Millisecond)
+
+	list := store.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 after expiry, got %d", len(list))
+	}
+	if list[0].Message != "long-lived" {
+		t.Errorf("expected long-lived, got %q", list[0].Message)
+	}
+}
+
 func TestAnnouncementStoreGetAfterSetReplacesExpired(t *testing.T) {
 	store := NewAnnouncementStore()
 
-	// Set an announcement that expires immediately.
 	store.Set("expires now", 1*time.Nanosecond)
-	time.Sleep(5 * time.Millisecond) // ensure it is expired
+	time.Sleep(5 * time.Millisecond)
 
 	store.Set("fresh announcement", 10*time.Minute)
 
@@ -90,45 +166,19 @@ func TestAnnouncementStoreGetAfterSetReplacesExpired(t *testing.T) {
 	}
 }
 
-// TestAnnouncementStoreGetSetRace exercises the actual race between Get()
-// and Set(). Get() reads under the read lock, releases, then under the write
-// lock decides whether to clear an expired announcement. A concurrent Set()
-// can land in that window with a fresh announcement, and the double-check
-// in Get() must NOT clear that fresh value.
-//
-// We run many short rounds: each round seeds an immediately-expired
-// announcement, then runs Set("fresh") and Get() concurrently. After both
-// goroutines return, Get() must always observe a non-nil "fresh"
-// announcement on the next call. If the race guard regresses, the
-// concurrent Get() inside the round can race-clear the fresh announcement
-// and the post-round assertion catches it.
-func TestAnnouncementStoreGetSetRace(t *testing.T) {
-	const rounds = 200
-	for i := 0; i < rounds; i++ {
-		store := NewAnnouncementStore()
-		store.Set("expires now", 1*time.Nanosecond)
-		time.Sleep(time.Microsecond) // ensure expired
-
-		var wg sync.WaitGroup
+func TestAnnouncementStoreConcurrentAddList(t *testing.T) {
+	store := NewAnnouncementStore()
+	var wg sync.WaitGroup
+	for range 50 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			store.Set("fresh announcement", 10*time.Minute)
+			store.Add("concurrent", 30*time.Minute)
 		}()
 		go func() {
 			defer wg.Done()
-			// May see nil (expired cleared before Set lands) or "fresh"
-			// (Set landed first). Must NOT race-clear the fresh value.
-			_ = store.Get()
+			_ = store.List()
 		}()
-		wg.Wait()
-
-		got := store.Get()
-		if got == nil {
-			t.Fatalf("round %d: expected Get() to return the fresh announcement after the concurrent pair, got nil — race guard regressed", i)
-		}
-		if got.Message != "fresh announcement" {
-			t.Fatalf("round %d: expected message %q, got %q", i, "fresh announcement", got.Message)
-		}
 	}
+	wg.Wait()
 }

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -373,6 +373,7 @@ type ReservedSlot struct {
 }
 
 type Announcement struct {
+	ID        string    `json:"id"`
 	Message   string    `json:"message" yaml:"message"`
 	SentAt    time.Time `json:"sentAt" yaml:"sent_at"`
 	ExpiresAt time.Time `json:"expiresAt" yaml:"expires_at"`

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -373,7 +373,7 @@ type ReservedSlot struct {
 }
 
 type Announcement struct {
-	ID        string    `json:"id"`
+	ID        string    `json:"id" yaml:"id"`
 	Message   string    `json:"message" yaml:"message"`
 	SentAt    time.Time `json:"sentAt" yaml:"sent_at"`
 	ExpiresAt time.Time `json:"expiresAt" yaml:"expires_at"`

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { isAnnouncementActive } from '../app.jsx';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isAnnouncementActive, filterActiveAnnouncements } from '../app.jsx';
 
 // isAnnouncementActive encapsulates the gate that decides whether an
 // announcement fetched at mount (or received via SSE) should be shown.
@@ -32,5 +32,65 @@ describe('isAnnouncementActive', () => {
     const now = new Date();
     const ann = { sentAt: 'ts1', expiresAt: now.toISOString() };
     expect(isAnnouncementActive(ann, null, now)).toBe(false);
+  });
+});
+
+describe('filterActiveAnnouncements', () => {
+  const now = new Date();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns active announcements unchanged', () => {
+    const anns = [
+      { id: 'a1', expiresAt: future, message: 'A' },
+      { id: 'a2', expiresAt: future, message: 'B' },
+    ];
+    expect(filterActiveAnnouncements(anns, now)).toEqual(anns);
+  });
+
+  it('filters out expired announcements', () => {
+    const anns = [
+      { id: 'a1', expiresAt: future, message: 'keep' },
+      { id: 'a2', expiresAt: past, message: 'drop' },
+    ];
+    const result = filterActiveAnnouncements(anns, now);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a1');
+  });
+
+  it('filters out announcements dismissed via sessionStorage key', () => {
+    sessionStorage.setItem('bc_dismissed_announcement_a1', 'true');
+    const anns = [
+      { id: 'a1', expiresAt: future, message: 'dismissed' },
+      { id: 'a2', expiresAt: future, message: 'visible' },
+    ];
+    const result = filterActiveAnnouncements(anns, now);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a2');
+  });
+
+  it('uses the ID-based sessionStorage key pattern', () => {
+    sessionStorage.setItem('bc_dismissed_announcement_xyz', 'true');
+    const ann = { id: 'xyz', expiresAt: future, message: 'x' };
+    expect(filterActiveAnnouncements([ann], now)).toHaveLength(0);
+  });
+
+  it('returns empty array when all are expired or dismissed', () => {
+    sessionStorage.setItem('bc_dismissed_announcement_a2', 'true');
+    const anns = [
+      { id: 'a1', expiresAt: past, message: 'expired' },
+      { id: 'a2', expiresAt: future, message: 'dismissed' },
+    ];
+    expect(filterActiveAnnouncements(anns, now)).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterActiveAnnouncements([], now)).toEqual([]);
   });
 });

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -1,7 +1,7 @@
 // Tournament-edit, competition-create, and bulk-import pages. See
 // web-mobile/admin_split_plan.md.
 
-const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
+const { useState: useStateA, useEffect: useEffectA, useCallback: useCallbackA, useRef: useRefA } = React;
 
 const validateAndNormalizeDate = window.validateAndNormalizeDate;
 const decideNumericUpdate = window.decideNumericUpdate;
@@ -113,17 +113,16 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [announcementInFlight, setAnnouncementInFlight] = useStateA(false);
   const [activeAnnouncements, setActiveAnnouncements] = useStateA([]);
 
-  // Fetch active announcements on mount and after any change.
-  const refreshAnnouncements = async () => {
+  const refreshAnnouncements = useCallbackA(async () => {
     try {
       const list = await window.API.fetchAnnouncements();
       setActiveAnnouncements(list || []);
     } catch (_e) {
       // non-fatal
     }
-  };
+  }, []);
 
-  useEffectA(() => { refreshAnnouncements(); }, []);
+  useEffectA(() => { refreshAnnouncements(); }, [refreshAnnouncements]);
 
   const handleSendAnnouncement = async () => {
     const trimmed = announcementMessage.trim();

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -111,6 +111,19 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [announcementMessage, setAnnouncementMessage] = useStateA("");
   const [announcementDuration, setAnnouncementDuration] = useStateA(5);
   const [announcementInFlight, setAnnouncementInFlight] = useStateA(false);
+  const [activeAnnouncements, setActiveAnnouncements] = useStateA([]);
+
+  // Fetch active announcements on mount and after any change.
+  const refreshAnnouncements = async () => {
+    try {
+      const list = await window.API.fetchAnnouncements();
+      setActiveAnnouncements(list || []);
+    } catch (_e) {
+      // non-fatal
+    }
+  };
+
+  useEffectA(() => { refreshAnnouncements(); }, []);
 
   const handleSendAnnouncement = async () => {
     const trimmed = announcementMessage.trim();
@@ -122,12 +135,31 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       if (showToast) {
         showToast(`Announcement broadcast for ${announcementDuration} minutes!`, "success");
       }
+      await refreshAnnouncements();
     } catch (e) {
       if (showToast) {
         showToast(e.message, "error");
       }
     } finally {
       setAnnouncementInFlight(false);
+    }
+  };
+
+  const handleDismissAnnouncement = async (id) => {
+    try {
+      await window.API.deleteAnnouncement(id, password);
+      await refreshAnnouncements();
+    } catch (e) {
+      if (showToast) showToast(e.message, "error");
+    }
+  };
+
+  const handleClearAnnouncements = async () => {
+    try {
+      await window.API.clearAnnouncements(password);
+      await refreshAnnouncements();
+    } catch (e) {
+      if (showToast) showToast(e.message, "error");
     }
   };
 
@@ -233,6 +265,24 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
 
         <div className="page-head" style={{ marginTop: 32 }}><h1 className="page-head__title">Broadcast announcement</h1></div>
         <div className="card card--pad-lg">
+          {activeAnnouncements.length > 0 && (
+            <div className="field" style={{ marginBottom: 16 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+                <label className="field__label" style={{ marginBottom: 0 }}>Active announcements</label>
+                <button className="btn btn--sm btn--danger" onClick={handleClearAnnouncements}>Clear all</button>
+              </div>
+              {activeAnnouncements.map(ann => (
+                <div key={ann.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 8px", background: "var(--color-surface-raised, #f5f5f5)", borderRadius: 4, marginBottom: 4 }}>
+                  <span style={{ flex: 1, fontSize: "0.9em" }}>{ann.message}</span>
+                  <button
+                    className="btn btn--sm"
+                    onClick={() => handleDismissAnnouncement(ann.id)}
+                    aria-label="Dismiss announcement"
+                  >&times;</button>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="field">
             <label className="field__label">Message</label>
             <textarea
@@ -244,7 +294,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               onChange={(e) => setAnnouncementMessage(e.target.value)}
             />
             <div className="field__hint" style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
-              <span>Maximum 200 characters. Pushes a temporary announcement to all active viewer screens.</span>
+              <span>Maximum 200 characters. Adds to the active announcement queue on all viewer screens.</span>
               <span>{announcementMessage.length}/200</span>
             </div>
           </div>

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -648,16 +648,33 @@ const API = {
         }
         return res.json();
     },
-    async fetchAnnouncement() {
-        const res = await fetch('/api/tournament/announcement');
-        if (res.status === 204) {
-            return null;
-        }
+    async fetchAnnouncements() {
+        const res = await fetch('/api/tournament/announcements');
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
-            throw new Error(err.error || `Failed to fetch announcement (Status ${res.status})`);
+            throw new Error(err.error || `Failed to fetch announcements (Status ${res.status})`);
         }
         return res.json();
+    },
+    async deleteAnnouncement(id, password) {
+        const res = await fetch(`/api/announcements/${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+            headers: { 'X-Tournament-Password': password }
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to delete announcement (Status ${res.status})`);
+        }
+    },
+    async clearAnnouncements(password) {
+        const res = await fetch('/api/announcements', {
+            method: 'DELETE',
+            headers: { 'X-Tournament-Password': password }
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to clear announcements (Status ${res.status})`);
+        }
     }
 };
 

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -130,7 +130,7 @@ class ErrorBoundary extends React.Component {
 function App() {
   const [tournament, setTournament] = useS(null);
   const [loading, setLoading] = useS(true);
-  const [activeAnnouncement, setActiveAnnouncement] = useS(null);
+  const [announcements, setAnnouncements] = useS([]);
   // Hydrate the route state from the URL synchronously, BEFORE the first
   // render. The post-mount useEffect that previously did this ran AFTER
   // the URL-sync effect, so a direct load of /reset (or any non-`/`
@@ -318,22 +318,12 @@ function App() {
   useE(() => { load(); }, []);
 
   useE(() => {
-    window.API.fetchAnnouncement()
-      .then(ann => {
-        if (ann) {
-          let dismissedKey = null;
-          try {
-            dismissedKey = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
-          } catch (_e) {
-            // private-browsing modes can throw
-          }
-          if (isAnnouncementActive(ann, dismissedKey)) {
-            setActiveAnnouncement(ann);
-          }
-        }
+    window.API.fetchAnnouncements()
+      .then(list => {
+        setAnnouncements(filterActiveAnnouncements(list || []));
       })
       .catch(err => {
-        console.error("Failed to fetch initial announcement:", err);
+        console.error("Failed to fetch initial announcements:", err);
       });
   }, []);
 
@@ -476,18 +466,9 @@ function App() {
             }
             jitteredTimeout(load, jitter);
         } else if (event.type === "announcement") {
-            const ann = event.data;
-            if (ann) {
-                let dismissedKey = null;
-                try {
-                    dismissedKey = sessionStorage.getItem(`bc_dismissed_announcement_${ann.sentAt}`);
-                } catch (_e) {
-                    // private-browsing modes can throw
-                }
-                setActiveAnnouncement(isAnnouncementActive(ann, dismissedKey) ? ann : null);
-            } else {
-                setActiveAnnouncement(null);
-            }
+            // Payload is now the full list snapshot.
+            const list = Array.isArray(event.data) ? event.data : [];
+            setAnnouncements(filterActiveAnnouncements(list));
         }
     }, (status) => {
         // T063: track SSE connection status so /display surfaces can
@@ -537,17 +518,14 @@ function App() {
   // parent render (the effect lists onDismiss as a dependency, so an
   // inline arrow function would reset the interval on every re-render).
   // Must be declared before any conditional returns to satisfy Rules of Hooks.
-  const handleDismissAnnouncement = useC(() => {
-    setActiveAnnouncement(prev => {
-      if (prev?.sentAt) {
-        try {
-          sessionStorage.setItem(`bc_dismissed_announcement_${prev.sentAt}`, "true");
-        } catch (_e) {
-          // private-browsing modes can throw
-        }
-      }
-      return null;
-    });
+  // Viewer-side dismiss: hides announcement locally without calling server.
+  const handleDismissAnnouncement = useC((id) => {
+    try {
+      sessionStorage.setItem(`bc_dismissed_announcement_${id}`, "true");
+    } catch (_e) {
+      // private-browsing modes can throw
+    }
+    setAnnouncements(prev => prev.filter(a => a.id !== id));
   }, []);
 
   if (loading && !selectedCompData) return <div className="loading">Loading...</div>;
@@ -610,9 +588,9 @@ function App() {
   // viewer mode
   return (
     <>
-      {activeAnnouncement && window.AnnouncementBanner && (
+      {announcements.length > 0 && window.AnnouncementBanner && (
         <window.AnnouncementBanner
-          announcement={activeAnnouncement}
+          announcements={announcements}
           onDismiss={handleDismissAnnouncement}
         />
       )}
@@ -965,12 +943,27 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   </ErrorBoundary>
 );
 
-// Pure helper: returns true when an announcement should be shown.
-// `dismissedKey` is the sessionStorage value for this sentAt (truthy = dismissed).
+// Pure helper: returns true when a single announcement should be shown.
+// `dismissedKey` is the sessionStorage value for this id (truthy = dismissed).
 // `now` defaults to new Date() and can be overridden in tests for determinism.
 function isAnnouncementActive(ann, dismissedKey, now) {
   if (!ann || dismissedKey) return false;
   return (now || new Date()) < new Date(ann.expiresAt);
 }
 
-export { parsePath, pathFromState, ErrorBoundary, isAnnouncementActive };
+// Filters a list from the server, removing expired and locally-dismissed items.
+function filterActiveAnnouncements(list, now) {
+  const t = now || new Date();
+  return list.filter(ann => {
+    if (t >= new Date(ann.expiresAt)) return false;
+    let dismissed = false;
+    try {
+      dismissed = !!sessionStorage.getItem(`bc_dismissed_announcement_${ann.id}`);
+    } catch (_e) {
+      // private-browsing modes can throw
+    }
+    return !dismissed;
+  });
+}
+
+export { parsePath, pathFromState, ErrorBoundary, isAnnouncementActive, filterActiveAnnouncements };

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -951,18 +951,15 @@ function isAnnouncementActive(ann, dismissedKey, now) {
   return (now || new Date()) < new Date(ann.expiresAt);
 }
 
-// Filters a list from the server, removing expired and locally-dismissed items.
 function filterActiveAnnouncements(list, now) {
-  const t = now || new Date();
   return list.filter(ann => {
-    if (t >= new Date(ann.expiresAt)) return false;
-    let dismissed = false;
+    let dismissedKey = null;
     try {
-      dismissed = !!sessionStorage.getItem(`bc_dismissed_announcement_${ann.id}`);
+      dismissedKey = sessionStorage.getItem(`bc_dismissed_announcement_${ann.id}`);
     } catch (_e) {
       // private-browsing modes can throw
     }
-    return !dismissed;
+    return isAnnouncementActive(ann, dismissedKey, now);
   });
 }
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2458,7 +2458,15 @@ function AnnouncementBanner({ announcements, onDismiss }) {
   const safeIdx = list.length > 0 ? idx % list.length : 0;
   const ann = list[safeIdx];
 
-  const [timeLeft, setTimeLeft] = useState(() => ann ? formatAnnouncementTimeLeft(ann.expiresAt) : '');
+  // Key timer state by ann.id so the displayed value is correct immediately
+  // on rotation, without waiting for the effect to fire after the first render.
+  const [timerState, setTimerState] = useState(() => ({
+    id: ann?.id ?? null,
+    value: ann ? formatAnnouncementTimeLeft(ann.expiresAt) : '',
+  }));
+  const timeLeft = timerState.id === ann?.id
+    ? timerState.value
+    : formatAnnouncementTimeLeft(ann?.expiresAt ?? '');
 
   useEffect(() => {
     if (!ann) return;
@@ -2468,7 +2476,7 @@ function AnnouncementBanner({ announcements, onDismiss }) {
         onDismiss(ann.id);
         return;
       }
-      setTimeLeft(formatAnnouncementTimeLeft(ann.expiresAt));
+      setTimerState({ id: ann.id, value: formatAnnouncementTimeLeft(ann.expiresAt) });
     };
     updateTimer();
     const interval = setInterval(updateTimer, 1000);

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2470,17 +2470,26 @@ function AnnouncementBanner({ announcements, onDismiss }) {
 
   useEffect(() => {
     if (!ann) return;
+    // intervalId and dismissed are captured in the closure so updateTimer can
+    // self-clear the interval on expiry and guard against repeated onDismiss
+    // calls if React state updates are delayed before cleanup runs.
+    let intervalId;
+    let dismissed = false;
     const updateTimer = () => {
       const diff = new Date(ann.expiresAt).getTime() - Date.now();
       if (diff <= 0) {
-        onDismiss(ann.id);
+        clearInterval(intervalId);
+        if (!dismissed) {
+          dismissed = true;
+          onDismiss(ann.id);
+        }
         return;
       }
       setTimerState({ id: ann.id, value: formatAnnouncementTimeLeft(ann.expiresAt) });
     };
     updateTimer();
-    const interval = setInterval(updateTimer, 1000);
-    return () => clearInterval(interval);
+    intervalId = setInterval(updateTimer, 1000);
+    return () => clearInterval(intervalId);
   }, [ann?.id, ann?.expiresAt, onDismiss]);
 
   if (!ann) return null;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2435,44 +2435,59 @@ function formatAnnouncementTimeLeft(expiresAtIso) {
   return minutes > 0 ? `${minutes}:${paddedSeconds} left` : `${seconds}s left`;
 }
 
-function AnnouncementBanner({ announcement, onDismiss }) {
-  // Initialize synchronously so the badge isn't blank on the first paint
-  // (Copilot finding on PR #128). The useEffect tick keeps it accurate.
-  const [timeLeft, setTimeLeft] = useState(() => formatAnnouncementTimeLeft(announcement.expiresAt));
+// AnnouncementBanner accepts either a single `announcement` (legacy) or an
+// `announcements` array. When multiple are active it rotates through them
+// every 8 seconds so all are visible without stacking vertically.
+function AnnouncementBanner({ announcement, announcements, onDismiss }) {
+  const list = announcements || (announcement ? [announcement] : []);
+  const [idx, setIdx] = useState(0);
+
+  // Rotate through items every 8 seconds when multiple are active.
+  useEffect(() => {
+    if (list.length <= 1) return;
+    const interval = setInterval(() => {
+      setIdx(i => (i + 1) % list.length);
+    }, 8000);
+    return () => clearInterval(interval);
+  }, [list.length]);
+
+  // Reset to first slot when the list shrinks and idx is out of bounds.
+  const safeIdx = list.length > 0 ? idx % list.length : 0;
+  const ann = list[safeIdx];
+
+  const [timeLeft, setTimeLeft] = useState(() => ann ? formatAnnouncementTimeLeft(ann.expiresAt) : '');
 
   useEffect(() => {
+    if (!ann) return;
     const updateTimer = () => {
-      const expiresAt = new Date(announcement.expiresAt).getTime();
-      const now = Date.now();
-      const diff = expiresAt - now;
-
+      const diff = new Date(ann.expiresAt).getTime() - Date.now();
       if (diff <= 0) {
-        onDismiss();
+        onDismiss(ann.id);
         return;
       }
-
-      setTimeLeft(formatAnnouncementTimeLeft(announcement.expiresAt));
+      setTimeLeft(formatAnnouncementTimeLeft(ann.expiresAt));
     };
-
     updateTimer();
     const interval = setInterval(updateTimer, 1000);
-
     return () => clearInterval(interval);
-  }, [announcement.expiresAt, onDismiss]);
+  }, [ann?.id, ann?.expiresAt, onDismiss]);
+
+  if (!ann) return null;
 
   return (
     <div className="announcement-banner">
       <div className="announcement-banner__content">
         <div className="announcement-banner__icon" aria-hidden="true">📢</div>
-        <p className="announcement-banner__message">{announcement.message}</p>
+        <p className="announcement-banner__message">{ann.message}</p>
       </div>
       <div className="announcement-banner__meta">
-        <span className="announcement-banner__badge">
-          {timeLeft}
-        </span>
+        {list.length > 1 && (
+          <span className="announcement-banner__count">{safeIdx + 1}/{list.length}</span>
+        )}
+        <span className="announcement-banner__badge">{timeLeft}</span>
         <button
           className="announcement-banner__dismiss"
-          onClick={onDismiss}
+          onClick={() => onDismiss(ann.id)}
           aria-label="Dismiss announcement"
         >
           &times;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2440,8 +2440,9 @@ function AnnouncementBanner({ announcements, onDismiss }) {
   const list = announcements || [];
   const [idx, setIdx] = useState(0);
 
-  // Reset to 0 whenever the list shrinks so the next item shown is
-  // deterministic (first/oldest) rather than wherever % lands.
+  // Reset to 0 on any list-length change (add or dismiss) so the viewer
+  // always restarts from item 0 — deterministic and prevents out-of-bounds
+  // after a dismiss.
   useEffect(() => {
     setIdx(0);
   }, [list.length]);

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2439,6 +2439,12 @@ function AnnouncementBanner({ announcements, onDismiss }) {
   const list = announcements || [];
   const [idx, setIdx] = useState(0);
 
+  // Reset to 0 whenever the list shrinks so the next item shown is
+  // deterministic (first/oldest) rather than wherever % lands.
+  useEffect(() => {
+    setIdx(0);
+  }, [list.length]);
+
   useEffect(() => {
     if (list.length <= 1) return;
     const len = list.length;
@@ -2448,7 +2454,6 @@ function AnnouncementBanner({ announcements, onDismiss }) {
     return () => clearInterval(interval);
   }, [list.length]);
 
-  // % keeps safeIdx in bounds when the list shrinks after a dismiss.
   const safeIdx = list.length > 0 ? idx % list.length : 0;
   const ann = list[safeIdx];
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2435,23 +2435,20 @@ function formatAnnouncementTimeLeft(expiresAtIso) {
   return minutes > 0 ? `${minutes}:${paddedSeconds} left` : `${seconds}s left`;
 }
 
-// AnnouncementBanner accepts either a single `announcement` (legacy) or an
-// `announcements` array. When multiple are active it rotates through them
-// every 8 seconds so all are visible without stacking vertically.
-function AnnouncementBanner({ announcement, announcements, onDismiss }) {
-  const list = announcements || (announcement ? [announcement] : []);
+function AnnouncementBanner({ announcements, onDismiss }) {
+  const list = announcements || [];
   const [idx, setIdx] = useState(0);
 
-  // Rotate through items every 8 seconds when multiple are active.
   useEffect(() => {
     if (list.length <= 1) return;
+    const len = list.length;
     const interval = setInterval(() => {
-      setIdx(i => (i + 1) % list.length);
+      setIdx(i => (i + 1) % len);
     }, 8000);
     return () => clearInterval(interval);
   }, [list.length]);
 
-  // Reset to first slot when the list shrinks and idx is out of bounds.
+  // % keeps safeIdx in bounds when the list shrinks after a dismiss.
   const safeIdx = list.length > 0 ? idx % list.length : 0;
   const ann = list[safeIdx];
 


### PR DESCRIPTION
## Summary

- **Backend**: Replaced single-slot \`AnnouncementStore\` with a list supporting \`Add\`, \`Remove\`, \`Clear\`. New endpoints \`DELETE /api/announcements/:id\` and \`DELETE /api/announcements\` for per-item and bulk dismissal. \`GET /api/tournament/announcements\` (plural) returns the full active list; the legacy singular endpoint is kept for backward compat. SSE broadcasts a full list snapshot (\`EventAnnouncement\`) on every change.
- **Frontend (viewer)**: \`AnnouncementBanner\` now accepts an \`announcements\` array. When multiple are active it rotates through them every 8 seconds with a \`N/M\` counter badge.
- **Frontend (admin)**: \`AdminEditTournament\` shows active announcements with per-row dismiss (×) and a "Clear all" button above the compose form.
- **Store cap**: At most 10 concurrent announcements; oldest is evicted on overflow.

## Test plan

- [x] \`go test -race ./internal/state/... ./internal/mobileapp/...\` — all pass
- [x] \`TestAnnouncementStore\`, \`TestAnnouncementStoreAdd\`, \`TestAnnouncementStoreRemove\`, \`TestAnnouncementStoreCapEvictsOldest\`, \`TestAnnouncementStoreListPrunesExpired\`, \`TestAnnouncementStoreConcurrentAddList\`
- [x] \`TestAnnouncementHandlers\` — 16 cases: auth, validation, 2-item coexistence, dismiss by ID, clear all, auth on DELETEs
- [x] Manual: post two announcements ("Lunch break at 12:30" and "Court 3 paused"), verify viewer rotates between them every ~8s with N/2 badge
- [x] Manual: dismiss first from admin panel; verify viewer shows only the second
- [x] Manual: "Clear all" from admin panel; verify viewer banner disappears
- [x] Manual: single announcement still works as before (no rotation, no counter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)