### PR TITLE
feat(participants): rename Replace → Edit for inline participant editing (mp-22k)

### DIFF
--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -578,7 +578,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
       await window.API.replaceParticipant(c.id, targetId, payload, password);
       if (!mountedRef.current) return;
       setReplaceTarget(null);
-      showToast(`${oldName} replaced with ${name}`);
+      showToast(oldName === name ? `Saved changes for ${name}` : `Renamed ${oldName} → ${name}`);
     } catch (err) {
       if (!mountedRef.current) return;
       showToast(err.message, "error");
@@ -990,7 +990,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
             <div role="dialog" aria-modal="true" aria-labelledby="replace-modal-title" style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)", zIndex: 200, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={e => { if (e.target === e.currentTarget) setReplaceTarget(null); }}>
               <EscapeListener onClose={() => setReplaceTarget(null)} />
               <div className="card" style={{ minWidth: 320, maxWidth: 420, margin: 16 }}>
-                <div className="card__head"><div id="replace-modal-title" className="card__title">Replace {replaceTarget.name}</div></div>
+                <div className="card__head"><div id="replace-modal-title" className="card__title">Edit {replaceTarget.name}</div></div>
                 <div className="card__body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                   <div>
                     <div className="field__label">Name *</div>
@@ -1010,11 +1010,11 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     <div className="field__label">Dan grade</div>
                     <input className="input" value={replaceDanGrade} onChange={e => setReplaceDanGrade(e.target.value)} placeholder="Optional" />
                   </div>
-                  <div className="field__hint">The participant's ID and seed assignment are preserved. Any existing seeds for this name are renamed automatically.</div>
+                  <div className="field__hint">ID, seed, and check-in state are preserved. Seed rankings are updated to match the new name automatically.</div>
                   <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
                     <button className="btn" onClick={() => setReplaceTarget(null)}>Cancel</button>
                     <button className="btn btn--primary" disabled={replaceLoading || !replaceName.trim() || !replaceDojo.trim()} onClick={handleReplaceParticipant}>
-                      {replaceLoading ? "Replacing…" : "Replace"}
+                      {replaceLoading ? "Saving…" : "Save"}
                     </button>
                   </div>
                 </div>
@@ -1099,7 +1099,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                       <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0 || reorderDisabled} aria-label="Move up">↑</button>
                       <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1 || reorderDisabled} aria-label="Move down">↓</button>
                       {isSetup && (
-                        <button className="btn btn--sm btn--icon-sm" style={{ fontSize: 9 }} title={`Replace ${p.name}`} onClick={() => { setReplaceTarget(p); setReplaceName(p.name); setReplaceDojo(p.dojo); setReplaceDanGrade(p.danGrade || ""); setReplaceZekken(c.withZekkenName ? (p.displayName || "") : ""); }} aria-label={`Replace ${p.name}`}>↔</button>
+                        <button className="btn btn--sm btn--icon-sm" style={{ fontSize: 11 }} title={`Edit ${p.name}`} onClick={() => { setReplaceTarget(p); setReplaceName(p.name); setReplaceDojo(p.dojo); setReplaceDanGrade(p.danGrade || ""); setReplaceZekken(c.withZekkenName ? (p.displayName || "") : ""); }} aria-label={`Edit ${p.name}`}>✎</button>
                       )}
                     </div>
                      <window.StableInput

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -575,10 +575,10 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
       const metadata = window.buildPlayerMetadata(danGrade, replaceTarget.metadata);
       const payload = { name, dojo, displayName: c.withZekkenName ? zekken : "", tag: targetTag };
       if (metadata !== undefined) payload.metadata = metadata;
-      await window.API.replaceParticipant(c.id, targetId, payload, password);
+      const updated = await window.API.replaceParticipant(c.id, targetId, payload, password);
       if (!mountedRef.current) return;
       setReplaceTarget(null);
-      showToast(oldName === name ? `Saved changes for ${name}` : `Renamed ${oldName} → ${name}`);
+      showToast(oldName === updated.name ? `Saved changes for ${updated.name}` : `Renamed ${oldName} → ${updated.name}`);
     } catch (err) {
       if (!mountedRef.current) return;
       showToast(err.message, "error");

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -987,10 +987,10 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
             </div>
           )}
           {replaceTarget && (
-            <div role="dialog" aria-modal="true" aria-labelledby="replace-modal-title" style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)", zIndex: 200, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={e => { if (e.target === e.currentTarget) setReplaceTarget(null); }}>
+            <div role="dialog" aria-modal="true" aria-labelledby="edit-modal-title" style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.4)", zIndex: 200, display: "flex", alignItems: "center", justifyContent: "center" }} onClick={e => { if (e.target === e.currentTarget) setReplaceTarget(null); }}>
               <EscapeListener onClose={() => setReplaceTarget(null)} />
               <div className="card" style={{ minWidth: 320, maxWidth: 420, margin: 16 }}>
-                <div className="card__head"><div id="replace-modal-title" className="card__title">Edit {replaceTarget.name}</div></div>
+                <div className="card__head"><div id="edit-modal-title" className="card__title">Edit {replaceTarget.name}</div></div>
                 <div className="card__body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                   <div>
                     <div className="field__label">Name *</div>


### PR DESCRIPTION
## Summary

- Renames the \`↔\` Replace affordance on each Check-in & Seeding row to a \`✎\` Edit pencil button, aligning the UI label with operator intent (editing a late substitution, not swapping to a different person)
- Modal title: **Replace {name}** → **Edit {name}**
- Modal button: **Replace** / **Replacing…** → **Save** / **Saving…**
- Modal hint: updated to explicitly mention UUID, seed, and check-in state preservation
- Toast: context-aware — "Saved changes for X" when name unchanged, "Renamed X → Y" when name changes

No functional changes — the backend \`PUT /api/competitions/:cid/participants/:pid\` endpoint, UUID preservation, seed renaming, and setup-status gate were already correct.

Closes mp-22k

## Test plan

- [x] Open admin Check-in & Seeding list — every row shows a \`✎\` pencil button (not \`↔\`)
- [x] Click \`✎\` on a participant — modal opens titled **Edit {name}**, pre-filled with current name/dojo/dan/zekken
- [x] Edit name and click **Save** — toast shows "Renamed Old → New"; row updates in list
- [x] Edit dojo only (no name change) and click **Save** — toast shows "Saved changes for {name}"
- [x] Click Cancel — modal closes, no changes
- [x] Click outside the modal — modal closes, no changes
- [x] Press Escape — modal closes, no changes
- [x] Start competition (move past setup) — \`✎\` button disappears (isSetup gate)
- [x] Try to rename to a duplicate name while in setup — backend returns 409, toast shows error
- [x] Try to edit after competition started (API call directly) — backend returns 409 ErrCompetitionNotInSetup

🤖 Generated with [Claude Code](https://claude.com/claude-code)