### PR TITLE
fix(mp-116): thread compKind/teamSize so viewer renders team KO sub-bouts

### DIFF
--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -433,28 +433,97 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
   });
 
   // mp-116: Individual match must still render the ippons block (regression guard).
-  it('renders individual ippons block when compKind is absent (individual match)', () => {
-    // The individual path calls window.isHikiwake — stub it for this test.
+  it('renders individual ippons block (not team subs) for an individual match', () => {
+    // The individual path calls window.isHikiwake — stub it for this test,
+    // restoring any prior value in finally so a thrown assertion can't leak
+    // the stub into later tests (mirrors the roundLabel pattern above).
+    const savedIsHikiwake = global.window.isHikiwake;
     global.window.isHikiwake = vi.fn(() => false);
+    try {
+      const match = {
+        compKind: 'individual',
+        teamSize: 0,
+        status: 'completed',
+        court: 'A',
+        phase: 'bracket',
+        round: 'QF',
+        sideA: { id: 'pA', name: 'Alice' },
+        sideB: { id: 'pB', name: 'Bob' },
+        ipponsA: ['M'],
+        ipponsB: [],
+        winner: { id: 'pA' },
+      };
+      const tree = runtime.mount(MatchDetailCard, { match, onClose: null });
+      const ipponsBlock = findInTree(tree, n => n?.props?.className === 'match-detail-card__ippons');
+      expect(ipponsBlock).toBeTruthy();
+      const teamSubs = findInTree(tree, n => n?.props?.className === 'match-detail-card__team-subs');
+      expect(teamSubs).toBeNull();
+    } finally {
+      if (savedIsHikiwake === undefined) delete global.window.isHikiwake;
+      else global.window.isHikiwake = savedIsHikiwake;
+    }
+  });
+});
+
+// mp-116 (Copilot review follow-up): the bracket-tab and pools-tab click sites
+// now enrich the match with phase/round (or poolName) before opening the modal,
+// because raw BracketMatch / pool match objects carry neither. MatchViewerModal's
+// header renders `phase === "pool" ? poolName : round`, so without that metadata
+// the header showed a dangling separator with an empty label. These tests lock
+// the modal-header contract the callers must satisfy.
+describe('MatchViewerModal header + team rendering (mp-116)', () => {
+  const realReact = global.React;
+  let runtime;
+  let MatchViewerModal;
+  const STUBBED = ['useEscapeToClose', 'ipponsFromScore'];
+  const savedGlobals = {};
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => { savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k) ? { had: true, val: global.window[k] } : { had: false }; });
+    global.window.useEscapeToClose = vi.fn();
+    global.window.ipponsFromScore = vi.fn(() => []);
+    vi.resetModules();
+    ({ MatchViewerModal } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('renders the round label in the header for a bracket match', () => {
     const match = {
-      compKind: 'individual',
-      teamSize: 0,
-      status: 'completed',
-      court: 'A',
-      phase: 'bracket',
-      round: 'QF',
-      sideA: { id: 'pA', name: 'Alice' },
-      sideB: { id: 'pB', name: 'Bob' },
-      ipponsA: ['M'],
-      ipponsB: [],
-      winner: { id: 'pA' },
+      phase: 'bracket', round: 'Final', compKind: 'team', teamSize: 5,
+      status: 'completed', court: 'A',
+      sideA: { id: 'tA', name: 'Team A' }, sideB: { id: 'tB', name: 'Team B' },
+      subResults: [{ position: 1, ipponsA: ['M'], ipponsB: [] }],
     };
-    const tree = runtime.mount(MatchDetailCard, { match, onClose: null });
-    delete global.window.isHikiwake;
-    const ipponsBlock = findInTree(tree, n => n?.props?.className === 'match-detail-card__ippons');
-    expect(ipponsBlock).toBeTruthy();
-    const teamSubs = findInTree(tree, n => n?.props?.className === 'match-detail-card__team-subs');
-    expect(teamSubs).toBeNull();
+    const tree = runtime.mount(MatchViewerModal, { match, onClose: () => {} });
+    const text = collectText(tree);
+    // Header must show the round label, not an empty string after "Shiaijo A ·".
+    expect(text).toContain('Final');
+    // Team path renders the SHIRO/Position/AKA sub-bout table.
+    expect(text).toContain('Position');
+  });
+
+  it('renders the pool name in the header for a pool match', () => {
+    const match = {
+      phase: 'pool', poolName: 'Pool A', compKind: 'team', teamSize: 5,
+      status: 'completed', court: 'B',
+      sideA: { id: 'tA', name: 'Team A' }, sideB: { id: 'tB', name: 'Team B' },
+      subResults: [{ position: 1, ipponsA: ['M'], ipponsB: [] }],
+    };
+    const tree = runtime.mount(MatchViewerModal, { match, onClose: () => {} });
+    expect(collectText(tree)).toContain('Pool A');
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -220,6 +220,58 @@ describe('Viewer Utils', () => {
       const c = mkComp({ status: 'setup', poolMatches: [{ id: 'Pool A-0', status: 'scheduled' }] });
       expect(compMatches(c)).toEqual([]);
     });
+
+    // mp-116: compKind/teamSize must be threaded onto every match so that
+    // MatchDetailCard.isTeam and MatchViewerModal.isTeam evaluate correctly.
+    it('threads compKind and teamSize onto pool matches for team comps', () => {
+      const c = mkComp({
+        kind: 'team',
+        teamSize: 3,
+        poolMatches: [{ id: 'Pool A-0', status: 'completed' }],
+      });
+      const ms = compMatches(c);
+      expect(ms[0].compKind).toBe('team');
+      expect(ms[0].teamSize).toBe(3);
+    });
+
+    it('zeroes out compKind/teamSize for pool-daihyosen matches (pool-DH guard)', () => {
+      const c = mkComp({
+        kind: 'team',
+        teamSize: 3,
+        poolMatches: [
+          { id: 'Pool A-0', status: 'completed' },
+          { id: 'Pool A-DH-0', status: 'completed' },
+        ],
+      });
+      const ms = compMatches(c);
+      const normal = ms.find(m => m.id === 'Pool A-0');
+      const dh = ms.find(m => m.id === 'Pool A-DH-0');
+      expect(normal.compKind).toBe('team');
+      expect(normal.teamSize).toBe(3);
+      expect(dh.compKind).toBe('');
+      expect(dh.teamSize).toBe(0);
+    });
+
+    it('threads compKind and teamSize onto bracket matches for team comps', () => {
+      global.window = global.window || {};
+      const savedRoundLabel = global.window.roundLabel;
+      global.window.roundLabel = (i, _total) => `Round ${i + 1}`;
+      try {
+        const c = mkComp({
+          kind: 'team',
+          teamSize: 5,
+          bracket: { rounds: [[{ id: 'QF-0', status: 'completed' }]] },
+        });
+        const ms = compMatches(c);
+        const bm = ms.find(m => m.phase === 'bracket');
+        expect(bm).toBeTruthy();
+        expect(bm.compKind).toBe('team');
+        expect(bm.teamSize).toBe(5);
+      } finally {
+        if (savedRoundLabel === undefined) delete global.window.roundLabel;
+        else global.window.roundLabel = savedRoundLabel;
+      }
+    });
   });
 
   describe('swissStandingsHeading', () => {
@@ -354,6 +406,55 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
     const text = collectText(tree);
     expect(text).toContain('Daihyosen');
     expect(text).not.toContain('Hantei');
+  });
+
+  // mp-116: Overview "Recent results" bug — allMatches useMemo was not threading
+  // compKind/teamSize, so isTeam evaluated false and the individual ippons block
+  // rendered instead of the team sub-bout rows.
+  // Verify that a match carrying compKind="team" (as allMatches now produces)
+  // renders match-detail-card__team-subs, NOT match-detail-card__ippons.
+  it('renders team sub-bout block (not individual ippons) when compKind="team" from allMatches', () => {
+    const match = {
+      ...mkTeamMatch([
+        { position: 1, ipponsA: ['M'], ipponsB: [], decidedByHantei: false },
+        { position: 2, ipponsA: [], ipponsB: ['D'], decidedByHantei: false },
+      ]),
+      // These flags are what allMatches now correctly supplies for team comps.
+      compKind: 'team',
+      teamSize: 3,
+    };
+    const tree = runtime.mount(MatchDetailCard, { match, onClose: null });
+    // Team sub-rows container must be present.
+    const teamSubs = findInTree(tree, n => n?.props?.className === 'match-detail-card__team-subs');
+    expect(teamSubs).toBeTruthy();
+    // Individual ippons block must NOT appear.
+    const ipponsBlock = findInTree(tree, n => n?.props?.className === 'match-detail-card__ippons');
+    expect(ipponsBlock).toBeNull();
+  });
+
+  // mp-116: Individual match must still render the ippons block (regression guard).
+  it('renders individual ippons block when compKind is absent (individual match)', () => {
+    // The individual path calls window.isHikiwake — stub it for this test.
+    global.window.isHikiwake = vi.fn(() => false);
+    const match = {
+      compKind: 'individual',
+      teamSize: 0,
+      status: 'completed',
+      court: 'A',
+      phase: 'bracket',
+      round: 'QF',
+      sideA: { id: 'pA', name: 'Alice' },
+      sideB: { id: 'pB', name: 'Bob' },
+      ipponsA: ['M'],
+      ipponsB: [],
+      winner: { id: 'pA' },
+    };
+    const tree = runtime.mount(MatchDetailCard, { match, onClose: null });
+    delete global.window.isHikiwake;
+    const ipponsBlock = findInTree(tree, n => n?.props?.className === 'match-detail-card__ippons');
+    expect(ipponsBlock).toBeTruthy();
+    const teamSubs = findInTree(tree, n => n?.props?.className === 'match-detail-card__team-subs');
+    expect(teamSubs).toBeNull();
   });
 });
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1174,16 +1174,19 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
     if (pools) {
         pools.forEach((p) => {
             const matches = poolMatches ? poolMatches.filter(m => m.id.startsWith(p.poolName + "-")) : [];
-            matches.forEach((m) => out.push({ ...m, phase: "pool", phaseName: p.poolName, poolName: p.poolName }));
+            matches.forEach((m) => {
+                const isDH = isPoolDaihyosenID(m.id || "");
+                out.push({ ...m, phase: "pool", phaseName: p.poolName, poolName: p.poolName, compKind: isDH ? "" : c.kind, teamSize: isDH ? 0 : c.teamSize });
+            });
         });
     }
     if (bracket && bracket.rounds) {
         bracket.rounds.forEach((round, ri) => {
-            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length) }));
+            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length), compKind: c.kind, teamSize: c.teamSize }));
         });
     }
     return out;
