### PR TITLE
fix(admin): show tag badge outside truncating name in Check-in & Seeding

### DIFF
--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -1034,7 +1034,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     <span className="seed-row__handle" title={reorderDisabled ? "Clear all filters to reorder" : "Drag to reorder"}>⠿</span>
                     <span className="seed-row__rank">{p.seed ? `#${p.seed}` : ""}</span>
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", minWidth: 0 }}>
                         <div className="seed-row__name" title={p.name} style={{ minWidth: 0, flex: "0 1 auto" }}>{p.name}</div>
                         {p.tag && <span className="tag-badge" style={{ flexShrink: 0 }}>{p.tag}</span>}
                       </div>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -1035,7 +1035,7 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     <span className="seed-row__rank">{p.seed ? `#${p.seed}` : ""}</span>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ display: "flex", alignItems: "center", minWidth: 0 }}>
-                        <div className="seed-row__name" title={p.name} style={{ minWidth: 0, flex: "0 1 auto" }}>{p.name}</div>
+                        <div className="seed-row__name" title={p.name} style={{ minWidth: 0 }}>{p.name}</div>
                         {p.tag && <span className="tag-badge" style={{ flexShrink: 0 }}>{p.tag}</span>}
                       </div>
                       <div className="seed-row__dojo">

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -1033,8 +1033,11 @@ function AdminParticipants({ c, tournament, reservedSlots, onUpdate, password, s
                     )}
                     <span className="seed-row__handle" title={reorderDisabled ? "Clear all filters to reorder" : "Drag to reorder"}>⠿</span>
                     <span className="seed-row__rank">{p.seed ? `#${p.seed}` : ""}</span>
-                    <div style={{ flex: 1 }}>
-                      <div className="seed-row__name" title={p.name}>{p.name}{p.tag && <span className="tag-badge">{p.tag}</span>}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+                        <div className="seed-row__name" title={p.name} style={{ minWidth: 0, flex: "0 1 auto" }}>{p.name}</div>
+                        {p.tag && <span className="tag-badge" style={{ flexShrink: 0 }}>{p.tag}</span>}
+                      </div>
                       <div className="seed-row__dojo">
                         {p.dojo}
                         {c.checkInEnabled && dojoFirstRowSet.has(p.id ?? p.name) && (dojoUncheckedCount.get(p.dojo) || 0) > 0 && (


### PR DESCRIPTION
## Summary
- The tag badge (`manual`/`registered`/`transfer`/`reserved`) in the Check-in & Seeding rows was nested inside `.seed-row__name`, which truncates with `white-space:nowrap; overflow:hidden; text-overflow:ellipsis`. For any non-trivial name the ellipsis hid the badge, so operators couldn't tell at a glance how a row got there.
- Wrap name + badge in a flex row so the badge is a sibling of the truncating container with `flex-shrink: 0`. Name keeps its ellipsis behavior; badge stays visible regardless of name length.
- No CSS changes — reuses the existing `.tag-badge` class.

Refs mp-7uo

## Test plan
- [x] `npx vitest run` — 854/854 tests pass
- [x] Manual: paste participants with tags (`Alice, Mumeishi, 3, manual` / `..., registered` / `..., transfer`) → each row shows its badge next to the name in the Check-in & Seeding card
- [x] Manual: tag-filter pills above the list (All / manual / registered / transfer) still work
- [x] Manual: with an injected 44-char name the `.seed-row__name` overflows and engages `text-overflow: ellipsis` while the badge remains fully visible at 6px gap (verified via getBoundingClientRect)
- [x] Manual: with `c.checkInEnabled = true`, all rows render the checkbox column and "Mark all from <dojo>" link
- [x] Reviewer task: computed `grid-template-columns` on `.seed-row` matches the spec `24px 20px 36px 1fr 32px 64px` — flex restructure did not shift the grid layout

## Follow-up
- mp-p2i (separate): `LoadParticipants` falls back to legacy CSV schema when the first column isn't a UUID, swapping name↔dojo for new tournaments. Discovered while verifying this PR's manual tests; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)