### PR TITLE
feat(mp-e21): elevated password for destructive operations

### DIFF
--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -72,7 +72,56 @@ In locked mode:
 - Rotating the credential requires restarting the server with a new hash; the runtime never reads the env var twice.
 - If `--lock-password` is set but `TOURNAMENT_PASSWORD_HASH` is empty or malformed, the server **refuses to start** — fail-closed, so a misconfigured deployment can't silently fall through to file mode.
 
-The public `GET /api/auth-config` endpoint reports `{mode: "file"|"locked", resetEnabled: bool}` so SPAs and external monitoring can see the active mode without authenticating.
+The public `GET /api/auth-config` endpoint reports `{mode: "file"|"locked", resetEnabled: bool, elevatedRequired: bool, elevatedConfigured: bool, elevatedEditable: bool}` so SPAs and external monitoring can see the active mode (and whether the destructive-ops password gate is active) without authenticating.
+
+### Destructive-ops password (second password)
+
+You can require a **second, separately-held password** for destructive
+actions, so that table staff who hold the main password can run matches and
+check-in without being able to destroy data. The gate covers:
+
+- Delete a competition; mark a competition invalid.
+- Discard a generated draw; reset rank/winner overrides.
+- Add, edit, or replace participants; import competitions from a folder.
+
+It does **not** cover routine operations (scoring, decisions, check-in,
+starting/finishing competitions, lineups) or the `/reset` recovery path.
+When a gated action is triggered the admin UI prompts for the destructive-ops
+password each time (no session is cached); the value is sent in an
+`X-Admin-Password` header alongside the main `X-Tournament-Password`.
+
+**File mode.** Set or change it from **Admin → Edit details → Destructive-ops
+password**. The current value is never displayed (write-only) and is stored in
+`tournament-data/tournament.md` under `admin_password`. Changing it once set
+requires entering the current destructive-ops password. While unset, the
+feature is off and destructive actions are gated by the main password only —
+so existing file-mode deployments are unaffected until you opt in.
+
+**Locked mode.** The destructive-ops password is the bcrypt hash in the
+`TOURNAMENT_ADMIN_PASSWORD_HASH` env var (the elevated-credential analogue of
+`TOURNAMENT_PASSWORD_HASH`); it is **not** editable from the UI. Generate it
+the same way:
+
+```bash
+printf '%s' "$MY_DESTRUCTIVE_OPS_SECRET" | bracket-creator hash-password
+TOURNAMENT_PASSWORD_HASH='$2a$10$...main...' \
+  TOURNAMENT_ADMIN_PASSWORD_HASH='$2a$10$...destructive...' \
+  bracket-creator mobile-app --lock-password -f ./tournament-data
+```
+
+> **Locked-mode behavior change.** In locked mode the destructive-ops gate is
+> **always active and fail-closed**: if `TOURNAMENT_ADMIN_PASSWORD_HASH` is
+> unset (or malformed), the gated endpoints return **503 "admin password not
+> configured"** rather than allowing the action with the main password alone.
+> A malformed/empty hash does **not** prevent startup — the server boots and
+> only the destructive endpoints 503 — so set the env var if your operators
+> need to delete competitions or edit rosters on a locked deployment.
+
+**Scope of protection.** This is a privilege-separation speed bump for
+shared-credential operation, not a network-security control. Over plain HTTP
+(the common LAN default) both passwords travel in cleartext; anyone with
+filesystem access to `tournament.md` reads both in file mode. For a real
+network boundary, run behind TLS and/or `--lock-password`.
 
 ### Operational notes
 
