### PR TITLE
feat(mp-825): per-match team lineups (additive MatchID key)

### DIFF
--- a/internal/domain/team_lineup.go
+++ b/internal/domain/team_lineup.go
@@ -27,15 +27,26 @@ const (
 func PositionNumbered(n int) Position { return Position(strconv.Itoa(n)) }
 
 // TeamLineup pins which player occupies each Position for a team in a
-// given round. The lineup is replaceable up until the round's first
-// match goes live, at which point LockedAt is set and further
+// given round OR for a specific match. The lineup is replaceable up
+// until its match (match-scoped) or its round's first match
+// (round-scoped) goes live, at which point LockedAt is set and further
 // PUT/PATCH operations are rejected.
+//
+// Keying (mp-825): when MatchID is non-empty the lineup is
+// match-scoped — a team may field a different order/roster for each
+// encounter (e.g. successive pool matches), and each entry locks
+// independently when its own match starts. When MatchID is empty the
+// lineup is round-scoped (the legacy behavior, still used by bracket
+// rounds and pre-mp-825 data): one lineup per (team, round), frozen
+// when the round's first match goes live. The two scopes coexist; a
+// match-scoped entry shadows the round-scoped fallback for that match.
 //
 // FR-040, data-model §4.
 type TeamLineup struct {
 	TeamID        string              `json:"teamId" yaml:"teamId"`
 	CompetitionID string              `json:"competitionId" yaml:"competitionId"`
 	Round         int                 `json:"round" yaml:"round"`
+	MatchID       string              `json:"matchId,omitempty" yaml:"matchId,omitempty"`
 	Positions     map[Position]string `json:"positions" yaml:"positions"`
 	LockedAt      *time.Time          `json:"lockedAt,omitempty" yaml:"lockedAt,omitempty"`
 }

--- a/internal/engine/kachinuki_export.go
+++ b/internal/engine/kachinuki_export.go
@@ -99,10 +99,10 @@ func buildKachinukiDetail(m *state.MatchResult, label string, positions map[stri
 		bouts = append(bouts, helper.KachinukiBout{
 			Position:  sub.Position,
 			SideAName: sub.SideA,
-			SideAPos:  positions[lineupKey(m.SideA, sub.SideA)],
+			SideAPos:  resolveKachinukiPosition(positions, m.ID, m.SideA, sub.SideA),
 			ScoreA:    strings.Join(sub.IpponsA, ""),
 			SideBName: sub.SideB,
-			SideBPos:  positions[lineupKey(m.SideB, sub.SideB)],
+			SideBPos:  resolveKachinukiPosition(positions, m.ID, m.SideB, sub.SideB),
 			ScoreB:    strings.Join(sub.IpponsB, ""),
 			Winner:    sub.Winner,
 			Decision:  sub.Decision,
@@ -153,16 +153,27 @@ func tallyKachinukiEliminations(m *state.MatchResult) (a, b int) {
 }
 
 // lineupKey is the composite key used to look up a player's lineup
-// position. Both team name and player name are needed because two teams
-// may field players with the same name in different positions.
+// position from a ROUND-scoped lineup. Both team name and player name
+// are needed because two teams may field players with the same name in
+// different positions.
 func lineupKey(team, player string) string {
 	return team + "\x00" + player
 }
 
+// matchLineupKey is the composite key for a MATCH-scoped lineup
+// position (mp-825): the same player may occupy a different position in
+// successive encounters, so the match ID is part of the key.
+func matchLineupKey(matchID, team, player string) string {
+	return matchID + "\x00" + team + "\x00" + player
+}
+
 // buildKachinukiPositionMap loads team lineups for the competition and
-// flattens them into a (teamName,playerName) → position map. Missing
-// lineups (Slice 7 integration is partial) yield an empty map — positions
-// render as empty strings in that case, the renderer handles it.
+// flattens them into a position lookup. Two namespaces share one map:
+// match-scoped entries (mp-825) keyed by matchLineupKey, and
+// round-scoped (legacy) entries keyed by lineupKey as the fallback.
+// resolveKachinukiPosition consults match-scoped first. Missing lineups
+// yield an empty map — positions render as empty strings, the renderer
+// handles it.
 func (e *Engine) buildKachinukiPositionMap(compID string, comp *state.Competition) map[string]string {
 	out := map[string]string{}
 	if comp == nil {
@@ -178,10 +189,27 @@ func (e *Engine) buildKachinukiPositionMap(compID string, comp *state.Competitio
 			if playerName == "" {
 				continue
 			}
-			out[lineupKey(teamName, playerName)] = formatPositionLabel(pos)
+			label := formatPositionLabel(pos)
+			if lineup.MatchID != "" {
+				out[matchLineupKey(lineup.MatchID, teamName, playerName)] = label
+			} else {
+				out[lineupKey(teamName, playerName)] = label
+			}
 		}
 	}
 	return out
+}
+
+// resolveKachinukiPosition returns the position label for (team, player)
+// in the given match, preferring a match-scoped lineup and falling back
+// to the round-scoped entry.
+func resolveKachinukiPosition(positions map[string]string, matchID, team, player string) string {
+	if matchID != "" {
+		if label, ok := positions[matchLineupKey(matchID, team, player)]; ok {
+			return label
+		}
+	}
+	return positions[lineupKey(team, player)]
 }
 
 // formatPositionLabel turns a domain.Position wire value into a

--- a/internal/engine/kachinuki_export_test.go
+++ b/internal/engine/kachinuki_export_test.go
@@ -294,3 +294,60 @@ func TestCollectKachinukiMatches_WithBracketStub(t *testing.T) {
 	// BracketMatch has no sub-results → stub has zero bouts → skipped.
 	assert.Empty(t, out, "bracket stub with no bouts should be skipped by the renderer guard")
 }
+
+// TestResolveKachinukiPosition_PrefersMatchScoped verifies the mp-825
+// selection: a match-scoped lineup wins over the round-scoped fallback,
+// and the fallback applies when no match-scoped entry exists.
+func TestResolveKachinukiPosition_PrefersMatchScoped(t *testing.T) {
+	positions := map[string]string{
+		lineupKey("TeamA", "alice"):                 "Senpo",  // round-scoped fallback
+		matchLineupKey("PoolA-1", "TeamA", "alice"): "Taisho", // match-scoped override for PoolA-1
+	}
+
+	// Match PoolA-1 has a match-scoped override → Taisho.
+	assert.Equal(t, "Taisho", resolveKachinukiPosition(positions, "PoolA-1", "TeamA", "alice"))
+	// Match PoolA-2 has no match-scoped entry → round-scoped fallback.
+	assert.Equal(t, "Senpo", resolveKachinukiPosition(positions, "PoolA-2", "TeamA", "alice"))
+	// Empty matchID → fallback only.
+	assert.Equal(t, "Senpo", resolveKachinukiPosition(positions, "", "TeamA", "alice"))
+	// Unknown player → empty.
+	assert.Equal(t, "", resolveKachinukiPosition(positions, "PoolA-1", "TeamA", "bob"))
+}
+
+// TestBuildKachinukiPositionMap_MatchScoped verifies the loader splits
+// match-scoped and round-scoped lineups into their respective key
+// namespaces.
+func TestBuildKachinukiPositionMap_MatchScoped(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	const compID = "kx-match"
+	comp := &state.Competition{ID: compID, TeamSize: 5}
+	require.NoError(t, store.SaveCompetition(comp))
+
+	// Round-scoped lineup.
+	require.NoError(t, store.SetTeamLineup(compID, domain.TeamLineup{
+		TeamID: "TeamA",
+		Positions: map[domain.Position]string{
+			domain.PosSenpo: "alice", domain.PosJiho: "b", domain.PosChuken: "c",
+			domain.PosFukusho: "d", domain.PosTaisho: "e",
+		},
+	}, 5))
+	// Match-scoped lineup for PoolA-1 puts alice at Taisho.
+	require.NoError(t, store.SetTeamLineup(compID, domain.TeamLineup{
+		TeamID:  "TeamA",
+		MatchID: "PoolA-1",
+		Positions: map[domain.Position]string{
+			domain.PosSenpo: "e", domain.PosJiho: "b", domain.PosChuken: "c",
+			domain.PosFukusho: "d", domain.PosTaisho: "alice",
+		},
+	}, 5))
+
+	e := New(store)
+	m := e.buildKachinukiPositionMap(compID, comp)
+
+	assert.Equal(t, "Senpo", resolveKachinukiPosition(m, "PoolA-2", "TeamA", "alice"),
+		"no match-scoped entry for PoolA-2 → round fallback Senpo")
+	assert.Equal(t, "Taisho", resolveKachinukiPosition(m, "PoolA-1", "TeamA", "alice"),
+		"match-scoped PoolA-1 overrides alice to Taisho")
+}

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -296,8 +296,18 @@ func (e *Engine) maybeLockTeamLineupsForRound(compId string, result *state.Match
 	if err != nil || comp == nil || comp.TeamSize <= 0 {
 		return
 	}
+	now := time.Now().UTC()
+	// Match-scoped freeze (mp-825): lock only THIS encounter's lineups,
+	// so a live pool match 1 does not freeze the match-2 lineup.
+	if result.ID != "" {
+		if err := e.store.LockTeamLineupForMatch(compId, result.ID, now); err != nil {
+			log.Printf("engine: LockTeamLineupForMatch compId=%s matchId=%s: %v", compId, result.ID, err)
+		}
+	}
+	// Round-scoped freeze (legacy): still applies to round-keyed lineups
+	// (bracket rounds, pre-mp-825 data). Skips match-scoped entries.
 	const round = 0
-	if err := e.store.LockTeamLineupsForRound(compId, round, time.Now().UTC()); err != nil {
+	if err := e.store.LockTeamLineupsForRound(compId, round, now); err != nil {
 		log.Printf("engine: LockTeamLineupsForRound compId=%s round=%d: %v", compId, round, err)
 	}
 }

--- a/internal/engine/scoring_match_lineup_test.go
+++ b/internal/engine/scoring_match_lineup_test.go
@@ -1,0 +1,92 @@
+package engine
+
+// Tests for the mp-825 wiring in the score path: RecordMatchResult (and
+// its tx twin) must lock the MATCH-scoped lineups for the encounter that
+// just went live, while leaving other matches' lineups editable. The
+// state-level lock primitive is covered in internal/state; these tests
+// guard the engine wiring so a regression that drops the
+// LockTeamLineupForMatch call (leaving only the legacy round sweep) would
+// fail.
+
+import (
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fiveLineupForMatch(teamID, matchID string) domain.TeamLineup {
+	return domain.TeamLineup{
+		TeamID:  teamID,
+		MatchID: matchID,
+		Positions: map[domain.Position]string{
+			domain.PosSenpo: "p1", domain.PosJiho: "p2", domain.PosChuken: "p3",
+			domain.PosFukusho: "p4", domain.PosTaisho: "p5",
+		},
+	}
+}
+
+func matchLineupLocked(t *testing.T, store *state.Store, compID, teamID, matchID string) bool {
+	t.Helper()
+	lineups, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	for _, l := range lineups {
+		if l.MatchID == matchID && l.TeamID == teamID {
+			return l.LockedAt != nil
+		}
+	}
+	t.Fatalf("no match-scoped lineup for team=%s match=%s", teamID, matchID)
+	return false
+}
+
+// TestRecordMatchResult_LocksMatchScopedLineup is the non-tx wiring test:
+// recording PoolA-0 as completed must freeze the PoolA-0 lineup but leave
+// the PoolA-1 lineup editable.
+func TestRecordMatchResult_LocksMatchScopedLineup(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	const compID = "rmr-match-lock"
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, TeamSize: 5}))
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "PoolA-0", SideA: "teamA", SideB: "teamB", Status: state.MatchStatusScheduled},
+		{ID: "PoolA-1", SideA: "teamA", SideB: "teamC", Status: state.MatchStatusScheduled},
+	}))
+	require.NoError(t, store.SetTeamLineup(compID, fiveLineupForMatch("teamA", "PoolA-0"), 5))
+	require.NoError(t, store.SetTeamLineup(compID, fiveLineupForMatch("teamA", "PoolA-1"), 5))
+
+	require.NoError(t, eng.RecordMatchResult(compID, "PoolA-0", &state.MatchResult{
+		Winner: "teamA",
+		Status: state.MatchStatusCompleted,
+	}))
+
+	assert.True(t, matchLineupLocked(t, store, compID, "teamA", "PoolA-0"),
+		"the completed match's lineup must be locked")
+	assert.False(t, matchLineupLocked(t, store, compID, "teamA", "PoolA-1"),
+		"a different match's lineup must remain editable")
+}
+
+// TestMaybeLockTeamLineupsForRoundTx_LocksMatchScopedLineup is the
+// tx-path twin: the helper invoked from RecordMatchResult...Tx must lock
+// the target match's lineup while leaving another match's lineup open.
+func TestMaybeLockTeamLineupsForRoundTx_LocksMatchScopedLineup(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	const compID = "rmrtx-match-lock"
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, TeamSize: 5}))
+	require.NoError(t, store.SetTeamLineup(compID, fiveLineupForMatch("teamA", "PoolA-0"), 5))
+	require.NoError(t, store.SetTeamLineup(compID, fiveLineupForMatch("teamA", "PoolA-1"), 5))
+
+	err := store.WithTransaction(compID, func(tx state.StoreTx) error {
+		eng.maybeLockTeamLineupsForRoundTx(tx, compID, &state.MatchResult{
+			ID:     "PoolA-0",
+			Status: state.MatchStatusRunning,
+		})
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.True(t, matchLineupLocked(t, store, compID, "teamA", "PoolA-0"),
+		"target match lineup must be locked via the tx path")
+	assert.False(t, matchLineupLocked(t, store, compID, "teamA", "PoolA-1"),
+		"other match lineup must remain editable")
+}

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -200,8 +200,16 @@ func (e *Engine) maybeLockTeamLineupsForRoundTx(tx state.StoreTx, compID string,
 	if err != nil || comp == nil || comp.TeamSize <= 0 {
 		return
 	}
+	now := time.Now().UTC()
+	// Match-scoped freeze (mp-825): lock only this encounter's lineups.
+	if result.ID != "" {
+		if err := tx.LockTeamLineupForMatch(compID, result.ID, now); err != nil {
+			log.Printf("engine: LockTeamLineupForMatch compId=%s matchId=%s: %v", compID, result.ID, err)
+		}
+	}
+	// Round-scoped freeze (legacy): round-keyed lineups only.
 	const round = 0
-	if err := tx.LockTeamLineupsForRound(compID, round, time.Now().UTC()); err != nil {
+	if err := tx.LockTeamLineupsForRound(compID, round, now); err != nil {
 		log.Printf("engine: LockTeamLineupsForRound compId=%s round=%d: %v", compID, round, err)
 	}
 }

--- a/internal/mobileapp/deps.go
+++ b/internal/mobileapp/deps.go
@@ -134,6 +134,10 @@ type TeamLineupStore interface {
 	SetTeamLineup(compID string, lineup domain.TeamLineup, teamSize int) error
 	DeleteTeamLineup(compID, teamID string, round int) error
 	LockTeamLineupsForRound(compID string, round int, lockedAt time.Time) error
+	// DeleteTeamLineupForMatch / LockTeamLineupForMatch are the
+	// match-scoped twins added for per-match lineups (mp-825).
+	DeleteTeamLineupForMatch(compID, teamID, matchID string) error
+	LockTeamLineupForMatch(compID, matchID string, lockedAt time.Time) error
 }
 
 // Broadcaster is the consumer-boundary view of *Hub used by handlers

--- a/internal/mobileapp/deps_test.go
+++ b/internal/mobileapp/deps_test.go
@@ -105,6 +105,14 @@ func (stubTeamLineupStore) LockTeamLineupsForRound(string, int, time.Time) error
 	return nil
 }
 
+func (stubTeamLineupStore) DeleteTeamLineupForMatch(string, string, string) error {
+	return nil
+}
+
+func (stubTeamLineupStore) LockTeamLineupForMatch(string, string, time.Time) error {
+	return nil
+}
+
 // stubCompetitionTransactor is a no-op implementation of
 // CompetitionTransactor. fn runs immediately with a nil StoreTx; tests
 // that exercise the transactional path use the real *state.Store

--- a/internal/mobileapp/handlers_lineup.go
+++ b/internal/mobileapp/handlers_lineup.go
@@ -78,6 +78,38 @@ func RegisterPublicLineupHandlers(r *gin.RouterGroup, store TeamLineupStore) {
 		}
 		c.JSON(http.StatusOK, lineup)
 	})