-  }, [pools, poolMatches, bracket]);
+  }, [pools, poolMatches, bracket, c.kind, c.teamSize]);
 
   const liveMatches = allMatches.filter((m) => m.status === "running" && hasBothSides(m));
   const upcomingMatches = allMatches.filter((m) => m.status === "scheduled" && hasBothSides(m)).slice(0, 3);
@@ -1313,7 +1316,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightedMatchId={currentMatch?.id}
                     autoScrollMatchId={bracketScrollTarget}
                     scrollContainerRef={bracketScrollRef}
-                    onMatchClick={(m) => setSelectedMatch(m)}
+                    onMatchClick={(m) => setSelectedMatch({ ...m, compKind: c.kind, teamSize: c.teamSize })}
                   />
                 </div>
               </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1316,7 +1316,10 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightedMatchId={currentMatch?.id}
                     autoScrollMatchId={bracketScrollTarget}
                     scrollContainerRef={bracketScrollRef}
-                    onMatchClick={(m) => setSelectedMatch({ ...m, compKind: c.kind, teamSize: c.teamSize })}
+                    onMatchClick={(m, ri) => {
+                      const label = window.roundLabel(ri, derivedBracket.rounds.length);
+                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, compKind: c.kind, teamSize: c.teamSize });
+                    }}
                   />
                 </div>
               </div>
