### PR TITLE
fix(mp-ptj): clone MatchResult pointer fields + deep-copy isolation tests

### DIFF
--- a/internal/state/bracket_test.go
+++ b/internal/state/bracket_test.go
@@ -225,6 +225,62 @@ func TestCopyBracket_Nil(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+// TestLoadBracket_DeepCopyIsolation guards copyBracket's deep-copy of the
+// reference-type fields on BracketMatch (Encho pointer, SubResults slice and
+// each SubMatchResult's IpponsA/IpponsB/Encho). A shallow copy would alias the
+// cached backing array/pointers, so a caller mutating a returned match in place
+// could silently corrupt cached state without going through Save/UpdateBracket.
+// Mirrors the pool-match copy path (copyMatchResults / cloneSubResults).
+func TestLoadBracket_DeepCopyIsolation(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	compID := "test-comp"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Test"}))
+
+	initial := &Bracket{
+		Rounds: [][]BracketMatch{
+			{
+				{
+					ID:    "M1",
+					SideA: "Team A",
+					SideB: "Team B",
+					Encho: &EnchoMetadata{PeriodCount: 1},
+					SubResults: []SubMatchResult{
+						{
+							SideA:   "A1",
+							SideB:   "B1",
+							IpponsA: []string{"M"},
+							IpponsB: []string{"K"},
+							Encho:   &EnchoMetadata{PeriodCount: 2},
+						},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, store.SaveBracket(compID, initial))
+
+	// First load, then mutate every reference field on the returned copy in
+	// place — without calling Save/UpdateBracket.
+	first, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	first.Rounds[0][0].Encho.PeriodCount = 99
+	first.Rounds[0][0].SubResults[0].IpponsA[0] = "MUTATED"
+	first.Rounds[0][0].SubResults[0].IpponsB[0] = "MUTATED"
+	first.Rounds[0][0].SubResults[0].Encho.PeriodCount = 99
+	first.Rounds[0][0].SubResults = append(first.Rounds[0][0].SubResults, SubMatchResult{SideA: "leak"})
+
+	// A fresh load must reflect the saved state, not the in-place mutation.
+	second, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	require.Len(t, second.Rounds[0][0].SubResults, 1, "appended sub-result must not leak into cache")
+	assert.Equal(t, 1, second.Rounds[0][0].Encho.PeriodCount)
+	assert.Equal(t, []string{"M"}, second.Rounds[0][0].SubResults[0].IpponsA)
+	assert.Equal(t, []string{"K"}, second.Rounds[0][0].SubResults[0].IpponsB)
+	assert.Equal(t, 2, second.Rounds[0][0].SubResults[0].Encho.PeriodCount)
+}
+
 // TestParseBracketFile_MalformedJSON covers the parseBracketBytes error
 // branch inside parseBracketFile.
 func TestParseBracketFile_MalformedJSON(t *testing.T) {

--- a/internal/state/bracket_test.go
+++ b/internal/state/bracket_test.go
@@ -266,16 +266,21 @@ func TestLoadBracket_DeepCopyIsolation(t *testing.T) {
 	first, err := store.LoadBracket(compID)
 	require.NoError(t, err)
 	first.Rounds[0][0].Encho.PeriodCount = 99
+	// Scalar field on an existing element: only stays isolated if the
+	// SubResults backing array itself was copied (a shallow slice copy would
+	// share the element and leak this write). append() can't prove this — it
+	// reallocates when cap==len, so an aliased slice's length wouldn't change.
+	first.Rounds[0][0].SubResults[0].SideA = "MUTATED"
 	first.Rounds[0][0].SubResults[0].IpponsA[0] = "MUTATED"
 	first.Rounds[0][0].SubResults[0].IpponsB[0] = "MUTATED"
 	first.Rounds[0][0].SubResults[0].Encho.PeriodCount = 99
-	first.Rounds[0][0].SubResults = append(first.Rounds[0][0].SubResults, SubMatchResult{SideA: "leak"})
 
 	// A fresh load must reflect the saved state, not the in-place mutation.
 	second, err := store.LoadBracket(compID)
 	require.NoError(t, err)
-	require.Len(t, second.Rounds[0][0].SubResults, 1, "appended sub-result must not leak into cache")
+	require.Len(t, second.Rounds[0][0].SubResults, 1)
 	assert.Equal(t, 1, second.Rounds[0][0].Encho.PeriodCount)
+	assert.Equal(t, "A1", second.Rounds[0][0].SubResults[0].SideA)
 	assert.Equal(t, []string{"M"}, second.Rounds[0][0].SubResults[0].IpponsA)
 	assert.Equal(t, []string{"K"}, second.Rounds[0][0].SubResults[0].IpponsB)
 	assert.Equal(t, 2, second.Rounds[0][0].SubResults[0].Encho.PeriodCount)

--- a/internal/state/pools.go
+++ b/internal/state/pools.go
@@ -110,6 +110,14 @@ func (s *Store) copyMatchResults(results []MatchResult) []MatchResult {
 			copy(res[i].IpponsB, r.IpponsB)
 		}
 		res[i].SubResults = cloneSubResults(r.SubResults)
+		// Deep-copy the pointer fields so a caller mutating a returned
+		// result through *Encho / *DecidedByHantei cannot corrupt cached
+		// state. Mirrors copyBracket, which already clones its Encho pointer.
+		res[i].Encho = r.Encho.Clone()
+		if r.DecidedByHantei != nil {
+			v := *r.DecidedByHantei
+			res[i].DecidedByHantei = &v
+		}
 	}
 	return res
 }

--- a/internal/state/pools_test.go
+++ b/internal/state/pools_test.go
@@ -322,6 +322,7 @@ func TestCopyMatchResults_WithSubResults(t *testing.T) {
 	compID := "pools-sub"
 	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Sub"}))
 
+	hantei := true
 	matches := []MatchResult{
 		{
 			ID:      "P1-0",
@@ -339,7 +340,9 @@ func TestCopyMatchResults_WithSubResults(t *testing.T) {
 					Winner:   "A1",
 				},
 			},
-			Status: MatchStatusCompleted,
+			Encho:           &EnchoMetadata{PeriodCount: 1},
+			DecidedByHantei: &hantei,
+			Status:          MatchStatusCompleted,
 		},
 	}
 	require.NoError(t, store.SavePoolMatches(compID, matches))
@@ -350,6 +353,26 @@ func TestCopyMatchResults_WithSubResults(t *testing.T) {
 	require.Len(t, loaded[0].SubResults, 1)
 	assert.Equal(t, "A1", loaded[0].SubResults[0].Winner)
 	assert.Equal(t, "M", loaded[0].IpponsA[0])
+
+	// Deep-copy isolation: mutating the returned value (including the Encho
+	// and DecidedByHantei pointers and the nested slices) in place must not
+	// corrupt the store's cached copy. Mirrors copyMatchResults' deep-copy.
+	loaded[0].IpponsA[0] = "MUTATED"
+	loaded[0].SubResults[0].SideA = "MUTATED"
+	loaded[0].SubResults[0].IpponsA[0] = "MUTATED"
+	loaded[0].Encho.PeriodCount = 99
+	*loaded[0].DecidedByHantei = false
+
+	fresh, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	require.Len(t, fresh, 1)
+	assert.Equal(t, "M", fresh[0].IpponsA[0])
+	assert.Equal(t, "A1", fresh[0].SubResults[0].SideA)
+	assert.Equal(t, "M", fresh[0].SubResults[0].IpponsA[0])
+	require.NotNil(t, fresh[0].Encho)
+	assert.Equal(t, 1, fresh[0].Encho.PeriodCount)
+	require.NotNil(t, fresh[0].DecidedByHantei)
+	assert.True(t, *fresh[0].DecidedByHantei)
 }
 
 func TestLoadPoolMatches_InvalidCompID(t *testing.T) {


### PR DESCRIPTION
## Summary
bead **mp-ptj**. Two parts:

**Production fix** — `copyMatchResults` (internal/state/pools.go, the pool-match mirror of `copyBracket`) deep-copied `IpponsA`/`IpponsB`/`SubResults` but did **not** clone the top-level pointer fields `MatchResult.Encho` (`*EnchoMetadata`) or `MatchResult.DecidedByHantei` (`*bool`). A caller mutating a returned result through either pointer could corrupt the store's cached copy — the same pointer-aliasing class this bead is about. `copyBracket` already clones its `Encho`; this brings the sibling into line.

**Regression tests** — the bracket deep-copy (`copyBracket`, landed in PR #182) and the pool-match deep-copy both lacked tests proving cache *isolation*:
- `TestLoadBracket_DeepCopyIsolation` (new): mutates a returned bracket's `Encho` / `SubResults` / nested `IpponsA`/`IpponsB`/`Encho` in place, asserts a fresh `LoadBracket` is unaffected.
- `TestCopyMatchResults_WithSubResults` (upgraded from round-trip → isolation): mutates the returned `MatchResult`'s `Encho`/`DecidedByHantei` pointers and nested slices, asserts a fresh `LoadPoolMatches` is unaffected.

Both tests were verified to **fail** under a shallow copy and **pass** with the deep-copy in place.

## Test plan
- [x] `go test ./internal/state/...` passes
- [x] `go vet ./internal/state/...` clean
- [x] `golangci-lint run ./internal/state/...` → 0 issues
- [x] `gofmt -l` clean
- [x] Both isolation tests confirmed to fail under a shallow copy (genuine regression guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)