### PR TITLE
fix(participants): preserve client ids, strip column 0 via HasParticipantIDs (mp-p7n)

### DIFF
--- a/internal/helper/uuid.go
+++ b/internal/helper/uuid.go
@@ -8,7 +8,14 @@ import (
 
 var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
-// IsUUIDv4 reports whether s is a lowercase UUID v4 string.
+// IsUUIDv4 reports whether s has the lowercase canonical-UUID shape
+// (8-4-4-4-12 lowercase hex). Despite the historical name, this is a
+// SHAPE check — it does NOT enforce the v4 version nibble or the
+// 8/9/a/b variant nibble. Many in-repo test fixtures use non-v4 or
+// invalid-variant UUIDs (e.g. `…-7c3a-11e7-…` v1 timestamps,
+// `…-4ddd-dddd-dddd-…` synthetic ids) and pass this check. Callers
+// that need true v4 validation should parse with `uuid.Parse(s)` and
+// inspect `Version()`/`Variant()` instead.
 func IsUUIDv4(s string) bool {
 	return uuidRE.MatchString(s)
 }

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -780,14 +780,17 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			//
 			// mp-p7n / Copilot PR #185 round-5: pass HasIDs=&true
 			// explicitly when we just persisted a non-empty roster.
-			// The deferred HasParticipantIDs=true flip above is
-			// best-effort (failures only log); if it failed, the
-			// loader's default branch would read the still-stale
-			// flag (false), fall back to uuidRE-on-row-0, mis-classify
-			// non-UUID ids as "no ids", and return the same shifted
-			// roster this PR is fixing. The hint is authoritative here
-			// because SaveParticipants succeeded — every row on disk
-			// carries an id in column 0.
+			// The hint is authoritative at this call site —
+			// SaveParticipants just succeeded and (per round-6) the
+			// deferred HasParticipantIDs=true flip is now part of the
+			// roster-write contract: on flip failure the handler
+			// returns 500 above, so by the time we reach this reload
+			// the flag is set on disk. Belt-and-suspenders: the
+			// explicit hint also defends against any future load path
+			// that reaches here before a hypothetical flag-write race
+			// resolves, and makes the call-site intent ("we just wrote
+			// a non-empty roster with ids in column 0") explicit at
+			// the reader.
 			loadOpts := state.LoadParticipantsOpts{WithSeeds: true}
 			if len(comp.Players) > 0 {
 				trueP := true

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -715,6 +715,21 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			// failed). A second transform here is cheap (metadata-only)
 			// and runs under the per-comp lock, so subsequent loads see
 			// a consistent (flag, file) pair.
+			//
+			// mp-p7n / Copilot PR #185 round-6: this flip is now part
+			// of the roster-write contract — not best-effort. With
+			// loadParticipantsNoLock's default branch keyed off
+			// Competition.HasParticipantIDs, a stale `false` flag on
+			// disk causes every subsequent no-hint reader (viewer
+			// list/detail, engine StartCompetition, etc.) to fall back
+			// to uuidRE-on-row-0 and mis-classify preserved non-UUID
+			// ids as "no ids" → column shift. The previous "log and
+			// continue" rationale was based on the older readers that
+			// derived the hint per-record from uuidRE; that's no
+			// longer how the load works. If the flip fails, return
+			// 500 so the operator retries (idempotent — the same body
+			// re-applied will re-save the file and re-attempt the
+			// flip).
 			if len(comp.Players) > 0 {
 				if _, fierr := store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
 					if current == nil {
@@ -723,17 +738,11 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 					current.HasParticipantIDs = true
 					return current, nil
 				}); fierr != nil {
-					// Log only — the file save succeeded (load-bearing
-					// write). A stale `false` flag is safe because every
-					// reader (handlers_viewer.go list + detail,
-					// engine StartCompetition) uses the conditional hint
-					// pattern: pass &true only when HasParticipantIDs is
-					// true; otherwise pass nil and let
-					// LoadParticipantsOpt auto-detect from the first
-					// line's UUID prefix. Aborting the PUT here after a
-					// successful save would mislead the caller into
-					// thinking the roster save failed.
-					fmt.Printf("Warning: failed to flip HasParticipantIDs after SaveParticipants: %v\n", fierr)
+					fmt.Printf("Warning: PUT /api/competitions/%s — failed to flip HasParticipantIDs after SaveParticipants: %v\n", id, fierr)
+					c.JSON(http.StatusInternalServerError, gin.H{
+						"error": "roster saved but failed to update HasParticipantIDs flag; retry the request (idempotent): " + fierr.Error(),
+					})
+					return
 				}
 			}
 			participantsChanged = true

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -772,7 +772,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			if players, lerr := store.LoadParticipants(id, updated.WithZekkenName); lerr == nil {
 				updated.Players = players
 			} else {
-				fmt.Printf("Warning: failed to re-load participants for roster-PUT response: %v\n", lerr)
+				fmt.Printf("Warning: PUT /api/competitions/%s — failed to re-load participants for roster-PUT response (falling back to request body, client may see un-normalised ids): %v\n", id, lerr)
 				updated.Players = comp.Players // fallback: echo body
 			}
 		} else {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -756,14 +756,13 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		}
 		if comp.Players != nil {
 			// Roster-PUT: re-load from disk so the response reflects what
-			// actually landed in participants.csv — including any IDs
-			// marshalParticipantsCSV normalised to UUIDv4 (mp-p7n: the
-			// JS layer's mintParticipantIds historically minted non-UUID
-			// ids in the `${compID}-p${N}` shape; the saver rewrites
-			// those to UUIDs so the loader's per-record id-strip works,
-			// and the response must surface those normalised ids so the
-			// client's next round-trip doesn't resend the old non-UUID
-			// values).
+			// actually landed in participants.csv — the canonical on-disk
+			// shape after the save round-trip (merged seeds, tag column,
+			// any empty-id rows that the saver minted a fresh UUID for).
+			// mp-p7n: client-supplied ids (UUID or not) are preserved
+			// verbatim on save, and the loader strips column 0 by trusting
+			// HasParticipantIDs, so the re-loaded ids match what the client
+			// sent — no normalisation churn.
 			//
 			// AdminParticipants's clear-roster path sends [] and the
 			// re-loaded roster will also be [] (LoadParticipants returns
@@ -772,7 +771,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			if players, lerr := store.LoadParticipants(id, updated.WithZekkenName); lerr == nil {
 				updated.Players = players
 			} else {
-				fmt.Printf("Warning: PUT /api/competitions/%s — failed to re-load participants for roster-PUT response (falling back to request body, client may see un-normalised ids): %v\n", id, lerr)
+				fmt.Printf("Warning: PUT /api/competitions/%s — failed to re-load participants for roster-PUT response (falling back to request body): %v\n", id, lerr)
 				updated.Players = comp.Players // fallback: echo body
 			}
 		} else {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -768,7 +768,23 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			// re-loaded roster will also be [] (LoadParticipants returns
 			// an empty slice for an empty file), so the cleared-roster
 			// contract still holds.
-			if players, lerr := store.LoadParticipants(id, updated.WithZekkenName); lerr == nil {
+			//
+			// mp-p7n / Copilot PR #185 round-5: pass HasIDs=&true
+			// explicitly when we just persisted a non-empty roster.
+			// The deferred HasParticipantIDs=true flip above is
+			// best-effort (failures only log); if it failed, the
+			// loader's default branch would read the still-stale
+			// flag (false), fall back to uuidRE-on-row-0, mis-classify
+			// non-UUID ids as "no ids", and return the same shifted
+			// roster this PR is fixing. The hint is authoritative here
+			// because SaveParticipants succeeded — every row on disk
+			// carries an id in column 0.
+			loadOpts := state.LoadParticipantsOpts{WithSeeds: true}
+			if len(comp.Players) > 0 {
+				trueP := true
+				loadOpts.HasIDs = &trueP
+			}
+			if players, lerr := store.LoadParticipantsOpt(id, updated.WithZekkenName, loadOpts); lerr == nil {
 				updated.Players = players
 			} else {
 				fmt.Printf("Warning: PUT /api/competitions/%s — failed to re-load participants for roster-PUT response (falling back to request body): %v\n", id, lerr)

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -778,19 +778,18 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			// an empty slice for an empty file), so the cleared-roster
 			// contract still holds.
 			//
-			// mp-p7n / Copilot PR #185 round-5: pass HasIDs=&true
-			// explicitly when we just persisted a non-empty roster.
-			// The hint is authoritative at this call site —
-			// SaveParticipants just succeeded and (per round-6) the
-			// deferred HasParticipantIDs=true flip is now part of the
-			// roster-write contract: on flip failure the handler
-			// returns 500 above, so by the time we reach this reload
-			// the flag is set on disk. Belt-and-suspenders: the
-			// explicit hint also defends against any future load path
-			// that reaches here before a hypothetical flag-write race
-			// resolves, and makes the call-site intent ("we just wrote
-			// a non-empty roster with ids in column 0") explicit at
-			// the reader.
+			// mp-p7n: pass HasIDs=&true explicitly when we just
+			// persisted a non-empty roster. We can rely on the
+			// HasParticipantIDs flag being already set on disk by
+			// this point (round-6 made the flip part of the contract
+			// — flip failures return 500 above and never reach this
+			// reload), so the loader's default branch would resolve
+			// the same way. The explicit hint is purely declarative:
+			// it pins the call-site invariant ("we just wrote a non-
+			// empty roster — every row has an id in column 0") at
+			// the reader, so future refactors that move or weaken
+			// the flip guarantee can't silently regress this reload
+			// to the no-hint auto-detect path.
 			loadOpts := state.LoadParticipantsOpts{WithSeeds: true}
 			if len(comp.Players) > 0 {
 				trueP := true

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -14,6 +14,23 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
+// flipHasParticipantIDs sets Competition.HasParticipantIDs=true after a
+// successful non-empty roster save. It's a package var (not an inline
+// closure) so tests can inject a deterministic failure without relying
+// on filesystem-race timing — see
+// TestPUTCompetition_RosterPUT_FlagFlipFailureReturns500. mp-p7n /
+// Copilot PR #185 round-9.
+var flipHasParticipantIDs = func(store *state.Store, id string) error {
+	_, err := store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
+		if current == nil {
+			return nil, nil
+		}
+		current.HasParticipantIDs = true
+		return current, nil
+	})
+	return err
+}
+
 // slugifyID derives a valid competition ID from a name: lowercase, non-alphanumeric
 // runs become a single hyphen, leading/trailing hyphens stripped, max 64 chars.
 func slugifyID(name string) string {
@@ -731,13 +748,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			// re-applied will re-save the file and re-attempt the
 			// flip).
 			if len(comp.Players) > 0 {
-				if _, fierr := store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
-					if current == nil {
-						return nil, nil
-					}
-					current.HasParticipantIDs = true
-					return current, nil
-				}); fierr != nil {
+				if fierr := flipHasParticipantIDs(store, id); fierr != nil {
 					fmt.Printf("Warning: PUT /api/competitions/%s — failed to flip HasParticipantIDs after SaveParticipants: %v\n", id, fierr)
 					c.JSON(http.StatusInternalServerError, gin.H{
 						"error": "roster saved but failed to update HasParticipantIDs flag; retry the request (idempotent): " + fierr.Error(),

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -755,10 +755,26 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		if comp.Players != nil {
-			// Roster-PUT: reflect what we just saved. AdminParticipants's
-			// clear-roster path sends [] and expects the response to
-			// reflect the cleared roster — preserve that shape.
-			updated.Players = comp.Players
+			// Roster-PUT: re-load from disk so the response reflects what
+			// actually landed in participants.csv — including any IDs
+			// marshalParticipantsCSV normalised to UUIDv4 (mp-p7n: the
+			// JS layer's mintParticipantIds historically minted non-UUID
+			// ids in the `${compID}-p${N}` shape; the saver rewrites
+			// those to UUIDs so the loader's per-record id-strip works,
+			// and the response must surface those normalised ids so the
+			// client's next round-trip doesn't resend the old non-UUID
+			// values).
+			//
+			// AdminParticipants's clear-roster path sends [] and the
+			// re-loaded roster will also be [] (LoadParticipants returns
+			// an empty slice for an empty file), so the cleared-roster
+			// contract still holds.
+			if players, lerr := store.LoadParticipants(id, updated.WithZekkenName); lerr == nil {
+				updated.Players = players
+			} else {
+				fmt.Printf("Warning: failed to re-load participants for roster-PUT response: %v\n", lerr)
+				updated.Players = comp.Players // fallback: echo body
+			}
 		} else {
 			// Settings-only PUT — load the on-disk roster for the
 			// response so the merge doesn't push null into local state.

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -1015,6 +1015,131 @@ func TestPUTCompetition_SettingsOnlyResponseIncludesPlayers(t *testing.T) {
 		"response must not ship `players: null` — clients merge this into local state")
 }
 
+// mp-p7n: Copilot PR #185 finding — pin the roster-PUT response contract.
+// When a client sends players with non-UUID ids (the JS-side
+// mintParticipantIds shape `${compID}-p${N}` or arbitrary import-supplied
+// ids), the saver normalises them to UUIDv4 on disk. The PUT response
+// must reflect those normalised ids so the next round-trip is stable;
+// otherwise the client keeps resending the old non-UUID ids and the
+// server keeps minting new UUIDs on every save — disk ids would churn
+// silently and tooling that joins by id would break.
+//
+// Also exercises Name/Dojo preservation as a defence against the original
+// column-shift corruption: pre-fix the load would have returned
+// Name="Asddasd-P1", Dojo="Aaron Adams", Metadata=["Team Alpha"].
+func TestPUTCompetition_RosterPUTResponseSurfacesNormalisedUUIDs(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	cid := "asddasd"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: cid, Name: "Asddasd", Date: "12-05-2026",
+		WithZekkenName: false, HasParticipantIDs: true,
+		Format: state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
+	}))
+
+	// PUT body carries the bug-prone id shape that mintParticipantIds
+	// historically minted.
+	body := []byte(`{
+		"id":"asddasd","name":"Asddasd","date":"12-05-2026",
+		"format":"playoffs","kind":"individual","courts":["A"],
+		"withZekkenName":false,
+		"players":[
+			{"id":"asddasd-p1","name":"Aaron Adams","dojo":"Team Alpha"},
+			{"id":"asddasd-p2","name":"Albus Blake","dojo":"Team Delta"}
+		]
+	}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+	var resp state.Competition
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Players, 2)
+
+	// Response ids MUST be UUIDv4, not the request-body's "asddasd-p1"
+	// shape. Otherwise the client would keep resending the un-normalised
+	// id on every save.
+	for i, p := range resp.Players {
+		assert.True(t, helper.IsUUIDv4(p.ID),
+			"resp.Players[%d].ID must be a UUIDv4 after the server normalises non-UUID ids; got %q", i, p.ID)
+		assert.NotEqual(t, "asddasd-p1", p.ID, "resp.Players[%d] must not echo the un-normalised id", i)
+		assert.NotEqual(t, "asddasd-p2", p.ID, "resp.Players[%d] must not echo the un-normalised id", i)
+	}
+
+	// Name and Dojo MUST round-trip without column shift.
+	assert.Equal(t, "Aaron Adams", resp.Players[0].Name)
+	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
+	assert.Empty(t, resp.Players[0].Metadata,
+		"Metadata must be empty — pre-fix column shift dumped Dojo into Metadata[0]")
+	assert.Equal(t, "Albus Blake", resp.Players[1].Name)
+	assert.Equal(t, "Team Delta", resp.Players[1].Dojo)
+
+	// Sanity: a second PUT with the SAME (now-normalised) ids returned
+	// in the previous response should re-save without churning the on-
+	// disk ids. This guards against the regression where the response
+	// echoed the body and the next save kept re-normalising.
+	firstID := resp.Players[0].ID
+	body2 := fmt.Appendf(nil, `{
+		"id":"asddasd","name":"Asddasd","date":"12-05-2026",
+		"format":"playoffs","kind":"individual","courts":["A"],
+		"withZekkenName":false,
+		"players":[
+			{"id":%q,"name":"Aaron Adams","dojo":"Team Alpha"},
+			{"id":%q,"name":"Albus Blake","dojo":"Team Delta"}
+		]
+	}`, resp.Players[0].ID, resp.Players[1].ID)
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+	var resp2 state.Competition
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp2))
+	assert.Equal(t, firstID, resp2.Players[0].ID,
+		"ids must be stable across save round-trips once normalised")
+}
+
+// mp-p7n: Copilot PR #185 finding — a client-supplied valid UUID with
+// uppercase hex digits must round-trip unchanged (canonicalised to
+// lowercase, but not replaced with a fresh id). Pre-canonicalisation
+// uuidRE only matched lowercase, so the upper-case variant would be
+// treated as a non-UUID and replaced.
+func TestPUTCompetition_RosterPUTAcceptsUppercaseUUID(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	cid := "upper-uuid"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: cid, Name: "Upper UUID", Date: "12-05-2026",
+		WithZekkenName: false, HasParticipantIDs: true,
+		Format: state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
+	}))
+
+	// Uppercase UUID, valid otherwise.
+	upperUUID := "85CDEB35-C066-4667-B7FD-43EBAE8A9F13"
+	lowerUUID := "85cdeb35-c066-4667-b7fd-43ebae8a9f13"
+	body := fmt.Appendf(nil, `{
+		"id":"upper-uuid","name":"Upper UUID","date":"12-05-2026",
+		"format":"playoffs","kind":"individual","courts":["A"],
+		"withZekkenName":false,
+		"players":[{"id":%q,"name":"Aaron Adams","dojo":"Team Alpha"}]
+	}`, upperUUID)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+	var resp state.Competition
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Players, 1)
+	assert.Equal(t, lowerUUID, resp.Players[0].ID,
+		"uppercase UUID must canonicalise to lowercase, not be replaced with a fresh id")
+}
+
 // TestPlayoff_ResponseIncludesPlayers pins the Copilot round-12
 // finding (#6) server-side: POST /playoffs used to ship `players: null`
 // in the create response (Go nil slice → JSON null). admin.jsx's

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
@@ -1126,6 +1127,91 @@ func TestPUTCompetition_RosterPUTPreservesUppercaseUUID(t *testing.T) {
 		"client-supplied id must round-trip intact (case preserved, no regeneration)")
 	assert.Equal(t, "Aaron Adams", resp.Players[0].Name)
 	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
+}
+
+// mp-p7n / Copilot PR #185 round-8: exercises the round-6
+// 500-on-flag-flip-failure branch end-to-end.
+//
+// The handler's flow is:
+//  1. SaveParticipants writes participants.csv (atomic-rename)
+//  2. SaveSeeds writes seeds.csv (best-effort log)
+//  3. UpdateCompetitionChanged flips HasParticipantIDs=true
+//     — on failure the handler returns 500 (round-6 contract)
+//
+// To inject failure between (1) and (3) without breaking (1), a
+// watcher goroutine polls for participants.csv to appear (signalling
+// step 1 completed), then replaces config.md with a directory so
+// step 3's loadCompetitionLocked → parseCompetitionFile → os.ReadFile
+// errors out. The race is tight but reliable in practice — the
+// polling loop is microsecond-grained and SaveSeeds + lock-handoff
+// gives the watcher enough scheduling time to act before
+// UpdateCompetitionChanged acquires the per-comp lock again.
+//
+// If the race ever proves flaky in CI we can refactor by extracting
+// the flip into a hookable helper. For now the goroutine approach
+// avoids changing production code purely for testability.
+func TestPUTCompetition_RosterPUT_FlagFlipFailureReturns500(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	cid := "flip-fails"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: cid, Name: "Flip Fails", Date: "12-05-2026",
+		HasParticipantIDs: false,
+		Format:            state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
+	}))
+
+	partPath := filepath.Join(tempDir, "competitions", cid, "participants.csv")
+	cfgPath := filepath.Join(tempDir, "competitions", cid, "config.md")
+
+	corrupted := make(chan struct{})
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(50 * time.Microsecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+			}
+			if _, err := os.Stat(partPath); err == nil {
+				_ = os.Remove(cfgPath)
+				_ = os.MkdirAll(cfgPath, 0o700)
+				close(corrupted)
+				return
+			}
+		}
+	}()
+	defer close(stop)
+
+	body, _ := json.Marshal(state.Competition{
+		ID: cid, Name: "Flip Fails", Date: "12-05-2026",
+		Format: state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
+		Players: []domain.Player{
+			{ID: "flip-fails-p1", Name: "Aaron Adams", Dojo: "Team Alpha"},
+		},
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	// Confirm the watcher fired — if it didn't, the test wasn't
+	// exercising the failure path even if the assertion below passes.
+	select {
+	case <-corrupted:
+	case <-time.After(2 * time.Second):
+		t.Skip("watcher goroutine did not catch the SaveParticipants → flip window; skipping flaky test")
+	}
+
+	// The flip's UpdateCompetitionChanged → loadCompetitionLocked
+	// failed because config.md is now a directory, so the handler
+	// returns 500 from the round-6 branch.
+	require.Equal(t, http.StatusInternalServerError, w.Code,
+		"flip failure must surface as 500 (round-6 contract) — got %d: %s", w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "HasParticipantIDs",
+		"error body must mention HasParticipantIDs (round-6 flip-failure branch); got %s", w.Body.String())
 }
 
 // mp-p7n / Copilot PR #185 round-5: when the roster-PUT response

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -1015,19 +1015,20 @@ func TestPUTCompetition_SettingsOnlyResponseIncludesPlayers(t *testing.T) {
 		"response must not ship `players: null` — clients merge this into local state")
 }
 
-// mp-p7n: Copilot PR #185 finding — pin the roster-PUT response contract.
-// When a client sends players with non-UUID ids (the JS-side
-// mintParticipantIds shape `${compID}-p${N}` or arbitrary import-supplied
-// ids), the saver normalises them to UUIDv4 on disk. The PUT response
-// must reflect those normalised ids so the next round-trip is stable;
-// otherwise the client keeps resending the old non-UUID ids and the
-// server keeps minting new UUIDs on every save — disk ids would churn
-// silently and tooling that joins by id would break.
+// mp-p7n: Copilot PR #185 round-3 finding — regenerating ids on save
+// would orphan CompetitorStatus.PlayerID / ReservedSlot.ParticipantID /
+// team-lineup PlayerIDs that reference the original ids. Fix: keep the
+// id verbatim on save; the loader (consulting Competition.HasParticipantIDs
+// for the strip decision) handles any shape.
 //
-// Also exercises Name/Dojo preservation as a defence against the original
-// column-shift corruption: pre-fix the load would have returned
-// Name="Asddasd-P1", Dojo="Aaron Adams", Metadata=["Team Alpha"].
-func TestPUTCompetition_RosterPUTResponseSurfacesNormalisedUUIDs(t *testing.T) {
+// This test pins the contract:
+//   - The PUT body's non-UUID ids round-trip to the response intact
+//     (no regeneration).
+//   - Name/Dojo are correctly aligned in the response (no column shift
+//     on load — the loader trusts HasParticipantIDs).
+//   - A second PUT with the same body produces an idempotent round-trip
+//     (ids don't churn).
+func TestPUTCompetition_RosterPUTPreservesIDsAndAlignsColumns(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -1038,8 +1039,6 @@ func TestPUTCompetition_RosterPUTResponseSurfacesNormalisedUUIDs(t *testing.T) {
 		Format: state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
 	}))
 
-	// PUT body carries the bug-prone id shape that mintParticipantIds
-	// historically minted.
 	body := []byte(`{
 		"id":"asddasd","name":"Asddasd","date":"12-05-2026",
 		"format":"playoffs","kind":"individual","courts":["A"],
@@ -1059,17 +1058,12 @@ func TestPUTCompetition_RosterPUTResponseSurfacesNormalisedUUIDs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Players, 2)
 
-	// Response ids MUST be UUIDv4, not the request-body's "asddasd-p1"
-	// shape. Otherwise the client would keep resending the un-normalised
-	// id on every save.
-	for i, p := range resp.Players {
-		assert.True(t, helper.IsUUIDv4(p.ID),
-			"resp.Players[%d].ID must be a UUIDv4 after the server normalises non-UUID ids; got %q", i, p.ID)
-		assert.NotEqual(t, "asddasd-p1", p.ID, "resp.Players[%d] must not echo the un-normalised id", i)
-		assert.NotEqual(t, "asddasd-p2", p.ID, "resp.Players[%d] must not echo the un-normalised id", i)
-	}
+	// Ids preserved — regeneration would orphan dependent stores.
+	assert.Equal(t, "asddasd-p1", resp.Players[0].ID,
+		"non-UUID id must round-trip intact; regeneration orphans competitor_status/reserved_slot refs")
+	assert.Equal(t, "asddasd-p2", resp.Players[1].ID)
 
-	// Name and Dojo MUST round-trip without column shift.
+	// Name and Dojo correctly aligned — no column shift on load.
 	assert.Equal(t, "Aaron Adams", resp.Players[0].Name)
 	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
 	assert.Empty(t, resp.Players[0].Metadata,
@@ -1077,11 +1071,7 @@ func TestPUTCompetition_RosterPUTResponseSurfacesNormalisedUUIDs(t *testing.T) {
 	assert.Equal(t, "Albus Blake", resp.Players[1].Name)
 	assert.Equal(t, "Team Delta", resp.Players[1].Dojo)
 
-	// Sanity: a second PUT with the SAME (now-normalised) ids returned
-	// in the previous response should re-save without churning the on-
-	// disk ids. This guards against the regression where the response
-	// echoed the body and the next save kept re-normalising.
-	firstID := resp.Players[0].ID
+	// Idempotent second PUT — ids stay stable.
 	body2 := fmt.Appendf(nil, `{
 		"id":"asddasd","name":"Asddasd","date":"12-05-2026",
 		"format":"playoffs","kind":"individual","courts":["A"],
@@ -1098,16 +1088,14 @@ func TestPUTCompetition_RosterPUTResponseSurfacesNormalisedUUIDs(t *testing.T) {
 	require.Equal(t, http.StatusOK, w2.Code)
 	var resp2 state.Competition
 	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp2))
-	assert.Equal(t, firstID, resp2.Players[0].ID,
-		"ids must be stable across save round-trips once normalised")
+	assert.Equal(t, "asddasd-p1", resp2.Players[0].ID, "ids must be stable across save round-trips")
 }
 
-// mp-p7n: Copilot PR #185 finding — a client-supplied valid UUID with
-// uppercase hex digits must round-trip unchanged (canonicalised to
-// lowercase, but not replaced with a fresh id). Pre-canonicalisation
-// uuidRE only matched lowercase, so the upper-case variant would be
-// treated as a non-UUID and replaced.
-func TestPUTCompetition_RosterPUTAcceptsUppercaseUUID(t *testing.T) {
+// mp-p7n: uppercase-UUID id round-trips intact (no canonicalisation,
+// no regeneration). The loader's HasParticipantIDs-based strip handles
+// any shape — case isn't load-bearing for the id-strip decision once
+// the flag is consulted.
+func TestPUTCompetition_RosterPUTPreservesUppercaseUUID(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -1118,9 +1106,7 @@ func TestPUTCompetition_RosterPUTAcceptsUppercaseUUID(t *testing.T) {
 		Format: state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
 	}))
 
-	// Uppercase UUID, valid otherwise.
 	upperUUID := "85CDEB35-C066-4667-B7FD-43EBAE8A9F13"
-	lowerUUID := "85cdeb35-c066-4667-b7fd-43ebae8a9f13"
 	body := fmt.Appendf(nil, `{
 		"id":"upper-uuid","name":"Upper UUID","date":"12-05-2026",
 		"format":"playoffs","kind":"individual","courts":["A"],
@@ -1136,8 +1122,10 @@ func TestPUTCompetition_RosterPUTAcceptsUppercaseUUID(t *testing.T) {
 	var resp state.Competition
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Players, 1)
-	assert.Equal(t, lowerUUID, resp.Players[0].ID,
-		"uppercase UUID must canonicalise to lowercase, not be replaced with a fresh id")
+	assert.Equal(t, upperUUID, resp.Players[0].ID,
+		"client-supplied id must round-trip intact (case preserved, no regeneration)")
+	assert.Equal(t, "Aaron Adams", resp.Players[0].Name)
+	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
 }
 
 // TestPlayoff_ResponseIncludesPlayers pins the Copilot round-12

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
@@ -1129,30 +1128,28 @@ func TestPUTCompetition_RosterPUTPreservesUppercaseUUID(t *testing.T) {
 	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
 }
 
-// mp-p7n / Copilot PR #185 round-8: exercises the round-6
-// 500-on-flag-flip-failure branch end-to-end.
+// mp-p7n / Copilot PR #185 round-9: exercises the round-6
+// 500-on-flag-flip-failure branch end-to-end, deterministically.
 //
-// The handler's flow is:
-//  1. SaveParticipants writes participants.csv (atomic-rename)
-//  2. SaveSeeds writes seeds.csv (best-effort log)
-//  3. UpdateCompetitionChanged flips HasParticipantIDs=true
-//     — on failure the handler returns 500 (round-6 contract)
-//
-// To inject failure between (1) and (3) without breaking (1), a
-// watcher goroutine polls for participants.csv to appear (signalling
-// step 1 completed), then replaces config.md with a directory so
-// step 3's loadCompetitionLocked → parseCompetitionFile → os.ReadFile
-// errors out. The race is tight but reliable in practice — the
-// polling loop is microsecond-grained and SaveSeeds + lock-handoff
-// gives the watcher enough scheduling time to act before
-// UpdateCompetitionChanged acquires the per-comp lock again.
-//
-// If the race ever proves flaky in CI we can refactor by extracting
-// the flip into a hookable helper. For now the goroutine approach
-// avoids changing production code purely for testability.
+// Round-8 used a watcher-goroutine filesystem race to inject the
+// failure between SaveParticipants and the flip; Copilot flagged that
+// as nondeterministic (if the watcher lost the race it could observe
+// participants.csv after the handler already returned 200, then assert
+// 500). Replaced with a package-level test seam: flipHasParticipantIDs
+// is a var, so the test swaps in a stub that returns an error with no
+// timing dependency.
 func TestPUTCompetition_RosterPUT_FlagFlipFailureReturns500(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
+
+	// Inject a deterministic flip failure; restore on exit. These
+	// handler tests do not run in parallel, so mutating the package
+	// var is safe.
+	orig := flipHasParticipantIDs
+	flipHasParticipantIDs = func(_ *state.Store, _ string) error {
+		return fmt.Errorf("injected flag-flip failure")
+	}
+	defer func() { flipHasParticipantIDs = orig }()
 
 	cid := "flip-fails"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
@@ -1160,30 +1157,6 @@ func TestPUTCompetition_RosterPUT_FlagFlipFailureReturns500(t *testing.T) {
 		HasParticipantIDs: false,
 		Format:            state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
 	}))
-
-	partPath := filepath.Join(tempDir, "competitions", cid, "participants.csv")
-	cfgPath := filepath.Join(tempDir, "competitions", cid, "config.md")
-
-	corrupted := make(chan struct{})
-	stop := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(50 * time.Microsecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stop:
-				return
-			case <-ticker.C:
-			}
-			if _, err := os.Stat(partPath); err == nil {
-				_ = os.Remove(cfgPath)
-				_ = os.MkdirAll(cfgPath, 0o700)
-				close(corrupted)
-				return
-			}
-		}
-	}()
-	defer close(stop)
 
 	body, _ := json.Marshal(state.Competition{
 		ID: cid, Name: "Flip Fails", Date: "12-05-2026",
@@ -1197,21 +1170,28 @@ func TestPUTCompetition_RosterPUT_FlagFlipFailureReturns500(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 
-	// Confirm the watcher fired — if it didn't, the test wasn't
-	// exercising the failure path even if the assertion below passes.
-	select {
-	case <-corrupted:
-	case <-time.After(2 * time.Second):
-		t.Skip("watcher goroutine did not catch the SaveParticipants → flip window; skipping flaky test")
-	}
-
-	// The flip's UpdateCompetitionChanged → loadCompetitionLocked
-	// failed because config.md is now a directory, so the handler
-	// returns 500 from the round-6 branch.
+	// Round-6 contract: a flip failure surfaces as 500, NOT a 200 with
+	// a stale flag.
 	require.Equal(t, http.StatusInternalServerError, w.Code,
 		"flip failure must surface as 500 (round-6 contract) — got %d: %s", w.Code, w.Body.String())
 	assert.Contains(t, w.Body.String(), "HasParticipantIDs",
 		"error body must mention HasParticipantIDs (round-6 flip-failure branch); got %s", w.Body.String())
+
+	// The roster file itself DID land before the flip — confirm the
+	// participants were saved (the failure is only in the metadata flip,
+	// which is why the operator's retry is idempotent). Read with an
+	// explicit HasIDs hint: a no-hint read would reproduce the column
+	// shift precisely BECAUSE the flag flip failed (HasParticipantIDs is
+	// still false on disk, so the loader auto-detects "no ids" for the
+	// non-UUID first column). The hinted read proves the on-disk bytes
+	// are correct and a successful retry (which lands the flip) recovers.
+	trueP := true
+	saved, lerr := store.LoadParticipantsOpt(cid, false, state.LoadParticipantsOpts{HasIDs: &trueP})
+	require.NoError(t, lerr)
+	require.Len(t, saved, 1)
+	assert.Equal(t, "Aaron Adams", saved[0].Name)
+	assert.Equal(t, "Team Alpha", saved[0].Dojo)
+	assert.Equal(t, "flip-fails-p1", saved[0].ID)
 }
 
 // mp-p7n / Copilot PR #185 round-5: when the roster-PUT response

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -1128,6 +1128,67 @@ func TestPUTCompetition_RosterPUTPreservesUppercaseUUID(t *testing.T) {
 	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
 }
 
+// mp-p7n / Copilot PR #185 round-5: when the roster-PUT response
+// re-loads participants, the deferred HasParticipantIDs=true flip is
+// best-effort (failures only log). If the flip never lands — or simply
+// hasn't landed yet — the loader's default branch reads the stale flag
+// (false) and falls back to uuidRE-on-row-0, mis-classifying non-UUID
+// ids as "no ids" and returning the column-shifted roster.
+//
+// Simulate the failure mode by forcing HasParticipantIDs=false on
+// disk BEFORE the PUT, then asserting the response still surfaces
+// correctly-aligned Name/Dojo. The handler now passes HasIDs=&true
+// explicitly when re-loading a non-empty roster, so the loader trusts
+// the call site (we just saved a non-empty roster, every row has an
+// id) regardless of the metadata flag's state.
+func TestPUTCompetition_RosterPUTResponseHardenedAgainstStaleFlag(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	cid := "stale-flag"
+	// Note: HasParticipantIDs explicitly FALSE — simulating either the
+	// pre-flip window (race) or a failed deferred flip (logged but not
+	// surfaced). The reload must not trust this flag.
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: cid, Name: "Stale Flag", Date: "12-05-2026",
+		WithZekkenName: false, HasParticipantIDs: false,
+		Format: state.CompFormatPlayoffs, Kind: "individual", Courts: []string{"A"},
+	}))
+
+	body := []byte(`{
+		"id":"stale-flag","name":"Stale Flag","date":"12-05-2026",
+		"format":"playoffs","kind":"individual","courts":["A"],
+		"withZekkenName":false,
+		"players":[
+			{"id":"stale-flag-p1","name":"Aaron Adams","dojo":"Team Alpha"},
+			{"id":"stale-flag-p2","name":"Albus Blake","dojo":"Team Delta"}
+		]
+	}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+	var resp state.Competition
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Players, 2)
+
+	// Response MUST surface correctly-aligned Name/Dojo even if the
+	// deferred HasParticipantIDs flip failed. Pre-fix, the reload
+	// would have returned Name="Stale-Flag-P1", Dojo="Aaron Adams",
+	// metadata=["Team Alpha"] (column shift).
+	assert.Equal(t, "Aaron Adams", resp.Players[0].Name,
+		"reload must use HasIDs=&true hint, not the stale comp flag — non-UUID id must be stripped from column 0")
+	assert.Equal(t, "Team Alpha", resp.Players[0].Dojo)
+	assert.Empty(t, resp.Players[0].Metadata)
+	assert.Equal(t, "stale-flag-p1", resp.Players[0].ID,
+		"original non-UUID id preserved across the round-trip")
+	assert.Equal(t, "Aaron Adams", resp.Players[0].Name)
+	assert.Equal(t, "Albus Blake", resp.Players[1].Name)
+	assert.Equal(t, "Team Delta", resp.Players[1].Dojo)
+}
+
 // TestPlayoff_ResponseIncludesPlayers pins the Copilot round-12
 // finding (#6) server-side: POST /playoffs used to ship `players: null`
 // in the create response (Go nil slice → JSON null). admin.jsx's

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -169,6 +169,15 @@ func (s *Store) saveCompetitionChangedLocked(c *Competition, write writeFn) (boo
 	cache.mtime = s.FileMtime(c.ID, "config.md")
 	cache.mu.Unlock()
 
+	// mp-p7n / Copilot PR #185 round-9: the participant loader derives
+	// its id-strip decision from Competition.HasParticipantIDs, so a
+	// config write (notably the deferred HasParticipantIDs=true flip)
+	// must invalidate the participant caches — otherwise a coarse-
+	// timestamp filesystem could leave the summed cache mtime unchanged
+	// and keep serving a stale "no-IDs" (column-shifted) parse.
+	// Deterministic regardless of mtime granularity.
+	s.invalidateParticipantCaches(c.ID)
+
 	return true, nil
 }
 

--- a/internal/state/mp_p7n_repro_test.go
+++ b/internal/state/mp_p7n_repro_test.go
@@ -1,0 +1,144 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mp-p7n: failing repro of "phantom leading column appears in textarea
+// after Apply".
+//
+// User-reported flow:
+//   - Competition has withZekkenName=false, numberPrefix empty,
+//     hasParticipantIDs=true.
+//   - User clicks Apply with clean 2-col text "Aaron Adams, Team Alpha".
+//   - After Apply the textarea regenerates as
+//     "Asddasd-P1, Aaron Adams, Team Alpha" — name and dojo shifted one
+//     column right, with the participant id leaking into Name (and
+//     getting title-cased: "asddasd-p1" → "Asddasd-P1").
+//
+// Root cause hypothesis: web-mobile/js/admin_participants.jsx::mintParticipantIds
+// generates participant IDs in the shape `${compID}-p${N}` for new
+// players (and the sample-roster generator data.jsx::makePlayer does the
+// same). Those values are NOT UUIDv4. participants.csv is saved with the
+// non-UUID id as the first column, e.g.
+//
+//	asddasd-p1,Aaron Adams,Team Alpha
+//
+// On the next LoadParticipantsOpt(_, withZekkenName=false), the per-record
+// check at participants.go:125 only strips the first field as an ID when
+// `uuidRE(record[0])` returns true. A non-UUID id leaves dataStart=0, so
+// the row gets parsed as `[Name="asddasd-p1", Dojo="Aaron Adams",
+// Metadata=["Team Alpha"]]`. CreatePlayersFromRecords title-cases Name →
+// "Asddasd-P1". The corrupted player flows back to the JS layer and the
+// textarea (which serialises `${p.name}, ${p.dojo}[, ${p.danGrade}]`)
+// renders the bug shape from the screenshot.
+//
+// These tests will fail until the save path normalises non-UUID ids
+// (regenerating them to UUIDv4 before the CSV write) or the load path
+// is hardened to skip non-UUID first columns when hasIDs is hinted true.
+
+func TestMpP7nRepro_NonUUIDIDCausesColumnShift(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "asddasd"
+
+	require.NoError(t, store.SaveCompetition(&Competition{
+		ID: compID, Name: "Asddasd", WithZekkenName: false, HasParticipantIDs: true,
+	}))
+
+	// Players carry mintParticipantIds-shaped IDs ("${compID}-p${N}"),
+	// NOT UUIDv4. This is what the JS layer hands the server when the
+	// frontend mints new participant rows (admin_participants.jsx:127-128).
+	players := []domain.Player{
+		{ID: "asddasd-p1", Name: "Aaron Adams", Dojo: "Team Alpha"},
+		{ID: "asddasd-p2", Name: "Albus Blake", Dojo: "Team Delta"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	// Confirm what the CSV writer actually persisted.
+	raw, err := os.ReadFile(filepath.Join(dir, "competitions", compID, "participants.csv"))
+	require.NoError(t, err)
+	t.Logf("participants.csv =\n%s", string(raw))
+
+	// Now load using the same hint the live handler uses
+	// (handlers_viewer.go:147 passes HasIDs=&true when
+	// HasParticipantIDs=true).
+	trueP := true
+	loaded, err := store.LoadParticipantsOpt(compID, false, LoadParticipantsOpts{
+		WithSeeds: false,
+		HasIDs:    &trueP,
+	})
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+
+	// THE BUG: pre-fix these assertions fail. Name becomes "Asddasd-P1"
+	// (the title-cased id), Dojo becomes "Aaron Adams" (the original
+	// name), and Metadata gets "Team Alpha" (the original dojo).
+	assert.Equal(t, "Aaron Adams", loaded[0].Name,
+		"Name must be the saved 'Aaron Adams', not a title-cased participant id")
+	assert.Equal(t, "Team Alpha", loaded[0].Dojo,
+		"Dojo must be 'Team Alpha', not 'Aaron Adams' (shifted from the Name column)")
+	assert.Empty(t, loaded[0].Metadata,
+		"Metadata must be empty — pre-bug it contains ['Team Alpha'] (shifted from the Dojo column)")
+}
+
+func TestMpP7nRepro_NonUUIDID_AutoDetect(t *testing.T) {
+	// Same shape but without the HasIDs hint — the auto-detect path
+	// from participants.go:111. uuidRE on a non-UUID first field
+	// returns false, so hasIDs=false, every column becomes data, same
+	// column-shift outcome.
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "asddasd"
+
+	require.NoError(t, store.SaveCompetition(&Competition{
+		ID: compID, Name: "Asddasd", WithZekkenName: false, HasParticipantIDs: false,
+	}))
+	players := []domain.Player{
+		{ID: "asddasd-p1", Name: "Aaron Adams", Dojo: "Team Alpha"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	loaded, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+
+	assert.Equal(t, "Aaron Adams", loaded[0].Name)
+	assert.Equal(t, "Team Alpha", loaded[0].Dojo)
+	assert.Empty(t, loaded[0].Metadata)
+}
+
+func TestMpP7nRepro_UUIDIDIsFine(t *testing.T) {
+	// Sanity: with proper UUIDv4 IDs, the round-trip is clean. This
+	// test should PASS both pre-fix and post-fix — it isolates the bug
+	// to the non-UUID id case.
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "uuid-ok"
+
+	require.NoError(t, store.SaveCompetition(&Competition{
+		ID: compID, Name: "UUID OK", WithZekkenName: false, HasParticipantIDs: true,
+	}))
+	players := []domain.Player{
+		{ID: "11111111-1111-4111-8111-111111111111", Name: "Aaron Adams", Dojo: "Team Alpha"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	trueP := true
+	loaded, err := store.LoadParticipantsOpt(compID, false, LoadParticipantsOpts{
+		WithSeeds: false, HasIDs: &trueP,
+	})
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, "Aaron Adams", loaded[0].Name)
+	assert.Equal(t, "Team Alpha", loaded[0].Dojo)
+}

--- a/internal/state/mp_p7n_repro_test.go
+++ b/internal/state/mp_p7n_repro_test.go
@@ -133,13 +133,13 @@ func TestMpP7nRepro_NonUUIDID_PreservesOriginalID(t *testing.T) {
 // HasParticipantIDs=true flip.
 //
 // Pre-fix sequence:
-//   1. SaveParticipants writes `${compID}-pN` rows; participants.csv mtime updates.
-//   2. Reader A loads BEFORE HasParticipantIDs is set; falls back to
-//      auto-detect, uuidRE-on-row-0 fails on the non-UUID first column,
-//      hasIDs=false, the row is parsed as data (column shift), cached.
-//   3. The deferred HasParticipantIDs=true flip lands in config.md, but
-//      participants.csv mtime is unchanged → cache still serves the
-//      shifted players.
+//  1. SaveParticipants writes `${compID}-pN` rows; participants.csv mtime updates.
+//  2. Reader A loads BEFORE HasParticipantIDs is set; falls back to
+//     auto-detect, uuidRE-on-row-0 fails on the non-UUID first column,
+//     hasIDs=false, the row is parsed as data (column shift), cached.
+//  3. The deferred HasParticipantIDs=true flip lands in config.md, but
+//     participants.csv mtime is unchanged → cache still serves the
+//     shifted players.
 //
 // Fix: include config.md's mtime in the participants-cache key so any
 // config write (notably the HasParticipantIDs flip) invalidates the

--- a/internal/state/mp_p7n_repro_test.go
+++ b/internal/state/mp_p7n_repro_test.go
@@ -89,31 +89,42 @@ func TestMpP7nRepro_NonUUIDIDCausesColumnShift(t *testing.T) {
 		"Metadata must be empty — pre-bug it contains ['Team Alpha'] (shifted from the Dojo column)")
 }
 
-func TestMpP7nRepro_NonUUIDID_AutoDetect(t *testing.T) {
-	// Same shape but without the HasIDs hint — the auto-detect path
-	// from participants.go:111. uuidRE on a non-UUID first field
-	// returns false, so hasIDs=false, every column becomes data, same
-	// column-shift outcome.
+func TestMpP7nRepro_NonUUIDID_PreservesOriginalID(t *testing.T) {
+	// mp-p7n: the loader now trusts the HasIDs hint and strips column
+	// 0 regardless of UUID shape. Together with the no-regeneration
+	// save path, that means a client-supplied non-UUID id round-trips
+	// intact — important for joining with other persisted state that
+	// references the player by id (CompetitorStatus.PlayerID,
+	// ReservedSlot.ParticipantID, team lineup PlayerIDs). Copilot
+	// PR #185 round-3 finding: regenerating ids would silently orphan
+	// those references.
 	dir := t.TempDir()
 	store, err := NewStore(dir)
 	require.NoError(t, err)
 	compID := "asddasd"
 
 	require.NoError(t, store.SaveCompetition(&Competition{
-		ID: compID, Name: "Asddasd", WithZekkenName: false, HasParticipantIDs: false,
+		ID: compID, Name: "Asddasd", WithZekkenName: false, HasParticipantIDs: true,
 	}))
 	players := []domain.Player{
 		{ID: "asddasd-p1", Name: "Aaron Adams", Dojo: "Team Alpha"},
 	}
 	require.NoError(t, store.SaveParticipants(compID, players))
 
-	loaded, err := store.LoadParticipants(compID, false)
+	trueP := true
+	loaded, err := store.LoadParticipantsOpt(compID, false, LoadParticipantsOpts{
+		WithSeeds: false, HasIDs: &trueP,
+	})
 	require.NoError(t, err)
 	require.Len(t, loaded, 1)
 
+	// Name / Dojo align correctly (no column shift) AND the original
+	// non-UUID id is preserved (no regeneration on save).
 	assert.Equal(t, "Aaron Adams", loaded[0].Name)
 	assert.Equal(t, "Team Alpha", loaded[0].Dojo)
 	assert.Empty(t, loaded[0].Metadata)
+	assert.Equal(t, "asddasd-p1", loaded[0].ID,
+		"original id must survive the round-trip — regenerating it would orphan competitor_status / reserved-slot references")
 }
 
 func TestMpP7nRepro_UUIDIDIsFine(t *testing.T) {

--- a/internal/state/mp_p7n_repro_test.go
+++ b/internal/state/mp_p7n_repro_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/stretchr/testify/assert"
@@ -125,6 +126,71 @@ func TestMpP7nRepro_NonUUIDID_PreservesOriginalID(t *testing.T) {
 	assert.Empty(t, loaded[0].Metadata)
 	assert.Equal(t, "asddasd-p1", loaded[0].ID,
 		"original id must survive the round-trip — regenerating it would orphan competitor_status / reserved-slot references")
+}
+
+// mp-p7n / Copilot PR #185 round-4: closes the cache-poisoning race
+// between a roster save (non-UUID ids on disk) and the deferred
+// HasParticipantIDs=true flip.
+//
+// Pre-fix sequence:
+//   1. SaveParticipants writes `${compID}-pN` rows; participants.csv mtime updates.
+//   2. Reader A loads BEFORE HasParticipantIDs is set; falls back to
+//      auto-detect, uuidRE-on-row-0 fails on the non-UUID first column,
+//      hasIDs=false, the row is parsed as data (column shift), cached.
+//   3. The deferred HasParticipantIDs=true flip lands in config.md, but
+//      participants.csv mtime is unchanged → cache still serves the
+//      shifted players.
+//
+// Fix: include config.md's mtime in the participants-cache key so any
+// config write (notably the HasParticipantIDs flip) invalidates the
+// cache.
+func TestMpP7nRepro_CacheInvalidatedOnHasParticipantIDsFlip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "race"
+
+	// HasParticipantIDs=false initially (simulating the pre-flip window).
+	require.NoError(t, store.SaveCompetition(&Competition{
+		ID: compID, Name: "Race", WithZekkenName: false, HasParticipantIDs: false,
+	}))
+	players := []domain.Player{
+		{ID: "race-p1", Name: "Aaron Adams", Dojo: "Team Alpha"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	// First load: HasParticipantIDs=false, non-UUID first column,
+	// falls into the auto-detect path → uuidRE-on-row-0 fails → no
+	// strip → column shift. The corrupted view gets cached.
+	loadedPre, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loadedPre, 1)
+	assert.Equal(t, "Race-P1", loadedPre[0].Name,
+		"pre-flip load takes the auto-detect path and mis-loads (column shift)")
+
+	// Wait at least 10ms so the next config.md write produces a
+	// distinct mtime — os.Stat resolution on macOS is millisecond on
+	// some filesystems, and back-to-back writes can collide.
+	time.Sleep(20 * time.Millisecond)
+
+	// Flip the flag — simulating the deferred HasParticipantIDs=true
+	// that lands after the first roster save succeeds.
+	current, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	current.HasParticipantIDs = true
+	require.NoError(t, store.SaveCompetition(current))
+
+	// Post-flip load: the cache MUST be invalidated (we fold config.md
+	// mtime into the cache key). The loader now takes the trustHint
+	// branch and correctly strips column 0.
+	loadedPost, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loadedPost, 1)
+	assert.Equal(t, "Aaron Adams", loadedPost[0].Name,
+		"post-flip load must reflect the new flag, not the cached pre-flip parse")
+	assert.Equal(t, "Team Alpha", loadedPost[0].Dojo)
+	assert.Equal(t, "race-p1", loadedPost[0].ID,
+		"original non-UUID id must be preserved (no regeneration)")
 }
 
 func TestMpP7nRepro_UUIDIDIsFine(t *testing.T) {

--- a/internal/state/mp_p7n_repro_test.go
+++ b/internal/state/mp_p7n_repro_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/stretchr/testify/assert"
@@ -128,9 +127,9 @@ func TestMpP7nRepro_NonUUIDID_PreservesOriginalID(t *testing.T) {
 		"original id must survive the round-trip — regenerating it would orphan competitor_status / reserved-slot references")
 }
 
-// mp-p7n / Copilot PR #185 round-4: closes the cache-poisoning race
-// between a roster save (non-UUID ids on disk) and the deferred
-// HasParticipantIDs=true flip.
+// mp-p7n / Copilot PR #185 round-4 + round-9: closes the cache-
+// poisoning race between a roster save (non-UUID ids on disk) and the
+// deferred HasParticipantIDs=true flip.
 //
 // Pre-fix sequence:
 //  1. SaveParticipants writes `${compID}-pN` rows; participants.csv mtime updates.
@@ -141,9 +140,13 @@ func TestMpP7nRepro_NonUUIDID_PreservesOriginalID(t *testing.T) {
 //     participants.csv mtime is unchanged → cache still serves the
 //     shifted players.
 //
-// Fix: include config.md's mtime in the participants-cache key so any
-// config write (notably the HasParticipantIDs flip) invalidates the
-// cache.
+// Fix: saveCompetitionChangedLocked explicitly invalidates the
+// participant cache variants on every config write (round-9). This is
+// deterministic regardless of filesystem timestamp granularity — note
+// this test does NOT sleep between the roster save and the flag flip,
+// so a coarse-mtime filesystem that left the summed cache mtime
+// unchanged would still pass (pre-round-9, this test needed a 20ms
+// sleep to force a distinct config.md mtime; that crutch is gone).
 func TestMpP7nRepro_CacheInvalidatedOnHasParticipantIDsFlip(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewStore(dir)
@@ -168,21 +171,18 @@ func TestMpP7nRepro_CacheInvalidatedOnHasParticipantIDsFlip(t *testing.T) {
 	assert.Equal(t, "Race-P1", loadedPre[0].Name,
 		"pre-flip load takes the auto-detect path and mis-loads (column shift)")
 
-	// Wait at least 10ms so the next config.md write produces a
-	// distinct mtime — os.Stat resolution on macOS is millisecond on
-	// some filesystems, and back-to-back writes can collide.
-	time.Sleep(20 * time.Millisecond)
-
 	// Flip the flag — simulating the deferred HasParticipantIDs=true
-	// that lands after the first roster save succeeds.
+	// that lands after the first roster save succeeds. NO sleep: the
+	// round-9 explicit cache invalidation must work even when this
+	// config write shares participants.csv's coarse mtime.
 	current, err := store.LoadCompetition(compID)
 	require.NoError(t, err)
 	current.HasParticipantIDs = true
 	require.NoError(t, store.SaveCompetition(current))
 
-	// Post-flip load: the cache MUST be invalidated (we fold config.md
-	// mtime into the cache key). The loader now takes the trustHint
-	// branch and correctly strips column 0.
+	// Post-flip load: the participant cache MUST have been invalidated
+	// by the config write. The loader now takes the trustHint branch
+	// and correctly strips column 0.
 	loadedPost, err := store.LoadParticipants(compID, false)
 	require.NoError(t, err)
 	require.Len(t, loadedPost, 1)

--- a/internal/state/mp_p7n_repro_test.go
+++ b/internal/state/mp_p7n_repro_test.go
@@ -193,6 +193,52 @@ func TestMpP7nRepro_CacheInvalidatedOnHasParticipantIDsFlip(t *testing.T) {
 		"original non-UUID id must be preserved (no regeneration)")
 }
 
+// mp-p7n / Copilot PR #185 round-6: the participant cache key must
+// split by HasIDs parse mode. Without the split, a no-hint
+// auto-detect load that lands a "no-IDs" parse can poison the same
+// cache entry that a later HasIDs=&true call reads — the hinted call
+// would return the cached shifted rows instead of stripping column 0.
+func TestMpP7nRepro_CacheKeySplitsByParseMode(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "cache-mode"
+
+	// HasParticipantIDs=false on disk — auto-detect path will fall back
+	// to uuidRE-on-row-0, which fails for the non-UUID id below and
+	// returns the column-shifted view.
+	require.NoError(t, store.SaveCompetition(&Competition{
+		ID: compID, Name: "Cache Mode", WithZekkenName: false, HasParticipantIDs: false,
+	}))
+	players := []domain.Player{
+		{ID: "cache-mode-p1", Name: "Aaron Adams", Dojo: "Team Alpha"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	// First: no-hint load lands the shifted parse and caches it.
+	loadedAuto, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, loadedAuto, 1)
+	assert.Equal(t, "Cache-Mode-P1", loadedAuto[0].Name,
+		"no-hint load takes the auto-detect path and mis-loads (column shift)")
+
+	// Second: hinted load against the SAME on-disk file (no mtime
+	// change) MUST not hit the auto-detect cache entry. Pre-fix this
+	// would have returned the same shifted parse from the shared cache;
+	// post-fix the parse-mode-keyed cache forces a fresh parse with
+	// the hint, which correctly strips column 0.
+	trueP := true
+	loadedHint, err := store.LoadParticipantsOpt(compID, false, LoadParticipantsOpts{
+		WithSeeds: true, HasIDs: &trueP,
+	})
+	require.NoError(t, err)
+	require.Len(t, loadedHint, 1)
+	assert.Equal(t, "Aaron Adams", loadedHint[0].Name,
+		"hinted load must NOT serve the auto-detect cache entry — distinct cache key per parse mode")
+	assert.Equal(t, "Team Alpha", loadedHint[0].Dojo)
+	assert.Equal(t, "cache-mode-p1", loadedHint[0].ID)
+}
+
 func TestMpP7nRepro_UUIDIDIsFine(t *testing.T) {
 	// Sanity: with proper UUIDv4 IDs, the round-trip is clean. This
 	// test should PASS both pre-fix and post-fix — it isolates the bug

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -72,6 +72,14 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 	if opts.WithSeeds {
 		mtime += s.FileMtime(compID, "seeds.csv")
 	}
+	// mp-p7n / Copilot PR #185 round-4: the load decision now depends
+	// on Competition.HasParticipantIDs (see the trustHint branch below).
+	// That flag lives in config.md, NOT participants.csv, so a flag flip
+	// (e.g. the deferred HasParticipantIDs=true after the first roster
+	// save) wouldn't bump participants.csv's mtime and would leave a
+	// stale "no-IDs" parse in the cache. Fold config.md's mtime into
+	// the cache key so any config write invalidates the cached players.
+	mtime += s.FileMtime(compID, "config.md")
 
 	if cache.data != nil && cache.mtime == mtime {
 		p := cache.data.([]domain.Player)

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -42,6 +42,43 @@ type LoadParticipantsOpts struct {
 	HasIDs    *bool // nil = auto-detect from first line; non-nil uses cached Competition.HasParticipantIDs
 }
 
+// participantsCacheKey returns a virtual filename used as the cache key
+// for a participants load. Splits by both WithSeeds and HasIDs parse
+// mode so the three mutually-exclusive parses don't poison each other's
+// cache entries (mp-p7n Copilot PR #185 round-6).
+func participantsCacheKey(opts LoadParticipantsOpts) string {
+	base := "participants"
+	if opts.WithSeeds {
+		base += "_with_seeds"
+	}
+	switch {
+	case opts.HasIDs == nil:
+		base += "_auto"
+	case *opts.HasIDs:
+		base += "_hint_true"
+	default:
+		base += "_hint_false"
+	}
+	return base + ".csv"
+}
+
+// allParticipantsCacheKeys enumerates every cache key that
+// participantsCacheKey can produce. Used by saveParticipantsNoLock to
+// invalidate all parse-mode variants in one pass on write.
+func allParticipantsCacheKeys() []string {
+	keys := make([]string, 0, 6)
+	for _, withSeeds := range []bool{false, true} {
+		trueP, falseP := true, false
+		for _, hint := range []*bool{nil, &trueP, &falseP} {
+			keys = append(keys, participantsCacheKey(LoadParticipantsOpts{
+				WithSeeds: withSeeds,
+				HasIDs:    hint,
+			}))
+		}
+	}
+	return keys
+}
+
 // LoadParticipants loads participants with seeds merged (default behavior).
 func (s *Store) LoadParticipants(compID string, withZekkenName bool) ([]domain.Player, error) {
 	return s.loadParticipants(compID, withZekkenName, LoadParticipantsOpts{WithSeeds: true})
@@ -60,11 +97,18 @@ func (s *Store) loadParticipants(compID string, withZekkenName bool, opts LoadPa
 }
 
 func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts LoadParticipantsOpts) ([]domain.Player, error) {
-	// Use a virtual filename for cache to distinguish between with/without seeds.
-	cacheKey := "participants.csv"
-	if opts.WithSeeds {
-		cacheKey = "participants_with_seeds.csv"
-	}
+	// Use a virtual filename for cache to distinguish between with/without
+	// seeds AND between the three possible parse modes
+	// (HasIDs=&true / HasIDs=&false / nil → auto-detect).
+	//
+	// mp-p7n / Copilot PR #185 round-6: without the parse-mode suffix,
+	// a no-hint auto-detect call that lands a "no-IDs" parse can poison
+	// the same cache key that a later HasIDs=&true call reads — the
+	// hinted call would return the cached shifted rows instead of
+	// stripping column 0. Splitting the cache key by parse mode means
+	// each mode's parse is cached independently. saveParticipantsNoLock
+	// invalidates all variants below to keep them coherent on write.
+	cacheKey := participantsCacheKey(opts)
 
 	cache := s.getFileCache(compID, cacheKey)
 	cache.mu.RLock()
@@ -644,9 +688,11 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 		return err
 	}
 
-	// Invalidate participant caches (with and without seeds) so the next Load
-	// sees the fresh data without a disk re-read.
-	for _, key := range []string{"participants.csv", "participants_with_seeds.csv"} {
+	// Invalidate every parse-mode variant of the participant cache so a
+	// subsequent Load (regardless of HasIDs hint / WithSeeds) re-parses
+	// from the freshly-written file. See participantsCacheKey for the
+	// matrix mp-p7n round-6 split into.
+	for _, key := range allParticipantsCacheKeys() {
 		cache := s.getFileCache(compID, key)
 		cache.mu.Lock()
 		cache.data = nil

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -692,6 +692,29 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 	// subsequent Load (regardless of HasIDs hint / WithSeeds) re-parses
 	// from the freshly-written file. See participantsCacheKey for the
 	// matrix mp-p7n round-6 split into.
+	s.invalidateParticipantCaches(compID)
+
+	return nil
+}
+
+// invalidateParticipantCaches drops every parse-mode variant of the
+// participant cache for compID. Called after a participants.csv write
+// (saveParticipantsNoLock) AND after a competition config write
+// (saveCompetitionChangedLocked) — the latter is load-bearing because
+// the load decision depends on Competition.HasParticipantIDs, so a flag
+// flip must force a re-parse even when participants.csv is untouched.
+//
+// mp-p7n / Copilot PR #185 round-9: this replaces sole reliance on
+// config.md's mtime in the cache key. On a filesystem with coarse
+// timestamp resolution, a save + flag-flip in quick succession can
+// land the same summed mtime and leave the auto-detect cache serving
+// the shifted parse. Explicit invalidation on the config write is
+// deterministic regardless of timestamp granularity. The config.md
+// mtime stays in the cache key as cheap cross-process defense.
+//
+// Each variant uses its own cache.mu; this is safe to call while the
+// per-comp lock is held (different lock) and acquires no other lock.
+func (s *Store) invalidateParticipantCaches(compID string) {
 	for _, key := range allParticipantsCacheKeys() {
 		cache := s.getFileCache(compID, key)
 		cache.mu.Lock()
@@ -699,6 +722,4 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 		cache.mtime = 0
 		cache.mu.Unlock()
 	}
-
-	return nil
 }

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -445,7 +445,18 @@ func marshalParticipantsCSV(players []domain.Player, withZekkenName bool) ([]byt
 	w := csv.NewWriter(&sb)
 	for _, p := range players {
 		id := p.ID
-		if id == "" {
+		// mp-p7n: only UUIDv4 IDs survive the round-trip cleanly. The
+		// loader's per-record id-strip at participants.go:125 gates on
+		// uuidRE — a non-UUID id (e.g. the `${compID}-p${N}` shape the
+		// JS-side mintParticipantIds was generating, or anything a
+		// client/import path supplies) leaves dataStart=0 on load, so
+		// the row's columns get parsed as [Name, Dojo, Metadata]
+		// instead of [id, Name, Dojo, Metadata] — every field shifts
+		// one column right and the id ends up title-cased in Name.
+		// Normalise non-UUID ids to a fresh UUIDv4 at write time so
+		// subsequent reads always strip the first column correctly.
+		// (`uuidRE` is helper.IsUUIDv4 via internal/state/ids.go.)
+		if id == "" || !uuidRE(id) {
 			id = newParticipantID()
 		}
 		var record []string

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -444,7 +444,6 @@ func marshalParticipantsCSV(players []domain.Player, withZekkenName bool) ([]byt
 	var sb strings.Builder
 	w := csv.NewWriter(&sb)
 	for _, p := range players {
-		id := p.ID
 		// mp-p7n: only UUIDv4 IDs survive the round-trip cleanly. The
 		// loader's per-record id-strip at participants.go:125 gates on
 		// uuidRE — a non-UUID id (e.g. the `${compID}-p${N}` shape the
@@ -456,6 +455,13 @@ func marshalParticipantsCSV(players []domain.Player, withZekkenName bool) ([]byt
 		// Normalise non-UUID ids to a fresh UUIDv4 at write time so
 		// subsequent reads always strip the first column correctly.
 		// (`uuidRE` is helper.IsUUIDv4 via internal/state/ids.go.)
+		//
+		// Copilot PR #185 finding: uuidRE only matches lowercase hex,
+		// so a client-supplied valid UUID with uppercase digits
+		// (e.g. "85CDEB35-...") would be replaced with a fresh id.
+		// Canonicalise via TrimSpace + ToLower before the check so
+		// otherwise-valid UUIDs round-trip unchanged.
+		id := strings.ToLower(strings.TrimSpace(p.ID))
 		if id == "" || !uuidRE(id) {
 			id = newParticipantID()
 		}

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -103,12 +103,40 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 		return nil, err
 	}
 
-	// Detect new format: first field is a UUID. Use cached flag if provided.
-	var hasIDs bool
-	if opts.HasIDs != nil {
+	// Detect ID column: when callers pass an explicit HasIDs hint we
+	// trust it; otherwise consult Competition.HasParticipantIDs (set on
+	// disk the first time participants are saved with IDs) and fall
+	// back to a UUID-shape sniff on the first row only when no comp
+	// record is available.
+	//
+	// mp-p7n: previously this path used only uuidRE on records[0][0],
+	// which mis-classified non-UUID-shaped ids (e.g. the JS-side
+	// `${compID}-p${N}` shape) as "no IDs" → column shift on load. The
+	// HasParticipantIDs flag is the authoritative signal: when set,
+	// every row has an id in column 0 regardless of its textual shape,
+	// and the loader must strip it. Auto-detect against the file is
+	// only used when we have no comp record (e.g. a stand-alone CSV
+	// loaded outside the normal handler flow).
+	// hasIDs: there is an id column in the file at all.
+	// trustHint: strip column 0 from EVERY row unconditionally — set
+	// only when the caller (or the comp's HasParticipantIDs flag)
+	// asserts "every row has an id". Without this signal, the auto-
+	// detect path falls back to a per-record UUID-shape check below
+	// to preserve mixed-format legacy support (TestStore_ParticipantsCSV_MixedIDs:
+	// a file with one UUID row and one bare-name row must load both).
+	var hasIDs, trustHint bool
+	switch {
+	case opts.HasIDs != nil:
 		hasIDs = *opts.HasIDs
-	} else {
-		hasIDs = len(records) > 0 && len(records[0]) > 0 && uuidRE(strings.TrimSpace(records[0][0]))
+		trustHint = *opts.HasIDs
+	default:
+		if comp, _ := s.loadCompetitionLocked(compID); comp != nil && comp.HasParticipantIDs {
+			hasIDs = true
+			trustHint = true
+		} else {
+			hasIDs = len(records) > 0 && len(records[0]) > 0 && uuidRE(strings.TrimSpace(records[0][0]))
+			trustHint = false
+		}
 	}
 
 	var ids []string
@@ -118,12 +146,40 @@ func (s *Store) loadParticipantsNoLock(compID string, withZekkenName bool, opts 
 	for _, record := range records {
 		isCheckedIn := false
 
-		// Determine data fields (everything after UUID if present).
-		// Per-record UUID check: only strip the first field as an ID
-		// when it actually matches the UUID pattern.
+		// Determine data fields (everything after the id if present).
+		//
+		// mp-p7n: pre-fix, this branch gated on `uuidRE(record[0])` —
+		// a per-record check that only stripped the first field when
+		// it matched the canonical-UUID shape. That broke any roster
+		// whose ids weren't UUID-shaped (e.g. the `${compID}-p${N}`
+		// shape the JS-side mintParticipantIds was generating, or
+		// arbitrary client-supplied ids): dataStart stayed 0, the
+		// row was parsed as [Name, Dojo, Metadata] instead of
+		// [id, Name, Dojo, Metadata], every field shifted one column
+		// right, and the id got title-cased into Name on load
+		// (producing the user-reported "Asddasd-P1, Aaron Adams,
+		// Team Alpha" corruption).
+		//
+		// Fix:
+		//   - `trustHint` (caller-supplied or comp.HasParticipantIDs=true):
+		//     strip column 0 unconditionally — every row has an id of
+		//     whatever shape. Preserves non-UUID ids (a client/import
+		//     path may carry one) and keeps them joinable with other
+		//     persisted state that references the player by id —
+		//     CompetitorStatus.PlayerID, ReservedSlot.ParticipantID,
+		//     team-lineup PlayerIDs (Copilot PR #185 round-3: an
+		//     alternative that regenerated non-UUID ids at save time
+		//     would silently orphan all those references).
+		//   - Auto-detected `hasIDs` (UUID-shape sniff on the first
+		//     row): keep the per-record uuidRE check so mixed-format
+		//     legacy files (some rows with UUID ids, some without)
+		//     load both kinds correctly — TestStore_ParticipantsCSV_MixedIDs
+		//     pins this contract.
 		dataStart := 0
-		if hasIDs && len(record) > 0 && uuidRE(strings.TrimSpace(record[0])) {
-			dataStart = 1
+		if hasIDs && len(record) > 0 {
+			if trustHint || uuidRE(strings.TrimSpace(record[0])) {
+				dataStart = 1
+			}
 		}
 		dataFields := record[dataStart:]
 
@@ -444,31 +500,8 @@ func marshalParticipantsCSV(players []domain.Player, withZekkenName bool) ([]byt
 	var sb strings.Builder
 	w := csv.NewWriter(&sb)
 	for _, p := range players {
-		// mp-p7n: only canonical-UUID-shaped ids (lowercase 8-4-4-4-12 hex)
-		// survive the round-trip cleanly. The loader's per-record id-strip
-		// at participants.go:125 gates on uuidRE — a non-UUID-shaped id
-		// (e.g. the `${compID}-p${N}` shape the JS-side mintParticipantIds
-		// was generating, or anything a client/import path supplies) leaves
-		// dataStart=0 on load, so the row's columns get parsed as
-		// [Name, Dojo, Metadata] instead of [id, Name, Dojo, Metadata] —
-		// every field shifts one column right and the id ends up
-		// title-cased in Name. Normalise non-conforming ids to a fresh
-		// UUIDv4 (via uuid.New()) at write time so subsequent reads always
-		// strip the first column correctly.
-		//
-		// `uuidRE` is helper.IsUUIDv4 via internal/state/ids.go — note
-		// that despite the name it's a shape check (doesn't enforce the
-		// v4 version nibble or 89ab variant nibble); any lowercase
-		// 8-4-4-4-12 hex string passes. The shape match is what the
-		// loader cares about, so save + load stay symmetric.
-		//
-		// Copilot PR #185 finding: uuidRE only matches lowercase hex,
-		// so a client-supplied UUID with uppercase digits
-		// (e.g. "85CDEB35-...") would be replaced with a fresh id.
-		// Canonicalise via TrimSpace + ToLower before the check so
-		// otherwise-conforming UUIDs round-trip unchanged.
-		id := strings.ToLower(strings.TrimSpace(p.ID))
-		if id == "" || !uuidRE(id) {
+		id := p.ID
+		if id == "" {
 			id = newParticipantID()
 		}
 		var record []string

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -444,23 +444,29 @@ func marshalParticipantsCSV(players []domain.Player, withZekkenName bool) ([]byt
 	var sb strings.Builder
 	w := csv.NewWriter(&sb)
 	for _, p := range players {
-		// mp-p7n: only UUIDv4 IDs survive the round-trip cleanly. The
-		// loader's per-record id-strip at participants.go:125 gates on
-		// uuidRE — a non-UUID id (e.g. the `${compID}-p${N}` shape the
-		// JS-side mintParticipantIds was generating, or anything a
-		// client/import path supplies) leaves dataStart=0 on load, so
-		// the row's columns get parsed as [Name, Dojo, Metadata]
-		// instead of [id, Name, Dojo, Metadata] — every field shifts
-		// one column right and the id ends up title-cased in Name.
-		// Normalise non-UUID ids to a fresh UUIDv4 at write time so
-		// subsequent reads always strip the first column correctly.
-		// (`uuidRE` is helper.IsUUIDv4 via internal/state/ids.go.)
+		// mp-p7n: only canonical-UUID-shaped ids (lowercase 8-4-4-4-12 hex)
+		// survive the round-trip cleanly. The loader's per-record id-strip
+		// at participants.go:125 gates on uuidRE — a non-UUID-shaped id
+		// (e.g. the `${compID}-p${N}` shape the JS-side mintParticipantIds
+		// was generating, or anything a client/import path supplies) leaves
+		// dataStart=0 on load, so the row's columns get parsed as
+		// [Name, Dojo, Metadata] instead of [id, Name, Dojo, Metadata] —
+		// every field shifts one column right and the id ends up
+		// title-cased in Name. Normalise non-conforming ids to a fresh
+		// UUIDv4 (via uuid.New()) at write time so subsequent reads always
+		// strip the first column correctly.
+		//
+		// `uuidRE` is helper.IsUUIDv4 via internal/state/ids.go — note
+		// that despite the name it's a shape check (doesn't enforce the
+		// v4 version nibble or 89ab variant nibble); any lowercase
+		// 8-4-4-4-12 hex string passes. The shape match is what the
+		// loader cares about, so save + load stay symmetric.
 		//
 		// Copilot PR #185 finding: uuidRE only matches lowercase hex,
-		// so a client-supplied valid UUID with uppercase digits
+		// so a client-supplied UUID with uppercase digits
 		// (e.g. "85CDEB35-...") would be replaced with a fresh id.
 		// Canonicalise via TrimSpace + ToLower before the check so
-		// otherwise-valid UUIDs round-trip unchanged.
+		// otherwise-conforming UUIDs round-trip unchanged.
 		id := strings.ToLower(strings.TrimSpace(p.ID))
 		if id == "" || !uuidRE(id) {
 			id = newParticipantID()

--- a/internal/state/reservedslots.go
+++ b/internal/state/reservedslots.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
-	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 )
 
 func (s *Store) LoadReservedSlots(compID string) ([]ReservedSlot, error) {
@@ -90,114 +88,39 @@ func (s *Store) saveReservedSlotsLocked(compID string, slots []ReservedSlot) err
 	return nil
 }
 
-// loadParticipantsLocked reads participants without acquiring a lock.
-// Caller must hold the per-comp lock for compID. Mirrors LoadParticipants.
+// loadParticipantsLocked reads participants (with seeds merged) without
+// acquiring a lock. Caller must hold the per-comp lock for compID.
+//
+// mp-p7n / Copilot PR #185 round-9 follow-up: this used to be a
+// hand-rolled copy of loadParticipantsNoLock's parse loop, but the copy
+// only had the auto-detect (uuidRE-on-row-0) path — it never consulted
+// Competition.HasParticipantIDs. That meant a roster with non-UUID ids
+// (the JS-side `${compID}-p${N}` shape) loaded here would column-shift
+// (id→Name, Name→Dojo, Dojo→Metadata) and, because AddReservedSlot /
+// RemoveReservedSlot load→modify→save the whole roster, the shift would
+// be PERSISTED. Delegating to the canonical loadParticipantsNoLock
+// (WithSeeds:true, no HasIDs hint → it consults HasParticipantIDs and
+// keeps the per-record uuidRE fallback for mixed legacy files) fixes
+// the divergence in one place. Both functions share the same
+// "caller-holds-the-per-comp-lock" contract, so this is a safe
+// substitution; the only added behaviour is caching, which is keyed by
+// parse mode + config.md mtime and invalidated on every write.
 func (s *Store) loadParticipantsLocked(compID string, withZekkenName bool) ([]domain.Player, error) {
-	path := s.compPath(compID, "participants.csv")
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return []domain.Player{}, nil
-	}
-
-	records, err := helper.ReadCSVFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	hasIDs := len(records) > 0 && len(records[0]) > 0 && uuidRE(strings.TrimSpace(records[0][0]))
-
-	var ids []string
-	var checkedInFlags []bool
-	var playerRecords [][]string
-	for _, record := range records {
-		isCheckedIn := false
-		dataStart := 0
-		if hasIDs && len(record) > 0 && uuidRE(strings.TrimSpace(record[0])) {
-			dataStart = 1
-		}
-		dataFields := record[dataStart:]
-
-		allEmpty := true
-		for _, f := range dataFields {
-			if strings.TrimSpace(f) != "" {
-				allEmpty = false
-				break
-			}
-		}
-		if allEmpty {
-			continue
-		}
-
-		if len(dataFields) > 2 {
-			last := strings.TrimSpace(dataFields[len(dataFields)-1])
-			if strings.ToLower(last) == "checked_in" {
-				isCheckedIn = true
-				dataFields = dataFields[:len(dataFields)-1]
-			}
-		}
-
-		if hasIDs {
-			id := ""
-			if dataStart > 0 {
-				id = strings.TrimSpace(record[0])
-			}
-			ids = append(ids, id)
-		}
-		playerRecords = append(playerRecords, dataFields)
-		checkedInFlags = append(checkedInFlags, isCheckedIn)
-	}
-
-	players, err := helper.CreatePlayersFromRecords(playerRecords, withZekkenName)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range players {
-		if hasIDs && i < len(ids) {
-			players[i].ID = ids[i]
-		}
-		if i < len(checkedInFlags) {
-			players[i].CheckedIn = checkedInFlags[i]
-		}
-	}
-
-	seeds, _ := helper.ParseSeedsFile(s.compPath(compID, "seeds.csv"))
-	if len(seeds) > 0 {
-		seedMap := make(map[string]int, len(seeds))
-		for _, sd := range seeds {
-			seedMap[sd.Name] = sd.SeedRank
-		}
-		for i := range players {
-			if seed, ok := seedMap[players[i].Name]; ok {
-				players[i].Seed = seed
-			}
-		}
-	}
-
-	// helper.Player is a type alias for domain.Player (NFR-007); the
-	// parser output is already []domain.Player.
-	return players, nil
+	return s.loadParticipantsNoLock(compID, withZekkenName, LoadParticipantsOpts{WithSeeds: true})
 }
 
 // saveParticipantsLocked writes participants without acquiring a lock and
 // invalidates the participant caches. Caller must hold the per-comp write lock
-// for compID. Mirrors SaveParticipants.
+// for compID.
+//
+// mp-p7n / Copilot PR #185 round-9 follow-up: delegates to
+// saveParticipantsNoLock so the marshal + write + cache-invalidation
+// logic lives in exactly one place. The pre-delegation copy invalidated
+// only 2 of the 6 parse-mode cache-key variants (the same stale-key bug
+// fixed in saveParticipantsNoLock at round-6), which could leave a
+// hinted-mode cache entry stale after a reserved-slot add/remove.
 func (s *Store) saveParticipantsLocked(compID string, players []domain.Player, withZekkenName bool) error {
-	path := s.compPath(compID, "participants.csv")
-	data, err := marshalParticipantsCSV(players, withZekkenName)
-	if err != nil {
-		return err
-	}
-	if err := s.atomicWrite(path, data, 0600); err != nil {
-		return err
-	}
-	for _, key := range []string{"participants.csv", "participants_with_seeds.csv"} {
-		cache := s.getFileCache(compID, key)
-		cache.mu.Lock()
-		cache.data = nil
-		cache.mtime = 0
-		cache.mu.Unlock()
-	}
-	return nil
+	return s.saveParticipantsNoLock(compID, players, withZekkenName)
 }
 
 // AddReservedSlot creates a placeholder participant and a reserved-slot entry

--- a/internal/state/reservedslots_test.go
+++ b/internal/state/reservedslots_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -149,6 +150,55 @@ func TestStore_ReservedSlots_LoadParticipantsLocked_WithSeeds(t *testing.T) {
 		}
 	}
 	assert.NotNil(t, slot)
+}
+
+// mp-p7n / Copilot PR #185 round-9 follow-up: AddReservedSlot loads the
+// whole roster via loadParticipantsLocked, appends the placeholder, then
+// saves it all back. Before delegating loadParticipantsLocked to the
+// canonical loader, that path used auto-detect only (no HasParticipantIDs
+// consultation), so a roster with non-UUID ids (the JS `${compID}-p${N}`
+// shape) would column-shift on load and the shift would be PERSISTED by
+// the subsequent save. This test pins the fix: adding a reserved slot to
+// such a roster must NOT corrupt the existing participants.
+func TestStore_AddReservedSlot_PreservesNonUUIDIDRoster(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "asddasd"
+	require.NoError(t, store.SaveCompetition(&Competition{
+		ID: compID, Name: "Asddasd", WithZekkenName: false, HasParticipantIDs: true,
+	}))
+
+	// Roster with non-UUID ids in column 0 (the bug-prone shape).
+	participantsPath := filepath.Join(dir, "competitions", compID, "participants.csv")
+	require.NoError(t, os.WriteFile(participantsPath,
+		[]byte("asddasd-p1,Aaron Adams,Team Alpha\nasddasd-p2,Albus Blake,Team Delta\n"), 0600))
+
+	// Add a reserved slot — this triggers loadParticipantsLocked →
+	// (append placeholder) → saveParticipantsLocked.
+	_, err = store.AddReservedSlot(compID, "source", 1, false)
+	require.NoError(t, err)
+
+	// The two real participants must still be correctly aligned after
+	// the load→modify→save round-trip. Pre-fix loadParticipantsLocked
+	// would have shifted them (Name="Asddasd-P1", Dojo="Aaron Adams",
+	// Metadata=["Team Alpha"]) and persisted that.
+	players, err := store.LoadParticipants(compID, false)
+	require.NoError(t, err)
+	require.Len(t, players, 3) // 2 real + 1 reserved placeholder
+
+	byID := map[string]domain.Player{}
+	for _, p := range players {
+		byID[p.ID] = p
+	}
+	require.Contains(t, byID, "asddasd-p1", "original non-UUID id must be preserved")
+	assert.Equal(t, "Aaron Adams", byID["asddasd-p1"].Name)
+	assert.Equal(t, "Team Alpha", byID["asddasd-p1"].Dojo)
+	assert.Empty(t, byID["asddasd-p1"].Metadata,
+		"Metadata must be empty — a column shift would have dumped the dojo here")
+	assert.Equal(t, "Albus Blake", byID["asddasd-p2"].Name)
+	assert.Equal(t, "Team Delta", byID["asddasd-p2"].Dojo)
 }
 
 func TestStore_AddReservedSlot_Idempotency(t *testing.T) {

--- a/web-mobile/js/__tests__/mp-p7n-repro.test.jsx
+++ b/web-mobile/js/__tests__/mp-p7n-repro.test.jsx
@@ -1,0 +1,151 @@
+// mp-p7n: reproduce "phantom leading column appears in textarea after Apply"
+//
+// User-reported flow (2026-05-26):
+//   - withZekkenName = false, numberPrefix empty
+//   - BEFORE Apply: textarea = "Aaron Adams, Team Alpha\n..." (clean 2-col)
+//   - AFTER Apply:  textarea = "Asddasd-P1, Aaron Adams, Team Alpha\n..."
+//
+// `Asddasd-P{N}` is sequential — matches the `${prefix}-p${i+1}` ID shape
+// that `data.jsx::makePlayer` produces for sample-roster players. So the
+// hypothesis is that the participant `id` (or a normalised form of it) is
+// leaking into the textarea — either by the JS serialiser including p.id
+// when it shouldn't, or by the round-trip through the server shifting
+// columns.
+//
+// This test file constructs the exact starting state from the screenshot
+// and walks the same path admin_participants.jsx::apply takes. If any
+// step produces a 3-col line beginning with a player-id-shaped value,
+// we've found the bug.
+
+import { describe, it, expect } from 'vitest';
+import { parseParticipantLines } from '../data.jsx';
+import { mintParticipantIds } from '../admin_participants.jsx';
+
+// generateText: a copy of the inline textarea serialiser in
+// admin_participants.jsx:212-219 / 233-240. Pulled out verbatim so we
+// can assert on its output without rendering the full component.
+function generateText(players, withZekkenName) {
+  return (players || []).map((p) => {
+    if (withZekkenName && p.displayName) {
+      const base = `${p.name ?? ''}, ${p.displayName ?? ''}, ${p.dojo ?? ''}`;
+      return p.danGrade ? `${base}, ${p.danGrade}` : base;
+    }
+    const base = `${p.name ?? ''}, ${p.dojo ?? ''}`;
+    return p.danGrade ? `${base}, ${p.danGrade}` : base;
+  }).join('\n');
+}
+
+describe('mp-p7n: Apply with clean 2-col paste does not introduce a phantom leading column', () => {
+  // The sample-data roster from data.jsx::makePlayer uses ids in the
+  // shape `${compID}-p${i+1}`. With compID="asddasd" this matches the
+  // bug-report screenshot's "Asddasd-P1..P8" pattern.
+  const SAMPLE_PLAYERS = [
+    { id: 'asddasd-p1', name: 'Aaron Adams',    dojo: 'Team Alpha',   displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p2', name: 'Albus Blake',    dojo: 'Team Delta',   displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p3', name: 'Arthur Dick',    dojo: 'Team Gamma',   displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p4', name: 'Benjamin Granger', dojo: 'Team Lambda', displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p5', name: 'Bilbo Herbert',  dojo: 'Team Omega',   displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p6', name: 'Bram Lannister', dojo: 'Team Pi',      displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p7', name: 'Caleb Martinez', dojo: 'Team Sigma',   displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+    { id: 'asddasd-p8', name: 'Charles Rodriguez', dojo: 'Team Upsilon', displayName: '', danGrade: '', tag: null, seed: null, checkedIn: false },
+  ];
+
+  it('initial textarea (from c.players) renders 2-col lines, not 3-col with id prefix', () => {
+    // First gate: does the serialiser itself leak p.id?  This file is what
+    // the user sees BEFORE clicking Apply.
+    const text = generateText(SAMPLE_PLAYERS, /*withZekkenName=*/false);
+    const lines = text.split('\n');
+    expect(lines).toHaveLength(8);
+    expect(lines[0]).toBe('Aaron Adams, Team Alpha');
+    expect(lines[0]).not.toMatch(/^asddasd-/i);
+    // Sanity: no line starts with the id-shaped prefix.
+    for (const ln of lines) {
+      expect(ln).not.toMatch(/^[a-z]+-p\d+,/i);
+    }
+  });
+
+  it('Apply with unchanged 2-col textarea keeps the data 2-col (no phantom column)', () => {
+    // Simulate: user opened the page, didn't edit the textarea, just
+    // pressed Apply. The textarea text equals the serialised c.players
+    // output from the previous test.
+    const text = generateText(SAMPLE_PLAYERS, false);
+    const lines = text.split('\n').filter(l => l.trim());
+    const parsed = parseParticipantLines(lines, /*withZekken=*/false);
+    const { np } = mintParticipantIds('asddasd', SAMPLE_PLAYERS, parsed);
+
+    // The PUT body sent to the server is `np`.  If any element of np has
+    // name="<id-shaped>" or danGrade=<dojo-shaped>, the bug is in
+    // parse/mint.  Each np[i] must mirror the user-intended fields.
+    expect(np).toHaveLength(8);
+    expect(np[0].name).toBe('Aaron Adams');
+    expect(np[0].dojo).toBe('Team Alpha');
+    expect(np[0].danGrade).toBeFalsy();
+    // Now serialise np back through the textarea generator (what
+    // useEffectA(c.players) produces after the apply response lands).
+    const afterText = generateText(np, false);
+    const afterLines = afterText.split('\n');
+    expect(afterLines[0]).toBe('Aaron Adams, Team Alpha');
+    expect(afterLines[0]).not.toMatch(/^asddasd-p\d+,/i);
+  });
+
+  it('Apply after the user EDITED the textarea down to clean 2-col input still produces 2-col', () => {
+    // Variant: user deletes the (possibly already-phantom) leading column
+    // and presses Apply on hand-typed clean text.
+    const lines = SAMPLE_PLAYERS.map(p => `${p.name}, ${p.dojo}`);
+    const parsed = parseParticipantLines(lines, false);
+    const { np } = mintParticipantIds('asddasd', SAMPLE_PLAYERS, parsed);
+    const afterText = generateText(np, false);
+    const afterLines = afterText.split('\n');
+    expect(afterLines).toEqual(lines);
+  });
+
+  it('Reserved-slot players (Tag=reserved) round-trip without phantom column', () => {
+    // The screenshot shows reserved slots as 2-col entries
+    // "Reserved: Naginata-Test Rank 1, TBD". Verify the serialiser
+    // produces that shape and the parse/mint chain preserves it.
+    const reserved = {
+      id: 'rsv-1',
+      name: 'Reserved: Naginata-Test Rank 1',
+      dojo: 'TBD',
+      displayName: 'Rsv Naginata-Test #1',
+      danGrade: '',
+      tag: 'reserved',
+      seed: null,
+      checkedIn: false,
+    };
+    const text = generateText([reserved], false);
+    expect(text).toBe('Reserved: Naginata-Test Rank 1, TBD');
+  });
+
+  it('regression: simulating a corrupted starting state where p.name = id-shaped, p.dojo = real name, p.danGrade = team', () => {
+    // If the user's c.players is ALREADY corrupt (3-col shift), what
+    // does generateText render? This codifies the post-bug state from
+    // the screenshot so we can detect any regression that re-introduces
+    // it during Apply.
+    const corrupt = [
+      { id: 'x', name: 'Asddasd-P1', dojo: 'Aaron Adams', danGrade: 'Team Alpha', tag: null, seed: null, checkedIn: false, displayName: '' },
+    ];
+    const text = generateText(corrupt, false);
+    // This is the BUG output. The test pins this so a fix that ALSO
+    // changes the serialiser breaks this test loudly.
+    expect(text).toBe('Asddasd-P1, Aaron Adams, Team Alpha');
+  });
+
+  it('end-to-end: starting from a corrupt c.players, Apply with clean text CLEANS the data', () => {
+    // The "after Apply, phantom column appears" symptom means the
+    // opposite must be true: starting from corrupt state, an Apply of
+    // clean text should REMOVE the corruption. Pin that contract.
+    const corrupt = [
+      { id: 'asddasd-p1', name: 'Asddasd-P1', dojo: 'Aaron Adams', danGrade: 'Team Alpha', tag: null, seed: null, checkedIn: false, displayName: '' },
+      { id: 'asddasd-p2', name: 'Asddasd-P2', dojo: 'Albus Blake', danGrade: 'Team Delta', tag: null, seed: null, checkedIn: false, displayName: '' },
+    ];
+    const userTypedLines = ['Aaron Adams, Team Alpha', 'Albus Blake, Team Delta'];
+    const parsed = parseParticipantLines(userTypedLines, false);
+    const { np } = mintParticipantIds('asddasd', corrupt, parsed);
+    const afterText = generateText(np, false);
+    expect(afterText).toBe('Aaron Adams, Team Alpha\nAlbus Blake, Team Delta');
+    // Verify the new player records are clean:
+    expect(np[0]).toMatchObject({ name: 'Aaron Adams', dojo: 'Team Alpha' });
+    expect(np[0].danGrade).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

User-reported on 2026-05-26: on the admin Participants page (`withZekkenName=false`, `numberPrefix` empty), clicking **Apply** with clean 2-col text `"Aaron Adams, Team Alpha"` left the textarea regenerated as `"Asddasd-P1, Aaron Adams, Team Alpha"` — a phantom leading column with the participant id title-cased into Name, the real Name shifted into Dojo, and the real Dojo shifted into Metadata (rendered as Dan grade).

Earlier rounds of this PR experimented with normalising non-UUID ids to fresh UUIDv4 on save. **That approach was wrong** and was reverted in round 3 — regenerating ids would silently orphan every dependent store keyed by `PlayerID`/`ParticipantID` (`competitor_status.yaml`, `reservedslots.csv`, team lineups). The current implementation **preserves** client-supplied ids verbatim.

## Root cause

- [web-mobile/js/admin_participants.jsx:127-128](web-mobile/js/admin_participants.jsx:127) — `mintParticipantIds` generates participant ids in the shape `${compID}-p${N}` for new players (and `data.jsx::makePlayer` for sample-roster players).
- [internal/state/participants.go::marshalParticipantsCSV](internal/state/participants.go) writes the id verbatim as column 0: `asddasd-p1,Aaron Adams,Team Alpha`.
- On the next read, the per-record id-strip in [participants.go:loadParticipantsNoLock](internal/state/participants.go) gated on `uuidRE(record[0])`. Non-UUID first columns left `dataStart=0`, so the row was parsed as `[Name, Dojo, Metadata]` instead of `[id, Name, Dojo, Metadata]`. `CreatePlayersFromRecords` title-cased `"asddasd-p1"` → `"Asddasd-P1"` into Name.

## Fix (current implementation)

- **[internal/state/participants.go](internal/state/participants.go) — loader hardening**
  - When `opts.HasIDs` is hinted (or `Competition.HasParticipantIDs=true` on disk), trust it: strip column 0 from every row regardless of its textual shape. Non-UUID ids round-trip intact, so dependent stores keyed by `PlayerID` / `ParticipantID` stay connected (Copilot PR #185 round-3).
  - Auto-detect path (no hint, no comp flag) still uses the per-record `uuidRE` check — preserves mixed-format legacy support (`TestStore_ParticipantsCSV_MixedIDs`).
  - Participants cache key now folds in `config.md` mtime so a deferred `HasParticipantIDs=true` flip invalidates a stale "no-IDs" parse landed by a reader in the pre-flip window (Copilot PR #185 round-4).
- **[internal/state/participants.go::marshalParticipantsCSV](internal/state/participants.go)** — unchanged from main (only mints a UUID when `p.ID` is empty). No regeneration.
- **[internal/mobileapp/handlers_competition.go](internal/mobileapp/handlers_competition.go)** — the roster-PUT response re-loads participants from disk so the client sees what actually landed (post-load alignment / title-casing / etc.). Falls back to the request body on load failure; logs include the competition id (Copilot PR #185 round-1).
- **[internal/helper/uuid.go](internal/helper/uuid.go)** — clarified `IsUUIDv4` is a SHAPE check, not a strict v4 validator (Copilot PR #185 round-2). ~12 in-repo test fixtures use v1 or invalid-variant UUIDs and pass; tightening would have broken them.

## TDD trail

Failing-first repro tests written before the fix:

| Test | Status pre-fix | Asserts |
|------|---------------|---------|
| `TestMpP7nRepro_NonUUIDIDCausesColumnShift` | FAILED | non-UUID id with `HasIDs` hint round-trips with correct Name/Dojo |
| `TestMpP7nRepro_NonUUIDID_PreservesOriginalID` | FAILED | original id preserved (not regenerated) — keeps competitor_status etc. joinable |
| `TestMpP7nRepro_CacheInvalidatedOnHasParticipantIDsFlip` | FAILED | post-flag-flip load reflects the new flag, not a cached pre-flip parse |
| `TestMpP7nRepro_UUIDIDIsFine` | PASSED both | sanity: UUID-shaped ids work pre and post fix |
| `TestPUTCompetition_RosterPUTPreservesIDsAndAlignsColumns` | FAILED | response round-trips non-UUID ids verbatim AND aligns Name/Dojo correctly |
| `TestPUTCompetition_RosterPUTPreservesUppercaseUUID` | FAILED | uppercase-UUID id stays uppercase (no canonicalisation, no regeneration) |

JS-side repro suite (`web-mobile/js/__tests__/mp-p7n-repro.test.jsx`) passed both pre and post — confirming the bug was server-side (load-time column shift), not in the textarea serialiser / `parseParticipantLines` / `mintParticipantIds`.

## Test plan

- [x] `go test ./...` — all green; 4 `TestMpP7nRepro_*` + 2 `TestPUTCompetition_RosterPUT*` regression tests.
- [x] `cd web-mobile && npm test` — all green; 6 JS repro tests.
- [x] End-to-end via live admin UI: seeded the bug-state CSV (`asddasd-p1,Aaron Adams,Team Alpha` rows with `HasParticipantIDs=true` in config). Before fix: GET returned `{name: "Asddasd-P1", dojo: "Aaron Adams", danGrade: "Team Alpha"}` (the user-reported corruption). After fix: GET returns `{name: "Aaron Adams", dojo: "Team Alpha", danGrade: null}` and the id `asddasd-p1` is preserved verbatim.

## Out of scope

- Updating `mintParticipantIds` in the JS layer to mint UUIDv4 directly. The server-side loader fix is the load-bearing change; whether JS uses UUIDs is cosmetic given the round-trip is now safe with any id shape.
- One-shot migration for tournament-data dirs whose `HasParticipantIDs` was never flipped (legacy state). Those still hit the auto-detect path; operators recover by re-saving the roster once via the admin Apply flow (which flips the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)