+
+	// Match-scoped read (mp-825). 404 lets the caller fall back to the
+	// round-scoped endpoint above.
+	r.GET("/competitions/:id/teams/:tid/match-lineups/:matchId", func(c *gin.Context) {
+		compID, teamID, matchID, ok := parseMatchLineupParams(c)
+		if !ok {
+			return
+		}
+		lineups, err := store.LoadTeamLineups(compID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		lineup, found := findMatchLineup(lineups, teamID, matchID)
+		if !found {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no lineup submitted for this team and match"})
+			return
+		}
+		c.JSON(http.StatusOK, lineup)
+	})
+}
+
+// findMatchLineup scans the loaded lineup map for the match-scoped entry
+// matching (teamID, matchID), avoiding any dependency on the store's
+// internal key format. Returns the lineup and whether it was found.
+func findMatchLineup(lineups map[string]domain.TeamLineup, teamID, matchID string) (domain.TeamLineup, bool) {
+	for _, l := range lineups {
+		if l.MatchID == matchID && l.TeamID == teamID {
+			return l, true
+		}
+	}
+	return domain.TeamLineup{}, false
 }
 
 // RegisterLineupHandlers wires the PUT/DELETE lineup endpoints under
@@ -223,6 +255,105 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 		}
 		c.Status(http.StatusNoContent)
 	})