@@ -117,7 +166,7 @@ State is stored as plain files in the data folder:
 
 ```
 tournament-data/
-  tournament.md                 ← YAML: name, date, venue, courts, password
+  tournament.md                 ← YAML: name, date, venue, courts, password, admin_password
   competitions/
     <id>/
       config.md                 ← YAML: kind, format, pool settings, courts, …

--- a/internal/mobileapp/auth_admin.go
+++ b/internal/mobileapp/auth_admin.go
@@ -1,0 +1,192 @@
+package mobileapp
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ElevatedVerifier gates the destructive-operation middleware
+// (RequireElevatedPassword) for spec 004 / mp-e21. It is intentionally
+// NARROWER than PasswordVerifier: there is no bootstrap branch, no reset
+// semantics, and no stored-password redaction policy — those belong to the
+// primary credential. The elevated password is a SECOND factor layered on
+// top of the main-password AuthMiddleware, so by the time these methods run
+// the request has already proven it holds the main password.
+//
+// Two orthogonal questions drive the middleware's three outcomes:
+// GateActive() (should we enforce at all?) and Configured() (is there a
+// credential to compare against?):
+//
+//	GateActive=false              -> pass through (file mode, no admin pw set;
+//	                                 back-compat: main password alone suffices)
+//	GateActive=true, Configured=false -> 503 "admin password not configured"
+//	                                 (locked mode, env hash unset; fail-closed)
+//	GateActive=true, Configured=true  -> compare X-Admin-Password via Verify()
+type ElevatedVerifier interface {
+	// GateActive reports whether the middleware should enforce at all.
+	//   file mode:   true only when an admin password has been set.
+	//   locked mode: always true (fail-closed — a locked deployment that
+	//                forgot the env var must NOT silently allow destructive
+	//                ops with the main password alone).
+	GateActive() bool
+
+	// Configured reports whether a credential exists to compare against.
+	//   file mode:   admin password non-empty (== GateActive there).
+	//   locked mode: TOURNAMENT_ADMIN_PASSWORD_HASH was a valid bcrypt hash.
+	Configured() bool
+
+	// Verify checks the presented X-Admin-Password value. Only consulted
+	// when GateActive() && Configured(); implementations may still be called
+	// defensively and must treat an empty presented value as a non-match.
+	Verify(presented string) (bool, error)
+
+	// Mode mirrors PasswordVerifier.Mode for /auth-config ("file"|"locked").
+	Mode() string
+}
+
+// fileElevatedVerifier implements ElevatedVerifier for file mode. It reads
+// Tournament.AdminPassword from the same store the rest of the app uses, so
+// a rotation through PUT /api/auth/admin-password takes effect immediately
+// on the next request (no process restart, unlike the bcrypt env-var path).
+type fileElevatedVerifier struct {
+	store *state.Store
+}
+
+// NewFileElevatedVerifier constructs the file-mode elevated verifier.
+func NewFileElevatedVerifier(store *state.Store) ElevatedVerifier {
+	return &fileElevatedVerifier{store: store}
+}
+
+// adminPassword loads the current on-disk elevated password, or "" if no
+// tournament exists yet. Errors propagate so the middleware can 500 rather
+// than fail open.
+func (v *fileElevatedVerifier) adminPassword() (string, error) {
+	t, err := v.store.LoadTournament()
+	if err != nil {
+		return "", err
+	}
+	if t == nil {
+		return "", nil
+	}
+	return t.AdminPassword, nil
+}
+
+// GateActive: in file mode the gate is opt-in — it activates only once the
+// operator has set an admin password. A load error is treated as
+// "active" so a transient store failure fails closed (the subsequent
+// Verify will surface the error and the middleware 500s) rather than
+// silently disabling the gate.
+func (v *fileElevatedVerifier) GateActive() bool {
+	pw, err := v.adminPassword()
+	if err != nil {
+		return true
+	}
+	return pw != ""
+}
+
+// Configured mirrors GateActive in file mode: the same on-disk field both
+// activates the gate and is the credential. A load error reports false so
+// the middleware's Configured() branch doesn't 503 on a transient error —
+// the error is surfaced by Verify instead.
+func (v *fileElevatedVerifier) Configured() bool {
+	pw, err := v.adminPassword()
+	if err != nil {
+		return false
+	}
+	return pw != ""
+}
+
+// Verify does an exact-string compare against the stored admin password.
+// An empty presented value never matches a non-empty stored password; the
+// middleware's GateActive() short-circuit means this is never reached when
+// the stored password is empty, so there is no empty-vs-empty vacuous match.
+func (v *fileElevatedVerifier) Verify(presented string) (bool, error) {
+	stored, err := v.adminPassword()
+	if err != nil {
+		return false, err
+	}
+	if stored == "" {
+		return false, nil
+	}
+	return presented == stored, nil
+}
+
+func (v *fileElevatedVerifier) Mode() string { return "file" }
+
+// bcryptElevatedVerifier implements ElevatedVerifier for locked mode when a
+// valid TOURNAMENT_ADMIN_PASSWORD_HASH is present. It reuses the exact
+// hardening proven in bcryptPasswordVerifier (auth_source.go): an empty or
+// oversized presented value is a non-match (never a 500), and only genuine
+// bcrypt mismatch/too-long errors are folded into "wrong credential".
+type bcryptElevatedVerifier struct {
+	hash []byte
+}
+
+// NewBcryptElevatedVerifier validates `hash` as a bcrypt-encoded password
+// hash and returns a configured locked-mode verifier. An empty hash is
+// rejected with a distinct error so the caller can fall back to the
+// unconfigured verifier (which 503s on use) rather than failing startup —
+// a locked deployment that never performs destructive ops shouldn't be
+// forced to set this env var just to boot.
+func NewBcryptElevatedVerifier(hash string) (ElevatedVerifier, error) {
+	if hash == "" {
+		return nil, errors.New("TOURNAMENT_ADMIN_PASSWORD_HASH is empty")
+	}
+	b := []byte(hash)
+	if _, err := bcrypt.Cost(b); err != nil {
+		return nil, fmt.Errorf("TOURNAMENT_ADMIN_PASSWORD_HASH is not a valid bcrypt hash: %w", err)
+	}
+	return &bcryptElevatedVerifier{hash: b}, nil
+}
+
+func (v *bcryptElevatedVerifier) GateActive() bool { return true }
+func (v *bcryptElevatedVerifier) Configured() bool { return true }
+
+func (v *bcryptElevatedVerifier) Verify(presented string) (bool, error) {
+	if presented == "" {
+		return false, nil
+	}
+	// Pre-check length so an oversized header can't trip a 500 (and thus a
+	// differential-error oracle) — identical rationale to
+	// bcryptPasswordVerifier.Verify, bcryptMaxInputBytes defined there.
+	if len(presented) > bcryptMaxInputBytes {
+		return false, nil
+	}
+	err := bcrypt.CompareHashAndPassword(v.hash, []byte(presented))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) || errors.Is(err, bcrypt.ErrPasswordTooLong) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (v *bcryptElevatedVerifier) Mode() string { return "locked" }
+
+// lockedUnconfiguredElevatedVerifier represents locked mode with no (or an
+// invalid) TOURNAMENT_ADMIN_PASSWORD_HASH. The gate is active (locked mode
+// fails closed) but there is no credential, so the middleware returns 503
+// "admin password not configured" on any gated endpoint. Routine
+// (non-gated) endpoints are unaffected.
+type lockedUnconfiguredElevatedVerifier struct{}
+
+// NewLockedUnconfiguredElevatedVerifier constructs the fail-closed locked
+// verifier used when the elevated env-var hash is absent or malformed.
+func NewLockedUnconfiguredElevatedVerifier() ElevatedVerifier {
+	return &lockedUnconfiguredElevatedVerifier{}
+}
+
+func (v *lockedUnconfiguredElevatedVerifier) GateActive() bool { return true }
+func (v *lockedUnconfiguredElevatedVerifier) Configured() bool { return false }
+
+// Verify should never be reached (the middleware checks Configured() first)
+// but returns a non-match defensively so a future caller can't fail open.
+func (v *lockedUnconfiguredElevatedVerifier) Verify(string) (bool, error) {
+	return false, nil
+}
+
+func (v *lockedUnconfiguredElevatedVerifier) Mode() string { return "locked" }

--- a/internal/mobileapp/auth_admin_test.go
+++ b/internal/mobileapp/auth_admin_test.go
@@ -1,0 +1,189 @@
+package mobileapp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// setAdminPassword writes an admin password onto the stored tournament so
+// the file-mode elevated verifier has something to compare against. Creates
+// the tournament record if needed.
+func setAdminPassword(t *testing.T, store *state.Store, admin string) {
+	t.Helper()
+	_, err := store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
+		if current != nil {
+			*desired = *current
+		} else {
+			desired.Name = "Test"
+			desired.Password = "main"
+		}
+		desired.AdminPassword = admin
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestFileElevatedVerifier_GateInactiveWhenUnset(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	v := NewFileElevatedVerifier(store)
+	assert.Equal(t, "file", v.Mode())
+	// No tournament / no admin password → gate inactive, not configured.
+	assert.False(t, v.GateActive())
+	assert.False(t, v.Configured())
+}
+
+func TestFileElevatedVerifier_SetActivatesGate(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	v := NewFileElevatedVerifier(store)
+	setAdminPassword(t, store, "secret-admin")
+
+	assert.True(t, v.GateActive())
+	assert.True(t, v.Configured())
+
+	t.Run("matching → true", func(t *testing.T) {
+		ok, err := v.Verify("secret-admin")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("wrong → false", func(t *testing.T) {
+		ok, err := v.Verify("nope")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("empty presented against non-empty stored → false", func(t *testing.T) {
+		ok, err := v.Verify("")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}
+
+func TestBcryptElevatedVerifier(t *testing.T) {
+	plain := "elevated-secret"
+	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.MinCost)
+	require.NoError(t, err)
+	v, err := NewBcryptElevatedVerifier(string(hash))
+	require.NoError(t, err)
+
+	assert.Equal(t, "locked", v.Mode())
+	assert.True(t, v.GateActive())
+	assert.True(t, v.Configured())
+
+	t.Run("matching → true", func(t *testing.T) {
+		ok, err := v.Verify(plain)
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+	t.Run("wrong → false", func(t *testing.T) {
+		ok, err := v.Verify("nope")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("empty → false (short-circuit)", func(t *testing.T) {
+		ok, err := v.Verify("")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+	// Hardening parity with bcryptPasswordVerifier: oversized input must not
+	// 500 (which would be a locked-vs-file differential oracle).
+	t.Run("oversize (>72 bytes) → false (no error)", func(t *testing.T) {
+		ok, err := v.Verify(strings.Repeat("x", 100))
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}
+
+func TestNewBcryptElevatedVerifier_EmptyAndInvalid(t *testing.T) {
+	_, err := NewBcryptElevatedVerifier("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+
+	_, err = NewBcryptElevatedVerifier("not-a-bcrypt-hash")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "valid bcrypt hash")
+}
+
+func TestLockedUnconfiguredElevatedVerifier(t *testing.T) {
+	v := NewLockedUnconfiguredElevatedVerifier()
+	assert.Equal(t, "locked", v.Mode())
+	// Gate active (fail-closed) but no credential → middleware must 503.
+	assert.True(t, v.GateActive())
+	assert.False(t, v.Configured())
+	ok, err := v.Verify("anything")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// --- middleware behavior ---
+
+// elevatedTestRouter mounts a single gated GET behind RequireElevatedPassword
+// so the three outcome paths can be exercised without the full admin stack.
+func elevatedTestRouter(ev ElevatedVerifier) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/gated", RequireElevatedPassword(ev), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	return r
+}
+
+func doGated(r *gin.Engine, adminHeader string, setHeader bool) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/gated", nil)
+	if setHeader {
+		req.Header.Set("X-Admin-Password", adminHeader)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestRequireElevatedPassword_GateInactivePassesThrough(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	// file mode, no admin password → gate inactive → request passes with no header.
+	r := elevatedTestRouter(NewFileElevatedVerifier(store))
+	w := doGated(r, "", false)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRequireElevatedPassword_FileMode(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	setAdminPassword(t, store, "the-admin-pw")
+	r := elevatedTestRouter(NewFileElevatedVerifier(store))
+
+	t.Run("missing header → 401", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, doGated(r, "", false).Code)
+	})
+	t.Run("wrong header → 401", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, doGated(r, "wrong", true).Code)
+	})
+	t.Run("correct header → 200", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, doGated(r, "the-admin-pw", true).Code)
+	})
+}
+
+func TestRequireElevatedPassword_LockedUnconfigured503(t *testing.T) {
+	r := elevatedTestRouter(NewLockedUnconfiguredElevatedVerifier())
+	// Even a (wrong or right-looking) header can't help — no credential exists.
+	w := doGated(r, "anything", true)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "not configured")
+}
+
+func TestRequireElevatedPassword_LockedConfigured(t *testing.T) {
+	plain := "locked-elevated"
+	hash, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.MinCost)
+	require.NoError(t, err)
+	ev, err := NewBcryptElevatedVerifier(string(hash))
+	require.NoError(t, err)
+	r := elevatedTestRouter(ev)
+
+	assert.Equal(t, http.StatusUnauthorized, doGated(r, "wrong", true).Code)
+	assert.Equal(t, http.StatusOK, doGated(r, plain, true).Code)
+}

--- a/internal/mobileapp/handlers_auth_admin.go
+++ b/internal/mobileapp/handlers_auth_admin.go
@@ -1,0 +1,120 @@
+package mobileapp
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// adminPasswordRequest is the body shape for PUT /api/auth/admin-password.
+//
+//   - NewPassword is the elevated password to store (required, non-empty).
+//   - CurrentPassword is required ONLY when an admin password is already set
+//     (rotation): it must equal the stored value so a main-password holder
+//     cannot silently re-set the elevated secret (spec 004 Finding 2). On
+//     first-time set (TOFU) it is ignored.
+//
+// Neither value is ever echoed back — the elevated password is write-only at
+// the API boundary (Tournament.AdminPassword has json:"-").
+type adminPasswordRequest struct {
+	NewPassword     string `json:"newPassword"`
+	CurrentPassword string `json:"currentPassword,omitempty"`
+}
+
+// RegisterAdminPasswordHandler wires PUT /api/auth/admin-password — the only
+// way to set or rotate the file-mode elevated password (spec 004 §6a). It is
+// registered inside the admin group, so AuthMiddleware has already verified
+// the MAIN password before this runs.
+//
+// Gating:
+//   - locked mode → 404. The elevated credential is the env-var bcrypt hash
+//     (TOURNAMENT_ADMIN_PASSWORD_HASH); it is not settable via the API. The
+//     404 (not 405/403) matches the "route doesn't exist in this mode" shape
+//     used by the password-reset endpoint.
+//   - file mode, no admin password set yet → trust-on-first-use: the main
+//     password (already verified) authorizes the initial set.
+//   - file mode, admin password already set → rotation requires the correct
+//     CurrentPassword (verified via the ElevatedVerifier) in addition to the
+//     main password.
+func RegisterAdminPasswordHandler(r *gin.RouterGroup, store *state.Store, ev ElevatedVerifier) {
+	r.PUT("/auth/admin-password", func(c *gin.Context) {
+		// Locked mode: not settable via API. ev.Mode() == "locked" for both
+		// the configured (bcrypt) and unconfigured locked verifiers.
+		if ev.Mode() == "locked" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "admin password is controlled by TOURNAMENT_ADMIN_PASSWORD_HASH and is not settable via the API"})
+			return
+		}
+
+		var req adminPasswordRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		// NewPassword is NOT trimmed (passwords may legitimately contain
+		// whitespace; the auth comparison is exact-string match — same
+		// policy as the main password).
+		if req.NewPassword == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "newPassword is required"})
+			return
+		}
+		if err := validateMaxLen("newPassword", req.NewPassword, MaxLenTournamentPassword); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := validateMaxLen("currentPassword", req.CurrentPassword, MaxLenTournamentPassword); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		// A tournament record must exist before an admin password can be
+		// attached to it — otherwise the set would land on a non-existent
+		// record (and the bulk PUT/POST guards require a name anyway).
+		t, err := store.LoadTournament()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if t == nil {
+			c.JSON(http.StatusConflict, gin.H{"error": "tournament not configured yet"})
+			return
+		}
+
+		// Rotation gate: if an admin password is already set, the caller
+		// must prove possession of the current one. GateActive() is true in
+		// file mode exactly when AdminPassword != "". Verify reads the
+		// current stored value, so this is the canonical "old password"
+		// check. First-time set (GateActive() == false) skips it (TOFU).
+		if ev.GateActive() {
+			ok, verr := ev.Verify(req.CurrentPassword)
+			if verr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "admin auth verification failed"})
+				return
+			}
+			if !ok {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "current admin password is incorrect"})
+				return
+			}
+		}
+
+		// Persist under the store's write lock. The desired struct's other
+		// fields are irrelevant — the transform copies everything from the
+		// current record forward and changes only AdminPassword, so a
+		// concurrent bulk PUT can't be clobbered by a stale desired here.
+		_, err = store.UpdateTournamentChanged(t, func(current, desired *state.Tournament) error {
+			if current != nil {
+				*desired = *current
+			}
+			desired.AdminPassword = req.NewPassword
+			return nil
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		// Write-only: never echo the value. Report only the resulting state.
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "elevatedConfigured": true})
+	})
+}

--- a/internal/mobileapp/handlers_auth_admin_test.go
+++ b/internal/mobileapp/handlers_auth_admin_test.go
@@ -1,0 +1,247 @@
+package mobileapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// elevatedHandlerRouter mounts the tournament + admin-password + auth-config
+// handlers for a given verifier. No AuthMiddleware — the main-password gate
+// is orthogonal to the elevated-password logic under test here.
+func elevatedHandlerRouter(t *testing.T, store *state.Store, verifier PasswordVerifier) (*gin.Engine, ElevatedVerifier) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	hub := NewHub()
+	ev := defaultElevatedVerifier(verifier, store)
+	api := r.Group("/api")
+	RegisterTournamentHandlers(api, store, hub, verifier)
+	RegisterAdminPasswordHandler(api, store, ev)
+	RegisterAuthConfigHandlers(api, verifier, ev)
+	return r, ev
+}
+
+func seedTournament(t *testing.T, store *state.Store) {
+	t.Helper()
+	_, err := store.SaveTournamentChanged(&state.Tournament{
+		Name: "Seeded", Date: "01-01-2026", Venue: "Hall", Courts: []string{"A"}, Password: "main",
+	})
+	require.NoError(t, err)
+}
+
+func putAdminPassword(r *gin.Engine, body map[string]string) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPut, "/api/auth/admin-password", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestAdminPasswordEndpoint_TOFUThenRotate(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	seedTournament(t, store)
+	r, ev := elevatedHandlerRouter(t, store, NewFileVerifier(store))
+
+	// First-time set: no current password needed (gate inactive).
+	require.False(t, ev.GateActive())
+	w := putAdminPassword(r, map[string]string{"newPassword": "first-admin"})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, ev.GateActive(), "gate should activate after first set")
+
+	// Rotation without the current password → 401.
+	w = putAdminPassword(r, map[string]string{"newPassword": "second-admin"})
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Rotation with wrong current password → 401.
+	w = putAdminPassword(r, map[string]string{"newPassword": "second-admin", "currentPassword": "wrong"})
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Rotation with correct current password → 200, new value takes effect.
+	w = putAdminPassword(r, map[string]string{"newPassword": "second-admin", "currentPassword": "first-admin"})
+	assert.Equal(t, http.StatusOK, w.Code)
+	ok, err := ev.Verify("second-admin")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	ok, _ = ev.Verify("first-admin")
+	assert.False(t, ok, "old admin password must no longer verify")
+}
+
+func TestAdminPasswordEndpoint_EmptyNewPasswordRejected(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	seedTournament(t, store)
+	r, _ := elevatedHandlerRouter(t, store, NewFileVerifier(store))
+	w := putAdminPassword(r, map[string]string{"newPassword": ""})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestAdminPasswordEndpoint_NoTournament409(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	r, _ := elevatedHandlerRouter(t, store, NewFileVerifier(store))
+	w := putAdminPassword(r, map[string]string{"newPassword": "x"})
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// Finding 1 regression: GET /tournament must NEVER expose the elevated
+// password, even in file mode where the main password IS returned.
+func TestTournamentGet_NeverLeaksAdminPassword(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	seedTournament(t, store)
+	setAdminPassword(t, store, "super-secret-admin")
+	r, _ := elevatedHandlerRouter(t, store, NewFileVerifier(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.NotContains(t, body, "super-secret-admin", "admin password leaked in GET /tournament")
+	assert.NotContains(t, body, "adminPassword")
+	assert.NotContains(t, body, "admin_password")
+}
+
+// Finding 2 regression: PUT /tournament (main-password gate) must NOT be able
+// to set or overwrite the elevated password, and a routine settings save must
+// preserve the existing one.
+func TestTournamentPut_CannotSetOrWipeAdminPassword(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	seedTournament(t, store)
+	setAdminPassword(t, store, "original-admin")
+	r, ev := elevatedHandlerRouter(t, store, NewFileVerifier(store))
+
+	// Attacker attempts to overwrite the elevated password via the bulk PUT,
+	// sending both the JSON field name variants.
+	body := []byte(`{"name":"Renamed","date":"01-01-2026","venue":"Hall","courts":["A"],"password":"main","adminPassword":"attacker","admin_password":"attacker"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/tournament", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// The elevated password is unchanged: attacker's value does NOT verify,
+	// the original still does (preserve-on-write).
+	ok, err := ev.Verify("attacker")
+	require.NoError(t, err)
+	assert.False(t, ok, "PUT /tournament overwrote the admin password — privilege escalation")
+	ok, err = ev.Verify("original-admin")
+	require.NoError(t, err)
+	assert.True(t, ok, "routine PUT /tournament wiped the admin password")
+
+	// And the rename actually took effect (sanity: the PUT did persist).
+	tn, err := store.LoadTournament()
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed", tn.Name)
+}
+
+func TestAuthConfig_ElevatedBits_FileMode(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	seedTournament(t, store)
+	r, _ := elevatedHandlerRouter(t, store, NewFileVerifier(store))
+
+	get := func() authConfigResponse {
+		req := httptest.NewRequest(http.MethodGet, "/api/auth-config", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp authConfigResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		return resp
+	}
+
+	// Before setting: editable (file mode) but not required/configured.
+	resp := get()
+	assert.Equal(t, "file", resp.Mode)
+	assert.True(t, resp.ElevatedEditable)
+	assert.False(t, resp.ElevatedRequired)
+	assert.False(t, resp.ElevatedConfigured)
+
+	// After setting: required + configured.
+	require.Equal(t, http.StatusOK, putAdminPassword(r, map[string]string{"newPassword": "abc"}).Code)
+	resp = get()
+	assert.True(t, resp.ElevatedRequired)
+	assert.True(t, resp.ElevatedConfigured)
+	assert.True(t, resp.ElevatedEditable)
+}
+
+func TestAdminPasswordEndpoint_LockedMode404(t *testing.T) {
+	store := setupVerifierTestStore(t)
+	seedTournament(t, store)
+	// Build a locked main verifier so defaultElevatedVerifier picks the
+	// locked branch. The env var is unset → unconfigured elevated verifier,
+	// which still reports Mode()=="locked" → endpoint 404s.
+	hash := mustBcrypt(t, "main")
+	mainV, err := NewBcryptVerifier(hash)
+	require.NoError(t, err)
+	r, ev := elevatedHandlerRouter(t, store, mainV)
+	assert.Equal(t, "locked", ev.Mode())
+
+	w := putAdminPassword(r, map[string]string{"newPassword": "x"})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// Regression for the bypass Copilot caught on PR #193: the elevated gate on
+// the dedicated participant endpoints was circumventable via PUT
+// /api/competitions/:id, which persists the roster (SaveParticipants/SaveSeeds)
+// whenever the body has a non-nil Players field — and that is the SPA's
+// primary roster flow. The bulk PUT must now enforce the same gate, but ONLY
+// when it carries a roster mutation; settings-only PUTs stay single-factor.
+func TestBulkCompetitionPut_RosterMutationIsGated(t *testing.T) {
+	r, store, _, _, dir := setupTestRouter(t)
+	defer os.RemoveAll(dir)
+
+	// Activate the gate (file mode) and create a competition.
+	setAdminPassword(t, store, "destroypw")
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "c1", Name: "C1", Format: "playoffs", Courts: []string{"A"}, Status: state.CompStatusSetup,
+	}))
+
+	putComp := func(body string, admin string, withAdmin bool) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPut, "/api/competitions/c1", bytes.NewReader([]byte(body)))
+		req.Header.Set("Content-Type", "application/json")
+		if withAdmin {
+			req.Header.Set("X-Admin-Password", admin)
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	rosterBody := `{"id":"c1","name":"C1","format":"playoffs","courts":["A"],"players":[{"name":"Alice","dojo":"D"}]}`
+	settingsBody := `{"id":"c1","name":"C1 Renamed","format":"playoffs","courts":["A"]}` // no players field → nil
+
+	t.Run("roster mutation without admin header → 401", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, putComp(rosterBody, "", false).Code)
+	})
+	t.Run("roster mutation with wrong admin header → 401", func(t *testing.T) {
+		assert.Equal(t, http.StatusUnauthorized, putComp(rosterBody, "wrong", true).Code)
+	})
+	t.Run("roster mutation with correct admin header → 200 and persists", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, putComp(rosterBody, "destroypw", true).Code)
+		players, err := store.LoadParticipants("c1", false)
+		require.NoError(t, err)
+		require.Len(t, players, 1)
+		assert.Equal(t, "Alice", players[0].Name)
+	})
+	t.Run("settings-only PUT (no players) is NOT gated", func(t *testing.T) {
+		// No admin header, gate active — must still succeed because the body
+		// carries no roster mutation.
+		assert.Equal(t, http.StatusOK, putComp(settingsBody, "", false).Code)
+	})
+}
+
+func mustBcrypt(t *testing.T, plain string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.MinCost)
+	require.NoError(t, err)
+	return string(h)
+}

