### PR TITLE
feat(mp-djc): dedicated dashboard "Announce" button

### DIFF
--- a/web-mobile/index.html
+++ b/web-mobile/index.html
@@ -66,6 +66,7 @@
     <script type="module" src="/dist/admin_pools.js?v=5"></script>
     <script type="module" src="/dist/admin_schedule.js?v=5"></script>
     <script type="module" src="/dist/admin_competition.js?v=5"></script>
+    <script type="module" src="/dist/admin_announcement.js?v=5"></script>
     <script type="module" src="/dist/admin_setup.js?v=5"></script>
     <script type="module" src="/dist/admin.js?v=5"></script>
     <script type="module" src="/dist/app.js?v=5"></script>

--- a/web-mobile/js/__tests__/admin_announcement.test.jsx
+++ b/web-mobile/js/__tests__/admin_announcement.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isSendAnnouncementDisabled, sendAnnouncementLabel } from '../admin_announcement.jsx';
+
+// Pure helpers for the announcement-broadcast button. Moved here from
+// admin_setup.test.jsx alongside the AnnouncementComposer extraction (mp-djc).
+
+describe('isSendAnnouncementDisabled', () => {
+  it('disabled when message is empty', () => {
+    expect(isSendAnnouncementDisabled('', false)).toBe(true);
+  });
+
+  it('disabled when message is whitespace-only (trimming guard)', () => {
+    expect(isSendAnnouncementDisabled('   ', false)).toBe(true);
+  });
+
+  it('disabled when in-flight (prevents double-send)', () => {
+    expect(isSendAnnouncementDisabled('Hello', true)).toBe(true);
+  });
+
+  it('enabled when message is non-empty and not in-flight', () => {
+    expect(isSendAnnouncementDisabled('Hello', false)).toBe(false);
+  });
+});
+
+describe('sendAnnouncementLabel', () => {
+  it('returns "Send announcement" when idle', () => {
+    expect(sendAnnouncementLabel(false)).toBe('Send announcement');
+  });
+
+  it('returns "Sending..." during in-flight request', () => {
+    expect(sendAnnouncementLabel(true)).toBe('Sending...');
+  });
+});

--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveCompetitionName, validatePoolSettings, validateSwissSettings, isSendAnnouncementDisabled, sendAnnouncementLabel } from '../admin_setup.jsx';
+import { deriveCompetitionName, validatePoolSettings, validateSwissSettings } from '../admin_setup.jsx';
 
 describe('deriveCompetitionName', () => {
   // Copilot round-8 finding: AdminCreateCompetition.create used
@@ -230,33 +230,5 @@ describe('validateSwissSettings (T190 / FR-050a)', () => {
       const r = validateSwissSettings('swiss', -3);
       expect(r.ok).toBe(false);
     });
-  });
-});
-
-describe('isSendAnnouncementDisabled', () => {
-  it('disabled when message is empty', () => {
-    expect(isSendAnnouncementDisabled('', false)).toBe(true);
-  });
-
-  it('disabled when message is whitespace-only (trimming guard)', () => {
-    expect(isSendAnnouncementDisabled('   ', false)).toBe(true);
-  });
-
-  it('disabled when in-flight (prevents double-send)', () => {
-    expect(isSendAnnouncementDisabled('Hello', true)).toBe(true);
-  });
-
-  it('enabled when message is non-empty and not in-flight', () => {
-    expect(isSendAnnouncementDisabled('Hello', false)).toBe(false);
-  });
-});
-
-describe('sendAnnouncementLabel', () => {
-  it('returns "Send announcement" when idle', () => {
-    expect(sendAnnouncementLabel(false)).toBe('Send announcement');
-  });
-
-  it('returns "Sending..." during in-flight request', () => {
-    expect(sendAnnouncementLabel(true)).toBe('Sending...');
   });
 });

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -104,6 +104,10 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   // Hooks must be declared unconditionally before any conditional returns.
   const [adminCompData, setAdminCompData] = useStateA(null);
   const [adminLoading, setAdminLoading] = useStateA(false);