+
+	// Match-scoped PUT/DELETE (mp-825). Mirrors the round-scoped flow but
+	// keys the lineup by matchID so successive encounters lock and edit
+	// independently.
+	r.PUT("/competitions/:id/teams/:tid/match-lineups/:matchId", func(c *gin.Context) {
+		compID, teamID, matchID, ok := parseMatchLineupParams(c)
+		if !ok {
+			return
+		}
+		var req LineupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		lineup := domain.TeamLineup{
+			TeamID:        teamID,
+			CompetitionID: compID,
+			MatchID:       matchID,
+			Positions:     req.Positions,
+		}
+
+		type httpErr struct {
+			status int
+			body   gin.H
+		}
+		var respErr *httpErr
+		var persistedLineup domain.TeamLineup
+		txErr := tx.WithTransaction(compID, func(stx state.StoreTx) error {
+			comp, err := stx.LoadCompetition(compID)
+			if err != nil {
+				respErr = &httpErr{status: http.StatusInternalServerError, body: gin.H{"error": err.Error()}}
+				return nil
+			}
+			if comp == nil {
+				respErr = &httpErr{status: http.StatusNotFound, body: gin.H{"error": "competition not found"}}
+				return nil
+			}
+			teamSize := comp.TeamSize
+			if teamSize <= 0 {
+				respErr = &httpErr{
+					status: http.StatusBadRequest,
+					body:   gin.H{"error": "competition is not configured for team play (teamSize must be > 0)"},
+				}
+				return nil
+			}
+			if err := stx.SetTeamLineup(compID, lineup, teamSize); err != nil {
+				switch {
+				case errors.Is(err, state.ErrLineupLocked):
+					respErr = &httpErr{status: http.StatusConflict, body: gin.H{"error": err.Error()}}
+				default:
+					// All domain validation errors (missing senpo/taisho,
+					// too-many-missing, bad team size, dynamic position
+					// messages) map to 400 — same surface as the
+					// round-scoped PUT.
+					respErr = &httpErr{status: http.StatusBadRequest, body: gin.H{"error": err.Error()}}
+				}
+				return nil
+			}
+			lineups, err := stx.LoadTeamLineups(compID)
+			if err != nil {
+				respErr = &httpErr{status: http.StatusInternalServerError, body: gin.H{"error": err.Error()}}
+				return nil
+			}
+			if persisted, found := findMatchLineup(lineups, teamID, matchID); found {
+				persistedLineup = persisted
+			} else {
+				// Defensive: Set just succeeded, so the entry must be
+				// present on reload; fall back to the request payload.
+				persistedLineup = lineup
+			}
+			return nil
+		})
+		if txErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": txErr.Error()})
+			return
+		}
+		if respErr != nil {
+			c.JSON(respErr.status, respErr.body)
+			return
+		}
+		c.JSON(http.StatusOK, persistedLineup)
+	})
+
+	r.DELETE("/competitions/:id/teams/:tid/match-lineups/:matchId", func(c *gin.Context) {
+		compID, teamID, matchID, ok := parseMatchLineupParams(c)
+		if !ok {
+			return
+		}
+		if err := store.DeleteTeamLineupForMatch(compID, teamID, matchID); err != nil {
+			if errors.Is(err, state.ErrLineupLocked) {
+				c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
 }
 
 // parseLineupParams extracts (compID, teamID, round) from the URL and
@@ -255,4 +386,27 @@ func parseLineupParams(c *gin.Context) (compID, teamID string, round int, ok boo
 		return "", "", 0, false
 	}
 	return compID, teamID, round, true
+}
+
+// parseMatchLineupParams extracts (compID, teamID, matchID) from the URL
+// for the match-scoped lineup endpoints (mp-825). matchID is opaque
+// (like teamID) — it's never used as a filesystem path, only as a map
+// key and a lookup against persisted match IDs — so no regex is imposed
+// beyond non-empty.
+func parseMatchLineupParams(c *gin.Context) (compID, teamID, matchID string, ok bool) {
+	compID, ok = requireValidCompID(c)
+	if !ok {
+		return "", "", "", false
+	}
+	teamID = c.Param("tid")
+	if teamID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "team ID is required"})
+		return "", "", "", false
+	}
+	matchID = c.Param("matchId")
+	if matchID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "match ID is required"})
+		return "", "", "", false
+	}
+	return compID, teamID, matchID, true
 }

--- a/internal/mobileapp/handlers_lineup.go
+++ b/internal/mobileapp/handlers_lineup.go
@@ -33,6 +33,13 @@ type LineupRequest struct {
 	Positions map[domain.Position]string `json:"positions"`
 }
 
+// matchLineupLockedMsg is the 409 body for the match-scoped endpoints.
+// state.ErrLineupLocked's own text says "round has started", which is
+// misleading here since these endpoints lock by match — so we surface a
+// match-accurate message at the boundary while still keeping the shared
+// sentinel for control flow (errors.Is).
+const matchLineupLockedMsg = "team lineup locked: match has started"
+
 // RegisterLineupHandlers wires the GET/PUT/DELETE lineup endpoints
 // under the admin group. Slice 7.B / T127.
 //
