### PR TITLE
feat(mp-0cg): bulk check-in endpoint for participants

### DIFF
--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -411,7 +411,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
-		result, err := store.BulkCheckIn(id, req.ParticipantIDs, comp.WithZekkenName)
+		result, err := store.BulkCheckIn(id, req.ParticipantIDs)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -386,6 +386,39 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		c.JSON(http.StatusOK, updatedPlayer)
 	})
 
+	r.POST("/competitions/:id/participants/check-in-bulk", func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+
+		var req struct {
+			ParticipantIDs []string `json:"participant_ids"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		comp, err := store.LoadCompetition(id)
+		if err != nil || comp == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+
+		result, err := store.BulkCheckIn(id, req.ParticipantIDs, comp.WithZekkenName)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		if result.CheckedIn > 0 {
+			hub.Broadcast(EventParticipantsUpdated, gin.H{"competitionId": id})
+		}
+
+		c.JSON(http.StatusOK, result)
+	})
+
 	r.DELETE("/competitions/:id/participants/:pid/checkin", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -386,14 +386,14 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		c.JSON(http.StatusOK, updatedPlayer)
 	})
 
-	r.POST("/competitions/:id/participants/check-in-bulk", func(c *gin.Context) {
+	r.POST("/competitions/:id/participants/checkin-bulk", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return
 		}
 
 		var req struct {
-			ParticipantIDs []string `json:"participant_ids"`
+			ParticipantIDs []string `json:"participantIds"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -401,7 +401,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		}
 
 		if len(req.ParticipantIDs) > MaxBulkCheckInIDs {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("participant_ids must not exceed %d entries", MaxBulkCheckInIDs)})
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("participantIds must not exceed %d entries", MaxBulkCheckInIDs)})
 			return
 		}
 

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -404,6 +404,12 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("participantIds must not exceed %d entries", MaxBulkCheckInIDs)})
 			return
 		}
+		for i, pid := range req.ParticipantIDs {
+			if err := validateMaxLen(fmt.Sprintf("participantIds[%d]", i), pid, MaxLenEntityID); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+		}
 
 		comp, err := store.LoadCompetition(id)
 		if err != nil || comp == nil {

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -400,14 +400,14 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
-		comp, err := store.LoadCompetition(id)
-		if err != nil || comp == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+		if len(req.ParticipantIDs) > MaxBulkCheckInIDs {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("participant_ids must not exceed %d entries", MaxBulkCheckInIDs)})
 			return
 		}
 
-		if len(req.ParticipantIDs) > MaxBulkCheckInIDs {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("participant_ids must not exceed %d entries", MaxBulkCheckInIDs)})
+		comp, err := store.LoadCompetition(id)
+		if err != nil || comp == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
 			return
 		}
 

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -406,6 +406,11 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 			return
 		}
 