@@ -1845,7 +1848,16 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
             {matches.length > 0 && isTeam && (
               <div style={{ marginTop: 12 }}>
                 <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                  {matches.map(m => <PoolMatchRow key={m.id} m={m} onClick={() => onMatchClick && onMatchClick(m)} />)}
+                  {matches.map(m => {
+                    // Thread the same metadata compMatches/allMatches supply so the
+                    // MatchViewerModal renders team sub-bouts (compKind/teamSize) and a
+                    // correct header (phase/poolName), not an empty round label. Pool
+                    // daihyosen bouts ("…-DH-…") are scored individually — null the team
+                    // flags so they route to the individual UI (mirrors compMatches).
+                    const isDH = isPoolDaihyosenID(m.id || "");
+                    const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compKind: isDH ? "" : competition.kind, teamSize: isDH ? 0 : competition.teamSize };
+                    return <PoolMatchRow key={m.id} m={m} onClick={() => onMatchClick && onMatchClick(enriched)} />;
+                  })}
                 </div>
               </div>
             )}
@@ -1984,7 +1996,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;


### PR DESCRIPTION
## Summary

Fixes mp-116: team knockout matches in the viewer were rendering as individual (single ippons line) instead of showing per-bout sub-rows, in two places:
- **Overview tab** — "Recent results" / Live / Up Next cards backed by `recentMatches`/`liveMatches`/`upcomingMatches`
- **Bracket tab** — clicking a bracket node opens `MatchViewerModal`