@@ -304,7 +311,7 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 			if err := stx.SetTeamLineup(compID, lineup, teamSize); err != nil {
 				switch {
 				case errors.Is(err, state.ErrLineupLocked):
-					respErr = &httpErr{status: http.StatusConflict, body: gin.H{"error": err.Error()}}
+					respErr = &httpErr{status: http.StatusConflict, body: gin.H{"error": matchLineupLockedMsg}}
 				default:
 					// All domain validation errors (missing senpo/taisho,
 					// too-many-missing, bad team size, dynamic position
@@ -346,7 +353,7 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 		}
 		if err := store.DeleteTeamLineupForMatch(compID, teamID, matchID); err != nil {
 			if errors.Is(err, state.ErrLineupLocked) {
-				c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+				c.JSON(http.StatusConflict, gin.H{"error": matchLineupLockedMsg})
 				return
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/mobileapp/handlers_match_lineup_test.go
+++ b/internal/mobileapp/handlers_match_lineup_test.go
@@ -1,0 +1,135 @@
+// internal/mobileapp/handlers_match_lineup_test.go covers the
+// match-scoped lineup endpoints (mp-825):
+// /api/competitions/:id/teams/:tid/match-lineups/:matchId. These mirror
+// the round-scoped endpoints but key the lineup by matchID so successive
+// encounters edit and lock independently.
+package mobileapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validPositionsBody() []byte {
+	b, _ := json.Marshal(LineupRequest{Positions: map[domain.Position]string{
+		domain.PosSenpo:   "p1",
+		domain.PosJiho:    "p2",
+		domain.PosChuken:  "p3",
+		domain.PosFukusho: "p4",
+		domain.PosTaisho:  "p5",
+	}})
+	return b
+}
+
+// TestMatchLineupPUTGET_RoundTrip: a match-scoped PUT persists and the
+// public GET returns it, carrying the matchID.
+func TestMatchLineupPUTGET_RoundTrip(t *testing.T) {
+	r, store, _ := setupLineupTestRouter(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "T", Password: "secret"}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c1", TeamSize: 5}))
+
+	// PUT (admin).
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", bytes.NewReader(validPositionsBody()))
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var put domain.TeamLineup
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &put))
+	assert.Equal(t, "PoolA-0", put.MatchID)
+
+	// GET (public, no auth).
+	greq := httptest.NewRequest(http.MethodGet,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", nil)
+	gw := httptest.NewRecorder()
+	r.ServeHTTP(gw, greq)
+	require.Equal(t, http.StatusOK, gw.Code)
+	var got domain.TeamLineup
+	require.NoError(t, json.Unmarshal(gw.Body.Bytes(), &got))
+	assert.Equal(t, "PoolA-0", got.MatchID)
+	assert.Equal(t, "p1", got.Positions[domain.PosSenpo])
+}
+
+// TestMatchLineupGET_404WhenAbsent: GET returns 404 so callers can fall
+// back to the round-scoped endpoint.
+func TestMatchLineupGET_404WhenAbsent(t *testing.T) {
+	r, store, _ := setupLineupTestRouter(t)
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c1", TeamSize: 5}))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-9", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestMatchLineupPUT_409WhenMatchLive: once the match is running, the
+// match-scoped PUT is refused with 409 (frozen).
+func TestMatchLineupPUT_409WhenMatchLive(t *testing.T) {
+	r, store, _ := setupLineupTestRouter(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "T", Password: "secret"}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c1", TeamSize: 5}))
+	require.NoError(t, store.SavePoolMatches("c1", []state.MatchResult{
+		{ID: "PoolA-0", SideA: "teamA", SideB: "teamB", Status: state.MatchStatusRunning},
+	}))
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", bytes.NewReader(validPositionsBody()))
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+}
+
+// TestMatchLineupDELETE: a match-scoped DELETE removes the entry and
+// returns 204.
+func TestMatchLineupDELETE(t *testing.T) {
+	r, store, _ := setupLineupTestRouter(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "T", Password: "secret"}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c1", TeamSize: 5}))
+	require.NoError(t, store.SetTeamLineup("c1", domain.TeamLineup{
+		TeamID:  "teamA",
+		MatchID: "PoolA-0",
+		Positions: map[domain.Position]string{
+			domain.PosSenpo: "p1", domain.PosJiho: "p2", domain.PosChuken: "p3",
+			domain.PosFukusho: "p4", domain.PosTaisho: "p5",
+		},
+	}, 5))
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	lineups, err := store.LoadTeamLineups("c1")
+	require.NoError(t, err)
+	_, found := findMatchLineup(lineups, "teamA", "PoolA-0")
+	assert.False(t, found, "entry must be gone after delete")
+}
+
+// TestMatchLineupPUT_RequiresAuth: the match-scoped PUT is on the admin
+// group and rejects requests without the password.
+func TestMatchLineupPUT_RequiresAuth(t *testing.T) {
+	r, store, _ := setupLineupTestRouter(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "T", Password: "secret"}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c1", TeamSize: 5}))
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", bytes.NewReader(validPositionsBody()))
+	// No password header.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/internal/mobileapp/handlers_match_lineup_test.go
+++ b/internal/mobileapp/handlers_match_lineup_test.go
@@ -89,6 +89,10 @@ func TestMatchLineupPUT_409WhenMatchLive(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+	// The 409 must use a match-accurate message, not the sentinel's
+	// "round has started" text.
+	assert.Contains(t, w.Body.String(), "match has started")
+	assert.NotContains(t, w.Body.String(), "round has started")
 }
 
 // TestMatchLineupDELETE: a match-scoped DELETE removes the entry and
@@ -128,6 +132,22 @@ func TestMatchLineupPUT_RequiresAuth(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", bytes.NewReader(validPositionsBody()))
+	// No password header.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestMatchLineupDELETE_RequiresAuth: the match-scoped DELETE is on the
+// admin group. A regression that registered it outside the admin group
+// would let a no-password DELETE through — this asserts it doesn't.
+func TestMatchLineupDELETE_RequiresAuth(t *testing.T) {
+	r, store, _ := setupLineupTestRouter(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "T", Password: "secret"}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c1", TeamSize: 5}))
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/api/competitions/c1/teams/teamA/match-lineups/PoolA-0", nil)
 	// No password header.
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/internal/state/team_lineup.go
+++ b/internal/state/team_lineup.go
@@ -42,12 +42,32 @@ type teamLineupFile struct {
 
 const teamLineupFilename = "lineups.yaml"
 
-// teamLineupKey is the in-memory map key. Two lineups for the same
-// team in different rounds coexist (a 5-person team might rotate a
-// kiken'd jiho between round 1 and round 2), so the round is part of
-// the key — not just teamID.
+// teamLineupKey is the in-memory map key for a ROUND-scoped lineup. Two
+// lineups for the same team in different rounds coexist (a 5-person team
+// might rotate a kiken'd jiho between round 1 and round 2), so the round
+// is part of the key — not just teamID.
 func teamLineupKey(teamID string, round int) string {
 	return fmt.Sprintf("%s-%d", teamID, round)
+}
+
+// teamLineupMatchKey is the in-memory map key for a MATCH-scoped lineup
+// (mp-825). Prefixed with "m:" so it can never collide with a
+// round-scoped key (which is "<teamID>-<int>"); match IDs are opaque
+// strings and may themselves look like "team-0". Both scopes share one
+// persisted map; the prefix keeps them disjoint.
+func teamLineupMatchKey(teamID, matchID string) string {
+	return "m:" + teamID + "-" + matchID
+}
+
+// lineupStorageKey returns the map key a lineup is stored under:
+// match-scoped when MatchID is set, else round-scoped. This is the one
+// place the scope decision lives — every load/set/delete routes through
+// it so the two namespaces stay consistent.
+func lineupStorageKey(l domain.TeamLineup) string {
+	if l.MatchID != "" {
+		return teamLineupMatchKey(l.TeamID, l.MatchID)
+	}
+	return teamLineupKey(l.TeamID, l.Round)
 }
 
 // LoadTeamLineups returns every lineup persisted for compID, keyed by
@@ -91,7 +111,7 @@ func parseTeamLineupsBytes(data []byte) (map[string]domain.TeamLineup, error) {
 	}
 	out := make(map[string]domain.TeamLineup, len(file.Lineups))
 	for _, l := range file.Lineups {
-		out[teamLineupKey(l.TeamID, l.Round)] = l
+		out[lineupStorageKey(l)] = l
 	}
 	return out, nil
 }
@@ -160,18 +180,28 @@ func (s *Store) setTeamLineupLocked(compID string, lineup domain.TeamLineup, tea
 	if err != nil {
 		return err
 	}
-	key := teamLineupKey(lineup.TeamID, lineup.Round)
+	key := lineupStorageKey(lineup)
 	if existing, ok := current[key]; ok && existing.LockedAt != nil {
 		return ErrLineupLocked
 	}
 	// T128a race-condition guard: a concurrent score-save could have
-	// transitioned a round's first match to running BETWEEN the
-	// caller's last GET and this PUT — without the lineup file yet
-	// recording LockedAt (the engine wires that as a follow-up).
-	// Re-check the round's match status inside this lock and refuse
-	// the write if the round is no longer mutable. Cheap pure-disk
-	// reads, both keyed to the same compPath we already cleaned.
-	if locked, err := s.roundHasLiveOrCompletedMatchLocked(compID, lineup.Round); err != nil {
+	// transitioned this lineup's match to running BETWEEN the caller's
+	// last GET and this PUT — without the lineup file yet recording
+	// LockedAt (the engine wires that as a follow-up). Re-check the
+	// relevant match status inside this lock and refuse the write if it
+	// is no longer mutable. Cheap pure-disk reads, both keyed to the
+	// same compPath we already cleaned.
+	//
+	// Match-scoped (mp-825): check only THIS match's status, so a live
+	// pool match 1 does not block editing the match-2 lineup.
+	// Round-scoped: keep the legacy round-wide check.
+	if lineup.MatchID != "" {
+		if locked, err := s.matchIsLiveOrCompletedLocked(compID, lineup.MatchID); err != nil {
+			return err
+		} else if locked {
+			return ErrLineupLocked
+		}
+	} else if locked, err := s.roundHasLiveOrCompletedMatchLocked(compID, lineup.Round); err != nil {
 		return err
 	} else if locked {
 		return ErrLineupLocked
@@ -231,6 +261,44 @@ func (s *Store) roundHasLiveOrCompletedMatchLocked(compID string, round int) (bo
 	return false, nil
 }
 
+// matchIsLiveOrCompletedLocked is the match-scoped twin of
+// roundHasLiveOrCompletedMatchLocked (mp-825): is the single match
+// `matchID` currently running or completed? Used by SetTeamLineup for
+// match-scoped lineups so the freeze check is keyed to the exact match,
+// not the whole round.
+//
+// Caller MUST already hold the per-competition lock. Reads pool-matches
+// and bracket directly from disk (bypassing the cache) for the same
+// stale-snapshot reason as the round variant. A match ID not found in
+// either file is treated as not-yet-live (false) — the lineup stays
+// editable until its match actually exists and starts.
+func (s *Store) matchIsLiveOrCompletedLocked(compID, matchID string) (bool, error) {
+	bracketParsed, err := parseBracketFile(s.compPath(compID, "bracket.json"))
+	if err != nil {
+		return false, err
+	}
+	if bracket, ok := bracketParsed.(*Bracket); ok && bracket != nil {
+		for _, round := range bracket.Rounds {
+			for _, m := range round {
+				if m.ID == matchID {
+					return m.Status == MatchStatusRunning || m.Status == MatchStatusCompleted, nil
+				}
+			}
+		}
+	}
+	poolParsed, err := parsePoolMatchesFile(s.compPath(compID, "pool-matches.csv"))
+	if err != nil {
+		return false, err
+	}
+	poolMatches, _ := poolParsed.([]MatchResult)
+	for _, m := range poolMatches {
+		if m.ID == matchID {
+			return m.Status == MatchStatusRunning || m.Status == MatchStatusCompleted, nil
+		}
+	}
+	return false, nil
+}
+
 // DeleteTeamLineup removes the lineup for (teamID, round) if present.
 // Same lock-protected refusal as SetTeamLineup when the entry is
 // already locked: deleting a frozen lineup would re-open the round to
@@ -259,6 +327,87 @@ func (s *Store) DeleteTeamLineup(compID, teamID string, round int) error {
 	}
 	delete(current, key)
 	return s.saveTeamLineupsLocked(compID, current, s.directWrite)
+}
+
+// DeleteTeamLineupForMatch removes the match-scoped lineup for
+// (teamID, matchID) if present (mp-825). Same lock-protected refusal as
+// the round variant when the entry is already frozen.
+//
+// Returns nil when no entry exists (idempotent delete).
+func (s *Store) DeleteTeamLineupForMatch(compID, teamID, matchID string) error {
+	if err := ValidateCompetitionID(compID); err != nil {
+		return err
+	}
+	mu := s.getCompLock(compID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	current, err := s.loadTeamLineupsLocked(compID)
+	if err != nil {
+		return err
+	}
+	key := teamLineupMatchKey(teamID, matchID)
+	existing, ok := current[key]
+	if !ok {
+		return nil
+	}
+	if existing.LockedAt != nil {
+		return ErrLineupLocked
+	}
+	delete(current, key)
+	return s.saveTeamLineupsLocked(compID, current, s.directWrite)
+}
+
+// LockTeamLineupForMatch stamps LockedAt on every persisted match-scoped
+// lineup whose MatchID matches `matchID` — i.e. both teams' lineups for
+// that single encounter (mp-825). Round-scoped (legacy) lineups are
+// untouched; those are frozen by LockTeamLineupsForRound. Idempotent:
+// already-locked entries keep their original LockedAt.
+//
+// Called by the engine when a team match transitions to running, in
+// addition to LockTeamLineupsForRound (the two scopes are locked
+// independently during the transition window).
+func (s *Store) LockTeamLineupForMatch(compID, matchID string, lockedAt time.Time) error {
+	if err := ValidateCompetitionID(compID); err != nil {
+		return err
+	}
+	mu := s.getCompLock(compID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	return s.lockTeamLineupForMatchLocked(compID, matchID, lockedAt, s.directWrite)
+}
+
+// lockTeamLineupForMatchLocked is the lock-free body of
+// LockTeamLineupForMatch. Caller MUST already hold the per-comp write
+// lock (typically via WithTransaction). Mirrors
+// lockTeamLineupsForRoundLocked so the tx-aware score path can freeze
+// under the same lock acquire as the score write.
+func (s *Store) lockTeamLineupForMatchLocked(compID, matchID string, lockedAt time.Time, write writeFn) error {
+	if matchID == "" {
+		return nil
+	}
+	current, err := s.loadTeamLineupsLocked(compID)
+	if err != nil {
+		return err
+	}
+	changed := false
+	for k, l := range current {
+		if l.MatchID != matchID {
+			continue
+		}
+		if l.LockedAt != nil {
+			continue
+		}
+		t := lockedAt
+		l.LockedAt = &t
+		current[k] = l
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	return s.saveTeamLineupsLocked(compID, current, write)
 }
 
 // LockTeamLineupsForRound stamps LockedAt on every persisted lineup
@@ -296,6 +445,14 @@ func (s *Store) lockTeamLineupsForRoundLocked(compID string, round int, lockedAt
 	}
 	changed := false
 	for k, l := range current {
+		// Match-scoped lineups (mp-825) are frozen per-match by
+		// LockTeamLineupForMatch, never by the round sweep — otherwise a
+		// live round-0 pool match would freeze every match-scoped pool
+		// lineup (Round defaults to 0 when unset), re-introducing the
+		// exact bug this change fixes.
+		if l.MatchID != "" {
+			continue
+		}
 		if l.Round != round {
 			continue
 		}

--- a/internal/state/team_lineup.go
+++ b/internal/state/team_lineup.go
@@ -52,11 +52,18 @@ func teamLineupKey(teamID string, round int) string {
 
 // teamLineupMatchKey is the in-memory map key for a MATCH-scoped lineup
 // (mp-825). Prefixed with "m:" so it can never collide with a
-// round-scoped key (which is "<teamID>-<int>"); match IDs are opaque
-// strings and may themselves look like "team-0". Both scopes share one
-// persisted map; the prefix keeps them disjoint.
+// round-scoped key (which is "<teamID>-<int>"); both scopes share one
+// persisted map and the prefix keeps them disjoint.
+//
+// The two components are joined with a NUL byte rather than "-" because
+// both teamID and matchID are opaque and routinely contain hyphens (pool
+// match IDs are "PoolA-0"). A "-" delimiter would be ambiguous —
+// ("a-b","c") and ("a","b-c") would collide — so NUL, which cannot
+// appear in either, is used (same technique as lineupKey in
+// kachinuki_export.go). This key is only ever a map key; it is never
+// persisted or parsed back, so the delimiter choice is free.
 func teamLineupMatchKey(teamID, matchID string) string {
-	return "m:" + teamID + "-" + matchID
+	return "m:" + teamID + "\x00" + matchID
 }
 
 // lineupStorageKey returns the map key a lineup is stored under:

--- a/internal/state/team_lineup.go
+++ b/internal/state/team_lineup.go
@@ -332,6 +332,14 @@ func (s *Store) DeleteTeamLineup(compID, teamID string, round int) error {
 	if existing.LockedAt != nil {
 		return ErrLineupLocked
 	}
+	// Same TOCTOU guard as SetTeamLineup: refuse the delete if the round
+	// has gone live before the lock stamp landed, so DELETE can't reopen
+	// a live/completed round's lineup.
+	if live, err := s.roundHasLiveOrCompletedMatchLocked(compID, round); err != nil {
+		return err
+	} else if live {
+		return ErrLineupLocked
+	}
 	delete(current, key)
 	return s.saveTeamLineupsLocked(compID, current, s.directWrite)
 }
@@ -359,6 +367,15 @@ func (s *Store) DeleteTeamLineupForMatch(compID, teamID, matchID string) error {
 		return nil
 	}
 	if existing.LockedAt != nil {
+		return ErrLineupLocked
+	}
+	// Same TOCTOU guard as SetTeamLineup: a concurrent score-save could
+	// have transitioned this match to running/completed before the
+	// follow-up lock stamp landed. Re-check the match status inside the
+	// lock so DELETE can't reopen a live/completed match's lineup.
+	if live, err := s.matchIsLiveOrCompletedLocked(compID, matchID); err != nil {
+		return err
+	} else if live {
 		return ErrLineupLocked
 	}
 	delete(current, key)

--- a/internal/state/team_lineup_match_test.go
+++ b/internal/state/team_lineup_match_test.go
@@ -218,3 +218,28 @@ func TestDeleteTeamLineupForMatch(t *testing.T) {
 	require.ErrorIs(t, store.DeleteTeamLineupForMatch(compID, "team-alpha", "P2"), ErrLineupLocked,
 		"locked match lineup must refuse delete")
 }
+
+// TestDeleteTeamLineupForMatch_RefusesWhenMatchLive guards the
+// delete-side TOCTOU window (PR #197 review): even with no LockedAt
+// stamp yet, a running/completed match must block DELETE so it cannot
+// reopen a live encounter's lineup — mirroring SetTeamLineup's guard.
+func TestDeleteTeamLineupForMatch_RefusesWhenMatchLive(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-delete-live"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, TeamSize: 5}))
+	require.NoError(t, store.SavePoolMatches(compID, []MatchResult{
+		{ID: "PoolA-0", SideA: "TeamA", SideB: "TeamB", Status: MatchStatusScheduled},
+	}))
+	// Set the lineup while the match is still scheduled.
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "PoolA-0"), 5))
+
+	// The match goes live WITHOUT the lock stamp landing (the TOCTOU
+	// window). DELETE must still be refused.
+	require.NoError(t, store.SavePoolMatches(compID, []MatchResult{
+		{ID: "PoolA-0", SideA: "TeamA", SideB: "TeamB", Status: MatchStatusRunning},
+	}))
+	require.ErrorIs(t, store.DeleteTeamLineupForMatch(compID, "team-alpha", "PoolA-0"), ErrLineupLocked,
+		"DELETE must be refused once the match is live, even before the lock stamp lands")
+}

--- a/internal/state/team_lineup_match_test.go
+++ b/internal/state/team_lineup_match_test.go
@@ -101,6 +101,34 @@ func TestMatchLineup_LockMatch1LeavesMatch2Editable(t *testing.T) {
 		"match 2 edit must have persisted")
 }
 
+// TestMatchLineup_KeyNoHyphenCollision guards the Copilot-found bug
+// (PR #197): joining teamID and matchID with "-" was ambiguous because
+// both routinely contain hyphens (pool match IDs are "PoolA-0"). The
+// pairs ("a-b","c") and ("a","b-c") both produced "m:a-b-c" and one
+// lineup silently overwrote the other. With the NUL-byte delimiter they
+// must remain distinct entries.
+func TestMatchLineup_KeyNoHyphenCollision(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-collision"
+	l1 := fiveStarterForMatch("a-b", "c")
+	l1.Positions[domain.PosSenpo] = "team-ab-senpo"
+	l2 := fiveStarterForMatch("a", "b-c")
+	l2.Positions[domain.PosSenpo] = "team-a-senpo"
+
+	require.NoError(t, store.SetTeamLineup(compID, l1, 5))
+	require.NoError(t, store.SetTeamLineup(compID, l2, 5))
+
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "(a-b,c) and (a,b-c) must be distinct keys, not a collision")
+	assert.Equal(t, "team-ab-senpo",
+		got[teamLineupMatchKey("a-b", "c")].Positions[domain.PosSenpo])
+	assert.Equal(t, "team-a-senpo",
+		got[teamLineupMatchKey("a", "b-c")].Positions[domain.PosSenpo])
+}
+
 // TestMatchLineup_RoundLockSkipsMatchScoped: the legacy round-0 sweep
 // must NOT freeze match-scoped lineups (their Round defaults to 0).
 // Otherwise a live round-0 pool match would re-introduce the bug.

--- a/internal/state/team_lineup_match_test.go
+++ b/internal/state/team_lineup_match_test.go
@@ -1,0 +1,192 @@
+// internal/state/team_lineup_match_test.go covers mp-825: match-scoped
+// team lineups. A team may field a different order/roster for each
+// encounter (e.g. successive pool matches), so a lineup keyed by MatchID
+// must lock independently of other matches and of the legacy
+// round-scoped sweep. The headline regression test is
+// TestMatchLineup_LockMatch1LeavesMatch2Editable — the exact behavior
+// the bug report asked for.
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fiveStarterForMatch is the match-scoped twin of fiveStarter: a fully
+// populated 5-person lineup pinned to a specific matchID.
+func fiveStarterForMatch(teamID, matchID string) domain.TeamLineup {
+	l := fiveStarter(teamID, 0)
+	l.MatchID = matchID
+	return l
+}
+
+// TestMatchLineup_RoundTrip: a match-scoped Set round-trips through Load
+// keyed independently of any round-scoped entry for the same team.
+func TestMatchLineup_RoundTrip(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-rt"
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P1"), 5))
+
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	persisted, ok := got[teamLineupMatchKey("team-alpha", "P1")]
+	require.True(t, ok, "lineup must be keyed by the match-scoped key")
+	assert.Equal(t, "P1", persisted.MatchID)
+	assert.Equal(t, compID, persisted.CompetitionID, "CompetitionID auto-stamped")
+	assert.Nil(t, persisted.LockedAt)
+}
+
+// TestMatchLineup_CoexistsWithRoundLineup: a match-scoped and a
+// round-scoped lineup for the same team live in disjoint namespaces and
+// neither clobbers the other.
+func TestMatchLineup_CoexistsWithRoundLineup(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-coexist"
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarter("team-alpha", 0), 5))
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P1"), 5))
+
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "round-scoped and match-scoped entries coexist")
+	assert.Contains(t, got, teamLineupKey("team-alpha", 0))
+	assert.Contains(t, got, teamLineupMatchKey("team-alpha", "P1"))
+}
+
+// TestMatchLineup_LockMatch1LeavesMatch2Editable is the headline mp-825
+// regression: in a pool a team plays several encounters. Starting (and
+// thereby locking) match 1 must NOT freeze the still-unstarted match-2
+// lineup. Under the old round-0 collapse this test would fail because
+// both lineups shared one round-0 key.
+func TestMatchLineup_LockMatch1LeavesMatch2Editable(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-isolation"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, TeamSize: 5}))
+
+	// Two pool encounters for the same team, each with its own lineup.
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P1"), 5))
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P2"), 5))
+
+	// Match 1 goes live and is frozen.
+	require.NoError(t, store.LockTeamLineupForMatch(compID, "P1", time.Now().UTC()))
+
+	// Match 1 is now locked: editing it must be refused.
+	swapped1 := fiveStarterForMatch("team-alpha", "P1")
+	swapped1.Positions[domain.PosJiho] = "p2-sub"
+	require.ErrorIs(t, store.SetTeamLineup(compID, swapped1, 5), ErrLineupLocked,
+		"match 1 is locked, its lineup must be frozen")
+
+	// Match 2 is STILL editable — the whole point of the change.
+	swapped2 := fiveStarterForMatch("team-alpha", "P2")
+	swapped2.Positions[domain.PosJiho] = "p2-sub"
+	require.NoError(t, store.SetTeamLineup(compID, swapped2, 5),
+		"match 2 has not started — its lineup must remain editable after match 1 locks")
+
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	assert.NotNil(t, got[teamLineupMatchKey("team-alpha", "P1")].LockedAt, "match 1 locked")
+	assert.Nil(t, got[teamLineupMatchKey("team-alpha", "P2")].LockedAt, "match 2 still open")
+	assert.Equal(t, "p2-sub", got[teamLineupMatchKey("team-alpha", "P2")].Positions[domain.PosJiho],
+		"match 2 edit must have persisted")
+}
+
+// TestMatchLineup_RoundLockSkipsMatchScoped: the legacy round-0 sweep
+// must NOT freeze match-scoped lineups (their Round defaults to 0).
+// Otherwise a live round-0 pool match would re-introduce the bug.
+func TestMatchLineup_RoundLockSkipsMatchScoped(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-roundsweep"
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P2"), 5))
+
+	// Engine fires the legacy round-0 lock when some match goes live.
+	require.NoError(t, store.LockTeamLineupsForRound(compID, 0, time.Now().UTC()))
+
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	assert.Nil(t, got[teamLineupMatchKey("team-alpha", "P2")].LockedAt,
+		"round-0 sweep must NOT freeze a match-scoped lineup")
+}
+
+// TestMatchLineup_SetGuardedByOwnMatchStatus: SetTeamLineup for a
+// match-scoped lineup is refused only when THAT match is live, and is
+// allowed when a DIFFERENT match is live.
+func TestMatchLineup_SetGuardedByOwnMatchStatus(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-toctou"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, TeamSize: 5}))
+	// Pool match IDs are persisted as "PoolName-Idx" (pools.go), so the
+	// test must use that form for the ID to survive the CSV round-trip
+	// and be found by matchIsLiveOrCompletedLocked.
+	require.NoError(t, store.SavePoolMatches(compID, []MatchResult{
+		{ID: "PoolA-0", SideA: "TeamA", SideB: "TeamB", Status: MatchStatusRunning},
+		{ID: "PoolA-1", SideA: "TeamA", SideB: "TeamC", Status: MatchStatusScheduled},
+	}))
+
+	// PoolA-0 is running → its match-scoped lineup is blocked even with
+	// no LockedAt stamp yet (TOCTOU guard).
+	require.ErrorIs(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "PoolA-0"), 5),
+		ErrLineupLocked, "running match PoolA-0 must block its own lineup")
+
+	// PoolA-1 is only scheduled → its lineup is freely settable.
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "PoolA-1"), 5),
+		"scheduled match PoolA-1 must allow its lineup")
+}
+
+// TestLockTeamLineupForMatch_OnlyTargetMatch: locking match P1 stamps
+// every team's P1 lineup but leaves other matches untouched.
+func TestLockTeamLineupForMatch_OnlyTargetMatch(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-locktarget"
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P1"), 5))
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-beta", "P1"), 5))
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P3"), 5))
+
+	require.NoError(t, store.LockTeamLineupForMatch(compID, "P1", time.Now().UTC()))
+
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	assert.NotNil(t, got[teamLineupMatchKey("team-alpha", "P1")].LockedAt, "both P1 teams locked")
+	assert.NotNil(t, got[teamLineupMatchKey("team-beta", "P1")].LockedAt, "both P1 teams locked")
+	assert.Nil(t, got[teamLineupMatchKey("team-alpha", "P3")].LockedAt, "P3 untouched")
+}
+
+// TestDeleteTeamLineupForMatch: idempotent delete, and frozen entries
+// refuse deletion.
+func TestDeleteTeamLineupForMatch(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	const compID = "team-match-delete"
+
+	// Idempotent on a missing entry.
+	require.NoError(t, store.DeleteTeamLineupForMatch(compID, "team-alpha", "P9"))
+
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P1"), 5))
+	require.NoError(t, store.DeleteTeamLineupForMatch(compID, "team-alpha", "P1"))
+	got, err := store.LoadTeamLineups(compID)
+	require.NoError(t, err)
+	assert.Empty(t, got, "match lineup gone after delete")
+
+	// A locked entry refuses deletion.
+	require.NoError(t, store.SetTeamLineup(compID, fiveStarterForMatch("team-alpha", "P2"), 5))
+	require.NoError(t, store.LockTeamLineupForMatch(compID, "P2", time.Now().UTC()))
+	require.ErrorIs(t, store.DeleteTeamLineupForMatch(compID, "team-alpha", "P2"), ErrLineupLocked,
+		"locked match lineup must refuse delete")
+}

