### PR TITLE
fix(css): make ghost danger buttons visible

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -373,6 +373,13 @@ a:hover {
   background: var(--red-soft);
 }
 
+/* Disabled buttons can still match :hover in browsers — suppress the
+   soft-red hover feedback so a disabled destructive action never looks
+   interactive. */
+.btn--ghost.btn--danger:disabled:hover {
+  background: transparent;
+}
+
 .btn--sm {
   padding: 5px 10px;
   font-size: 12.5px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -364,6 +364,15 @@ a:hover {
   border-color: transparent;
 }
 
+.btn--ghost.btn--danger {
+  color: var(--red);
+  border-color: transparent;
+}
+
+.btn--ghost.btn--danger:hover {
+  background: var(--red-soft);
+}
+
 .btn--sm {
   padding: 5px 10px;
   font-size: 12.5px;


### PR DESCRIPTION
## Summary
- `.btn--ghost` overrode `.btn--danger`'s background/border (same specificity, later in file) but not `color: white` — producing invisible white-on-white buttons
- Added a `.btn--ghost.btn--danger` combined selector with `color: var(--red)` and `background: var(--red-soft)` on hover
- Added a `.btn--ghost.btn--danger:disabled:hover` override (keeps background transparent) so a disabled destructive action never shows hover feedback (Copilot review)
- Affects three buttons: **Discard draw**, **Delete competition**, **Mark competition invalid**

## Test plan
- [x] `make run-mobile`, open a competition → Settings tab → confirm "Delete competition" is visible in red text at bottom — verified: computed `color: rgb(193, 18, 31)` on transparent background; confirmed in browser screenshot
- [x] Start a competition → Settings → confirm "Mark competition invalid" appears in red above Delete — verified: both buttons render red (`rgb(193, 18, 31)`), "Mark competition invalid" listed above "Delete competition"; confirmed in browser screenshot
- [x] Generate a draw (Preview draw) → confirm "Discard draw" button is visible in the action bar — verified: class `btn btn--ghost btn--danger`, red text in action bar; confirmed in browser screenshot
- [x] Hover each button → confirm soft-red hover background appears — verified: `.btn--ghost.btn--danger:hover { background: var(--red-soft) }` present in served CSS; `--red-soft` resolves to `#fde7e8` (soft red). (CSS `:hover` cannot be triggered by synthetic events for a pixel capture; rule presence + resolved color confirmed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
