### PR TITLE
feat(mp-8sw): Hantei marker + "Daihyosen" label on viewer team sub-bout rows

### DIFF
--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestApplyTournamentDefaults_ZeroValues(t *testing.T) {
@@ -62,6 +63,37 @@ func TestMatchResult_HanteiOmitempty(t *testing.T) {
 		b, err := json.Marshal(mr)
 		require.NoError(t, err)
 		assert.Contains(t, string(b), `"decidedByHantei":true`)
+	})
+}
+
+// TestSubMatchResult_HanteiRoundTrip pins the wire/storage contract for the
+// per-bout hantei flag the viewer reads (mp-8sw). Unlike MatchResult, the
+// SubMatchResult flag is a plain bool, so omitempty omits it when false and
+// emits it when true — across both the JSON HTTP path and the YAML config.md
+// persistence path.
+func TestSubMatchResult_HanteiRoundTrip(t *testing.T) {
+	t.Run("true survives JSON round-trip", func(t *testing.T) {
+		sub := SubMatchResult{Position: -1, DecidedByHantei: true}
+		b, err := json.Marshal(sub)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"decidedByHantei":true`)
+		var got SubMatchResult
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.True(t, got.DecidedByHantei)
+	})
+	t.Run("false is omitted from JSON", func(t *testing.T) {
+		b, err := json.Marshal(SubMatchResult{Position: 1})
+		require.NoError(t, err)
+		assert.NotContains(t, string(b), "decidedByHantei")
+	})
+	t.Run("true survives YAML round-trip", func(t *testing.T) {
+		sub := SubMatchResult{Position: -1, DecidedByHantei: true}
+		b, err := yaml.Marshal(sub)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "decided_by_hantei: true")
+		var got SubMatchResult
+		require.NoError(t, yaml.Unmarshal(b, &got))
+		assert.True(t, got.DecidedByHantei)
 	})
 }
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,6 +1,21 @@
-import { describe, it, expect } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches } from '../viewer.jsx';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
+import { makeReactive } from './helpers/reactive_react.js';
+
+// Walks a vnode tree and concatenates all string/number leaves. Child
+// component vnodes (e.g. <TermV>) are NOT executed by the reactive shim,
+// but their literal children (the term text) still live in props.children,
+// so this captures everything MatchDetailCard renders itself. Mirrors the
+// collectText helper in reset.test.jsx.
+function collectText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children) return collectText(node.children);
+  if (node.props?.children) return collectText(node.props.children);
+  return '';
+}
 
 describe('Viewer Utils', () => {
   describe('formatDate', () => {
@@ -203,6 +218,100 @@ describe('Viewer Utils', () => {
       const c = { format: 'swiss', swissRounds: 4, swissCurrentRound: 0 };
       expect(swissStandingsHeading(c, [])).toBe('Standings — pending');
     });
+  });
+
+  // mp-8sw — subBoutLabel: the team sub-bout center label. The daihyosen
+  // (rep bout) is stored with sentinel position -1 and must render as
+  // "Daihyosen", not the literal "Match -1" the position||index fallback
+  // would produce. Shared by both viewer sub-row sites; the Hantei marker
+  // beside it is a trivial `sub.decidedByHantei` gate verified manually.
+  describe('subBoutLabel', () => {
+    it('renders "Daihyosen" for the sentinel position -1 (not "Match -1")', () => {
+      expect(subBoutLabel({ position: -1 }, 0)).toBe('Daihyosen');
+      expect(subBoutLabel({ position: -1 }, 4)).toBe('Daihyosen');
+    });
+
+    it('renders "Match N" using the stored position for normal bouts', () => {
+      expect(subBoutLabel({ position: 1 }, 0)).toBe('Match 1');
+      expect(subBoutLabel({ position: 3 }, 0)).toBe('Match 3');
+    });
+
+    it('falls back to index+1 when position is missing/zero', () => {
+      expect(subBoutLabel({}, 0)).toBe('Match 1');
+      expect(subBoutLabel({ position: 0 }, 2)).toBe('Match 3');
+      expect(subBoutLabel(undefined, 1)).toBe('Match 2');
+    });
+  });
+});
+
+// mp-8sw — MatchDetailCard team sub-rows: render-level proof that the
+// daihyosen row labels as "Daihyosen" (not "Match -1") and shows the
+// "Hantei" marker only when sub.decidedByHantei. Asserts the actual
+// rendered tree, complementing the subBoutLabel unit tests above.
+describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
+  const realReact = global.React;
+  let runtime;
+  let MatchDetailCard;
+
+  const mkTeamMatch = (subs) => ({
+    compKind: 'team',
+    status: 'completed',
+    court: 'A',
+    phase: 'bracket',
+    round: 'Final',
+    sideA: { id: 'tA', name: 'Team A' },
+    sideB: { id: 'tB', name: 'Team B' },
+    // Present (truthy) so the component skips window.ipponsFromScore.
+    ipponsA: [],
+    ipponsB: [],
+    subResults: subs,
+  });
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    // Only globals MatchDetailCard executes on the team path. The non-team
+    // ippons block (which calls window.isHikiwake) is gated out for teams.
+    global.window.formatIpponsScore = vi.fn(() => '3-2');
+    global.window.ipponsFromScore = vi.fn(() => []);
+    vi.resetModules();
+    ({ MatchDetailCard } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('labels the daihyosen row "Daihyosen" and shows "Hantei" when decidedByHantei', () => {
+    const tree = runtime.mount(MatchDetailCard, {
+      match: mkTeamMatch([
+        { position: 1, ipponsA: ['M'], ipponsB: [], decidedByHantei: false },
+        { position: -1, ipponsA: ['K'], ipponsB: [], decidedByHantei: true },
+      ]),
+      onClose: null,
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Match 1');
+    expect(text).toContain('Daihyosen');
+    expect(text).not.toContain('Match -1');
+    expect(text).toContain('Hantei');
+  });
+
+  it('omits the "Hantei" marker when no sub was decided by hantei', () => {
+    const tree = runtime.mount(MatchDetailCard, {
+      match: mkTeamMatch([
+        { position: 1, ipponsA: ['M'], ipponsB: [], decidedByHantei: false },
+        { position: -1, ipponsA: ['K'], ipponsB: ['K'], decidedByHantei: false },
+      ]),
+      onClose: null,
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Daihyosen');
+    expect(text).not.toContain('Hantei');
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -17,6 +17,29 @@ function collectText(node) {
   return '';
 }
 
+// Depth-first search for the first vnode matching predicate. Mirrors the
+// helper in reset.test.jsx; used to assert props (e.g. style) on a rendered
+// element, which collectText (text-only) can't see.
+function findInTree(node, predicate) {
+  if (!node || typeof node !== 'object') return null;
+  // Arrays appear wherever the component renders a .map() (e.g. the sub-rows),
+  // so recurse into them rather than treating the array itself as a vnode.
+  if (Array.isArray(node)) {
+    for (const k of node) {
+      const found = findInTree(k, predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (predicate(node)) return node;
+  const kids = node.children || node.props?.children || [];
+  for (const k of [].concat(kids)) {
+    const found = findInTree(k, predicate);
+    if (found) return found;
+  }
+  return null;
+}
+
 describe('Viewer Utils', () => {
   describe('formatDate', () => {
     it('should format canonical DD-MM-YYYY correctly', () => {
@@ -252,6 +275,12 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
   const realReact = global.React;
   let runtime;
   let MatchDetailCard;
+  // Preserve any pre-existing window globals we stub so we can restore exact
+  // state in afterEach. vi.restoreAllMocks() only undoes vi.spyOn, NOT direct
+  // `global.window.x = vi.fn()` assignments — without this the mocked globals
+  // leak into later suites and make failures order-dependent.
+  const savedGlobals = {};
+  const STUBBED = ['formatIpponsScore', 'ipponsFromScore'];
 
   const mkTeamMatch = (subs) => ({
     compKind: 'team',
@@ -271,6 +300,7 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
     runtime = makeReactive();
     global.React = runtime.React;
     global.window = global.window || {};
+    STUBBED.forEach(k => { savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k) ? { had: true, val: global.window[k] } : { had: false }; });
     // Only globals MatchDetailCard executes on the team path. The non-team
     // ippons block (which calls window.isHikiwake) is gated out for teams.
     global.window.formatIpponsScore = vi.fn(() => '3-2');
@@ -282,6 +312,13 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
   afterEach(() => {
     runtime.unmount();
     global.React = realReact;
+    // Restore the exact prior state of the window globals we stubbed so they
+    // don't leak into other suites (vi.restoreAllMocks does not cover direct
+    // property assignments).
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
     vi.restoreAllMocks();
     vi.resetModules();
   });
@@ -299,6 +336,11 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
     expect(text).toContain('Daihyosen');
     expect(text).not.toContain('Match -1');
     expect(text).toContain('Hantei');
+    // The marker must carry left spacing so it does not render flush against
+    // the label as "DaihyosenHantei" (Copilot review on #192).
+    const marker = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-row-hantei');
+    expect(marker).toBeTruthy();
+    expect(marker.props.style?.marginLeft).toBeTruthy();
   });
 
   it('omits the "Hantei" marker when no sub was decided by hantei', () => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1355,7 +1355,7 @@ function MatchDetailCard({ match, onClose }) {
                 <span className="match-detail-card__sub-score">{sB}</span>
                 <span className="match-detail-card__sub-pos">
                   {subBoutLabel(sub, i)}
-                  {sub.decidedByHantei && <span className="match-detail-card__decision" data-testid="sub-row-hantei">Hantei</span>}
+                  {sub.decidedByHantei && <span className="match-detail-card__decision" data-testid="sub-row-hantei" style={{ marginLeft: 6 }}>Hantei</span>}
                 </span>
                 <span className="match-detail-card__sub-score match-detail-card__sub-score--right">{sA}</span>
               </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -619,6 +619,18 @@ export function mymatchQueueLabel(m) {
   return `${qp - 1} before yours`;
 }
 
+// subBoutLabel — center label for a team sub-bout row. The daihyosen
+// (representative bout) is stored with the sentinel position -1 (see
+// admin_scoring_modal.jsx buildPatch); render it as "Daihyosen" (matching
+// admin_pools.jsx wording) rather than the literal "Match -1" the
+// `position || index+1` fallback would otherwise produce. Shared by both
+// viewer sub-row sites (MatchDetailCard, MatchViewerModal). Exported for
+// unit-testing.
+export function subBoutLabel(sub, index) {
+  if (sub && sub.position === -1) return "Daihyosen";
+  return `Match ${(sub && sub.position) || index + 1}`;
+}
+
 // MyMatchPanel — "Find my matches" entry point + active "Your next match"
 // card. Two states:
 //   1) No followed player yet → render a picker; selecting persists to
@@ -1341,7 +1353,10 @@ function MatchDetailCard({ match, onClose }) {
             return (
               <div key={i} className="match-detail-card__sub-row">
                 <span className="match-detail-card__sub-score">{sB}</span>
-                <span className="match-detail-card__sub-pos">Match {sub.position || i + 1}</span>
+                <span className="match-detail-card__sub-pos">
+                  {subBoutLabel(sub, i)}
+                  {sub.decidedByHantei && <span className="match-detail-card__decision" data-testid="sub-row-hantei">Hantei</span>}
+                </span>
                 <span className="match-detail-card__sub-score match-detail-card__sub-score--right">{sA}</span>
               </div>
             );
@@ -1885,7 +1900,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -2394,7 +2409,8 @@ function MatchViewerModal({ match, onClose }) {
                      {hansokuB > 0 && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>Fouls: {hansokuB}</span>}
                    </div>
                    <div style={{ flex: 1, textAlign: "center", fontSize: 13, color: "var(--ink-3)" }}>
-                     Match {sub.position || i+1}
+                     {subBoutLabel(sub, i)}
+                     {sub.decidedByHantei && <span data-testid="sub-pool-hantei" style={{ marginLeft: 6, fontWeight: 600 }}>Hantei</span>}
                    </div>
                    <div style={{ width: 80, textAlign: "right", display: "flex", flexDirection: "column" }}>
                      <span style={{ fontWeight: 600, fontSize: 14 }}>{sIpponsA || "—"}</span>


### PR DESCRIPTION
## What & why
The two viewer sub-bout render sites (`MatchDetailCard` bracket detail, `MatchViewerModal`) showed raw ippons for team sub-bouts but ignored `sub.decidedByHantei` — so observers couldn't distinguish a hantei-decided daihyosen from a regular draw. Closes mp-8sw.

The backend plumbing (`SubMatchResult.DecidedByHantei` + admin write path + serializer passthrough) **already shipped with mp-4pc** — verified, not re-implemented. This PR is the viewer display only.

## Changes (3 files, +162/−5)
- **`web-mobile/js/viewer.jsx`** — new exported pure helper `subBoutLabel(sub, i)`: renders **"Daihyosen"** for the daihyosen sentinel `position === -1` (folds in a fix for the pre-existing **"Match -1"** label) else "Match N". Used by **both** sub-row sites (DRY). Adds the **"Hantei"** marker (consistent with the existing individual-match marker) at both sites when `sub.decidedByHantei`.
- **`web-mobile/js/__tests__/viewer.test.jsx`** — 3 `subBoutLabel` unit tests + 2 `MatchDetailCard` render tests (asserts rendered "Daihyosen"+"Hantei"; marker-absent case).
- **`internal/state/models_test.go`** — JSON + YAML round-trip for `SubMatchResult.DecidedByHantei`.

## Behavior note
Per mp-4pc, per-bout hantei is valid **only on the daihyosen sub** today, so the marker currently appears only on the Daihyosen row. The marker keys off `sub.decidedByHantei` (not position) so it stays correct if that rule broadens.

## Test plan
- [x] `cd web-mobile && npm test` — 873 pass (incl. 5 new)
- [x] `npm run lint` — clean
- [x] `go test ./internal/state/...` — pass (incl. new round-trip test)
- [x] `make go/build` — builds, JSX recompiled/embedded
- [x] **Live browser** (mobile-app, seeded team-KO comp with a hantei-decided daihyosen): tournament-wide schedule → team Final → `MatchViewerModal` renders the sub-bout table ending in **"Daihyosen  Hantei"** (not "Match -1"); no console errors. Screenshot captured during verification.

## Known follow-up (pre-existing, out of scope)
**mp-116** — the viewer **overview** and **bracket tab** render team KO matches as *individual* (no sub-bouts surfaced): `allMatches` drops `compKind`/`teamSize`, and the bracket tab feeds a placeholder `derivedBracket` with no `subResults`. So site-1's marker is only reachable via the tournament-wide schedule today. mp-8sw's site-1 code is correct (proven by the render test); reachability is mp-116's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)