+		if len(req.ParticipantIDs) > MaxBulkCheckInIDs {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("participant_ids must not exceed %d entries", MaxBulkCheckInIDs)})
+			return
+		}
+
 		result, err := store.BulkCheckIn(id, req.ParticipantIDs, comp.WithZekkenName)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -485,6 +485,28 @@ func TestBulkCheckIn(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
+
+	t.Run("oversized array returns 400", func(t *testing.T) {
+		over := make([]string, MaxBulkCheckInIDs+1)
+		for i := range over {
+			over[i] = added[0].ID
+		}
+		w := doPost(t, over)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("duplicate pids counted only once", func(t *testing.T) {
+		// Eve (added[4]) already checked in from "unknown pid" sub-test.
+		// Send her PID twice — must count as 1 already_checked_in, not 2.
+		pids := []string{added[4].ID, added[4].ID}
+		w := doPost(t, pids)
+		require.Equal(t, http.StatusOK, w.Code)
+		var res state.BulkCheckInResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		assert.Equal(t, 0, res.CheckedIn)
+		assert.Equal(t, 1, res.AlreadyCheckedIn)
+		assert.Empty(t, res.NotFound)
+	})
 }
 
 func mustLoad(t *testing.T, store *state.Store, compID string) []domain.Player {

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -393,7 +394,7 @@ func TestReplaceDoesNotInheritOldDisplayName(t *testing.T) {
 		"stale A. SMITH from replaced slot must not carry over")
 }
 
-// TestBulkCheckIn exercises the POST /competitions/:id/participants/check-in-bulk endpoint.
+// TestBulkCheckIn exercises the POST /competitions/:id/participants/checkin-bulk endpoint.
 func TestBulkCheckIn(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
@@ -414,9 +415,9 @@ func TestBulkCheckIn(t *testing.T) {
 
 	doPost := func(t *testing.T, pids []string) *httptest.ResponseRecorder {
 		t.Helper()
-		body, _ := json.Marshal(map[string]interface{}{"participant_ids": pids})
+		body, _ := json.Marshal(map[string]interface{}{"participantIds": pids})
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants/check-in-bulk", bytes.NewBuffer(body))
+		req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants/checkin-bulk", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
 		r.ServeHTTP(w, req)
 		return w
@@ -479,9 +480,9 @@ func TestBulkCheckIn(t *testing.T) {
 	})
 
 	t.Run("competition not found returns 404", func(t *testing.T) {
-		body, _ := json.Marshal(map[string]interface{}{"participant_ids": []string{}})
+		body, _ := json.Marshal(map[string]interface{}{"participantIds": []string{}})
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("POST", "/api/competitions/nonexistent/participants/check-in-bulk", bytes.NewBuffer(body))
+		req, _ := http.NewRequest("POST", "/api/competitions/nonexistent/participants/checkin-bulk", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusNotFound, w.Code)
@@ -507,6 +508,37 @@ func TestBulkCheckIn(t *testing.T) {
 		assert.Equal(t, 0, res.CheckedIn)
 		assert.Equal(t, 1, res.AlreadyCheckedIn)
 		assert.Empty(t, res.NotFound)
+	})
+
+	t.Run("no file write when nothing toggles", func(t *testing.T) {
+		csvPath := filepath.Join(tempDir, "competitions", compID, "participants.csv")
+
+		// Snapshot mtime before a no-op call (empty array).
+		before, err := os.Stat(csvPath)
+		require.NoError(t, err)
+
+		w := doPost(t, []string{})
+		require.Equal(t, http.StatusOK, w.Code)
+
+		after, err := os.Stat(csvPath)
+		require.NoError(t, err)
+		assert.Equal(t, before.ModTime(), after.ModTime(), "participants.csv must not be written for an empty-array call")
+
+		// All participants already checked in — file must also not be written.
+		// At this point Alice, Bob, Carol, Dave, Eve are all checked in.
+		allPIDs := make([]string, len(added))
+		for i, p := range added {
+			allPIDs[i] = p.ID
+		}
+		before2, err := os.Stat(csvPath)
+		require.NoError(t, err)
+
+		w = doPost(t, allPIDs)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		after2, err := os.Stat(csvPath)
+		require.NoError(t, err)
+		assert.Equal(t, before2.ModTime(), after2.ModTime(), "participants.csv must not be written when all participants are already checked-in")
 	})
 }
 
@@ -553,9 +585,9 @@ func TestBulkCheckIn_BroadcastBehaviour(t *testing.T) {
 	require.NoError(t, err)
 
 	doPost := func(pids []string) *httptest.ResponseRecorder {
-		body, _ := json.Marshal(map[string]any{"participant_ids": pids})
+		body, _ := json.Marshal(map[string]any{"participantIds": pids})
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants/check-in-bulk", bytes.NewBuffer(body))
+		req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants/checkin-bulk", bytes.NewBuffer(body))
 		req.Header.Set("Content-Type", "application/json")
 		r.ServeHTTP(w, req)
 		return w

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -497,6 +497,11 @@ func TestBulkCheckIn(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
+	t.Run("oversized individual pid returns 400", func(t *testing.T) {
+		w := doPost(t, []string{string(make([]byte, MaxLenEntityID+1))})
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
 	t.Run("duplicate pids counted only once", func(t *testing.T) {
 		// Eve (added[4]) already checked in from "unknown pid" sub-test.
 		// Send her PID twice — must count as 1 already_checked_in, not 2.

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -392,6 +392,101 @@ func TestReplaceDoesNotInheritOldDisplayName(t *testing.T) {
 		"stale A. SMITH from replaced slot must not carry over")
 }
 
+// TestBulkCheckIn exercises the POST /competitions/:id/participants/check-in-bulk endpoint.
+func TestBulkCheckIn(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	compID := "comp-bulk-checkin"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: compID, Name: "Bulk Check-in Test", Status: state.CompStatusSetup,
+	}))
+
+	// Seed five participants via the store directly.
+	names := []string{"Alice", "Bob", "Carol", "Dave", "Eve"}
+	added := make([]domain.Player, 0, len(names))
+	for _, n := range names {
+		p, err := store.AddParticipant(compID, domain.Player{Name: n, Dojo: "Dojo"}, false)
+		require.NoError(t, err)
+		added = append(added, *p)
+	}
+
+	doPost := func(t *testing.T, pids []string) *httptest.ResponseRecorder {
+		t.Helper()
+		body, _ := json.Marshal(map[string]interface{}{"participant_ids": pids})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants/check-in-bulk", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("empty array returns zero counts", func(t *testing.T) {
+		w := doPost(t, []string{})
+		require.Equal(t, http.StatusOK, w.Code)
+		var res state.BulkCheckInResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		assert.Equal(t, 0, res.CheckedIn)
+		assert.Equal(t, 0, res.AlreadyCheckedIn)
+		assert.Empty(t, res.NotFound)
+	})
+
+	t.Run("checks in 3 unchecked participants", func(t *testing.T) {
+		pids := []string{added[0].ID, added[1].ID, added[2].ID}
+		w := doPost(t, pids)
+		require.Equal(t, http.StatusOK, w.Code)
+		var res state.BulkCheckInResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		assert.Equal(t, 3, res.CheckedIn)
+		assert.Equal(t, 0, res.AlreadyCheckedIn)
+		assert.Empty(t, res.NotFound)
+
+		// Verify persisted state.
+		players, err := store.LoadParticipants(compID, false)
+		require.NoError(t, err)
+		checkedByID := make(map[string]bool, len(players))
+		for _, p := range players {
+			checkedByID[p.ID] = p.CheckedIn
+		}
+		assert.True(t, checkedByID[added[0].ID], "Alice must be checked in")
+		assert.True(t, checkedByID[added[1].ID], "Bob must be checked in")
+		assert.True(t, checkedByID[added[2].ID], "Carol must be checked in")
+		assert.False(t, checkedByID[added[3].ID], "Dave must NOT be checked in yet")
+	})
+
+	t.Run("already-checked-in participants counted separately", func(t *testing.T) {
+		// Alice, Bob, Carol already checked in from previous sub-test; check in Alice again + Dave (new).
+		pids := []string{added[0].ID, added[3].ID}
+		w := doPost(t, pids)
+		require.Equal(t, http.StatusOK, w.Code)
+		var res state.BulkCheckInResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		assert.Equal(t, 1, res.CheckedIn)
+		assert.Equal(t, 1, res.AlreadyCheckedIn)
+		assert.Empty(t, res.NotFound)
+	})
+
+	t.Run("unknown pid appears in not_found", func(t *testing.T) {
+		pids := []string{added[4].ID, "00000000-0000-0000-0000-000000000099"}
+		w := doPost(t, pids)
+		require.Equal(t, http.StatusOK, w.Code)
+		var res state.BulkCheckInResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &res))
+		assert.Equal(t, 1, res.CheckedIn)
+		assert.Equal(t, 0, res.AlreadyCheckedIn)
+		assert.Equal(t, []string{"00000000-0000-0000-0000-000000000099"}, res.NotFound)
+	})
+
+	t.Run("competition not found returns 404", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{"participant_ids": []string{}})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/nonexistent/participants/check-in-bulk", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}
+
 func mustLoad(t *testing.T, store *state.Store, compID string) []domain.Player {
 	t.Helper()
 	players, err := store.LoadParticipants(compID, false)

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -507,6 +508,68 @@ func TestBulkCheckIn(t *testing.T) {
 		assert.Equal(t, 1, res.AlreadyCheckedIn)
 		assert.Empty(t, res.NotFound)
 	})
+}
+
+// spyBroadcaster counts Broadcast calls for asserting SSE fan-out behaviour.
+type spyBroadcaster struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *spyBroadcaster) Broadcast(_ EventType, _ any) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+}
+
+func (s *spyBroadcaster) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestBulkCheckIn_BroadcastBehaviour verifies the conditional SSE broadcast:
+// exactly one event when at least one participant is toggled, zero events when
+// all participants are already checked-in.
+func TestBulkCheckIn_BroadcastBehaviour(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "mobileapp-test-broadcast-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+
+	spy := &spyBroadcaster{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	admin := r.Group("/api")
+	RegisterParticipantHandlers(admin, store, spy)
+
+	compID := "comp-broadcast-test"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: compID, Name: "Broadcast Test", Status: state.CompStatusSetup,
+	}))
+	p, err := store.AddParticipant(compID, domain.Player{Name: "Alice", Dojo: "Dojo"}, false)
+	require.NoError(t, err)
+
+	doPost := func(pids []string) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(map[string]any{"participant_ids": pids})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants/check-in-bulk", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	// First call: toggles Alice → exactly 1 broadcast.
+	w := doPost([]string{p.ID})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, spy.count(), "one broadcast expected when a participant is newly checked-in")
+
+	// Second call: Alice already checked-in → zero additional broadcasts.
+	w = doPost([]string{p.ID})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, spy.count(), "no additional broadcast expected when participant is already checked-in")
 }
 
 func mustLoad(t *testing.T, store *state.Store, compID string) []domain.Player {

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -60,9 +60,10 @@ const (
 	MaxLenCheckInWindow = 5 // "HH:MM"
 
 	// MaxBulkCheckInIDs is the upper bound on the participant_ids array
-	// accepted by POST /participants/check-in-bulk. A single per-comp
-	// write lock is held for the duration; 1000 is a practical ceiling
-	// for tournament rosters (no real competition has exceeded ~200).
+	// accepted by POST /competitions/:id/participants/check-in-bulk. A
+	// single per-comp write lock is held for the duration; 1000 is a
+	// practical ceiling for tournament rosters (no real competition has
+	// exceeded ~200).
 	MaxBulkCheckInIDs = 1000
 )
 

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -59,8 +59,8 @@ const (
 
 	MaxLenCheckInWindow = 5 // "HH:MM"
 
-	// MaxBulkCheckInIDs is the upper bound on the participant_ids array
-	// accepted by POST /competitions/:id/participants/check-in-bulk. A
+	// MaxBulkCheckInIDs is the upper bound on the participantIds array
+	// accepted by POST /competitions/:id/participants/checkin-bulk. A
 	// single per-comp write lock is held for the duration; 1000 is a
 	// practical ceiling for tournament rosters (no real competition has
 	// exceeded ~200).

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -58,6 +58,12 @@ const (
 	MaxLenSeedAssignmentName = 100
 
 	MaxLenCheckInWindow = 5 // "HH:MM"
+
+	// MaxBulkCheckInIDs is the upper bound on the participant_ids array
+	// accepted by POST /participants/check-in-bulk. A single per-comp
+	// write lock is held for the duration; 1000 matches the practical
+	// tournament roster ceiling used elsewhere in the project.
+	MaxBulkCheckInIDs = 1000
 )
 
 // hhmmRE matches HH:MM time strings (00:00–23:59).

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -61,8 +61,8 @@ const (
 
 	// MaxBulkCheckInIDs is the upper bound on the participant_ids array
 	// accepted by POST /participants/check-in-bulk. A single per-comp
-	// write lock is held for the duration; 1000 matches the practical
-	// tournament roster ceiling used elsewhere in the project.
+	// write lock is held for the duration; 1000 is a practical ceiling
+	// for tournament rosters (no real competition has exceeded ~200).
 	MaxBulkCheckInIDs = 1000
 )
 

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -259,12 +259,17 @@ func (s *Store) BulkCheckIn(compID string, pids []string) (BulkCheckInResult, er
 
 	byPID := make(map[string]int, len(players))
 	for i := range players {
-		byPID[players[i].ID] = i
+		if players[i].ID != "" {
+			byPID[players[i].ID] = i
+		}
 	}
 
 	seen := make(map[string]struct{}, len(pids))
 	result := BulkCheckInResult{NotFound: []string{}}
 	for _, pid := range pids {
+		if pid == "" {
+			continue
+		}
 		if _, dup := seen[pid]; dup {
 			continue
 		}

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -257,8 +257,14 @@ func (s *Store) BulkCheckIn(compID string, pids []string, withZekkenName bool) (
 		byPID[players[i].ID] = i
 	}
 
+	seen := make(map[string]struct{}, len(pids))
 	result := BulkCheckInResult{NotFound: []string{}}
 	for _, pid := range pids {
+		if _, dup := seen[pid]; dup {
+			continue
+		}
+		seen[pid] = struct{}{}
+
 		idx, ok := byPID[pid]
 		if !ok {
 			result.NotFound = append(result.NotFound, pid)

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -233,9 +233,9 @@ func (s *Store) withZekkenNameLocked(compID string) (bool, error) {
 
 // BulkCheckInResult carries the outcome of a BulkCheckIn call.
 type BulkCheckInResult struct {
-	CheckedIn        int      `json:"checked_in"`
-	AlreadyCheckedIn int      `json:"already_checked_in"`
-	NotFound         []string `json:"not_found"`
+	CheckedIn        int      `json:"checkedIn"`
+	AlreadyCheckedIn int      `json:"alreadyCheckedIn"`
+	NotFound         []string `json:"notFound"`
 }
 
 // BulkCheckIn atomically marks all participants in pids as checked-in under a

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -231,6 +231,57 @@ func (s *Store) withZekkenNameLocked(compID string) (bool, error) {
 	return comp.WithZekkenName, nil
 }
 
+// BulkCheckInResult carries the outcome of a BulkCheckIn call.
+type BulkCheckInResult struct {
+	CheckedIn        int      `json:"checked_in"`
+	AlreadyCheckedIn int      `json:"already_checked_in"`
+	NotFound         []string `json:"not_found"`
+}
+
+// BulkCheckIn atomically marks all participants in pids as checked-in under a
+// single lock acquire, writing participants.csv exactly once. Only participants
+// that were not already checked in count toward CheckedIn; the file is only
+// written when at least one participant was actually toggled. Returns the
+// aggregate counts so the caller can decide whether to broadcast an SSE event.
+func (s *Store) BulkCheckIn(compID string, pids []string, withZekkenName bool) (BulkCheckInResult, error) {
+	mu := s.getCompLock(compID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	players, err := s.loadParticipantsNoLock(compID, withZekkenName, LoadParticipantsOpts{WithSeeds: false})
+	if err != nil {
+		return BulkCheckInResult{}, err
+	}
+
+	byPID := make(map[string]int, len(players))
+	for i := range players {
+		byPID[players[i].ID] = i
+	}
+
+	result := BulkCheckInResult{NotFound: []string{}}
+	for _, pid := range pids {
+		idx, ok := byPID[pid]
+		if !ok {
+			result.NotFound = append(result.NotFound, pid)
+			continue
+		}
+		if players[idx].CheckedIn {
+			result.AlreadyCheckedIn++
+		} else {
+			players[idx].CheckedIn = true
+			result.CheckedIn++
+		}
+	}
+
+	if result.CheckedIn > 0 {
+		if err := s.saveParticipantsNoLock(compID, players, withZekkenName); err != nil {
+			return BulkCheckInResult{}, err
+		}
+	}
+
+	return result, nil
+}
+
 // UpdateParticipant atomically loads the participant list, applies transform
 // to the target player, and persists the result. Used to avoid TOCTOU races
 // on concurrent check-ins.

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -242,10 +242,15 @@ type BulkCheckInResult struct {
 // single lock acquire, writing participants.csv exactly once. Only participants
 // that were not already checked in count toward CheckedIn; the file is only
 // written when at least one participant was actually toggled.
-func (s *Store) BulkCheckIn(compID string, pids []string, withZekkenName bool) (BulkCheckInResult, error) {
+func (s *Store) BulkCheckIn(compID string, pids []string) (BulkCheckInResult, error) {
 	mu := s.getCompLock(compID)
 	mu.Lock()
 	defer mu.Unlock()
+
+	withZekkenName, err := s.withZekkenNameLocked(compID)
+	if err != nil {
+		return BulkCheckInResult{}, err
+	}
 
 	players, err := s.loadParticipantsNoLock(compID, withZekkenName, LoadParticipantsOpts{WithSeeds: false})
 	if err != nil {

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -241,8 +241,7 @@ type BulkCheckInResult struct {
 // BulkCheckIn atomically marks all participants in pids as checked-in under a
 // single lock acquire, writing participants.csv exactly once. Only participants
 // that were not already checked in count toward CheckedIn; the file is only
-// written when at least one participant was actually toggled. Returns the
-// aggregate counts so the caller can decide whether to broadcast an SSE event.
+// written when at least one participant was actually toggled.
 func (s *Store) BulkCheckIn(compID string, pids []string, withZekkenName bool) (BulkCheckInResult, error) {
 	mu := s.getCompLock(compID)
 	mu.Lock()


### PR DESCRIPTION
## Summary

- Adds \`POST /api/competitions/:id/participants/checkin-bulk\` (admin, smallBody group) that accepts \`{"participantIds": ["uuid", ...]}\` and atomically marks all matching participants as checked-in under a single per-competition lock
- Replaces N individual PUT calls + N SSE broadcasts with a single transaction and one \`participants_updated\` broadcast — eliminates the thundering-herd problem discovered in PR #136 (mp-6nq)
- Returns \`{checkedIn: N, alreadyCheckedIn: N, notFound: ["uuid", ...]}\` where \`notFound\` is a list of participant IDs that were not found; file is only written when at least one participant was actually toggled
- Rejects arrays > 1000 entries (400) and deduplicates PIDs so counts are always consistent
- \`BulkCheckIn\` derives \`withZekkenName\` internally under the per-comp lock (via \`withZekkenNameLocked\`) to eliminate the TOCTOU gap between the handler's \`LoadCompetition\` and lock acquire

## Test plan

- [x] \`TestBulkCheckIn/empty_array_returns_zero_counts\` — 200 with zero counts, no write
- [x] \`TestBulkCheckIn/checks_in_3_unchecked_participants\` — correct counts + persisted state verified
- [x] \`TestBulkCheckIn/already-checked-in_participants_counted_separately\` — mixed input counted correctly
- [x] \`TestBulkCheckIn/unknown_pid_appears_in_not_found\` — unknown PID in notFound array
- [x] \`TestBulkCheckIn/competition_not_found_returns_404\`
- [x] \`TestBulkCheckIn/oversized_array_returns_400\` — >1000 entries rejected with 400
- [x] \`TestBulkCheckIn/duplicate_pids_counted_only_once\` — duplicate PIDs counted once
- [x] \`TestBulkCheckIn/no_file_write_when_nothing_toggles\` — participants.csv mtime unchanged for empty-array and all-already-checked-in cases
- [x] All existing participant handler tests pass
- [x] \`golangci-lint\` clean on changed packages
- [x] Manual (browser console, fetch to localhost:8091): POST with 2 PIDs → \`200 {checkedIn:2, alreadyCheckedIn:0, notFound:[]}\` + exactly 1 \`participants_updated\` SSE event; repeat call → \`{checkedIn:0, alreadyCheckedIn:2}\` + 0 SSE events ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)