+  // mp-djc: dashboard "📣 Announce" button opens the broadcast composer
+  // in a modal. State lives here (alongside other AdminApp UI state) so
+  // the modal overlays whichever screen is rendered.
+  const [announceOpen, setAnnounceOpen] = useStateA(false);
 
   // Expose a navigation helper used by AdminTopbar's live-strip chips,
   // avoiding prop-drilling through every screen. Set once per mount.
@@ -512,20 +516,28 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   }, [view.id, view.kind]); // t and onUpdate accessed via refs to avoid churn
 
   if (view.kind === "dashboard") {
-    return <AdminDashboard
-      tournament={t}
-      onOpenCompetition={(id, section) => setView({ kind: "competition", id, section: section || "overview" })}
-      onCreateCompetition={() => setView({ kind: "createComp" })}
-      onEditTournament={() => setView({ kind: "editTournament" })}
-      onOpenSchedule={() => setView({ kind: "schedule" })}
-      onOpenScoreEditor={() => setView({ kind: "scoreEditor" })}
-      onOpenImport={() => setView({ kind: "import" })}
-      onStartAll={startAllCompetitions}
-      onStartCompetition={startCompetition}
-      onLogout={onLogout}
-      onViewerMode={onViewerMode}
-      onUpdate={onUpdate}
-    />;
+    return <>
+      <AdminDashboard
+        tournament={t}
+        onOpenCompetition={(id, section) => setView({ kind: "competition", id, section: section || "overview" })}
+        onCreateCompetition={() => setView({ kind: "createComp" })}
+        onEditTournament={() => setView({ kind: "editTournament" })}
+        onAnnounce={() => setAnnounceOpen(true)}
+        onOpenSchedule={() => setView({ kind: "schedule" })}
+        onOpenScoreEditor={() => setView({ kind: "scoreEditor" })}
+        onOpenImport={() => setView({ kind: "import" })}
+        onStartAll={startAllCompetitions}
+        onStartCompetition={startCompetition}
+        onLogout={onLogout}
+        onViewerMode={onViewerMode}
+        onUpdate={onUpdate}
+      />
+      {announceOpen && <window.AnnouncementModal
+        password={password}
+        showToast={showToast}
+        onClose={() => setAnnounceOpen(false)}
+      />}
+    </>;
   }
 
   if (view.kind === "createComp") {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -105,8 +105,10 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   const [adminCompData, setAdminCompData] = useStateA(null);
   const [adminLoading, setAdminLoading] = useStateA(false);
   // mp-djc: dashboard "📣 Announce" button opens the broadcast composer
-  // in a modal. State lives here (alongside other AdminApp UI state) so
-  // the modal overlays whichever screen is rendered.
+  // in a modal. State lives here (alongside other AdminApp UI state); the
+  // modal is rendered only in the dashboard branch below, since that's the
+  // sole screen exposing the Announce button. (Other screens reach the
+  // composer via the Edit-details page.)
   const [announceOpen, setAnnounceOpen] = useStateA(false);
 
   // Expose a navigation helper used by AdminTopbar's live-strip chips,

--- a/web-mobile/js/admin_announcement.jsx
+++ b/web-mobile/js/admin_announcement.jsx
@@ -1,0 +1,172 @@
+// Announcement composer + modal. Extracted from admin_setup.jsx so the
+// same broadcast UI can be reached two ways: inline on the Edit-details
+// page (AdminEditTournament) and via a dedicated "Announce" button on the
+// admin dashboard (mp-djc). Endpoint is unchanged — POST /api/tournament/announce
+// (handlers_announcement.go), driven through window.API.sendAnnouncement.
+
+const { useState: useStateAn, useEffect: useEffectAn, useCallback: useCallbackAn } = React;
+
+// Pure helpers for the announcement-broadcast controls.
+// isSendDisabled drives the button's `disabled` attribute.
+// sendLabel drives the button's text (inFlight → "Sending…").
+function isSendAnnouncementDisabled(message, inFlight) {
+  return !message.trim() || inFlight;
+}
+function sendAnnouncementLabel(inFlight) {
+  return inFlight ? "Sending..." : "Send announcement";
+}
+
+// AnnouncementComposer — the broadcast card body (active-announcements
+// list + message + duration + send). Owns all announcement state and
+// handlers. `password` is forwarded to the mutating API calls; `showToast`
+// surfaces success/error feedback. Both are optional — guarded at call sites.
+function AnnouncementComposer({ password, showToast }) {
+  const [announcementMessage, setAnnouncementMessage] = useStateAn("");
+  const [announcementDuration, setAnnouncementDuration] = useStateAn(5);
+  const [announcementInFlight, setAnnouncementInFlight] = useStateAn(false);
+  const [activeAnnouncements, setActiveAnnouncements] = useStateAn([]);
+
+  const refreshAnnouncements = useCallbackAn(async () => {
+    try {
+      const list = await window.API.fetchAnnouncements();
+      setActiveAnnouncements(list || []);
+    } catch (_e) {
+      // non-fatal
+    }
+  }, []);
+
+  useEffectAn(() => { refreshAnnouncements(); }, [refreshAnnouncements]);
+
+  const handleSendAnnouncement = async () => {
+    const trimmed = announcementMessage.trim();
+    if (!trimmed) return;
+    setAnnouncementInFlight(true);
+    try {
+      await window.API.sendAnnouncement(trimmed, announcementDuration, password);
+      setAnnouncementMessage("");
+      if (showToast) {
+        showToast(`Announcement broadcast for ${announcementDuration} minutes!`, "success");
+      }
+      await refreshAnnouncements();
+    } catch (e) {
+      if (showToast) {
+        showToast(e.message, "error");
+      }
+    } finally {
+      setAnnouncementInFlight(false);
+    }
+  };
+
+  const handleDismissAnnouncement = async (id) => {
+    try {
+      await window.API.deleteAnnouncement(id, password);
+      await refreshAnnouncements();
+    } catch (e) {
+      if (showToast) showToast(e.message, "error");
+    }
+  };
+
+  const handleClearAnnouncements = async () => {
+    try {
+      await window.API.clearAnnouncements(password);
+      await refreshAnnouncements();
+    } catch (e) {
+      if (showToast) showToast(e.message, "error");
+    }
+  };
+
+  return (
+    <>
+      {activeAnnouncements.length > 0 && (
+        <div className="field" style={{ marginBottom: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+            <label className="field__label" style={{ marginBottom: 0 }}>Active announcements</label>
+            <button className="btn btn--sm btn--danger" onClick={handleClearAnnouncements}>Clear all</button>
+          </div>
+          {activeAnnouncements.map(ann => (
+            <div key={ann.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 8px", background: "var(--color-surface-raised, #f5f5f5)", borderRadius: 4, marginBottom: 4 }}>
+              <span style={{ flex: 1, fontSize: "0.9em" }}>{ann.message}</span>
+              <button
+                className="btn btn--sm"
+                onClick={() => handleDismissAnnouncement(ann.id)}
+                aria-label="Dismiss announcement"
+              >&times;</button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="field">
+        <label className="field__label">Message</label>
+        <textarea
+          className="input"
+          style={{ width: "100%", height: 80, boxSizing: "border-box", padding: "8px 12px", resize: "vertical" }}
+          maxLength={200}
+          placeholder="e.g. Lunch break for 30 minutes, Delay on court B..."
+          value={announcementMessage}
+          onChange={(e) => setAnnouncementMessage(e.target.value)}
+        />
+        <div className="field__hint" style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+          <span>Maximum 200 characters. Adds to the active announcement queue on all viewer screens.</span>
+          <span>{announcementMessage.length}/200</span>
+        </div>
+      </div>
+      <div className="field">
+        <label className="field__label">Duration</label>
+        <div style={{ display: "flex", gap: 16, marginTop: 8 }}>
+          {[5, 10, 15, 30].map((m) => (
+            <label key={m} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontWeight: 500 }}>
+              <input
+                type="radio"
+                name="duration"
+                value={m}
+                checked={announcementDuration === m}
+                onChange={() => setAnnouncementDuration(m)}
+              />
+              <span>{m} min</span>
+            </label>
+          ))}
+        </div>
+      </div>
+      <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
+        <button
+          className="btn btn--primary"
+          disabled={isSendAnnouncementDisabled(announcementMessage, announcementInFlight)}
+          onClick={handleSendAnnouncement}
+        >
+          {sendAnnouncementLabel(announcementInFlight)}
+        </button>
+      </div>
+    </>
+  );
+}
+
+// AnnouncementModal — dashboard entry point (mp-djc). Wraps the composer
+// in the shared .modal-backdrop / .modal pattern (mirrors AuthModal in
+// app.jsx). Backdrop click + Escape close.
+function AnnouncementModal({ password, showToast, onClose }) {
+  window.useEscapeToClose(onClose);
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      {/* modal--lg (720px) matches the width the composer was designed for
+          on the Edit-details page (its card is maxWidth 720). At the default
+          460px the message-hint row's space-between flex wraps the char
+          counter into the middle of the sentence. */}
+      <div className="modal modal--lg" onClick={(e) => e.stopPropagation()}>
+        <div className="modal__head">
+          <div className="modal__title">Broadcast announcement</div>
+          <button className="modal__close" onClick={onClose} aria-label="Close">&times;</button>
+        </div>
+        <div className="modal__body">
+          <AnnouncementComposer password={password} showToast={showToast} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.AnnouncementComposer = AnnouncementComposer;
+window.AnnouncementModal = AnnouncementModal;
+
+// ES export for the vitest suite — pure helpers only. Components stay
+// behind the window.* pattern to match the rest of admin_*.jsx.
+export { isSendAnnouncementDisabled, sendAnnouncementLabel };

--- a/web-mobile/js/admin_announcement.jsx
+++ b/web-mobile/js/admin_announcement.jsx
@@ -8,7 +8,8 @@ const { useState: useStateAn, useEffect: useEffectAn, useCallback: useCallbackAn
 
 // Pure helpers for the announcement-broadcast controls.
 // isSendDisabled drives the button's `disabled` attribute.
-// sendLabel drives the button's text (inFlight → "Sending…").
+// sendLabel drives the button's text (inFlight → "Sending...", three
+// dots — kept ASCII to match the literal the tests assert on).
 function isSendAnnouncementDisabled(message, inFlight) {
   return !message.trim() || inFlight;
 }

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -1,7 +1,7 @@
 // Tournament-edit, competition-create, and bulk-import pages. See
 // web-mobile/admin_split_plan.md.
 
-const { useState: useStateA, useEffect: useEffectA, useCallback: useCallbackA, useRef: useRefA } = React;
+const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
 
 const validateAndNormalizeDate = window.validateAndNormalizeDate;
 const decideNumericUpdate = window.decideNumericUpdate;
@@ -101,60 +101,6 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [checkInEnd, setCheckInEnd] = useStateA(tournament.checkInWindowEnd || "");
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
-
-  const [announcementMessage, setAnnouncementMessage] = useStateA("");
-  const [announcementDuration, setAnnouncementDuration] = useStateA(5);
-  const [announcementInFlight, setAnnouncementInFlight] = useStateA(false);
-  const [activeAnnouncements, setActiveAnnouncements] = useStateA([]);
-
-  const refreshAnnouncements = useCallbackA(async () => {
-    try {
-      const list = await window.API.fetchAnnouncements();
-      setActiveAnnouncements(list || []);
-    } catch (_e) {
-      // non-fatal
-    }
-  }, []);
-
-  useEffectA(() => { refreshAnnouncements(); }, [refreshAnnouncements]);
-
-  const handleSendAnnouncement = async () => {
-    const trimmed = announcementMessage.trim();
-    if (!trimmed) return;
-    setAnnouncementInFlight(true);
-    try {
-      await window.API.sendAnnouncement(trimmed, announcementDuration, password);
-      setAnnouncementMessage("");
-      if (showToast) {
-        showToast(`Announcement broadcast for ${announcementDuration} minutes!`, "success");
-      }
-      await refreshAnnouncements();
-    } catch (e) {
-      if (showToast) {
-        showToast(e.message, "error");
-      }
-    } finally {
-      setAnnouncementInFlight(false);
-    }
-  };
-
-  const handleDismissAnnouncement = async (id) => {
-    try {
-      await window.API.deleteAnnouncement(id, password);
-      await refreshAnnouncements();
-    } catch (e) {
-      if (showToast) showToast(e.message, "error");
-    }
-  };
-
-  const handleClearAnnouncements = async () => {
-    try {
-      await window.API.clearAnnouncements(password);
-      await refreshAnnouncements();
-    } catch (e) {
-      if (showToast) showToast(e.message, "error");
-    }
-  };
 
   const handleSave = () => {
     // Trim early and send the trimmed value. The empty-name check below
@@ -258,65 +204,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
 
         <div className="page-head" style={{ marginTop: 32 }}><h1 className="page-head__title">Broadcast announcement</h1></div>
         <div className="card card--pad-lg">
-          {activeAnnouncements.length > 0 && (
-            <div className="field" style={{ marginBottom: 16 }}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
-                <label className="field__label" style={{ marginBottom: 0 }}>Active announcements</label>
-                <button className="btn btn--sm btn--danger" onClick={handleClearAnnouncements}>Clear all</button>
-              </div>
-              {activeAnnouncements.map(ann => (
-                <div key={ann.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 8px", background: "var(--color-surface-raised, #f5f5f5)", borderRadius: 4, marginBottom: 4 }}>
-                  <span style={{ flex: 1, fontSize: "0.9em" }}>{ann.message}</span>
-                  <button
-                    className="btn btn--sm"
-                    onClick={() => handleDismissAnnouncement(ann.id)}
-                    aria-label="Dismiss announcement"
-                  >&times;</button>
-                </div>
-              ))}
-            </div>
-          )}
-          <div className="field">
-            <label className="field__label">Message</label>
-            <textarea
-              className="input"
-              style={{ width: "100%", height: 80, boxSizing: "border-box", padding: "8px 12px", resize: "vertical" }}
-              maxLength={200}
-              placeholder="e.g. Lunch break for 30 minutes, Delay on court B..."
-              value={announcementMessage}
-              onChange={(e) => setAnnouncementMessage(e.target.value)}
-            />
-            <div className="field__hint" style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
-              <span>Maximum 200 characters. Adds to the active announcement queue on all viewer screens.</span>
-              <span>{announcementMessage.length}/200</span>
-            </div>
-          </div>
-          <div className="field">
-            <label className="field__label">Duration</label>
-            <div style={{ display: "flex", gap: 16, marginTop: 8 }}>
-              {[5, 10, 15, 30].map((m) => (
-                <label key={m} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontWeight: 500 }}>
-                  <input
-                    type="radio"
-                    name="duration"
-                    value={m}
-                    checked={announcementDuration === m}
-                    onChange={() => setAnnouncementDuration(m)}
-                  />
-                  <span>{m} min</span>
-                </label>
-              ))}
-            </div>
-          </div>
-          <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
-            <button
-              className="btn btn--primary"
-              disabled={isSendAnnouncementDisabled(announcementMessage, announcementInFlight)}
-              onClick={handleSendAnnouncement}
-            >
-              {sendAnnouncementLabel(announcementInFlight)}
-            </button>
-          </div>
+          <window.AnnouncementComposer password={password} showToast={showToast} />
         </div>
       </div>
     </div>
@@ -885,16 +773,9 @@ window.AdminEditTournament = AdminEditTournament;
 window.AdminCreateCompetition = AdminCreateCompetition;
 window.AdminImportPage = AdminImportPage;
 
-// Pure helpers for the announcement-broadcast controls.
-// isSendDisabled drives the button's `disabled` attribute.
-// sendLabel drives the button's text (inFlight → "Sending…").
-function isSendAnnouncementDisabled(message, inFlight) {
-  return !message.trim() || inFlight;
-}
-function sendAnnouncementLabel(inFlight) {
-  return inFlight ? "Sending..." : "Send announcement";
-}
-
 // ES export for the vitest suite — pure helpers only. Components stay
 // behind the window.* pattern to match the rest of admin_*.jsx.
-export { deriveCompetitionName, validatePoolSettings, validateSwissSettings, isSendAnnouncementDisabled, sendAnnouncementLabel };
+// The announcement-broadcast helpers (isSendAnnouncementDisabled /
+// sendAnnouncementLabel) moved to admin_announcement.jsx alongside the
+// AnnouncementComposer component they drive (mp-djc).
+export { deriveCompetitionName, validatePoolSettings, validateSwissSettings };

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -109,7 +109,7 @@ function initialSectionFor(status) {
   return "overview";
 }
 
-function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, onEditTournament, onOpenSchedule, onOpenScoreEditor, onOpenImport, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate }) {
+function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, onEditTournament, onAnnounce, onOpenSchedule, onOpenScoreEditor, onOpenImport, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate }) {
   const t = tournament;
   const comps = t.competitions || [];
 
@@ -185,6 +185,7 @@ function AdminDashboard({ tournament, onOpenCompetition, onCreateCompetition, on
             </div>
           </div>
           <div className="page-head__actions">
+            <button className="btn" onClick={onAnnounce}>📣 Announce</button>
             <button className="btn" onClick={onEditTournament}>Edit details</button>
             {comps.some(c => c.status === "setup" && (c.players || []).length >= 2) && (
               <button className="btn btn--danger" onClick={onStartAll}>Start all</button>


### PR DESCRIPTION
## Summary
Closes **mp-djc**. Adds a top-level **📣 Announce** button to the admin dashboard action bar (next to *Edit details* / *+ Add competition*), so operators can broadcast an announcement in one click instead of navigating into *Edit tournament details*.

**DRY approach:** the ~100-line announcement composer that was inlined in `AdminEditTournament` is extracted into a reusable `AnnouncementComposer` component in a new file [`web-mobile/js/admin_announcement.jsx`](web-mobile/js/admin_announcement.jsx), plus an `AnnouncementModal` wrapper using the existing `.modal-backdrop` pattern. The composer is now reused by **both** the dashboard modal and the Edit-details page (kept as a fallback per the bead design). Backend endpoint is unchanged (`POST /api/tournament/announce`).

Net `+36 / −169` on tracked files — the change mostly removes duplication.

## Changes
- **New** `admin_announcement.jsx` — `AnnouncementComposer` (`window.AnnouncementComposer`) + `AnnouncementModal` (`window.AnnouncementModal`); the pure helpers `isSendAnnouncementDisabled` / `sendAnnouncementLabel` move here alongside the component they drive.
- `admin_shell.jsx` — 📣 Announce button + `onAnnounce` prop on `AdminDashboard`.
- `admin.jsx` — `announceOpen` state in `AdminApp`; renders `AnnouncementModal` over the dashboard.
- `admin_setup.jsx` — `AdminEditTournament` now renders the extracted composer; ~100 lines of inlined state/handlers/JSX removed.
- `index.html` — `<script>` tag for the new module (before `admin_setup.js` / `admin.js`).
- **New** `admin_announcement.test.jsx` — the two helpers' unit tests migrated from `admin_setup.test.jsx`.
- The modal uses `.modal--lg` (720px) — the width the composer was designed for; the default 460px wrapped the char counter mid-sentence.

## Automated tests
- ✅ `eslint . --max-warnings 0` clean
- ✅ `vitest run` — **868/868** pass (`admin_announcement.test.jsx` + migrated suite green)
- ✅ `make go/build` (esbuild + embed) succeeds
- Note: no unit test renders these components (suites cover pure functions only), so the browser pass below is load-bearing, not redundant.

## Manual browser test plan (executed via mobile-app UI, all ✅)
| # | Test | Result |
|---|------|--------|
| T1 | 📣 Announce button present in dashboard action bar | ✅ |
| T2 | Click opens modal; title "Broadcast announcement"; send disabled when empty; 4 duration radios | ✅ |
| T3 | Backdrop click closes modal | ✅ |
| T4 | Type + Send → toast "✅ Announcement broadcast for 5 minutes!", active list updates, textarea clears, persisted via `GET /api/tournament/announcements` | ✅ |
| T5 | Dismiss single announcement (×) → removed from list **and** server | ✅ |
| T6 | Clear all → active count 2 → 0 | ✅ |
| T7 | **Public viewer** (non-admin) shows the announcement banner with countdown ("Finals start at 14:00 · 4:39 LEFT") | ✅ |
| T8 | Edit-details fallback page still renders the composer inline (not a modal) | ✅ |
| — | Escape closes modal | ✅ |
| — | `.modal--lg` 720px; hint + char-counter share one line | ✅ |

## Notes
- Verified the binary serves the **rebuilt embedded** assets (`make go/build`, not just `esbuild-jsx`) by `curl`-checking the served module — the `//go:embed` + `?v=5` cache combo will silently serve stale JS otherwise.
- Coordinates with mp-udb / mp-cw1 (same announcement surface) but is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)