--- a/internal/mobileapp/handlers_auth_config.go
+++ b/internal/mobileapp/handlers_auth_config.go
@@ -20,6 +20,22 @@ import (
 type authConfigResponse struct {
 	Mode         string `json:"mode"`
 	ResetEnabled bool   `json:"resetEnabled"`
+
+	// Elevated-password (destructive-ops) bits — spec 004 / mp-e21. The SPA
+	// reads these on mount to decide whether to prompt for X-Admin-Password
+	// before a destructive action and whether the Settings field is editable.
+	//
+	//   ElevatedRequired   — is the gate active? (file: admin pw set;
+	//                         locked: always true). When false, destructive
+	//                         ops need only the main password.
+	//   ElevatedConfigured — does a credential exist? (file: admin pw set;
+	//                         locked: env hash present). When required but
+	//                         not configured, gated endpoints return 503.
+	//   ElevatedEditable   — can the admin password be set via the API?
+	//                         file mode true; locked mode false (env-var).
+	ElevatedRequired   bool `json:"elevatedRequired"`
+	ElevatedConfigured bool `json:"elevatedConfigured"`
+	ElevatedEditable   bool `json:"elevatedEditable"`
 }
 
 // RegisterAuthConfigHandlers wires GET /api/auth-config. The endpoint is
@@ -32,11 +48,16 @@ type authConfigResponse struct {
 // inferable from any 404 on /api/tournament/reset. Exposing it
 // explicitly lets the SPA branch up-front rather than relying on a
 // 404-probe race during form rendering.
-func RegisterAuthConfigHandlers(r *gin.RouterGroup, verifier PasswordVerifier) {
+func RegisterAuthConfigHandlers(r *gin.RouterGroup, verifier PasswordVerifier, elevated ElevatedVerifier) {
 	r.GET("/auth-config", func(c *gin.Context) {
 		c.JSON(http.StatusOK, authConfigResponse{
-			Mode:         verifier.Mode(),
-			ResetEnabled: verifier.ResetEnabled(),
+			Mode:               verifier.Mode(),
+			ResetEnabled:       verifier.ResetEnabled(),
+			ElevatedRequired:   elevated.GateActive(),
+			ElevatedConfigured: elevated.Configured(),
+			// Editable only in file mode — the locked-mode credential is the
+			// TOURNAMENT_ADMIN_PASSWORD_HASH env var, not settable via API.
+			ElevatedEditable: elevated.Mode() == "file",
 		})
 	})
 }

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -188,7 +188,7 @@ func checkUniqueCompName(store *state.Store, name, excludeID string) error {
 	return nil
 }
 
-func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.Engine, hub *Hub) {
+func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.Engine, hub *Hub, elevated ElevatedVerifier) {
 	r.GET("/competitions", func(c *gin.Context) {
 		ids, err := store.ListCompetitions()
 		if err != nil {
@@ -414,6 +414,20 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		comp.ID = id // ensure ID matches URL (also for empty-body case)
+
+		// Elevated-password gate for the ROSTER-mutation path (spec 004 /
+		// mp-e21; Copilot PR #193). This handler doubles as a roster writer:
+		// a non-nil Players field below triggers SaveParticipants/SaveSeeds.
+		// That is the SPA's PRIMARY roster flow (paste/import, seed edits via
+		// API.updateCompetition), so gating only the dedicated
+		// POST/PUT /participants endpoints would leave the gate bypassable.
+		// Route-level middleware can't see Players (it runs before binding),
+		// so enforce inline now that the body is decoded. Settings-only PUTs
+		// (Players == nil) are unaffected and stay single-factor.
+		if comp.Players != nil && !enforceElevated(c, elevated) {
+			return
+		}
+
 		comp.Name = strings.TrimSpace(comp.Name)
 		// See POST handler comment — same trim is needed here so the
 		// SETTINGS edit path can't persist whitespace-padded prefixes.
@@ -827,7 +841,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.JSON(http.StatusOK, updated)
 	})
 
-	r.DELETE("/competitions/:id", func(c *gin.Context) {
+	r.DELETE("/competitions/:id", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return
@@ -851,7 +865,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.Status(http.StatusNoContent)
 	})
 
-	r.POST("/competitions/:id/invalidate", func(c *gin.Context) {
+	r.POST("/competitions/:id/invalidate", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return
@@ -974,7 +988,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.JSON(http.StatusOK, comp)
 	})
 
-	r.DELETE("/competitions/:id/draw", func(c *gin.Context) {
+	r.DELETE("/competitions/:id/draw", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return
@@ -1252,7 +1266,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.JSON(http.StatusCreated, playoff)
 	})
 
-	r.DELETE("/competitions/:id/overrides", func(c *gin.Context) {
+	r.DELETE("/competitions/:id/overrides", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return

--- a/internal/mobileapp/handlers_import.go
+++ b/internal/mobileapp/handlers_import.go
@@ -53,8 +53,8 @@ type ImportResult struct {
 	Error            string `json:"error,omitempty"`
 }
 
-func RegisterImportHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
-	r.POST("/tournament/import", func(c *gin.Context) {
+func RegisterImportHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub, elevated ElevatedVerifier) {
+	r.POST("/tournament/import", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		if err := c.Request.ParseMultipartForm(64 << 20); err != nil { // 64 MB limit
 			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse multipart form: " + err.Error()})
 			return

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
-func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Broadcaster) {
+func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Broadcaster, elevated ElevatedVerifier) {
 	r.GET("/competitions/:id/participants", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
@@ -31,7 +31,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		c.JSON(http.StatusOK, players)
 	})
 
-	r.POST("/competitions/:id/participants", func(c *gin.Context) {
+	r.POST("/competitions/:id/participants", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return
@@ -219,7 +219,7 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, hub Bro
 		c.JSON(http.StatusOK, saved)
 	})
 
-	r.PUT("/competitions/:id/participants/:pid", func(c *gin.Context) {
+	r.PUT("/competitions/:id/participants/:pid", RequireElevatedPassword(elevated), func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
 			return

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -580,7 +580,7 @@ func TestBulkCheckIn_BroadcastBehaviour(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	admin := r.Group("/api")
-	RegisterParticipantHandlers(admin, store, spy)
+	RegisterParticipantHandlers(admin, store, spy, NewFileElevatedVerifier(store))
 
 	compID := "comp-broadcast-test"
 	require.NoError(t, store.SaveCompetition(&state.Competition{

--- a/internal/mobileapp/handlers_reset_test.go
+++ b/internal/mobileapp/handlers_reset_test.go
@@ -37,7 +37,7 @@ func setupResetTest(t *testing.T, verifier PasswordVerifier) (*state.Store, *gin
 	r := gin.New()
 	api := r.Group("/api")
 	RegisterResetHandlers(api, store, verifier, hub)
-	RegisterAuthConfigHandlers(api, verifier)
+	RegisterAuthConfigHandlers(api, verifier, defaultElevatedVerifier(verifier, store))
 
 	return store, r, hub
 }

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -47,9 +47,9 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *state.Store, *engine.Engine, *
 	// Admin API
 	admin := r.Group("/api")
 	RegisterTournamentHandlers(admin, store, hub, NewFileVerifier(store))
-	RegisterImportHandlers(admin, store, hub)
-	RegisterCompetitionHandlers(admin, store, eng, hub)
-	RegisterParticipantHandlers(admin, store, hub)
+	RegisterImportHandlers(admin, store, hub, NewFileElevatedVerifier(store))
+	RegisterCompetitionHandlers(admin, store, eng, hub, NewFileElevatedVerifier(store))
+	RegisterParticipantHandlers(admin, store, hub, NewFileElevatedVerifier(store))
 	RegisterMatchHandlers(admin, eng, store, store, hub)
 	RegisterDecisionHandlers(admin, eng, store, store, hub)
 	RegisterEligibilityHandlers(admin, store, hub)

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -288,6 +288,14 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		// immediately instead of waiting for their next write to 401.
 		passwordChanged := false
 		changed, err := store.UpdateTournamentChanged(&t, func(current, desired *state.Tournament) error {
+			// Preserve the write-only elevated password (spec 004). It has
+			// json:"-", so the bound body always leaves desired.AdminPassword
+			// == "" — without copying it forward, a routine name/venue save
+			// would silently wipe the elevated credential. It is changed only
+			// via PUT /api/auth/admin-password, never here.
+			if current != nil {
+				desired.AdminPassword = current.AdminPassword
+			}
 			if locked {
 				// Reset passwordChanged to false defensively — the
 				// non-empty case is already rejected above, but keep
@@ -442,6 +450,15 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		} else if t.Password == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "tournament password is required"})
 			return
+		}
+
+		// Preserve the write-only elevated password (spec 004) across a
+		// re-bootstrap POST. It has json:"-" so the bound body never carries
+		// it; without this a re-POST over an existing record would wipe the
+		// elevated credential. On a true first bootstrap (existingForPost ==
+		// nil) it stays "" — the operator sets it later via Settings.
+		if existingForPost != nil {
+			t.AdminPassword = existingForPost.AdminPassword
 		}
 
 		if _, err := store.SaveTournamentChanged(&t); err != nil {

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -125,6 +125,70 @@ func requireValidCompID(c *gin.Context) (string, bool) {
 	return id, true
 }
 
+// RequireElevatedPassword gates destructive operations behind a SECOND
+// password supplied in the X-Admin-Password header (spec 004 / mp-e21). It
+// is layered on top of AuthMiddleware — the route group already verified the
+// main password, so this only adds the second factor. Attach it per-route to
+// the gated subset (competition delete / invalidate / draw / overrides,
+// participant roster mutations, CSV import) rather than to the whole group,
+// since most admin routes stay single-factor.
+//
+// Three outcomes, driven by the ElevatedVerifier contract:
+//
+//   - GateActive() == false  → c.Next(). File mode with no admin password
+//     set: the feature is opt-in, so destructive ops behave exactly as
+//     before (main password only). This is the back-compat path.
+//   - Configured() == false  → 503. Locked mode with no/invalid
+//     TOURNAMENT_ADMIN_PASSWORD_HASH: fail closed rather than silently
+//     allowing destructive ops with the main password alone.
+//   - otherwise               → Verify(X-Admin-Password); 401 on mismatch.
+//
+// Per the product decision (re-prompt every time) there is no elevation
+// token or session — the password travels on each gated request.
+func RequireElevatedPassword(ev ElevatedVerifier) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !enforceElevated(c, ev) {
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// enforceElevated runs the elevated-password gate decision and returns true
+// when the request may proceed. On a blocked request it writes the
+// appropriate response (503 unconfigured / 401 wrong / 500 verify-error) and
+// returns false — the caller must stop (Abort in middleware, or `return` in a
+// handler).
+//
+// It exists as a standalone function — not just the middleware closure —
+// because some gated mutations can't be caught by route-level middleware:
+// PUT /api/competitions/:id persists the roster (SaveParticipants/SaveSeeds)
+// only when the bound body has a non-nil Players field, so its gate must run
+// INSIDE the handler after binding. Sharing this one decision keeps the
+// inline check and the middleware byte-for-byte identical (same status codes,
+// same fail-closed semantics) — Copilot PR #193 caught that gating only the
+// dedicated participant endpoints left the bulk-PUT roster path open.
+func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
+	if !ev.GateActive() {
+		return true
+	}
+	if !ev.Configured() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "admin password not configured"})
+		return false
+	}
+	ok, err := ev.Verify(c.GetHeader("X-Admin-Password"))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "admin auth verification failed"})
+		return false
+	}
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid admin password"})
+		return false
+	}
+	return true
+}
+
 // AuthMiddleware gates admin endpoints behind the X-Tournament-Password
 // header. The actual credential check is delegated to the PasswordVerifier
 // so file-based and locked (bcrypt-env-var) modes share a single middleware.

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -3,7 +3,9 @@ package mobileapp
 import (
 	"io/fs"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -12,6 +14,31 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/resources"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
+
+// AdminPasswordHashEnv is the env var holding the bcrypt hash of the
+// elevated (destructive-ops) password in locked mode (spec 004 / mp-e21).
+// It is the elevated-credential analogue of TOURNAMENT_PASSWORD_HASH.
+const AdminPasswordHashEnv = "TOURNAMENT_ADMIN_PASSWORD_HASH"
+
+// defaultElevatedVerifier derives the elevated-password verifier from the
+// main verifier's mode (spec 004). File mode reads the write-only
+// Tournament.AdminPassword from the store (no env var); locked mode reads
+// the bcrypt hash from TOURNAMENT_ADMIN_PASSWORD_HASH, falling back to the
+// fail-closed unconfigured verifier (503 on gated endpoints) when the env
+// var is absent or malformed. Reading the env here — rather than threading
+// an explicit param through NewRouter — keeps the router signature stable
+// for the many existing callers; file-mode tests never touch the env.
+func defaultElevatedVerifier(verifier PasswordVerifier, store *state.Store) ElevatedVerifier {
+	if verifier != nil && verifier.Mode() == "locked" {
+		if v, err := NewBcryptElevatedVerifier(os.Getenv(AdminPasswordHashEnv)); err == nil {
+			return v
+		}
+		slog.Warn("mobile-app: locked mode without a valid " + AdminPasswordHashEnv +
+			"; destructive operations will return 503 until it is set")
+		return NewLockedUnconfiguredElevatedVerifier()
+	}
+	return NewFileElevatedVerifier(store)
+}
 
 // NewRouter wires the mobile-app gin engine. The returned *gin.Engine
 // is the HTTP handler; the returned *Hub is exposed so the caller
@@ -34,11 +61,15 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 		verifier = NewFileVerifier(store)
 	}
 
+	// Elevated (destructive-ops) password verifier — spec 004 / mp-e21.
+	// Derived from the main verifier's mode; see defaultElevatedVerifier.
+	elevated := defaultElevatedVerifier(verifier, store)
+
 	// Enable CORS
 	r.Use(func(c *gin.Context) {
 		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-Tournament-Password")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-Tournament-Password, X-Admin-Password")
 
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(204)
@@ -92,7 +123,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	// inert payloads when locked mode is active — see handlers_reset.go
 	// and handlers_auth_config.go.
 	RegisterResetHandlers(api, store, verifier, hub)
-	RegisterAuthConfigHandlers(api, verifier)
+	RegisterAuthConfigHandlers(api, verifier, elevated)
 
 	// Admin API endpoints (protected). Split into three sub-groups by
 	// expected body size so the body cap fires BEFORE AuthMiddleware at
@@ -109,8 +140,9 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 
 	adminSmallBody := adminGroup(r, DefaultMaxBodyBytes, verifier, store)
 	RegisterTournamentHandlers(adminSmallBody, store, hub, verifier)
-	RegisterCompetitionHandlers(adminSmallBody, store, eng, hub)
-	RegisterParticipantHandlers(adminSmallBody, store, hub)
+	RegisterAdminPasswordHandler(adminSmallBody, store, elevated)
+	RegisterCompetitionHandlers(adminSmallBody, store, eng, hub, elevated)
+	RegisterParticipantHandlers(adminSmallBody, store, hub, elevated)
 	RegisterMatchHandlers(adminSmallBody, eng, store, store, hub)
 	RegisterDecisionHandlers(adminSmallBody, eng, store, store, hub)
 	RegisterEligibilityHandlers(adminSmallBody, store, hub)
@@ -120,7 +152,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	RegisterSwissHandlers(adminSmallBody, store, eng, hub)
 
 	adminLargeBody := adminGroup(r, MaxImportBodyBytes, verifier, store)
-	RegisterImportHandlers(adminLargeBody, store, hub)
+	RegisterImportHandlers(adminLargeBody, store, hub, elevated)
 
 	// Static files & SPA Fallback
 	mobileFS := res.GetMobileWebFS()

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -14,6 +14,23 @@ type Tournament struct {
 	Courts   []string `yaml:"courts" json:"courts"`
 	Password string   `yaml:"password" json:"password"`
 
+	// AdminPassword gates destructive operations (spec 004 / mp-e21):
+	// competition delete, draw/override/invalidate, and participant roster
+	// mutations. It is a SEPARATE, higher-privilege credential from
+	// Password (which gates the API as a whole).
+	//
+	// CRITICAL: it is WRITE-ONLY at the API boundary — `json:"-"` means it
+	// is never emitted in any response AND never populated by binding a
+	// request body into a Tournament. That is the opposite of Password
+	// (which is a peer of the credential gating /tournament, so returning
+	// it is harmless). AdminPassword is HIGHER privilege than that gate, so
+	// leaking it via GET — or letting a main-password holder overwrite it
+	// via the bulk PUT — would collapse the separation. It is set only via
+	// the dedicated, elevated-gated PUT /api/auth/admin-password handler.
+	// File mode only; in locked mode the env-var bcrypt hash is
+	// authoritative and any on-disk value here is inert.
+	AdminPassword string `yaml:"admin_password,omitempty" json:"-"`
+
 	// Ceremony blocks expressed as human duration strings (e.g. "30m",
 	// "1h"). When set, the auto-scheduler reserves a contiguous range
 	// at the appropriate point in the day and skips match slots that

--- a/specs/004-elevated-password/spec.md
+++ b/specs/004-elevated-password/spec.md
@@ -1,0 +1,364 @@
+# Spec 004 — Elevated (second) password for destructive operations
+
+**Issue:** mp-e21
+**Status:** Draft — awaiting approval before implementation
+**Author:** Claude (Opus 4.8) with Ricardo Oliveira
+**Date:** 2026-05-29
+
+---
+
+## 0. Revision history
+
+- **v2 (2026-05-29, post critical-thinking review)** — fixed two fatal flaws in v1:
+  1. v1 said to store/return `adminPassword` mirroring `Password`. That would have
+     **leaked** the elevated password via `GET /tournament` and **allowed
+     overwrite** via `PUT /tournament` — both gated only by the main password,
+     defeating the feature. v2 makes the field **write-only** (`json:"-"`, §6) and
+     moves setting it to a **dedicated elevated-gated endpoint** (§6a).
+  2. Added an explicit **threat model** (§1a) — this is an insider speed bump, not
+     a network control; over HTTP both secrets are sniffable.
+
+## 1. Problem
+
+Today the mobile app has a single admin credential, resolved at startup by one
+`PasswordVerifier` ([internal/mobileapp/auth_source.go](../../internal/mobileapp/auth_source.go)):
+
+- **file mode** (default) — plaintext compare against `password:` in `tournament.md`.
+- **locked mode** (`--lock-password` + `TOURNAMENT_PASSWORD_HASH`) — bcrypt compare.
+
+Any operator who knows the admin password can perform *every* action, including
+irreversible ones (deleting a competition, wiping a generated draw, rewriting the
+participant roster). During a live event the admin password is often shared with
+table staff. The operator wants a **second, separately-held password** that gates
+only the genuinely destructive operations, so routine staff can score matches and
+manage check-in without being able to destroy data.
+
+## 1a. Threat model (what this does and does NOT defend)
+
+State this in the operator docs so the feature is not over-trusted.
+
+**Defends against:** an *insider* who legitimately holds the shared main password
+(table/scoring staff) but is not entrusted with the elevated password — accidental
+or unauthorized deletion of competitions, draws, overrides, and roster edits. This
+is the operator's actual stated need.
+
+**Does NOT defend against:**
+- A **network attacker** on an HTTP (non-TLS) deployment — the documented LAN
+  default. Both `X-Tournament-Password` and `X-Admin-Password` travel in cleartext
+  and are sniffable. The second password adds nothing here. Operators wanting a
+  real network boundary must run behind TLS and/or `--lock-password`.
+- Anyone with **filesystem access** to `tournament.md` (file mode) — they read
+  both plaintext passwords directly. The credential boundary is API-level only.
+
+The feature is a **privilege-separation speed bump for shared-credential
+operation**, not a cryptographic access-control system. RBAC / per-user identity
+is explicitly out of scope (§12).
+
+## 2. Decisions (locked with the user — 2026-05-29)
+
+| # | Question | Decision |
+|---|----------|----------|
+| D1 | Which operations are gated? | **Data-destructive ops only** (see §3). |
+| D2 | Session model? | **Re-prompt every time.** No elevation token, no `/auth/elevate` endpoint, no in-memory token store. The password travels in a per-request header. |
+| D3 | Locked-mode storage? | **Separate bcrypt env var** `TOURNAMENT_ADMIN_PASSWORD_HASH`. If unset, gated endpoints return **503**. |
+| D4 | Does the elevated password gate `/api/tournament/reset`? | **No.** That endpoint is the *forgotten-main-password recovery path* — it is intentionally public and already protected by a same-origin check + locked-mode 404. Gating it behind a second password would create a recovery lockout. |
+| D5 | Gate draw/override deletions + invalidate? | **Yes** — they discard generated bracket/pool data. |
+
+### Key correction captured during research
+The bd issue framed "tournament reset" as "wipes all tournament data." That is
+**inaccurate**: `POST /api/tournament/reset`
+([handlers_reset.go](../../internal/mobileapp/handlers_reset.go)) only **rotates the
+admin password** and is the recovery path for a forgotten password. There is **no
+data-wipe endpoint** in the codebase. Per D4 the recovery endpoint is left untouched.
+
+## 3. Scope — gated operations
+
+All gated endpoints already sit behind `AuthMiddleware` (main password). The
+elevated check is an **additional** middleware layered on top, so a gated request
+must present **both** `X-Tournament-Password` **and** `X-Admin-Password`.
+
+**Gated (require `X-Admin-Password`):**
+
+| Method & path | Handler | Why |
+|---|---|---|
+| `DELETE /api/competitions/:id` | handlers_competition.go:830 | Deletes a competition + all its data |
+| `POST /api/competitions/:id/invalidate` | handlers_competition.go:854 | Discards results, returns comp to draft |
+| `DELETE /api/competitions/:id/draw` | handlers_competition.go:1048 | Discards a generated draw |
+| `DELETE /api/competitions/:id/overrides` | handlers_competition.go:1355 | Discards manual rank overrides |
+| `POST /api/competitions/:id/participants` | handlers_participants.go:34 | Roster add / full-list replace |
+| `PUT /api/competitions/:id/participants/:pid` | handlers_participants.go:222 | Roster edit |
+| `PUT /api/competitions/:id` *(when body has non-nil `players`)* | handlers_competition.go:396 | **Bulk roster writer** — persists participants/seeds via `SaveParticipants`/`SaveSeeds`. The SPA's *primary* roster flow (paste/import, seed edits go through `API.updateCompetition`). Gated **inline** (not via route middleware, which runs before the body is bound) using the shared `enforceElevated`. Settings-only PUTs (`players == nil`) stay single-factor. **Added after Copilot caught that gating only the dedicated participant endpoints left this path open (PR #193).** |
+| `POST /api/tournament/import` | handlers_import.go:57 | CSV import — replaces roster wholesale |
+
+> **Why the bulk PUT needs an inline gate, not route middleware.** `RequireElevatedPassword`
+> runs before the handler binds the JSON body, so it can't see whether the request
+> carries a roster (`players`) vs. a settings-only change. The handler therefore calls
+> `enforceElevated(c, elevated)` itself, immediately after binding, only when
+> `comp.Players != nil`. Both paths share the one `enforceElevated` decision so the
+> status codes / fail-closed semantics stay identical.
+>
+> **Seeds:** the dedicated `PUT /api/competitions/:id/seeds` endpoint (which calls only
+> `SaveSeeds`, never the roster file) remains **ungated** per the "seeds are a ranking
+> aid" decision. But the SPA's seed-reorder UI submits the *full roster payload* through
+> `API.updateCompetition`, which rewrites `participants.csv` — so those flows take the
+> roster gate. This is correct: anything that rewrites the roster file is gated; the
+> seed-only endpoint that never touches it is not. The roster file cannot be replaced
+> through any ungated path. (`POST /competitions` rejects an existing ID with 400, so it
+> can only create new competitions, never overwrite an existing roster.)
+
+**NOT gated (routine live-tournament ops — main password only):**
+
+- Check-in toggles: `PUT/DELETE .../checkin`, `POST .../checkin-bulk`
+- Seeds: `PUT /api/competitions/:id/seeds` (ranking aid, not roster membership)
+- Competition lifecycle: `start`, `generate-draw`, `complete`, `playoffs`
+- Match scoring, decisions, lineups, daihyosen, swiss, announcements
+- `POST /api/tournament/reset` (recovery path — see D4)
+- All `GET` / viewer / public endpoints
+
+> **Open confirmation:** there is no `DELETE participant` route today — roster
+> deletion happens via the full-list `POST .../participants` body. Gating the POST
+> covers it.
+
+## 4. Auth core
+
+New file: **`internal/mobileapp/auth_admin.go`**.
+
+```go
+// ElevatedVerifier gates the destructive-op middleware. It is intentionally
+// NARROWER than PasswordVerifier: no bootstrap, no reset semantics, no
+// stored-password redaction policy — those belong to the primary credential.
+type ElevatedVerifier interface {
+    // GateActive reports whether the middleware should enforce at all.
+    //   file mode:   true only when an admin password has been set.
+    //   locked mode: always true (fail-closed).
+    GateActive() bool
+
+    // Configured reports whether a credential exists to compare against.
+    //   file mode:   admin password non-empty (== GateActive there).
+    //   locked mode: TOURNAMENT_ADMIN_PASSWORD_HASH was a valid bcrypt hash.
+    Configured() bool
+
+    // Verify checks the presented X-Admin-Password value.
+    Verify(presented string) (bool, error)
+
+    // Mode mirrors PasswordVerifier.Mode for /auth-config ("file"|"locked").
+    Mode() string
+}
+```
+
+Two implementations, mirroring `auth_source.go`:
+
+- **`fileElevatedVerifier{store}`** — loads `tournament.md`, reads new
+  `AdminPassword` field, plaintext compares. `GateActive()`/`Configured()` ==
+  `AdminPassword != ""`.
+- **`bcryptElevatedVerifier{hash []byte}`** — locked mode, env-var bcrypt. Reuses
+  the exact hardening already proven in `bcryptPasswordVerifier` (length pre-check
+  at `bcryptMaxInputBytes`, `errors.Is` on `ErrMismatchedHashAndPassword` /
+  `ErrPasswordTooLong`, no timing/differential-error leak). `GateActive()` always
+  true. A `bcryptElevatedVerifier` with no/invalid hash is represented by a
+  `lockedUnconfiguredElevatedVerifier` whose `GateActive()==true`,
+  `Configured()==false` → drives the 503 branch.
+
+### Construction ([cmd/mobile_app.go](../../cmd/mobile_app.go))
+- file mode → `NewFileElevatedVerifier(store)`.
+- locked mode → read `TOURNAMENT_ADMIN_PASSWORD_HASH`:
+  - valid bcrypt → `bcryptElevatedVerifier`.
+  - empty/invalid → `lockedUnconfiguredElevatedVerifier` (do **not** fail startup —
+    the operator may not need destructive ops; they get 503 only if they try one).
+    Log a `slog.Warn` so the gap is visible.
+
+## 5. Middleware ([internal/mobileapp/middleware.go](../../internal/mobileapp/middleware.go))
+
+```go
+func RequireElevatedPassword(ev ElevatedVerifier) gin.HandlerFunc {
+    return func(c *gin.Context) {
+        if !ev.GateActive() {          // file mode, no admin pw set → back-compat no-op
+            c.Next(); return
+        }
+        if !ev.Configured() {          // locked mode, env hash unset → fail-closed
+            c.JSON(http.StatusServiceUnavailable,
+                gin.H{"error": "admin password not configured"})
+            c.Abort(); return
+        }
+        ok, err := ev.Verify(c.GetHeader("X-Admin-Password"))
+        if err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": "admin auth verification failed"})
+            c.Abort(); return
+        }
+        if !ok {
+            c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid admin password"})
+            c.Abort(); return
+        }
+        c.Next()
+    }
+}
+```
+
+Runs **after** `AuthMiddleware` (the admin group already ran it). Applied
+per-route, not per-group, because the gated set is a *subset* of `adminSmallBody`.
+Add `X-Admin-Password` to the CORS `Access-Control-Allow-Headers` list in
+server.go.
+
+### Wiring
+Two viable shapes; recommend **(a)** for minimal blast radius:
+
+- **(a) Per-route** — `RegisterCompetitionHandlers` / `RegisterParticipantHandlers`
+  / `RegisterImportHandlers` gain an `elevated ElevatedVerifier` param and attach
+  `RequireElevatedPassword(elevated)` to exactly the gated routes via
+  `group.DELETE(path, RequireElevatedPassword(ev), handler)`.
+- (b) A dedicated sub-group — awkward because gated routes are interleaved with
+  non-gated ones sharing the same `:id` prefix.
+
+## 6. Storage ([internal/state/models.go](../../internal/state/models.go))
+
+> **⚠ Corrected after critical review (see §0).** The elevated password is a
+> *higher* privilege than the main password that gates `/tournament`. It must
+> therefore be **write-only over the API in every mode** — never serialized in a
+> response, never settable through the main-password-gated PUT. This is the
+> opposite of how `Password` is handled, and the difference is the whole point of
+> the feature.
+
+Add to `Tournament`:
+```go
+// AdminPassword gates destructive operations (spec 004). It is WRITE-ONLY at
+// the API boundary: `json:"-"` guarantees it is never emitted in any response
+// AND never populated by binding a request body into a Tournament — so it
+// cannot be read or overwritten through the main-password-gated /tournament
+// endpoints. It is set only via the dedicated, elevated-gated endpoint in §6a.
+// Persisted to tournament.md via the yaml tag.
+AdminPassword string `yaml:"admin_password,omitempty" json:"-"`
+```
+
+- **`json:"-"` closes Findings 1 & 2 by construction**: `GET /tournament`
+  (handlers_tournament.go:196) can no longer leak it, and `PUT /tournament`
+  (`ShouldBindJSON` into `Tournament`) can no longer set it.
+- **Preserve-on-write**: the existing `PUT /tournament` transform replaces the
+  stored record. Because the bound struct's `AdminPassword` is always `""`
+  (json:"-"), the transform MUST copy `AdminPassword` from the current on-disk
+  record forward (exactly as it already does for `Password` at
+  handlers_tournament.go:298-303) — otherwise a routine settings save would wipe
+  the elevated password. Add a regression test for this.
+- **Locked mode**: `AdminPassword` is irrelevant to auth (env hash wins). With
+  `json:"-"` it is never emitted regardless of mode, so no extra
+  `RedactStoredPassword`-style branch is needed for it. A stale on-disk value is
+  inert.
+
+## 6a. Setting / rotating the elevated password — dedicated endpoint
+
+A new endpoint owns the credential, so the privilege rules live in one place:
+
+```
+PUT /api/auth/admin-password      (file mode only; 404 in locked mode)
+body: { "newPassword": "...", "currentPassword": "..." (required iff already set) }
+```
+
+Gating logic (bootstrap = trust-on-first-use, rotation = prove-you-hold-it):
+
+| State | Auth required | Rationale |
+|-------|---------------|-----------|
+| No admin password set yet | Main password only (`X-Tournament-Password`) | TOFU bootstrap. There is no elevated secret to prove yet; the operator setting it for the first time is the same trust level as configuring the tournament. |
+| Admin password already set | Main password **AND** `X-Admin-Password` matching the *current* value | Rotation must prove possession of the current elevated secret — otherwise a main-password holder could silently re-set it (Finding 2). Equivalent to "change-password requires old password". |
+| Locked mode | — | `404`. The credential is the env-var hash; not settable via API. SPA shows the read-only "controlled by env var" message. |
+
+This endpoint lives **outside** the bulk `/tournament` PUT precisely so the
+conditional gating (TOFU vs prove-current) is explicit and testable, not smuggled
+into a handler whose other fields only need the main password.
+
+## 7. UI ([web-mobile/](../../web-mobile/))
+
+- **Settings page** — new "Admin / destructive-ops password" control next to the
+  existing tournament password input. The current value is **never displayed**
+  (write-only, §6) — the field is an empty "set / change" input, like any
+  change-password form.
+  - file mode → editable; saved via the **dedicated** `PUT /api/auth/admin-password`
+    endpoint (§6a), **not** the general tournament PUT. When a value is already
+    set, the form also collects the current admin password to authorize rotation.
+  - locked mode → read-only, shows "controlled by `TOURNAMENT_ADMIN_PASSWORD_HASH`".
+  - State (set vs unset vs env-controlled) comes from `/auth-config` (§8).
+- **Dangerous-op flow** (re-prompt every time, D2): a small `promptAdminPassword()`
+  modal. When a gated action fires (delete competition, edit/import roster), prompt,
+  then send the value in the `X-Admin-Password` header for that one request.
+  - `401` → "Incorrect admin password", re-prompt.
+  - `503` → "Admin password not configured on this server."
+  - No caching (per D2). A single multi-field roster edit may reuse the value for
+    its own submit only.
+- A shared client helper (`web-mobile/js/api*.js`) wraps gated calls so the header
+  plumbing lives in one place. Mirror existing `X-Tournament-Password` handling in
+  `api.js`.
+
+## 8. auth-config exposure ([handlers_auth_config.go](../../internal/mobileapp/handlers_auth_config.go))
+
+Extend `authConfigResponse`:
+```go
+ElevatedRequired  bool `json:"elevatedRequired"`  // ev.GateActive()
+ElevatedEditable  bool `json:"elevatedEditable"`  // file mode only
+ElevatedConfigured bool `json:"elevatedConfigured"` // ev.Configured()
+```
+The SPA reads these on mount to decide whether to prompt for the admin password
+at all and whether to render the Settings field editable.
+
+## 9. Migration / back-compat
+
+- **File mode**: existing deployments have no `admin_password` → `GateActive()==false`
+  → destructive ops behave exactly as today (main password only). Opt-in by setting
+  the field in Settings. **No breaking change.**
+- **Locked mode**: a deployment that upgrades and does *not* set
+  `TOURNAMENT_ADMIN_PASSWORD_HASH` will get **503 on the gated endpoints** (per D3).
+  This **is** a behavior change for locked deployments — documented as a release
+  note and in `docs/user-guide/mobile-app.md`. Rationale: locked mode is the
+  hardened, internet-exposed posture; fail-closed on destructive ops is the
+  correct default there.
+
+## 10. Tests
+
+- **Write-only guarantee (regression for Findings 1 & 2)**: `GET /tournament` in
+  file mode never includes `admin_password`/`adminPassword` in the JSON body even
+  when set on disk; `PUT /tournament` with `adminPassword` in the body does NOT
+  change the stored elevated password; a routine `PUT /tournament` (other fields)
+  preserves the existing `AdminPassword` rather than wiping it.
+- **Dedicated endpoint** (`PUT /api/auth/admin-password`): TOFU first-set with main
+  password only; rotation requires correct current admin password (wrong → 401/403);
+  404 in locked mode.
+- **Verifier** (`auth_admin_test.go`): file mode set/unset; locked configured;
+  locked unconfigured; bcrypt length/mismatch hardening parity with
+  `auth_source_test.go`; GateActive short-circuits before Verify so an empty
+  on-disk admin password + empty header never vacuously matches (F4-style guard).
+- **Middleware**: `GateActive==false` pass-through; 503 when unconfigured; 401 on
+  wrong header; 200 on correct header; verifies it runs *after* main-password auth
+  (a request missing `X-Tournament-Password` still 401s at the outer layer).
+- **Endpoint integration**: each gated route returns 401/503 without/with bad
+  `X-Admin-Password` and 2xx with the correct one; each non-gated route is
+  unaffected.
+- **Storage**: `AdminPassword` round-trips through `tournament.md`; redacted in
+  locked-mode responses; preserved on locked-mode writes.
+- **auth-config**: the three new bits reflect each mode.
+- **Frontend** (vitest): prompt-on-gated-action, 401 re-prompt, 503 message,
+  Settings field editable/read-only per mode.
+
+## 11. Coordination
+
+- **mp-j39** (Remove reserved slots) is **in_progress** and also touches
+  `handlers_competition.go` + participant endpoints. Per its design note, **land
+  mp-j39 first**, then rebase this branch. The reserved-slots routes
+  (`/reserved-slots`) are being removed by mp-j39 and are *not* in this spec's gated
+  set, so the conflict is limited to nearby lines in the same files.
+
+## 12. Out of scope
+
+- Elevation tokens / sessions (explicitly rejected, D2).
+- Gating routine lifecycle/scoring ops.
+- A data-wipe endpoint (none exists; not requested).
+- Per-user identities / RBAC (single shared elevated secret only).
+
+## 13. Phased delivery
+
+1. **Phase 1 — core**: `auth_admin.go` + verifier tests; `AdminPassword` field
+   (`json:"-"`, write-only) + PUT-preserve logic; the dedicated
+   `PUT /api/auth/admin-password` endpoint (§6a) with TOFU/rotation gating;
+   construction in `cmd/mobile_app.go`.
+2. **Phase 2 — middleware + wiring**: `RequireElevatedPassword`, per-route
+   attachment, CORS header, endpoint integration tests.
+3. **Phase 3 — auth-config**: extend response + tests.
+4. **Phase 4 — UI**: Settings field, prompt modal, client helper, vitest.
+5. **Phase 5 — docs**: `docs/user-guide/mobile-app.md`, release note for the
+   locked-mode 503 behavior change.

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -473,6 +473,84 @@ paths:
                   resetEnabled:
                     type: boolean
                     description: Whether POST /api/tournament/reset is honored.
+                  elevatedRequired:
+                    type: boolean
+                    description: |
+                      Whether the destructive-ops password gate is active. File mode:
+                      true once an admin password has been set. Locked mode: always true.
+                      When false, destructive endpoints require only the main password.
+                  elevatedConfigured:
+                    type: boolean
+                    description: |
+                      Whether a destructive-ops credential exists. File mode: an admin
+                      password is set. Locked mode: TOURNAMENT_ADMIN_PASSWORD_HASH is a
+                      valid bcrypt hash. When required but not configured, gated
+                      endpoints return 503.
+                  elevatedEditable:
+                    type: boolean
+                    description: |
+                      Whether the destructive-ops password can be set via
+                      PUT /api/auth/admin-password. True in file mode; false in locked
+                      mode (the credential is the TOURNAMENT_ADMIN_PASSWORD_HASH env var).
+
+  /api/auth/admin-password:
+    put:
+      tags: [tournament]
+      summary: Set or rotate the destructive-ops (elevated) password
+      description: |
+        Sets or rotates the file-mode destructive-ops password (spec 004 /
+        mp-e21). Gated by the MAIN password (`X-Tournament-Password`) via the
+        admin middleware.
+
+          * First-time set (no admin password yet) — trust-on-first-use: the
+            main password authorizes it; `currentPassword` is ignored.
+          * Rotation (admin password already set) — `currentPassword` must
+            equal the stored value, else 401. This prevents a main-password
+            holder from silently re-setting the elevated credential.
+
+        Locked mode returns 404 — the credential is the
+        `TOURNAMENT_ADMIN_PASSWORD_HASH` env var and is not settable via the
+        API. The response never echoes any password (write-only).
+      security:
+        - TournamentPassword: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [newPassword]
+              properties:
+                newPassword:
+                  type: string
+                  maxLength: 256
+                  description: The destructive-ops password to store (non-empty).
+                currentPassword:
+                  type: string
+                  maxLength: 256
+                  description: Required only when an admin password is already set (rotation).
+      responses:
+        '200':
+          description: Admin password set or rotated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  elevatedConfigured:
+                    type: boolean
+                    example: true
+        '400':
+          description: Empty newPassword or over-length field.
+        '401':
+          description: Wrong currentPassword on rotation (or missing/invalid main password).
+        '404':
+          description: Locked mode — not settable via the API.
+        '409':
+          description: No tournament configured yet.
 
   /api/tournament/import:
     post:
@@ -483,8 +561,13 @@ paths:
         via a multipart form upload. The server accepts files under any field name(s).
         One of the uploaded files must be named `manifest.yaml` (or `.yml`); it declares
         which competitions to create and which participant/seed CSV files to associate with each.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); returns 503 when locked mode is
+        active but `TOURNAMENT_ADMIN_PASSWORD_HASH` is unset.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       requestBody:
         required: true
         content:
@@ -714,8 +797,19 @@ paths:
         Server-managed fields — `status`, `hasParticipantIDs` — are
         IGNORED in the body. Use the dedicated transition endpoints
         (`/start`, `/complete`, `/invalidate`) to change status.
+
+        **Elevated password (spec 004 / mp-e21):** the ROSTER-save path
+        (non-null `players`) additionally requires `X-Admin-Password`
+        when the destructive-ops gate is active — it rewrites
+        `participants.csv`, the same protected operation as the dedicated
+        participant endpoints. Returns 503 if locked mode is active without
+        `TOURNAMENT_ADMIN_PASSWORD_HASH`. The SETTINGS-only path
+        (`players` omitted) is NOT gated and needs only the main password.
+        The gate runs inside the handler (after body binding), so the
+        security requirement below is conditional on the body shape.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       requestBody:
         required: true
         content:
@@ -743,8 +837,13 @@ paths:
         Allowed in any non-in-progress state (`setup`, `completed`,
         `invalid`, or unset). In-progress competitions (`pools`/`playoffs`)
         must first be invalidated via `POST /api/competitions/{id}/invalidate`.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); 503 if locked mode is active
+        without `TOURNAMENT_ADMIN_PASSWORD_HASH`.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       responses:
         '204':
           description: Competition deleted (or did not exist).
@@ -768,8 +867,13 @@ paths:
         which is the prerequisite for deletion of an already-started
         competition. Returns 400 if the competition is not in an in-progress
         state.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); 503 if locked mode is active
+        without `TOURNAMENT_ADMIN_PASSWORD_HASH`.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       parameters:
         - $ref: '#/components/parameters/CompetitionId'
       responses:
@@ -822,8 +926,13 @@ paths:
         artifacts (pools.csv, pool-matches.csv, bracket.json), and resets the
         competition to `setup`. Returns 400 if the competition is not in `draw-ready`
         state.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); 503 if locked mode is active
+        without `TOURNAMENT_ADMIN_PASSWORD_HASH`.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       parameters:
         - $ref: '#/components/parameters/CompetitionId'
       responses:
@@ -942,9 +1051,15 @@ paths:
     delete:
       tags: [competitions]
       summary: Reset all overrides
-      description: Clears all manual rank and bracket-winner overrides for this competition.
+      description: |
+        Clears all manual rank and bracket-winner overrides for this competition.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); 503 if locked mode is active
+        without `TOURNAMENT_ADMIN_PASSWORD_HASH`.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       parameters:
         - $ref: '#/components/parameters/CompetitionId'
       responses:
@@ -1027,9 +1142,15 @@ paths:
     post:
       tags: [participants]
       summary: Set participants (JSON)
-      description: Replaces the current participants list for the competition with the provided JSON.
+      description: |
+        Replaces the current participants list for the competition with the provided JSON.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); 503 if locked mode is active
+        without `TOURNAMENT_ADMIN_PASSWORD_HASH`.
       security:
         - TournamentPassword: []
+          AdminPassword: []
       parameters:
         - $ref: '#/components/parameters/CompetitionId'
       requestBody:
@@ -1753,6 +1874,38 @@ components:
         The active mode is exposed via the public
         `GET /api/auth-config` endpoint so clients can branch their
         UI without authenticating.
+
+    AdminPassword:
+      type: apiKey
+      in: header
+      name: X-Admin-Password
+      description: |
+        Elevated (destructive-ops) password — spec 004 / mp-e21. Required
+        IN ADDITION to `X-Tournament-Password` on destructive endpoints:
+        `DELETE /api/competitions/{id}`, `POST /api/competitions/{id}/invalidate`,
+        `DELETE /api/competitions/{id}/draw`, `DELETE /api/competitions/{id}/overrides`,
+        `POST /api/competitions/{id}/participants`,
+        `PUT /api/competitions/{id}/participants/{pid}`,
+        `POST /api/tournament/import`, and
+        `PUT /api/competitions/{id}` **when the body carries a non-null
+        `players` field** (the roster-save path — settings-only PUTs are not
+        gated).
+
+        Gate behavior:
+          * File mode — verified exact-string against the write-only
+            `admin_password` in `tournament.md`. While unset the gate is
+            INACTIVE (the header is not required; the main password alone
+            authorizes the action), so existing file deployments are
+            unaffected until an admin password is set.
+          * Locked mode — verified via bcrypt against
+            `TOURNAMENT_ADMIN_PASSWORD_HASH`. The gate is always active
+            (fail-closed): if the env var is unset/malformed the gated
+            endpoints return 503 "admin password not configured".
+
+        On a missing/incorrect header (when the gate is active and
+        configured) the endpoint returns 401. Set or rotate the file-mode
+        value via `PUT /api/auth/admin-password`. There is no session — the
+        header is required on each gated request.
 
   parameters:
     CompetitionId:

--- a/web-mobile/js/__tests__/admin_elevated.test.jsx
+++ b/web-mobile/js/__tests__/admin_elevated.test.jsx
@@ -1,0 +1,144 @@
+// Spec 004 / mp-e21 — elevated (destructive-ops) password: client header
+// plumbing + the promptAdminPassword UI helper.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { API } from '../api_client.jsx';
+import { promptAdminPassword, setCachedAuthConfig, getCachedAuthConfig } from '../admin_helpers.jsx';
+
+describe('API elevated-password header (X-Admin-Password)', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  // Each gated method must send X-Admin-Password when an adminPassword arg is
+  // given, alongside the existing X-Tournament-Password.
+  const gated = [
+    ['deleteCompetition', () => API.deleteCompetition('c1', 'main', 'adminpw'), 'DELETE', '/api/competitions/c1'],
+    ['invalidateCompetition', () => API.invalidateCompetition('c1', 'main', 'adminpw'), 'POST', '/api/competitions/c1/invalidate'],
+    ['discardDraw', () => API.discardDraw('c1', 'main', 'adminpw'), 'DELETE', '/api/competitions/c1/draw'],
+    ['resetOverrides', () => API.resetOverrides('c1', 'main', 'adminpw'), 'DELETE', '/api/competitions/c1/overrides'],
+    ['addParticipant', () => API.addParticipant('c1', { name: 'X', dojo: 'D' }, 'main', 'adminpw'), 'POST', '/api/competitions/c1/participants'],
+    ['replaceParticipant', () => API.replaceParticipant('c1', 'p1', { name: 'X', dojo: 'D' }, 'main', 'adminpw'), 'PUT', '/api/competitions/c1/participants/p1'],
+  ];
+
+  gated.forEach(([label, call, method, url]) => {
+    it(`${label} sends X-Admin-Password when provided`, async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+      await call();
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method,
+          headers: expect.objectContaining({
+            'X-Tournament-Password': 'main',
+            'X-Admin-Password': 'adminpw',
+          }),
+        })
+      );
+    });
+  });
+
+  it('omits X-Admin-Password when no admin password is supplied (gate inactive)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    await API.deleteCompetition('c1', 'main', '');
+    const sentHeaders = global.fetch.mock.calls[0][1].headers;
+    expect(sentHeaders).not.toHaveProperty('X-Admin-Password');
+    expect(sentHeaders['X-Tournament-Password']).toBe('main');
+  });
+
+  // Copilot PR #193: the bulk PUT /competitions/:id is the SPA's primary
+  // roster writer and must carry X-Admin-Password when it bears a roster.
+  it('updateCompetition forwards X-Admin-Password (roster-bearing)', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    await API.updateCompetition('c1', { id: 'c1', players: [{ name: 'A', dojo: 'D' }] }, 'main', 'adminpw');
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe('/api/competitions/c1');
+    expect(opts.method).toBe('PUT');
+    expect(opts.headers).toMatchObject({ 'X-Tournament-Password': 'main', 'X-Admin-Password': 'adminpw' });
+  });
+
+  it('updateCompetition omits X-Admin-Password for settings-only saves', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+    await API.updateCompetition('c1', { id: 'c1', name: 'Renamed' }, 'main', '');
+    expect(global.fetch.mock.calls[0][1].headers).not.toHaveProperty('X-Admin-Password');
+  });
+
+  it('importCompetitions forwards X-Admin-Password', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    await API.importCompetitions(new FormData(), 'main', 'adminpw');
+    expect(global.fetch.mock.calls[0][1].headers).toMatchObject({
+      'X-Tournament-Password': 'main',
+      'X-Admin-Password': 'adminpw',
+    });
+  });
+
+  describe('setAdminPassword', () => {
+    it('sends newPassword + currentPassword with the main password header', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'ok' }) });
+      await API.setAdminPassword('newpw', 'oldpw', 'main');
+      const [url, opts] = global.fetch.mock.calls[0];
+      expect(url).toBe('/api/auth/admin-password');
+      expect(opts.method).toBe('PUT');
+      expect(opts.headers['X-Tournament-Password']).toBe('main');
+      expect(JSON.parse(opts.body)).toEqual({ newPassword: 'newpw', currentPassword: 'oldpw' });
+    });
+
+    it('omits currentPassword on first-time set (TOFU)', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ status: 'ok' }) });
+      await API.setAdminPassword('newpw', '', 'main');
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({ newPassword: 'newpw' });
+    });
+
+    it('throws with status on failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({ error: 'current admin password is incorrect' }) });
+      await expect(API.setAdminPassword('a', 'b', 'main')).rejects.toThrow('current admin password is incorrect');
+    });
+  });
+});
+
+describe('promptAdminPassword', () => {
+  beforeEach(() => { setCachedAuthConfig(null); });
+  afterEach(() => { vi.restoreAllMocks(); setCachedAuthConfig(null); });
+
+  it('returns "" (no prompt) when the gate is inactive', () => {
+    setCachedAuthConfig({ mode: 'file', elevatedRequired: false });
+    const spy = vi.spyOn(window, 'prompt');
+    expect(promptAdminPassword()).toBe('');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns "" when authConfig is unset (loading / fail-open)', () => {
+    expect(promptAdminPassword()).toBe('');
+  });
+
+  it('alerts and returns null when required but not configured (locked, env unset)', () => {
+    setCachedAuthConfig({ mode: 'locked', elevatedRequired: true, elevatedConfigured: false });
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const promptSpy = vi.spyOn(window, 'prompt');
+    expect(promptAdminPassword()).toBeNull();
+    expect(alertSpy).toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
+  });
+
+  it('prompts and returns the typed password when required + configured', () => {
+    setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
+    vi.spyOn(window, 'prompt').mockReturnValue('typed-secret');
+    expect(promptAdminPassword()).toBe('typed-secret');
+  });
+
+  it('returns null when the operator cancels the prompt', () => {
+    setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
+    vi.spyOn(window, 'prompt').mockReturnValue(null);
+    expect(promptAdminPassword()).toBeNull();
+  });
+
+  it('returns null on empty submit (empty is never a valid admin password)', () => {
+    setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
+    vi.spyOn(window, 'prompt').mockReturnValue('');
+    expect(promptAdminPassword()).toBeNull();
+  });
+
+  it('cache is shared via window across import sites', () => {
+    setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
+    expect(getCachedAuthConfig()).toMatchObject({ elevatedRequired: true });
+    // window-backed so a separately-bundled reader sees the same value.
+    expect(window.__bcAuthConfig).toMatchObject({ elevatedRequired: true });
+  });
+});

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -196,9 +196,21 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   // succession (AdminParticipants.apply) or a "Last saved 13:45:22"
   // stamp on a failed save (AdminSettings.saveNow).
   const updateCompetition = async (cid, next) => {
+    // Elevated-password gate (spec 004 / mp-e21). This PUT doubles as the
+    // SPA's primary roster writer: a non-null `players` payload makes the
+    // server persist participants/seeds, which is a destructive op. Prompt
+    // for the admin password here (centrally) only when the payload carries
+    // a roster mutation — settings-only saves omit `players` and stay
+    // single-factor. promptAdminPassword returns "" when the gate is
+    // inactive (proceed) and null when cancelled/not-configured (abort).
+    let admin = "";
+    if (next && next.players != null) {
+      admin = window.promptAdminPassword();
+      if (admin === null) return;
+    }
     let updated;
     try {
-      updated = await window.API.updateCompetition(cid, next, password);
+      updated = await window.API.updateCompetition(cid, next, password, admin);
     } catch (e) {
       showToast(e.message, "error");
       throw e;

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -760,9 +760,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           <div>
             <button className="btn btn--danger btn--ghost" disabled={invalidating || deleting} onClick={async () => {
               if (confirm(`Mark "${local.name}" as invalid? It will be excluded from results and can be deleted afterwards.`)) {
+                const admin = window.promptAdminPassword();
+                if (admin === null) return;
                 setInvalidating(true);
                 try {
-                  const updated = await window.API.invalidateCompetition(local.id, password);
+                  const updated = await window.API.invalidateCompetition(local.id, password, admin);
                   if (mountedRef.current) {
                     // Use the server response (if any) so that server-side
                     // field updates are reflected immediately. Fall back to
@@ -795,9 +797,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
             ? `"${local.name}" has already started. Deleting it will remove ALL matches and results. This cannot be undone. Continue?`
             : `Are you sure you want to delete "${local.name}"? This action cannot be undone.`;
           if (confirm(msg)) {
+            const admin = window.promptAdminPassword();
+            if (admin === null) return;
             setDeleting(true);
             try {
-              const ok = await window.API.deleteCompetition(local.id, password);
+              const ok = await window.API.deleteCompetition(local.id, password, admin);
               // onBack() unmounts AdminSettings via the parent's view
               // switch; setDeleting(false) in finally would then fire on
               // a torn-down component. Gate via mountedRef.
@@ -1138,9 +1142,11 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
 
   const discardDraw = async () => {
     if (!confirm(`Discard the generated draw for "${c.name}"? The pools/bracket will be removed and you can regenerate.`)) return;
+    const admin = window.promptAdminPassword();
+    if (admin === null) return;
     setDiscarding(true);
     try {
-      await window.API.discardDraw(c.id, password);
+      await window.API.discardDraw(c.id, password, admin);
       if (!mountedRef.current) return;
       onRefreshCompetition?.();
       showToast(`Draw discarded for ${c.name}`);
@@ -1154,9 +1160,13 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const regenerateDraw = async () => {
+    // Regenerate discards the existing draw first (DELETE /draw is gated),
+    // so collect the elevated password up front before any work begins.
+    const admin = window.promptAdminPassword();
+    if (admin === null) return;
     setGenerating(true);
     try {
-      await window.API.discardDraw(c.id, password);
+      await window.API.discardDraw(c.id, password, admin);
       if (!mountedRef.current) return;
       // Refresh after discard so the UI reflects setup status immediately;
       // if generateDraw then fails the UI is consistent with the server.

--- a/web-mobile/js/admin_helpers.jsx
+++ b/web-mobile/js/admin_helpers.jsx
@@ -273,11 +273,69 @@ if (typeof window !== "undefined") {
   window.MAX_TEAM_SIZE = MAX_TEAM_SIZE;
   window.MAX_COURTS = MAX_COURTS;
   window.MAX_RANK = MAX_RANK;
+  window.setCachedAuthConfig = setCachedAuthConfig;
+  window.getCachedAuthConfig = getCachedAuthConfig;
+  window.promptAdminPassword = promptAdminPassword;
 }
 
-// Also exported so the vitest suite under web-mobile/js/__tests__/ can
-// import these directly without going through window globals.
+// --- Elevated (destructive-ops) password prompt (spec 004 / mp-e21) ---
+//
+// authConfig is held in app.jsx state and threaded to only a few components.
+// Rather than prop-drill it to every destructive call site, app.jsx pushes
+// the latest value here whenever it resolves /api/auth-config, and the
+// destructive handlers read it via promptAdminPassword(). Single writer
+// (app.jsx), many readers — no React context needed for an imperative prompt.
+//
+// IMPORTANT: the cache lives on `window`, NOT a module-level variable.
+// esbuild bundles this file into BOTH the app and admin entry chunks, so a
+// module-scoped `let` would be two independent instances — app.jsx's writes
+// would never be visible to the admin components' reads. A single window slot
+// is shared across both bundles. Guarded for non-browser (vitest) use.
+const _authConfigSlot = () => (typeof window !== "undefined" ? window : globalThis);
+
+// setCachedAuthConfig is called by app.jsx after every fetchAuthConfig().
+function setCachedAuthConfig(cfg) {
+  _authConfigSlot().__bcAuthConfig = cfg || null;
+}
+
+function getCachedAuthConfig() {
+  return _authConfigSlot().__bcAuthConfig || null;
+}
+
+// promptAdminPassword returns the elevated password to send with a
+// destructive action, following the "re-prompt every time" model:
+//
+//   - gate inactive (file mode, no admin pw set) → returns "" so the caller
+//     proceeds; the server ignores the (omitted) X-Admin-Password header.
+//   - gate active but not configured (locked mode, env var unset) → alerts
+//     the operator and returns null so the caller ABORTS (the server would
+//     503 anyway).
+//   - gate active and configured → window.prompt for the password. Returns
+//     the typed value, or null if the operator cancels or submits empty
+//     (the caller aborts).
+//
+// Caller contract: `const a = promptAdminPassword(); if (a === null) return;`
+// then pass `a` as the trailing adminPassword arg to the API method. A wrong
+// password surfaces as the API's 401 error (caught/toasted by the caller);
+// the operator simply retries the action, which re-prompts.
+function promptAdminPassword(message) {
+  const cfg = getCachedAuthConfig();
+  if (!cfg || !cfg.elevatedRequired) return "";
+  if (cfg.elevatedConfigured === false) {
+    window.alert(
+      "This action requires an admin password, but none is configured on this server. " +
+      "In locked mode set TOURNAMENT_ADMIN_PASSWORD_HASH; in file mode set one in Settings."
+    );
+    return null;
+  }
+  const pw = window.prompt(message || "This action requires the admin (destructive-ops) password:");
+  return pw ? pw : null;
+}
+
 export {
+  setCachedAuthConfig,
+  getCachedAuthConfig,
+  promptAdminPassword,
   sideName,
   hasBothSides,
   compMatchStats,

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -529,6 +529,8 @@ function AdminParticipants({ c, tournament, onUpdate, password, showToast, onSec
     const name = addName.trim(), dojo = addDojo.trim(), danGrade = addDanGrade.trim();
     const zekken = addZekken.trim();
     if (!name || !dojo) { showToast("Name and dojo are required", "error"); return; }
+    const admin = window.promptAdminPassword();
+    if (admin === null) return;
     setAddLoading(true);
     try {
       // displayName is only forwarded for zekken-enabled competitions; for
@@ -537,7 +539,7 @@ function AdminParticipants({ c, tournament, onUpdate, password, showToast, onSec
       // poison the slot with a stale value (see TestReplaceDoesNotInherit…).
       const payload = { name, dojo, danGrade: danGrade || undefined };
       if (c.withZekkenName && zekken) payload.displayName = zekken;
-      await window.API.addParticipant(c.id, payload, password);
+      await window.API.addParticipant(c.id, payload, password, admin);
       if (!mountedRef.current) return;
       setAddName(""); setAddDojo(""); setAddDanGrade(""); setAddZekken(""); setShowAddForm(false);
       showToast(`${name} added`);
@@ -559,6 +561,8 @@ function AdminParticipants({ c, tournament, onUpdate, password, showToast, onSec
     const oldName = replaceTarget.name;
     const targetId = replaceTarget.id;
     const targetTag = replaceTarget.tag || "";
+    const admin = window.promptAdminPassword();
+    if (admin === null) return;
     setReplaceLoading(true);
     try {
       // Build metadata from danGrade so the edited grade actually persists —
@@ -574,7 +578,7 @@ function AdminParticipants({ c, tournament, onUpdate, password, showToast, onSec
       const metadata = window.buildPlayerMetadata(danGrade, replaceTarget.metadata);
       const payload = { name, dojo, displayName: c.withZekkenName ? zekken : "", tag: targetTag };
       if (metadata !== undefined) payload.metadata = metadata;
-      const updated = await window.API.replaceParticipant(c.id, targetId, payload, password);
+      const updated = await window.API.replaceParticipant(c.id, targetId, payload, password, admin);
       if (!mountedRef.current) return;
       setReplaceTarget(null);
       showToast(oldName === updated.name ? `Saved changes for ${updated.name}` : `Renamed ${oldName} → ${updated.name}`);

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -210,8 +210,10 @@ function RankInput({ initial, className, onCommit, style }) {
 function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, password }) {
   const resetOverrides = async () => {
     if (!confirm("Are you sure you want to reset ALL manual overrides (ranks and winners) for this competition?")) return;
+    const admin = window.promptAdminPassword();
+    if (admin === null) return;
     try {
-      await window.API.resetOverrides(c.id, password);
+      await window.API.resetOverrides(c.id, password, admin);
     } catch (e) {
       alert("Failed to reset overrides: " + e.message);
     }

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -102,6 +102,35 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
 
+  // Elevated (destructive-ops) password — spec 004 / mp-e21. File mode only;
+  // in locked mode it's the TOURNAMENT_ADMIN_PASSWORD_HASH env var (read-only
+  // here). `elevatedConfigured` decides whether the current-password field is
+  // shown (rotation) vs. a first-time set (TOFU).
+  const elevatedConfigured = authConfig && authConfig.elevatedConfigured === true;
+  const [adminNew, setAdminNew] = useStateA("");
+  const [adminCurrent, setAdminCurrent] = useStateA("");
+  const [adminSaving, setAdminSaving] = useStateA(false);
+
+  const handleSetAdminPassword = async () => {
+    if (!adminNew) { if (showToast) showToast("Enter a new admin password", "error"); return; }
+    setAdminSaving(true);
+    try {
+      await window.API.setAdminPassword(adminNew, adminCurrent, password);
+      setAdminNew(""); setAdminCurrent("");
+      // Refresh auth-config so elevatedConfigured/elevatedRequired reflect the
+      // new state (the gate is now active) for subsequent destructive actions.
+      try {
+        const cfg = await window.API.fetchAuthConfig();
+        if (cfg && typeof cfg === "object") window.setCachedAuthConfig(cfg);
+      } catch (_e) { /* non-fatal */ }
+      if (showToast) showToast("Admin password updated", "success");
+    } catch (e) {
+      if (showToast) showToast(e.message, "error");
+    } finally {
+      setAdminSaving(false);
+    }
+  };
+
   const handleSave = () => {
     // Trim early and send the trimmed value. The empty-name check below
     // already used `name.trim()`, but the onSave payload was passing the
@@ -194,6 +223,31 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               <label className="field__label">Admin Password</label>
               <input className="input" type="password" value={pass} onChange={(e) => { setPass(e.target.value); setError(""); }} placeholder="••••••••" autoComplete="new-password" />
               <div className="field__hint">Enter a new password to change it. Leave blank to keep the current one.</div>
+            </div>
+          )}
+          {/* Elevated (destructive-ops) password — spec 004 / mp-e21. */}
+          {locked ? (
+            <div className="field">
+              <label className="field__label">Destructive-ops password</label>
+              <div className="field__hint" style={{ marginTop: 4 }}>
+                This server is in locked mode. The destructive-ops password comes from <code>TOURNAMENT_ADMIN_PASSWORD_HASH</code> and can only be changed by restarting the server with a new hash. If unset, destructive actions (delete competition, discard draw, roster changes, import) return 503.
+              </div>
+            </div>
+          ) : (
+            <div className="field">
+              <label className="field__label">Destructive-ops password {elevatedConfigured ? "(set)" : "(not set)"}</label>
+              {elevatedConfigured && (
+                <input className="input" type="password" value={adminCurrent} onChange={(e) => setAdminCurrent(e.target.value)} placeholder="Current destructive-ops password" autoComplete="off" style={{ marginBottom: 8 }} />
+              )}
+              <div style={{ display: "flex", gap: 8 }}>
+                <input className="input" type="password" value={adminNew} onChange={(e) => setAdminNew(e.target.value)} placeholder={elevatedConfigured ? "New destructive-ops password" : "Set destructive-ops password"} autoComplete="new-password" />
+                <button className="btn" disabled={adminSaving} onClick={handleSetAdminPassword}>
+                  {adminSaving ? "Saving…" : (elevatedConfigured ? "Update" : "Set")}
+                </button>
+              </div>
+              <div className="field__hint">
+                A separate password required for destructive actions (delete competition, discard draw, roster add/edit, import). Leave unset to gate those behind the main password only. {elevatedConfigured && "Changing it requires the current destructive-ops password."}
+              </div>
             </div>
           )}
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
@@ -634,6 +688,8 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
   const doImport = async () => {
     if (!files.length) return;
     if (!confirm("Are you sure you want to import these competitions? This will add new competitions to the tournament.")) return;
+    const admin = window.promptAdminPassword();
+    if (admin === null) return;
     setLoading(true);
     setError(null);
     try {
@@ -641,7 +697,7 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
       files.forEach(f => fd.append("files", f, f.webkitRelativePath || f.name));
       // Use the centralized API wrapper (api.jsx) so auth + error handling
       // stay consistent with the rest of the admin UI.
-      const body = await window.API.importCompetitions(fd, password);
+      const body = await window.API.importCompetitions(fd, password, admin);
       // mountedRef gates the post-await setStates so a navigate-back
       // during the upload doesn't fire setResults / setTimeout on a
       // torn-down component. importedTimerRef has its own unmount

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -25,6 +25,16 @@
 
 import { normalizeCompetitionDetail, normalizePlayer, toBackendMatchResult, buildPlayerMetadata } from './api_serializers.jsx';
 
+// adminHdr returns the X-Admin-Password header object for the elevated
+// (destructive-ops) password (spec 004 / mp-e21), or an empty object when no
+// admin password is supplied. Destructive methods spread it into their
+// headers so a request can carry BOTH X-Tournament-Password (main) and
+// X-Admin-Password (elevated). When the gate is inactive on the server
+// (file mode, no admin pw set) callers pass "" and the header is omitted.
+function adminHdr(adminPassword) {
+    return adminPassword ? { 'X-Admin-Password': adminPassword } : {};
+}
+
 const API = {
     async fetchTournament() {
         const res = await fetch('/api/viewer/tournament');
@@ -83,6 +93,29 @@ const API = {
         // body throws SyntaxError per the Fetch spec (same pattern as
         // overridePoolRank etc. above).
         return true;
+    },
+    // Set or rotate the elevated (destructive-ops) admin password (spec 004
+    // / mp-e21). File mode only — locked mode 404s (credential is the
+    // TOURNAMENT_ADMIN_PASSWORD_HASH env var). `password` is the MAIN
+    // tournament password (gates the endpoint via AuthMiddleware).
+    // `currentAdminPassword` is required only when an admin password is
+    // already set (rotation); on first-time set (TOFU) the server ignores it.
+    // The endpoint never echoes any password back.
+    async setAdminPassword(newPassword, currentAdminPassword, password) {
+        const body = { newPassword };
+        if (currentAdminPassword) body.currentPassword = currentAdminPassword;
+        const res = await fetch('/api/auth/admin-password', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password },
+            body: JSON.stringify(body)
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            const e = new Error(err.error || `Failed to set admin password (Status ${res.status})`);
+            e.status = res.status;
+            throw e;
+        }
+        return res.json();
     },
     async fetchCompetitions() {
         const res = await fetch('/api/viewer/competitions');
@@ -153,7 +186,7 @@ const API = {
         }
         return res.json();
     },
-    async updateCompetition(id, config, password) {
+    async updateCompetition(id, config, password, adminPassword) {
         // Go's domain.Player uses json:"metadata" (array); the JS layer uses the
         // friendlier danGrade string. Convert before encoding so the backend can
         // unmarshal the dan grade into Player.Metadata.
@@ -177,7 +210,11 @@ const API = {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
-                'X-Tournament-Password': password
+                'X-Tournament-Password': password,
+                // Roster-bearing updates (non-null players) hit the server's
+                // elevated-password gate (spec 004); the caller threads the
+                // admin password for those. Settings-only saves omit it.
+                ...adminHdr(adminPassword)
             },
             body: JSON.stringify(body)
         });
@@ -226,10 +263,10 @@ const API = {
         const data = await res.json();
         return normalizeCompetitionDetail(data);
     },
-    async discardDraw(id, password) {
+    async discardDraw(id, password, adminPassword) {
         const res = await fetch(`/api/competitions/${id}/draw`, {
             method: 'DELETE',
-            headers: { 'X-Tournament-Password': password }
+            headers: { 'X-Tournament-Password': password, ...adminHdr(adminPassword) }
         });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
@@ -374,10 +411,10 @@ const API = {
         // Backend returns 200 with empty body — see overridePoolRank.
         return true;
     },
-    async resetOverrides(compID, password) {
+    async resetOverrides(compID, password, adminPassword) {
         const res = await fetch(`/api/competitions/${compID}/overrides`, {
             method: 'DELETE',
-            headers: { 'X-Tournament-Password': password }
+            headers: { 'X-Tournament-Password': password, ...adminHdr(adminPassword) }
         });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
@@ -448,10 +485,10 @@ const API = {
         }
         return true;
     },
-    async importCompetitions(formData, password) {
+    async importCompetitions(formData, password, adminPassword) {
         const res = await fetch('/api/tournament/import', {
             method: 'POST',
-            headers: { 'X-Tournament-Password': password },
+            headers: { 'X-Tournament-Password': password, ...adminHdr(adminPassword) },
             body: formData
         });
         if (!res.ok) {
@@ -471,10 +508,10 @@ const API = {
         }
         return res.json();
     },
-    async deleteCompetition(id, password) {
+    async deleteCompetition(id, password, adminPassword) {
         const res = await fetch(`/api/competitions/${id}`, {
             method: 'DELETE',
-            headers: { 'X-Tournament-Password': password }
+            headers: { 'X-Tournament-Password': password, ...adminHdr(adminPassword) }
         });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
@@ -485,10 +522,10 @@ const API = {
     // Returns the updated competition JSON (including the new `status`) so
     // callers can apply it to local state immediately instead of waiting for
     // the SSE refresh / tournament refetch to land.
-    async invalidateCompetition(id, password) {
+    async invalidateCompetition(id, password, adminPassword) {
         const res = await fetch(`/api/competitions/${id}/invalidate`, {
             method: 'POST',
-            headers: { 'X-Tournament-Password': password }
+            headers: { 'X-Tournament-Password': password, ...adminHdr(adminPassword) }
         });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
@@ -605,10 +642,10 @@ const API = {
         }
         return res.json();
     },
-    async addParticipant(compID, payload, password) {
+    async addParticipant(compID, payload, password, adminPassword) {
         const res = await fetch(`/api/competitions/${compID}/participants`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password },
+            headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password, ...adminHdr(adminPassword) },
             body: JSON.stringify(payload)
         });
         if (!res.ok) {
@@ -617,10 +654,10 @@ const API = {
         }
         return res.json();
     },
-    async replaceParticipant(compID, pid, payload, password) {
+    async replaceParticipant(compID, pid, payload, password, adminPassword) {
         const res = await fetch(`/api/competitions/${compID}/participants/${pid}`, {
             method: 'PUT',
-            headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password },
+            headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password, ...adminHdr(adminPassword) },
             body: JSON.stringify(payload)
         });
         if (!res.ok) {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -2,6 +2,7 @@
 // (Men's Individual, Women's Individual, Teams, etc.). Auth gates admin mode.
 
 import { applyPatch as patchCompetitionData } from './patch.jsx';
+import { setCachedAuthConfig } from './admin_helpers.jsx';
 
 const { useState: useS, useEffect: useE, useRef: useR, useCallback: useC } = React;
 
@@ -342,6 +343,11 @@ function App() {
       setAuthConfig(fileDefault);
     });
   }, []);
+
+  // Mirror authConfig into the admin_helpers cache so promptAdminPassword()
+  // (spec 004) can read the elevated-password bits at destructive call sites
+  // without prop-drilling authConfig through every admin component.
+  useE(() => { setCachedAuthConfig(authConfig); }, [authConfig]);
 
   useE(() => {
     // Track every jittered timer so the cleanup can cancel them when


### PR DESCRIPTION
Closes mp-e21.

Adds a **second, higher-privilege password** (`X-Admin-Password`) gating destructive operations, on top of the existing main-password `AuthMiddleware`. Lets shared-credential table staff run matches and check-in without being able to destroy data. Spec: [`specs/004-elevated-password/spec.md`](specs/004-elevated-password/spec.md).

## Decisions (locked with @gitrgoliveira)
- **Gated:** competition delete/invalidate, draw/override discard, participant add/edit, CSV import.
- **Not gated:** scoring, check-in, lifecycle, lineups, and the public `/reset` recovery path.
- **Re-prompt every time** — no elevation token/session; the password rides each gated request.
- **Locked mode** uses a separate `TOURNAMENT_ADMIN_PASSWORD_HASH` bcrypt env var; unset ⇒ gated endpoints **503** (fail-closed).

## Critical-thinking review caught two fatal flaws (fixed)
The first spec draft said to mirror the existing `Password` handling. A `/critical-thinking` pass found that would have:
1. **leaked** the elevated password via `GET /tournament` (returns the struct in file mode), and
2. let any main-password holder **overwrite** it via the bulk `PUT /tournament`.

Both defeat the feature (the elevated password is *higher* privilege than the gate exposing it). Fixed by making the field **write-only** (`json:"-"` — never serialized, never bound) and routing set/rotate through a dedicated endpoint. Regression guards added (`TestTournamentGet_NeverLeaksAdminPassword`, `TestTournamentPut_CannotSetOrWipeAdminPassword`).

## Changes
- **`auth_admin.go`** — `ElevatedVerifier` (file / locked-bcrypt / locked-unconfigured), mirroring the existing verifier's hardening.
- **`RequireElevatedPassword`** middleware on the 7 gated routes, layered after `AuthMiddleware`. Inactive in file mode until an admin password is set (**no breaking change** for file deployments).
- **`PUT /api/auth/admin-password`** — file mode only (404 in locked); trust-on-first-use initial set, current-password required to rotate.
- **`/auth-config`** exposes `elevatedRequired/Configured/Editable`.
- **UI** — `X-Admin-Password` on gated API methods; `promptAdminPassword` helper (window-backed cache, prompts per action); Settings page write-only set/rotate field (file) / env-var note (locked).
- **Docs** — `mobile-app.md` section + OpenAPI (`AdminPassword` scheme, new path, auth-config fields, AND-requirement on the 6 documented gated endpoints).

## Verification
- Go: verifier/middleware/endpoint tests + the two regression guards. `golangci-lint` 0 issues.
- JS: 18 new vitest assertions (header plumbing, `setAdminPassword`, prompt helper); full suite 886 pass; eslint clean.
- **End-to-end (curl):** gate 401 (missing/wrong) → 204 (correct); no password leak on GET; rotation-without-current blocked (no escalation); TOFU + rotate.
- **Browser:** Settings field renders "(set)" with rotation input; `window.promptAdminPassword()` fires against live `authConfig`. (Screenshot in PR comments.)
- Rebased onto current `main` (resolved one conflict with mp-djc's announcement refactor in `admin_setup.jsx`).

## ⚠️ Behavior change (locked mode only)
An upgraded **locked** deployment that does not set `TOURNAMENT_ADMIN_PASSWORD_HASH` will get **503 on the gated endpoints** (fail-closed, per design). Documented as a release note in `mobile-app.md`.

## Note for reviewers
This PR is not gated on mp-j39 (per @gitrgoliveira: "eat the rebase"). The pre-existing `cmd` test `TestDiagnoseFolderError_OwnerInfo` fails only in this sandbox (temp-dir gid) and is unrelated — 0 `cmd/` files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)