--- a/internal/state/transactions.go
+++ b/internal/state/transactions.go
@@ -119,6 +119,10 @@ type StoreTx interface {
 	// (T128 / T156) so the lineup freeze happens under the same lock
 	// acquire as the score write.
 	LockTeamLineupsForRound(compID string, round int, lockedAt time.Time) error
+	// LockTeamLineupForMatch is the tx-aware twin of
+	// Store.LockTeamLineupForMatch (mp-825). Freezes the match-scoped
+	// lineups for a single encounter under the score-write lock.
+	LockTeamLineupForMatch(compID, matchID string, lockedAt time.Time) error
 	// UpdateParticipant is the tx-aware twin of
 	// Store.updateParticipantNoLock. Applies transform to the target
 	// participant while the transaction lock is held, so the caller
@@ -515,7 +519,7 @@ func (t *storeTx) SetTeamLineup(compID string, l domain.TeamLineup, teamSize int
 		if perr != nil {
 			return perr
 		}
-		key := teamLineupKey(l.TeamID, l.Round)
+		key := lineupStorageKey(l)
 		if existing, present := current[key]; present && existing.LockedAt != nil {
 			return ErrLineupLocked
 		}
@@ -624,6 +628,10 @@ func (t *storeTx) LockTeamLineupsForRound(compID string, round int, lockedAt tim
 		}
 		changed := false
 		for k, l := range current {
+			// Skip match-scoped entries — see lockTeamLineupsForRoundLocked.
+			if l.MatchID != "" {
+				continue
+			}
 			if l.Round != round {
 				continue
 			}
@@ -641,4 +649,44 @@ func (t *storeTx) LockTeamLineupsForRound(compID string, round int, lockedAt tim
 		return t.store.saveTeamLineupsLocked(compID, current, t.txWriteFn())
 	}
 	return t.store.lockTeamLineupsForRoundLocked(compID, round, lockedAt, t.txWriteFn())
+}
+
+// LockTeamLineupForMatch dispatches to the lock-free body of
+// Store.LockTeamLineupForMatch (mp-825). Caller (WithTransaction) holds
+// the per-comp lock. Read-your-own-writes: if lineups.yaml is staged in
+// this tx, this load + lock + save sees the staged version.
+func (t *storeTx) LockTeamLineupForMatch(compID, matchID string, lockedAt time.Time) error {
+	if err := t.checkCompID(compID); err != nil {
+		return err
+	}
+	if err := ValidateCompetitionID(compID); err != nil {
+		return err
+	}
+	if matchID == "" {
+		return nil
+	}
+	if pending, ok := t.pendingFor(teamLineupFilename); ok {
+		current, perr := parseTeamLineupsBytes(pending)
+		if perr != nil {
+			return perr
+		}
+		changed := false
+		for k, l := range current {
+			if l.MatchID != matchID {
+				continue
+			}
+			if l.LockedAt != nil {
+				continue
+			}
+			ts := lockedAt
+			l.LockedAt = &ts
+			current[k] = l
+			changed = true
+		}
+		if !changed {
+			return nil
+		}
+		return t.store.saveTeamLineupsLocked(compID, current, t.txWriteFn())
+	}
+	return t.store.lockTeamLineupForMatchLocked(compID, matchID, lockedAt, t.txWriteFn())
 }

--- a/specs/005-per-match-lineup/spec.md
+++ b/specs/005-per-match-lineup/spec.md
@@ -1,0 +1,72 @@
+# 005 — Per-match team lineups
+
+**Bead:** mp-825
+**Status:** Backend slice (Phases 0–4). UI (Phase 5) and viewer overlay (Phase 6) tracked as follow-ups.
+
+## Problem
+
+`domain.TeamLineup` is keyed `(competitionID, teamID, round)`. Pool matches have no
+round field, so the store collapses every pool match to **round 0**
+(`internal/state/team_lineup.go` `roundHasLiveOrCompletedMatchLocked`,
+`internal/engine/scoring.go` `maybeLockTeamLineupsForRound` hard-codes `round = 0`).
+
+Consequences for a pool of N teams (each team plays N−1 encounters in one "round"):
+
+- A team has a single round-0 lineup.
+- When that team's **first** pool match goes live, `LockTeamLineupsForRound(comp, 0)`
+  freezes it.
+- The lineup is then frozen for pool matches 2..N — the operator **cannot** field a
+  different order/roster for later encounters.
+
+This contradicts FIK practice: a team may change its order and players between each
+team encounter.
+
+> Note: bracket/elimination is already correct — a team appears in exactly one match
+> per `Rounds[N]`, so `(teamID, round)` is already 1:1 with the match there. The defect
+> is **pool-specific**.
+
+## Approach — additive `MatchID` key (not a full re-key)
+
+Add an optional `MatchID string` to `TeamLineup`.
+
+- Store key resolves to a **match-scoped** key when `MatchID != ""`, else the existing
+  **round-scoped** key. The two namespaces never collide (match keys are prefixed).
+- Bracket and legacy round-only data load unchanged — **no on-disk migration**. A
+  round-only lineup remains valid and is the fallback when no per-match entry exists.
+- Per-match entries lock independently: locking pool match 1 does **not** freeze the
+  (still-unstarted) lineup for pool match 2.
+
+### Resolved decisions
+
+1. **Lock granularity.** A per-match (`MatchID != ""`) lineup locks only when *its*
+   match transitions to live/completed. Round-keyed (legacy) lineups keep the existing
+   round-0 freeze behavior. The engine score path calls **both**
+   `LockTeamLineupForMatch(comp, matchID)` (new) and the legacy
+   `LockTeamLineupsForRound(comp, 0)` (unchanged) so neither keying regresses during
+   transition.
+2. **TOCTOU set-guard.** `SetTeamLineup` for a match-scoped lineup refuses with
+   `ErrLineupLocked` when *that match* is already running/completed (checked by ID).
+   Round-scoped sets keep the existing round-status check.
+3. **Migration.** None on disk. The fallback key means existing round-keyed lineups
+   keep working; the new UI writes match-keyed entries going forward.
+4. **FIK 5-person rule.** `Validate(teamSize)` is unchanged and runs per set, regardless
+   of keying.
+5. **Engine advancement.** `MaybeAdvanceKachinuki` does **not** read lineups (it works
+   off a roster snapshot) — untouched. The only lineup consumer in the engine is the
+   XLSX exporter (`kachinuki_export.go`), which now prefers a match-scoped lineup when
+   present.
+
+## API
+
+`GET/PUT/DELETE /api/competitions/:id/teams/:tid/lineups/:round` — unchanged (round-scoped).
+
+New, match-scoped (added alongside, both live one release):
+`GET/PUT/DELETE /api/competitions/:id/teams/:tid/match-lineups/:matchId`
+
+`GET` returns 404 when no match-scoped lineup exists (caller may fall back to the
+round-scoped endpoint).
+
+## Out of scope (follow-up beads)
+
+- **Phase 5** — Score-editor UI: per-side lineup edit panel + "Copy from previous match".
+- **Phase 6** — Viewer/TV overlay rendering of the per-match lineup.


### PR DESCRIPTION
Closes mp-825.

## Problem

`domain.TeamLineup` is keyed `(competitionID, teamID, round)`. Pool matches have no round field, so the store collapses every pool match to **round 0** (`roundHasLiveOrCompletedMatchLocked`; `maybeLockTeamLineupsForRound` hard-codes `round = 0`).

For a pool of N teams (each plays N−1 encounters in one "round"): a team has a single round-0 lineup, it freezes when that team's **first** pool match goes live, and is then frozen for matches 2..N. The operator cannot field a different order/roster for later encounters — which contradicts FIK practice.

Bracket/elimination was already correct (a team appears in exactly one match per `Rounds[N]`, so `(teamID, round)` is already 1:1 with the match there). **The defect is pool-specific.**

## Approach — additive `MatchID` key (not a full re-key)

This started from a larger "re-key everything to matchID" plan; an evidence pass scoped it down (`specs/005-per-match-lineup/spec.md`):

- **Additive field.** `TeamLineup` gains optional `MatchID`. Store key resolves to a match-scoped key when set, else the existing round-scoped key (disjoint namespaces). **Bracket and legacy round-only data load unchanged — no on-disk migration.**
- **Per-match lock.** `LockTeamLineupForMatch` freezes only one encounter's lineups. The legacy round-0 sweep now **skips** match-scoped entries (whose `Round` defaults to 0), so a live pool match 1 no longer freezes the match-2 lineup.
- **Per-match TOCTOU guard.** `SetTeamLineup` for a match-scoped lineup checks only **that** match's status (`matchIsLiveOrCompletedLocked`).
- **Engine.** The score path now locks by matchID in addition to the legacy round sweep (`scoring.go` + tx twin). The live `MaybeAdvanceKachinuki` does **not** read lineups, so it's untouched — the original plan's "engine reads lineup" phase was phantom work. The only engine consumer is the XLSX exporter, which now prefers a match-scoped lineup with round fallback.
- **API.** New endpoints alongside the round-scoped ones:
  `GET/PUT/DELETE /api/competitions/:id/teams/:tid/match-lineups/:matchId` (GET public, PUT/DELETE admin). GET 404s so callers can fall back to the round endpoint.

## Out of scope (follow-up beads)

- **Phase 5** — Score-editor UI: per-side lineup panel + "Copy from previous match".
- **Phase 6** — Viewer/TV overlay rendering of the per-match lineup.

These need browser verification and are better reviewed separately.

## Test plan

- [x] `make go/test` — Go lint clean, gosec 0 issues, govulncheck clean, all Go tests pass. (`js/lint` fails only because `eslint` isn't installed in this env; no JS changed. `cmd/TestDiagnoseFolderError_OwnerInfo` fails on `main` too — pre-existing, environment-specific.)
- [x] **state** — per-match CRUD round-trip; coexistence with round lineups; **headline regression: lock match 1 → match 2 still editable**; round-sweep skips match-scoped; per-match TOCTOU; lock targets only its match; match-scoped delete (incl. locked-refuses-delete).
- [x] **mobileapp** — match-scoped PUT/GET round-trip; 404 when absent; 409 when match live; DELETE 204; PUT requires auth.
- [x] **engine** — match-scoped position resolution prefers match over round fallback; `buildKachinukiPositionMap` namespace split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)