## Root cause

`MatchDetailCard.isTeam` and `MatchViewerModal.isTeam` gate on `match.compKind === "team" || match.teamSize > 0`. Both evaluated `false` because the matches passed to these components were missing `compKind`/`teamSize`:

1. The `allMatches` useMemo inside `ViewerCompetition` (line ~1135) flattened pools + bracket adding only `phase`/`round`/`poolName`, **not** `compKind`/`teamSize`. `recentMatches`/`liveMatches`/`upcomingMatches` derive from it.
2. The Bracket tab `onMatchClick` passed the raw bracket node to `setSelectedMatch`, also without the flags.

The module-level `compMatches` helper already did this correctly (including the pool-DH guard); `allMatches` was simply missing the same threading.

## Changes

- **`web-mobile/js/viewer.jsx`**
  - `allMatches` useMemo pool push: add `compKind: isDH ? "" : c.kind, teamSize: isDH ? 0 : c.teamSize` (replicating the pool-DH guard from `compMatches`)
  - `allMatches` useMemo bracket push: add `compKind: c.kind, teamSize: c.teamSize`
  - `allMatches` deps: add `c.kind`, `c.teamSize`
  - Bracket tab `onMatchClick`: spread `compKind: c.kind, teamSize: c.teamSize` onto the selected match

- **`web-mobile/js/__tests__/viewer.test.jsx`**
  - 3 new `compMatches` unit tests: flag threading for team pool matches, pool-DH guard, bracket matches
  - 2 new `MatchDetailCard` render tests: team sub-bout block renders when `compKind="team"` (Overview regression), individual ippons block renders for non-team matches (regression guard)

## Test plan

- [x] `make go/build` — esbuild + Go binary build (PASS)
- [x] `make go/test` — JS lint, JS tests (878/878), Go tests (all packages PASS; `TestDiagnoseFolderError_OwnerInfo` fails pre-existing on this environment due to gid mismatch, also fails on `main`)
- [x] `node_modules/.bin/vitest run` — 37 viewer tests pass
- [x] Manual browser verification (done 2026-05-30, mobile viewport against the `teams` fixture): Overview "Recent results" — expanding completed team match *Team Eta A vs Team Epsilon Blue* renders the team sub-bout block (5 per-bout rows incl. the `Hantei` marker on Match 2), individual ippons block correctly suppressed. Bracket tab — clicking that node opens `MatchViewerModal` showing the SHIRO/Position/AKA per-bout table (Match 1–5), not the `Ippons N-N` fallback. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)