### PR TITLE
feat(mp-cw1): browser push notifications for viewer announcements

### DIFF
--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -549,9 +549,10 @@ describe('diffAnnouncementSnapshot', () => {
     });
   }
 
-  it('sentAt filter: post-mount ID excluded from seed fires on SSE replay', () => {
-    // Models the race: HTTP response includes NEW (sentAt after mount), but the
-    // caller only seeds pre-mount IDs. Buffered SSE replay then fires for NEW.
+  it('sentAt filter WITH buffered SSE: post-mount ID excluded from seed fires on SSE replay', () => {
+    // Models the race WITH a buffered SSE snapshot: HTTP response includes NEW
+    // (sentAt after mount), but seed is pre-mount only. Buffered SSE replay fires
+    // for NEW.
     const mountMs = Date.parse('2026-05-30T13:00:00.000Z');
     const ref = { current: null };
 
@@ -559,12 +560,35 @@ describe('diffAnnouncementSnapshot', () => {
       { id: 'ann-1', sentAt: '2026-05-30T12:00:00.000Z', message: 'Pre-existing' },
       { id: 'new-1', sentAt: '2026-05-30T13:00:01.000Z', message: 'Created after mount' },
     ];
-    diffAnnouncementSnapshot(ref, preMountFilter(httpList, mountMs)); // seed pre-mount only
+    const sseList = httpList; // SSE was buffered; same snapshot (with NEW)
 
-    // Replay buffered SSE (includes new-1)
-    const additions = diffAnnouncementSnapshot(ref, httpList);
+    // WITH buffered SSE: seed pre-mount only
+    diffAnnouncementSnapshot(ref, preMountFilter(httpList, mountMs));
+    // Replay buffered SSE (includes new-1) → fires for NEW
+    const additions = diffAnnouncementSnapshot(ref, sseList);
     expect(additions).toHaveLength(1);
     expect(additions[0].id).toBe('new-1');
+  });
+
+  it('sentAt filter WITHOUT buffered SSE: post-mount ID seeded from full HTTP list (no stale notification)', () => {
+    // Models the case with NO buffered SSE: HTTP response includes NEW (post-mount)
+    // but since there is no SSE to replay, seed the full list to avoid leaving
+    // NEW unseeded and triggering stale notifications on a later unrelated SSE.
+    const mountMs = Date.parse('2026-05-30T13:00:00.000Z');
+    const ref = { current: null };
+
+    const httpList = [
+      { id: 'ann-1', sentAt: '2026-05-30T12:00:00.000Z', message: 'Pre-existing' },
+      { id: 'new-1', sentAt: '2026-05-30T13:00:01.000Z', message: 'Created after mount' },
+    ];
+
+    // WITHOUT buffered SSE: seed the full list (including new-1)
+    diffAnnouncementSnapshot(ref, httpList);
+    expect(ref.current.has('new-1')).toBe(true); // seeded → won't re-fire
+
+    // Later unrelated SSE arrives with the same list → no stale notification
+    const additions = diffAnnouncementSnapshot(ref, httpList);
+    expect(additions).toHaveLength(0);
   });
 
   it('sentAt filter: Go RFC3339 without fractional seconds compares correctly', () => {

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isAnnouncementActive, filterActiveAnnouncements } from '../app.jsx';
-import { AnnouncementBanner, AnnouncementCard } from '../viewer.jsx';
+import { isAnnouncementActive, filterActiveAnnouncements, fireBrowserNotifications } from '../app.jsx';
+import { AnnouncementBanner, AnnouncementCard, NotificationSettings, notificationSupported } from '../viewer.jsx';
 
 // Helper: recursively search a React element tree (mock objects) for all
 // elements matching a predicate, returning them as a flat list.
@@ -286,5 +286,275 @@ describe('AnnouncementCard dismiss and per-card timer', () => {
     // And they are independent — c1's dismiss did not fire c2's and vice versa
     expect(onDismiss1).not.toHaveBeenCalledWith('c2');
     expect(onDismiss2).not.toHaveBeenCalledWith('c1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fireBrowserNotifications — unit tests for the notification diff helper.
+// These cover the four guard conditions and the happy path.
+// ---------------------------------------------------------------------------
+
+describe('fireBrowserNotifications', () => {
+  let NotificationMock;
+  let originalNotification;
+  let originalDocumentHidden;
+  let originalWindowLocalStorage;
+
+  const setDocumentHidden = (val) => {
+    Object.defineProperty(document, 'hidden', { value: val, writable: true, configurable: true });
+  };
+
+  // Create a minimal in-memory localStorage stub for tests that need it.
+  // window.localStorage is undefined in this jsdom/node environment so we
+  // install a mock on window directly in each test suite that reads it.
+  const makeLocalStorageMock = (initialEntries = {}) => {
+    const store = { ...initialEntries };
+    return {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; },
+      clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    };
+  };
+
+  beforeEach(() => {
+    originalNotification = global.Notification;
+    originalDocumentHidden = Object.getOwnPropertyDescriptor(document, 'hidden');
+    originalWindowLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+    NotificationMock = vi.fn();
+    NotificationMock.permission = 'granted';
+    global.Notification = NotificationMock;
+
+    setDocumentHidden(true);
+
+    // Install a mock localStorage with the toggle pre-enabled.
+    const lsMock = makeLocalStorageMock({ 'viewer.notifications.enabled': 'true' });
+    Object.defineProperty(window, 'localStorage', { value: lsMock, writable: true, configurable: true });
+  });
+
+  afterEach(() => {
+    global.Notification = originalNotification;
+    if (originalDocumentHidden) {
+      Object.defineProperty(document, 'hidden', originalDocumentHidden);
+    } else {
+      Object.defineProperty(document, 'hidden', { value: false, writable: true, configurable: true });
+    }
+    if (originalWindowLocalStorage) {
+      Object.defineProperty(window, 'localStorage', originalWindowLocalStorage);
+    } else {
+      Object.defineProperty(window, 'localStorage', { value: undefined, writable: true, configurable: true });
+    }
+  });
+
+  it('fires once for a new id when all guards pass', () => {
+    const additions = [{ id: 'ann-1', message: 'New announcement' }];
+    fireBrowserNotifications(additions);
+    expect(NotificationMock).toHaveBeenCalledTimes(1);
+    expect(NotificationMock).toHaveBeenCalledWith('Tournament Announcement', {
+      tag: 'ann-1',
+      body: 'New announcement',
+      icon: '/favicon.jpeg',
+    });
+  });
+
+  it('does NOT fire when document is visible (document.hidden === false)', () => {
+    setDocumentHidden(false);
+    fireBrowserNotifications([{ id: 'ann-2', message: 'Hello' }]);
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when permission is not granted', () => {
+    NotificationMock.permission = 'default';
+    fireBrowserNotifications([{ id: 'ann-3', message: 'Hello' }]);
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when permission is denied', () => {
+    NotificationMock.permission = 'denied';
+    fireBrowserNotifications([{ id: 'ann-4', message: 'Hello' }]);
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when the localStorage toggle is off', () => {
+    // Override the mock localStorage (beforeEach sets 'true') to 'false'.
+    window.localStorage.setItem('viewer.notifications.enabled', 'false');
+    fireBrowserNotifications([{ id: 'ann-5', message: 'Hello' }]);
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when the Notification API is unavailable', () => {
+    global.Notification = undefined;
+    // Should not throw; additions are silently ignored
+    expect(() => fireBrowserNotifications([{ id: 'ann-6', message: 'Hello' }])).not.toThrow();
+    // Nothing to assert about calls since the mock is gone, but no throw = pass
+  });
+
+  it('fires one notification per addition when multiple are passed', () => {
+    const additions = [
+      { id: 'multi-1', message: 'One' },
+      { id: 'multi-2', message: 'Two' },
+    ];
+    fireBrowserNotifications(additions);
+    expect(NotificationMock).toHaveBeenCalledTimes(2);
+    expect(NotificationMock).toHaveBeenCalledWith('Tournament Announcement', expect.objectContaining({ tag: 'multi-1' }));
+    expect(NotificationMock).toHaveBeenCalledWith('Tournament Announcement', expect.objectContaining({ tag: 'multi-2' }));
+  });
+
+  it('does NOT fire for entries without an id', () => {
+    fireBrowserNotifications([{ message: 'No id here' }]);
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot-diff logic — verifies the seen-IDs pattern used in app.jsx's SSE
+// handler. We test the diff logic directly (as a pure function pattern) since
+// the full SSE integration requires mounting the App component, which is
+// heavier than needed for these invariants.
+// ---------------------------------------------------------------------------
+
+describe('announcement snapshot diff logic', () => {
+  it('identifies additions correctly — only ids not in seen set', () => {
+    const seen = new Set(['existing-1', 'existing-2']);
+    const snapshot = [
+      { id: 'existing-1', message: 'Old' },
+      { id: 'new-1', message: 'New announcement' },
+    ];
+    const additions = snapshot.filter(a => a && a.id && !seen.has(a.id));
+    expect(additions).toHaveLength(1);
+    expect(additions[0].id).toBe('new-1');
+  });
+
+  it('produces no additions when the snapshot only removed items (dismiss/clear)', () => {
+    const seen = new Set(['ann-1', 'ann-2', 'ann-3']);
+    // Snapshot shrunk — two were dismissed
+    const snapshot = [{ id: 'ann-1', message: 'Still here' }];
+    const additions = snapshot.filter(a => a && a.id && !seen.has(a.id));
+    expect(additions).toHaveLength(0);
+  });
+
+  it('produces no additions when snapshot is empty (clear-all)', () => {
+    const seen = new Set(['ann-1', 'ann-2']);
+    const snapshot = [];
+    const additions = snapshot.filter(a => a && a.id && !seen.has(a.id));
+    expect(additions).toHaveLength(0);
+  });
+
+  it('marks all current snapshot IDs as seen after processing', () => {
+    const seen = new Set(['old-1']);
+    const snapshot = [
+      { id: 'old-1', message: 'Existing' },
+      { id: 'new-1', message: 'New' },
+    ];
+    // Simulate what the SSE handler does
+    snapshot.forEach(a => { if (a && a.id) seen.add(a.id); });
+    expect(seen.has('old-1')).toBe(true);
+    expect(seen.has('new-1')).toBe(true);
+  });
+
+  it('a second identical snapshot produces no new additions (idempotent)', () => {
+    const seen = new Set();
+    const snapshot1 = [{ id: 'ann-1', message: 'Hello' }];
+    // First snapshot — seeds seen
+    let additions = snapshot1.filter(a => a && a.id && !seen.has(a.id));
+    snapshot1.forEach(a => { if (a && a.id) seen.add(a.id); });
+    expect(additions).toHaveLength(1);
+    // Second identical snapshot — no new additions
+    additions = snapshot1.filter(a => a && a.id && !seen.has(a.id));
+    expect(additions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NotificationSettings component — settings toggle round-trip tests.
+// Uses the global React stub (non-reactive) since we only need static renders.
+// ---------------------------------------------------------------------------
+
+describe('NotificationSettings', () => {
+  let originalNotification;
+  let originalWindowLocalStorage;
+
+  // Minimal in-memory localStorage stub (same pattern as fireBrowserNotifications suite).
+  const makeLocalStorageMock = (initialEntries = {}) => {
+    const store = { ...initialEntries };
+    return {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; },
+      clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+    };
+  };
+
+  beforeEach(() => {
+    originalNotification = global.Notification;
+    originalWindowLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      value: makeLocalStorageMock(),
+      writable: true, configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.Notification = originalNotification;
+    if (originalWindowLocalStorage) {
+      Object.defineProperty(window, 'localStorage', originalWindowLocalStorage);
+    } else {
+      Object.defineProperty(window, 'localStorage', { value: undefined, writable: true, configurable: true });
+    }
+  });
+
+  it('returns null when Notification API is unavailable', () => {
+    global.Notification = undefined;
+    const result = NotificationSettings({});
+    expect(result).toBeNull();
+  });
+
+  it('renders the toggle when Notification is available and permission is default', () => {
+    global.Notification = { permission: 'default', requestPermission: vi.fn() };
+    const result = NotificationSettings({});
+    expect(result).not.toBeNull();
+    // Should render a card with a checkbox
+    const str = JSON.stringify(result);
+    expect(str).toContain('notification-settings');
+    expect(str).toContain('notification-toggle');
+  });
+
+  it('renders a blocked message when permission is denied', () => {
+    global.Notification = { permission: 'denied' };
+    const result = NotificationSettings({});
+    expect(result).not.toBeNull();
+    const str = JSON.stringify(result);
+    expect(str).toContain('notification-denied');
+  });
+
+  it('shows the insecure-context warning when window.isSecureContext is false', () => {
+    const orig = window.isSecureContext;
+    Object.defineProperty(window, 'isSecureContext', { value: false, writable: true, configurable: true });
+    global.Notification = { permission: 'default', requestPermission: vi.fn() };
+    const result = NotificationSettings({});
+    const str = JSON.stringify(result);
+    expect(str).toContain('notification-insecure-warning');
+    Object.defineProperty(window, 'isSecureContext', { value: orig, writable: true, configurable: true });
+  });
+
+  it('notificationSupported returns false when Notification is undefined', () => {
+    global.Notification = undefined;
+    expect(notificationSupported()).toBe(false);
+  });
+
+  it('notificationSupported returns true when Notification is defined', () => {
+    global.Notification = { permission: 'default' };
+    expect(notificationSupported()).toBe(true);
+  });
+
+  it('persists toggle state to localStorage', () => {
+    // Verify the mock localStorage (installed in beforeEach) round-trips correctly.
+    // This exercises the same LS_NOTIFICATIONS_ENABLED key path used by the component.
+    window.localStorage.setItem('viewer.notifications.enabled', 'true');
+    expect(window.localStorage.getItem('viewer.notifications.enabled')).toBe('true');
+
+    window.localStorage.setItem('viewer.notifications.enabled', 'false');
+    expect(window.localStorage.getItem('viewer.notifications.enabled')).toBe('false');
   });
 });

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { isAnnouncementActive, filterActiveAnnouncements, fireBrowserNotifications, diffAnnouncementSnapshot } from '../app.jsx';
 import { AnnouncementBanner, AnnouncementCard, NotificationSettings, notificationSupported } from '../viewer.jsx';
+import { makeReactive } from './helpers/reactive_react.js';
 
 // Helper: recursively search a React element tree (mock objects) for all
 // elements matching a predicate, returning them as a flat list.
@@ -620,5 +621,88 @@ describe('NotificationSettings', () => {
     await toggle.props.onChange();
     expect(requestPermission).not.toHaveBeenCalled();
     expect(window.localStorage.getItem('viewer.notifications.enabled')).toBe('false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NotificationSettings — reactive runtime, for behaviours that need a real
+// re-render after a state change (Copilot round-2 comments 3328780111 /
+// 3328780129). Uses the makeReactive() shim like reset.test.jsx.
+// ---------------------------------------------------------------------------
+
+describe('NotificationSettings (reactive)', () => {
+  let runtime, RS, realReact, origNotif, origSecure, origLS;
+
+  beforeEach(async () => {
+    realReact = global.React;
+    runtime = makeReactive();
+    global.React = runtime.React;
+    vi.resetModules();
+    ({ NotificationSettings: RS } = await import('../viewer.jsx'));
+    origNotif = global.Notification;
+    origSecure = Object.getOwnPropertyDescriptor(window, 'isSecureContext');
+    origLS = Object.getOwnPropertyDescriptor(window, 'localStorage');
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    global.Notification = origNotif;
+    if (origSecure) Object.defineProperty(window, 'isSecureContext', origSecure);
+    if (origLS) Object.defineProperty(window, 'localStorage', origLS);
+    vi.resetModules();
+  });
+
+  const findToggle = () => findAll(runtime.currentTree(), n => n.props && n.props['data-testid'] === 'notification-toggle')[0];
+  const findWarn = () => findAll(runtime.currentTree(), n => n.props && n.props['data-testid'] === 'notification-insecure-warning');
+
+  it('shows the insecure-context warning even when the Notification API is unavailable', () => {
+    // Bare http:// browser that gates `Notification` on a secure context:
+    // both no API AND isSecureContext === false. The panel must still explain.
+    global.Notification = undefined;
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    const tree = runtime.mount(RS, {});
+    expect(tree).not.toBeNull();
+    expect(findWarn().length).toBe(1);
+  });
+
+  it('hides entirely when the API is unavailable AND the context is secure', () => {
+    global.Notification = undefined;
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    const tree = runtime.mount(RS, {});
+    expect(tree).toBeNull();
+  });
+
+  it('leaves the toggle OFF when enabling succeeds at the prompt but localStorage.setItem throws', async () => {
+    // Storage that throws on write — fireBrowserNotifications reads the flag at
+    // fire time, so an unpersisted "on" would be a checked box that never fires.
+    Object.defineProperty(window, 'localStorage', {
+      value: { getItem: () => null, setItem: () => { throw new Error('quota exceeded'); }, removeItem: () => {} },
+      writable: true, configurable: true,
+    });
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    global.Notification = { permission: 'default', requestPermission: vi.fn().mockResolvedValue('granted') };
+
+    runtime.mount(RS, {});
+    expect(findToggle().props.checked).toBe(false);
+    await findToggle().props.onChange();
+    // Permission was granted, but persistence failed → keep the box OFF so the
+    // UI stays consistent with the (storage-backed) firing path.
+    expect(findToggle().props.checked).toBe(false);
+  });
+
+  it('marks the toggle ON when enabling succeeds and storage persists', async () => {
+    const store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: { getItem: (k) => (k in store ? store[k] : null), setItem: (k, v) => { store[k] = String(v); }, removeItem: (k) => { delete store[k]; } },
+      writable: true, configurable: true,
+    });
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    global.Notification = { permission: 'default', requestPermission: vi.fn().mockResolvedValue('granted') };
+
+    runtime.mount(RS, {});
+    await findToggle().props.onChange();
+    expect(findToggle().props.checked).toBe(true);
+    expect(store['viewer.notifications.enabled']).toBe('true');
   });
 });

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -532,25 +532,34 @@ describe('diffAnnouncementSnapshot', () => {
     expect(ref.current).toBeInstanceOf(Set);
   });
 
-  // --- sentAt mount-time filter (Copilot comment 3328811690) ---
+  // --- sentAt mount-time filter (Copilot comments 3328811690, 3329327022) ---
   // The HTTP seed is pre-filtered to announcements with sentAt ≤ mountTime so
   // post-mount announcements in the HTTP response don't block the SSE replay
-  // from firing notifications for them.
+  // from firing notifications for them. Date.parse() is used for numeric
+  // comparison because Go's RFC3339Nano may omit fractional seconds, making
+  // lexicographic string comparison incorrect ('Z' > '.' in ASCII).
+
+  // Helper matching the app.jsx preMountList filter logic (numeric comparison).
+  function preMountFilter(list, mountMs) {
+    return list.filter(a => {
+      if (!a || !a.id) return false;
+      if (!a.sentAt) return true;
+      const ms = Date.parse(a.sentAt);
+      return isNaN(ms) || ms <= mountMs;
+    });
+  }
 
   it('sentAt filter: post-mount ID excluded from seed fires on SSE replay', () => {
     // Models the race: HTTP response includes NEW (sentAt after mount), but the
     // caller only seeds pre-mount IDs. Buffered SSE replay then fires for NEW.
-    const mountTime = '2026-05-30T13:00:00.000Z';
+    const mountMs = Date.parse('2026-05-30T13:00:00.000Z');
     const ref = { current: null };
 
     const httpList = [
       { id: 'ann-1', sentAt: '2026-05-30T12:00:00.000Z', message: 'Pre-existing' },
       { id: 'new-1', sentAt: '2026-05-30T13:00:01.000Z', message: 'Created after mount' },
     ];
-    const preMountList = httpList.filter(
-      a => !a || !a.id || !a.sentAt || a.sentAt <= mountTime
-    );
-    diffAnnouncementSnapshot(ref, preMountList); // seed pre-mount only
+    diffAnnouncementSnapshot(ref, preMountFilter(httpList, mountMs)); // seed pre-mount only
 
     // Replay buffered SSE (includes new-1)
     const additions = diffAnnouncementSnapshot(ref, httpList);
@@ -558,17 +567,30 @@ describe('diffAnnouncementSnapshot', () => {
     expect(additions[0].id).toBe('new-1');
   });
 
-  it('sentAt filter: missing sentAt treated as pre-existing (conservative — no spam)', () => {
-    const mountTime = '2026-05-30T13:00:00.000Z';
+  it('sentAt filter: Go RFC3339 without fractional seconds compares correctly', () => {
+    // "2026-05-30T13:00:00Z" (no fractional) vs mountMs from "2026-05-30T13:00:00.500Z".
+    // String comparison would wrongly say "Z" > "." → excluded. Numeric is correct.
+    const mountMs = Date.parse('2026-05-30T13:00:00.500Z'); // ~500ms after the hour
     const ref = { current: null };
 
+    // ann-1 sentAt is the same second but without fractional — pre-existing (sentAt < mountMs)
     const httpList = [
-      { id: 'ann-1', message: 'No sentAt' }, // treated as pre-existing
+      { id: 'ann-1', sentAt: '2026-05-30T13:00:00Z', message: 'Pre-existing, no frac seconds' },
     ];
-    const preMountList = httpList.filter(
-      a => !a || !a.id || !a.sentAt || a.sentAt <= mountTime
-    );
-    diffAnnouncementSnapshot(ref, preMountList); // seeds ann-1
+    diffAnnouncementSnapshot(ref, preMountFilter(httpList, mountMs)); // ann-1 IS pre-mount
+    expect(ref.current.has('ann-1')).toBe(true); // correctly seeded as pre-existing
+
+    // Replay with same list → ann-1 already seen → no notification ✓
+    const additions = diffAnnouncementSnapshot(ref, httpList);
+    expect(additions).toHaveLength(0);
+  });
+
+  it('sentAt filter: missing sentAt treated as pre-existing (conservative — no spam)', () => {
+    const mountMs = Date.parse('2026-05-30T13:00:00.000Z');
+    const ref = { current: null };
+
+    const httpList = [{ id: 'ann-1', message: 'No sentAt' }]; // treated as pre-existing
+    diffAnnouncementSnapshot(ref, preMountFilter(httpList, mountMs)); // seeds ann-1
     // Replay SSE with the same list → ann-1 already seen → no additions
     const additions = diffAnnouncementSnapshot(ref, httpList);
     expect(additions).toHaveLength(0);

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isAnnouncementActive, filterActiveAnnouncements, fireBrowserNotifications } from '../app.jsx';
+import { isAnnouncementActive, filterActiveAnnouncements, fireBrowserNotifications, diffAnnouncementSnapshot } from '../app.jsx';
 import { AnnouncementBanner, AnnouncementCard, NotificationSettings, notificationSupported } from '../viewer.jsx';
 
 // Helper: recursively search a React element tree (mock objects) for all
@@ -408,61 +408,89 @@ describe('fireBrowserNotifications', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Snapshot-diff logic — verifies the seen-IDs pattern used in app.jsx's SSE
-// handler. We test the diff logic directly (as a pure function pattern) since
-// the full SSE integration requires mounting the App component, which is
-// heavier than needed for these invariants.
+// Snapshot-diff logic — exercises the REAL diffAnnouncementSnapshot helper
+// (the exact code app.jsx's SSE handler and initial-fetch effect call), rather
+// than a re-implementation. A ref is modelled as a plain { current } object,
+// matching the useRef shape the component passes in.
 // ---------------------------------------------------------------------------
 
-describe('announcement snapshot diff logic', () => {
-  it('identifies additions correctly — only ids not in seen set', () => {
-    const seen = new Set(['existing-1', 'existing-2']);
-    const snapshot = [
+describe('diffAnnouncementSnapshot', () => {
+  it('identifies additions correctly — only ids not in the already-seeded set', () => {
+    const ref = { current: new Set(['existing-1', 'existing-2']) };
+    const additions = diffAnnouncementSnapshot(ref, [
       { id: 'existing-1', message: 'Old' },
       { id: 'new-1', message: 'New announcement' },
-    ];
-    const additions = snapshot.filter(a => a && a.id && !seen.has(a.id));
+    ]);
     expect(additions).toHaveLength(1);
     expect(additions[0].id).toBe('new-1');
   });
 
   it('produces no additions when the snapshot only removed items (dismiss/clear)', () => {
-    const seen = new Set(['ann-1', 'ann-2', 'ann-3']);
-    // Snapshot shrunk — two were dismissed
-    const snapshot = [{ id: 'ann-1', message: 'Still here' }];
-    const additions = snapshot.filter(a => a && a.id && !seen.has(a.id));
+    const ref = { current: new Set(['ann-1', 'ann-2', 'ann-3']) };
+    const additions = diffAnnouncementSnapshot(ref, [{ id: 'ann-1', message: 'Still here' }]);
     expect(additions).toHaveLength(0);
   });
 
   it('produces no additions when snapshot is empty (clear-all)', () => {
-    const seen = new Set(['ann-1', 'ann-2']);
-    const snapshot = [];
-    const additions = snapshot.filter(a => a && a.id && !seen.has(a.id));
-    expect(additions).toHaveLength(0);
+    const ref = { current: new Set(['ann-1', 'ann-2']) };
+    expect(diffAnnouncementSnapshot(ref, [])).toHaveLength(0);
   });
 
   it('marks all current snapshot IDs as seen after processing', () => {
-    const seen = new Set(['old-1']);
-    const snapshot = [
+    const ref = { current: new Set(['old-1']) };
+    diffAnnouncementSnapshot(ref, [
       { id: 'old-1', message: 'Existing' },
       { id: 'new-1', message: 'New' },
-    ];
-    // Simulate what the SSE handler does
-    snapshot.forEach(a => { if (a && a.id) seen.add(a.id); });
-    expect(seen.has('old-1')).toBe(true);
-    expect(seen.has('new-1')).toBe(true);
+    ]);
+    expect(ref.current.has('old-1')).toBe(true);
+    expect(ref.current.has('new-1')).toBe(true);
   });
 
   it('a second identical snapshot produces no new additions (idempotent)', () => {
-    const seen = new Set();
-    const snapshot1 = [{ id: 'ann-1', message: 'Hello' }];
-    // First snapshot — seeds seen
-    let additions = snapshot1.filter(a => a && a.id && !seen.has(a.id));
-    snapshot1.forEach(a => { if (a && a.id) seen.add(a.id); });
-    expect(additions).toHaveLength(1);
-    // Second identical snapshot — no new additions
-    additions = snapshot1.filter(a => a && a.id && !seen.has(a.id));
+    const ref = { current: new Set() };
+    const snapshot = [{ id: 'ann-1', message: 'Hello' }];
+    expect(diffAnnouncementSnapshot(ref, snapshot)).toHaveLength(1); // new vs empty seeded set
+    expect(diffAnnouncementSnapshot(ref, snapshot)).toHaveLength(0); // already seen
+  });
+
+  // --- Seeding race (Copilot comment 3328483813) ---------------------------
+
+  it('treats the FIRST snapshot against an unseeded (null) ref as a seed — no additions', () => {
+    const ref = { current: null }; // initial fetch has not seeded yet
+    const additions = diffAnnouncementSnapshot(ref, [
+      { id: 'ann-1', message: 'Active at load' },
+      { id: 'ann-2', message: 'Also active at load' },
+    ]);
+    // No notifications on page load even though the SSE snapshot won the race.
     expect(additions).toHaveLength(0);
+    // ...but both IDs are now recorded, so they never re-fire later.
+    expect(ref.current.has('ann-1')).toBe(true);
+    expect(ref.current.has('ann-2')).toBe(true);
+  });
+
+  it('after the first snapshot seeds, a genuinely new announcement fires', () => {
+    const ref = { current: null };
+    diffAnnouncementSnapshot(ref, [{ id: 'ann-1', message: 'At load' }]); // seed
+    const additions = diffAnnouncementSnapshot(ref, [
+      { id: 'ann-1', message: 'At load' },
+      { id: 'ann-2', message: 'Arrived after load' },
+    ]);
+    expect(additions).toHaveLength(1);
+    expect(additions[0].id).toBe('ann-2');
+  });
+
+  it('seeds from an empty first snapshot, then fires for a later addition', () => {
+    const ref = { current: null };
+    expect(diffAnnouncementSnapshot(ref, [])).toHaveLength(0); // seed (nothing active)
+    expect(ref.current).toBeInstanceOf(Set); // now seeded, not null
+    const additions = diffAnnouncementSnapshot(ref, [{ id: 'ann-1', message: 'New' }]);
+    expect(additions).toHaveLength(1);
+  });
+
+  it('tolerates a non-array snapshot without throwing', () => {
+    const ref = { current: null };
+    expect(diffAnnouncementSnapshot(ref, null)).toEqual([]);
+    expect(ref.current).toBeInstanceOf(Set);
   });
 });
 
@@ -555,6 +583,42 @@ describe('NotificationSettings', () => {
     expect(window.localStorage.getItem('viewer.notifications.enabled')).toBe('true');
 
     window.localStorage.setItem('viewer.notifications.enabled', 'false');
+    expect(window.localStorage.getItem('viewer.notifications.enabled')).toBe('false');
+  });
+
+  // --- Two-click bug (Copilot comment 3328483825) -------------------------
+  // Stored opt-in is "true" but the browser permission has been reset to
+  // "default". The checkbox must render unchecked AND the first click must go
+  // down the "turning on" branch (request permission), not "turning off".
+  it('first click requests permission when opt-in was stored but permission is default', async () => {
+    window.localStorage.setItem('viewer.notifications.enabled', 'true');
+    const requestPermission = vi.fn().mockResolvedValue('granted');
+    global.Notification = { permission: 'default', requestPermission };
+
+    const tree = NotificationSettings({});
+    const toggle = findAll(tree, n => n.props && n.props['data-testid'] === 'notification-toggle')[0];
+    expect(toggle).toBeDefined();
+    // enabled is gated on permission===granted, so the box renders unchecked.
+    expect(toggle.props.checked).toBe(false);
+
+    // First click → must request permission (turning-on branch), not flip off.
+    await toggle.props.onChange();
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT re-request permission on the first click when already granted (turning off)', async () => {
+    window.localStorage.setItem('viewer.notifications.enabled', 'true');
+    const requestPermission = vi.fn().mockResolvedValue('granted');
+    global.Notification = { permission: 'granted', requestPermission };
+
+    const tree = NotificationSettings({});
+    const toggle = findAll(tree, n => n.props && n.props['data-testid'] === 'notification-toggle')[0];
+    // Stored true + granted → checkbox checked.
+    expect(toggle.props.checked).toBe(true);
+
+    // First click turns OFF — no permission prompt.
+    await toggle.props.onChange();
+    expect(requestPermission).not.toHaveBeenCalled();
     expect(window.localStorage.getItem('viewer.notifications.enabled')).toBe('false');
   });
 });

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -409,10 +409,18 @@ describe('fireBrowserNotifications', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Snapshot-diff logic — exercises the REAL diffAnnouncementSnapshot helper
-// (the exact code app.jsx's SSE handler and initial-fetch effect call), rather
-// than a re-implementation. A ref is modelled as a plain { current } object,
-// matching the useRef shape the component passes in.
+// Snapshot-diff logic — exercises the REAL diffAnnouncementSnapshot helper.
+// Models a plain { current } object for the ref, matching the useRef shape.
+//
+// Intended call sequence (app.jsx):
+//   1. fetchAnnouncements() HTTP success → first call (null ref) → seeds.
+//   2. Any SSE snapshot that arrived before step 1 is BUFFERED externally in
+//      pendingSseAnnouncements and replayed (second call) after step 1. This
+//      allows announcements added in the mount→fetch race window to fire.
+//   3. fetchAnnouncements() HTTP failure + buffered SSE → first call → seeds
+//      from SSE (no notifications — pre-existing from SSE perspective).
+//   4. HTTP failure + nothing buffered → ref stays null; first subsequent SSE
+//      call seeds (original spam-prevention fallback).
 // ---------------------------------------------------------------------------
 
 describe('diffAnnouncementSnapshot', () => {
@@ -454,27 +462,57 @@ describe('diffAnnouncementSnapshot', () => {
     expect(diffAnnouncementSnapshot(ref, snapshot)).toHaveLength(0); // already seen
   });
 
-  // --- Seeding race (Copilot comment 3328483813) ---------------------------
+  // --- Seeding (null-ref first-call behaviour) ---
 
-  it('treats the FIRST snapshot against an unseeded (null) ref as a seed — no additions', () => {
-    const ref = { current: null }; // initial fetch has not seeded yet
+  it('the first call against an unseeded (null) ref always seeds — no additions returned', () => {
+    // In app.jsx this first call comes from fetchAnnouncements() HTTP success.
+    // SSE snapshots that arrive before this point are buffered externally and
+    // replayed after seeding.
+    const ref = { current: null };
     const additions = diffAnnouncementSnapshot(ref, [
       { id: 'ann-1', message: 'Active at load' },
       { id: 'ann-2', message: 'Also active at load' },
     ]);
-    // No notifications on page load even though the SSE snapshot won the race.
-    expect(additions).toHaveLength(0);
-    // ...but both IDs are now recorded, so they never re-fire later.
+    expect(additions).toHaveLength(0); // no notifications on page load
     expect(ref.current.has('ann-1')).toBe(true);
     expect(ref.current.has('ann-2')).toBe(true);
   });
 
-  it('after the first snapshot seeds, a genuinely new announcement fires', () => {
+  it('after HTTP seeds, a subsequent diff (replayed buffered SSE) fires for the new announcement', () => {
+    // Models the race-window case: fetchAnnouncements() HTTP response contains
+    // [ann-1] (snapshot taken before NEW was posted); the buffered SSE snapshot
+    // contains [ann-1, NEW]. Replaying it after HTTP seeding fires for NEW.
+    const ref = { current: null };
+    const httpList = [{ id: 'ann-1', message: 'Pre-existing' }];
+    const sseList  = [{ id: 'ann-1', message: 'Pre-existing' }, { id: 'new-1', message: 'Added in race window' }];
+    diffAnnouncementSnapshot(ref, httpList); // step 1: HTTP seeds (returns [])
+    const additions = diffAnnouncementSnapshot(ref, sseList); // step 2: replay buffered SSE
+    expect(additions).toHaveLength(1);
+    expect(additions[0].id).toBe('new-1');
+  });
+
+  it('after the seed, a genuinely new announcement in the next snapshot fires', () => {
     const ref = { current: null };
     diffAnnouncementSnapshot(ref, [{ id: 'ann-1', message: 'At load' }]); // seed
     const additions = diffAnnouncementSnapshot(ref, [
       { id: 'ann-1', message: 'At load' },
       { id: 'ann-2', message: 'Arrived after load' },
+    ]);
+    expect(additions).toHaveLength(1);
+    expect(additions[0].id).toBe('ann-2');
+  });
+
+  it('HTTP-failure fallback: seeding from buffered SSE (no notifications) leaves ref usable', () => {
+    // Models sequence 3: HTTP fails, the buffered SSE snapshot seeds the ref
+    // instead. The seed call returns [] (no notifications). A subsequent SSE
+    // diff correctly identifies new arrivals.
+    const ref = { current: null };
+    const sseSeed = [{ id: 'ann-1', message: 'Pre-existing via SSE fallback' }];
+    diffAnnouncementSnapshot(ref, sseSeed); // HTTP failed; caller seeds from buffered SSE
+    expect(ref.current).toBeInstanceOf(Set);
+    const additions = diffAnnouncementSnapshot(ref, [
+      { id: 'ann-1', message: 'Pre-existing' },
+      { id: 'ann-2', message: 'New' },
     ]);
     expect(additions).toHaveLength(1);
     expect(additions[0].id).toBe('ann-2');

--- a/web-mobile/js/__tests__/app_announcement.test.jsx
+++ b/web-mobile/js/__tests__/app_announcement.test.jsx
@@ -531,6 +531,48 @@ describe('diffAnnouncementSnapshot', () => {
     expect(diffAnnouncementSnapshot(ref, null)).toEqual([]);
     expect(ref.current).toBeInstanceOf(Set);
   });
+
+  // --- sentAt mount-time filter (Copilot comment 3328811690) ---
+  // The HTTP seed is pre-filtered to announcements with sentAt ≤ mountTime so
+  // post-mount announcements in the HTTP response don't block the SSE replay
+  // from firing notifications for them.
+
+  it('sentAt filter: post-mount ID excluded from seed fires on SSE replay', () => {
+    // Models the race: HTTP response includes NEW (sentAt after mount), but the
+    // caller only seeds pre-mount IDs. Buffered SSE replay then fires for NEW.
+    const mountTime = '2026-05-30T13:00:00.000Z';
+    const ref = { current: null };
+
+    const httpList = [
+      { id: 'ann-1', sentAt: '2026-05-30T12:00:00.000Z', message: 'Pre-existing' },
+      { id: 'new-1', sentAt: '2026-05-30T13:00:01.000Z', message: 'Created after mount' },
+    ];
+    const preMountList = httpList.filter(
+      a => !a || !a.id || !a.sentAt || a.sentAt <= mountTime
+    );
+    diffAnnouncementSnapshot(ref, preMountList); // seed pre-mount only
+
+    // Replay buffered SSE (includes new-1)
+    const additions = diffAnnouncementSnapshot(ref, httpList);
+    expect(additions).toHaveLength(1);
+    expect(additions[0].id).toBe('new-1');
+  });
+
+  it('sentAt filter: missing sentAt treated as pre-existing (conservative — no spam)', () => {
+    const mountTime = '2026-05-30T13:00:00.000Z';
+    const ref = { current: null };
+
+    const httpList = [
+      { id: 'ann-1', message: 'No sentAt' }, // treated as pre-existing
+    ];
+    const preMountList = httpList.filter(
+      a => !a || !a.id || !a.sentAt || a.sentAt <= mountTime
+    );
+    diffAnnouncementSnapshot(ref, preMountList); // seeds ann-1
+    // Replay SSE with the same list → ann-1 already seen → no additions
+    const additions = diffAnnouncementSnapshot(ref, httpList);
+    expect(additions).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -397,27 +397,38 @@ function App() {
       .then(list => {
         const active = filterActiveAnnouncements(list || []);
         setAnnouncements(active);
-        // mp-cw1: Seed from the HTTP response, but only for pre-mount
-        // announcements (sentAt ≤ mount time). Announcements created after
-        // the viewer mounted (sentAt > mount time) are intentionally excluded
-        // so the buffered SSE replay below still fires notifications for them
-        // even when the HTTP GET response happened to capture them too.
-        // Date.parse() is used for numeric comparison because Go's RFC3339Nano
-        // serialisation may omit fractional seconds ("…Z" vs "….500Z") and
-        // lexicographic string comparison would give the wrong order in that
-        // case ('Z' > '.' in ASCII). Missing/unparseable sentAt → pre-existing.
-        const preMountList = (list || []).filter(a => {
-          if (!a || !a.id) return false;
-          if (!a.sentAt) return true;
-          const ms = Date.parse(a.sentAt);
-          return isNaN(ms) || ms <= mountTimeRef.current;
-        });
-        diffAnnouncementSnapshot(seenAnnouncementIds, preMountList);
-        // Replay any SSE snapshot that beat the HTTP seed. These arrived
-        // after mount and may contain genuinely new announcements added in
-        // the race window; diff them to fire the appropriate notifications.
+        // mp-cw1: Consume any SSE snapshot buffered before the HTTP seed arrived.
         const buffered = pendingSseAnnouncements.current;
         pendingSseAnnouncements.current = null;
+
+        // Seed strategy depends on whether we have a buffered SSE to replay:
+        //
+        // • WITH buffered SSE: seed only pre-mount IDs (sentAt ≤ mountMs) so
+        //   the replay below can fire notifications for post-mount IDs even
+        //   when the HTTP GET happened to capture them. Date.parse() for numeric
+        //   comparison — Go's RFC3339Nano may omit fractional seconds, making
+        //   lexicographic comparison wrong ('Z' > '.' in ASCII).
+        //   Missing/unparseable sentAt → treated as pre-existing (no spam risk).
+        //
+        // • WITHOUT buffered SSE: seed the full HTTP list. Excluding post-mount
+        //   IDs with no SSE to replay would leave them unseeded, causing a later
+        //   unrelated SSE snapshot to treat them as new and fire stale
+        //   notifications for announcements the viewer already sees on screen.
+        let seedList;
+        if (buffered !== null) {
+          seedList = (list || []).filter(a => {
+            if (!a || !a.id) return false;
+            if (!a.sentAt) return true;
+            const ms = Date.parse(a.sentAt);
+            return isNaN(ms) || ms <= mountTimeRef.current;
+          });
+        } else {
+          seedList = list || [];
+        }
+        diffAnnouncementSnapshot(seenAnnouncementIds, seedList);
+
+        // Replay the buffered SSE (if any) to fire for announcements added in
+        // the mount→fetch race window.
         if (buffered !== null) {
           const additions = diffAnnouncementSnapshot(seenAnnouncementIds, buffered);
           if (additions.length > 0) {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -150,6 +150,32 @@ export function fireBrowserNotifications(additions) {
   }
 }
 
+// mp-cw1: Given a ref holding the seen-ID Set (or null if not yet seeded) and
+// a new full-list announcement snapshot, returns the additions that should
+// fire a notification and updates the ref's Set in place.
+//
+// The FIRST snapshot to encounter an unseeded (null) ref is treated as the
+// SEED: every ID is recorded and NO additions are returned. This closes the
+// race where an SSE `announcement` snapshot arrives before the initial
+// fetchAnnouncements() seed resolves (or after it fails) — without it, every
+// already-active announcement in that first snapshot would be misread as new
+// and spam the user on page load. Dismiss/clear snapshots (shrinking lists)
+// never produce additions because their remaining IDs are all already seen.
+export function diffAnnouncementSnapshot(seenRef, list) {
+  const arr = Array.isArray(list) ? list : [];
+  if (!seenRef.current) {
+    seenRef.current = new Set();
+    arr.forEach(a => { if (a && a.id) seenRef.current.add(a.id); });
+    return []; // first snapshot is the seed — fire nothing
+  }
+  const seen = seenRef.current;
+  const additions = arr.filter(a => a && a.id && !seen.has(a.id));
+  // Mark ALL current IDs as seen (additions + existing) so a later snapshot
+  // that still contains the same IDs won't re-fire.
+  arr.forEach(a => { if (a && a.id) seen.add(a.id); });
+  return additions;
+}
+
 function App() {
   const [tournament, setTournament] = useS(null);
   const [loading, setLoading] = useS(true);
@@ -353,11 +379,10 @@ function App() {
         const active = filterActiveAnnouncements(list || []);
         setAnnouncements(active);
         // Seed the seen-IDs set so a page reload does NOT re-fire
-        // notifications for already-active announcements.
-        if (!seenAnnouncementIds.current) {
-          seenAnnouncementIds.current = new Set();
-        }
-        (list || []).forEach(a => { if (a && a.id) seenAnnouncementIds.current.add(a.id); });
+        // notifications for already-active announcements. Routed through the
+        // same helper as the SSE path: if this fetch wins the race it seeds;
+        // if an SSE snapshot already seeded, these IDs are simply re-marked.
+        diffAnnouncementSnapshot(seenAnnouncementIds, list || []);
       })
       .catch(err => {
         console.error("Failed to fetch initial announcements:", err);
@@ -515,18 +540,11 @@ function App() {
             const list = Array.isArray(event.data) ? event.data : [];
             setAnnouncements(filterActiveAnnouncements(list));
 
-            // mp-cw1: diff against seen IDs to fire browser notifications
-            // ONLY for genuinely new announcements. Dismiss/clear snapshots
-            // (where the list shrinks) must never re-fire for removed IDs.
-            if (!seenAnnouncementIds.current) {
-              seenAnnouncementIds.current = new Set();
-            }
-            const seen = seenAnnouncementIds.current;
-            const additions = list.filter(a => a && a.id && !seen.has(a.id));
-            // Mark ALL current IDs as seen (additions + existing), so a
-            // later snapshot that still contains the same IDs won't re-fire.
-            list.forEach(a => { if (a && a.id) seen.add(a.id); });
-
+            // mp-cw1: diff against seen IDs to fire browser notifications ONLY
+            // for genuinely new announcements. diffAnnouncementSnapshot handles
+            // the seeding race (first snapshot seeds + fires nothing) and the
+            // dismiss/clear case (shrinking lists produce no additions).
+            const additions = diffAnnouncementSnapshot(seenAnnouncementIds, list);
             if (additions.length > 0) {
               fireBrowserNotifications(additions);
             }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -157,13 +157,18 @@ export function fireBrowserNotifications(additions) {
 // a new full-list announcement snapshot, returns the additions that should
 // fire a notification and updates the ref's Set in place.
 //
-// The FIRST snapshot to encounter an unseeded (null) ref is treated as the
-// SEED: every ID is recorded and NO additions are returned. This closes the
-// race where an SSE `announcement` snapshot arrives before the initial
-// fetchAnnouncements() seed resolves (or after it fails) — without it, every
-// already-active announcement in that first snapshot would be misread as new
-// and spam the user on page load. Dismiss/clear snapshots (shrinking lists)
-// never produce additions because their remaining IDs are all already seen.
+// The FIRST call with an unseeded (null) ref is always treated as the SEED:
+// every ID is recorded and NO additions are returned. The intended caller flow:
+//   1. fetchAnnouncements() HTTP success → first call → seeds from HTTP response.
+//   2. SSE snapshots that arrive before the HTTP seed → buffered externally in
+//      pendingSseAnnouncements; replayed (second call) AFTER step 1 to detect
+//      announcements added in the race window.
+//   3. fetchAnnouncements() HTTP failure + buffered SSE → first call → seeds
+//      from SSE (no notifications for pre-fetch announcements).
+//   4. fetchAnnouncements() HTTP failure + nothing buffered → ref stays null;
+//      first subsequent SSE call seeds (original fallback).
+// Dismiss/clear snapshots (shrinking lists) never produce additions because
+// their remaining IDs are all already seen.
 export function diffAnnouncementSnapshot(seenRef, list) {
   const arr = Array.isArray(list) ? list : [];
   if (!seenRef.current) {
@@ -255,11 +260,14 @@ function App() {
       : `c${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }
   // mp-cw1: Set of announcement IDs already seen by this session.
-  // Seeded from the initial fetchAnnouncements snapshot so page-reload
-  // does NOT re-fire notifications for already-active announcements.
-  // Updated on every SSE snapshot: all current IDs are added so that
-  // remove/clear snapshots (smaller lists) never re-fire.
+  // Seeded by the initial HTTP fetchAnnouncements response (source of truth
+  // for pre-existing announcements). SSE snapshots that arrive before the HTTP
+  // seed are buffered in pendingSseAnnouncements and replayed after seeding to
+  // detect announcements added in the race window.
   const seenAnnouncementIds = useR(null); // lazily initialised to a Set below
+  // Holds the latest SSE announcement snapshot received before the HTTP seed
+  // has settled. Full snapshots are idempotent: only the latest matters.
+  const pendingSseAnnouncements = useR(null);
 
   // Auth-mode discovery (file vs. locked). Fetched once on App mount
   // from GET /api/auth-config. Starts as null ("loading") so that
@@ -381,14 +389,32 @@ function App() {
       .then(list => {
         const active = filterActiveAnnouncements(list || []);
         setAnnouncements(active);
-        // Seed the seen-IDs set so a page reload does NOT re-fire
-        // notifications for already-active announcements. Routed through the
-        // same helper as the SSE path: if this fetch wins the race it seeds;
-        // if an SSE snapshot already seeded, these IDs are simply re-marked.
+        // mp-cw1: Seed from the HTTP response — the canonical list of
+        // announcements that existed when the viewer mounted.
         diffAnnouncementSnapshot(seenAnnouncementIds, list || []);
+        // Replay any SSE snapshot that beat the HTTP seed. These arrived
+        // after mount and may contain genuinely new announcements added in
+        // the race window; diff them to fire the appropriate notifications.
+        const buffered = pendingSseAnnouncements.current;
+        pendingSseAnnouncements.current = null;
+        if (buffered !== null) {
+          const additions = diffAnnouncementSnapshot(seenAnnouncementIds, buffered);
+          if (additions.length > 0) {
+            fireBrowserNotifications(additions);
+          }
+        }
       })
       .catch(err => {
         console.error("Failed to fetch initial announcements:", err);
+        // Fall back: if an SSE snapshot was buffered while the HTTP request
+        // was in flight, seed from it so the next SSE diff works correctly.
+        // If nothing was buffered, leave the ref null so the first subsequent
+        // SSE snapshot becomes the seed (original spam-prevention fallback).
+        const buffered = pendingSseAnnouncements.current;
+        pendingSseAnnouncements.current = null;
+        if (buffered !== null && seenAnnouncementIds.current === null) {
+          diffAnnouncementSnapshot(seenAnnouncementIds, buffered); // seed, no notifications
+        }
       });
   }, []);
 
@@ -549,12 +575,18 @@ function App() {
             setAnnouncements(filterActiveAnnouncements(list));
 
             // mp-cw1: diff against seen IDs to fire browser notifications ONLY
-            // for genuinely new announcements. diffAnnouncementSnapshot handles
-            // the seeding race (first snapshot seeds + fires nothing) and the
-            // dismiss/clear case (shrinking lists produce no additions).
-            const additions = diffAnnouncementSnapshot(seenAnnouncementIds, list);
-            if (additions.length > 0) {
-              fireBrowserNotifications(additions);
+            // for genuinely new announcements.
+            // If the HTTP seed hasn't arrived yet, buffer this snapshot and let
+            // fetchAnnouncements replay it — so an announcement added in the
+            // mount→fetch race window still fires a notification (the HTTP seed
+            // records only pre-existing IDs; the replay surfaces the new one).
+            if (seenAnnouncementIds.current === null) {
+              pendingSseAnnouncements.current = list; // keep latest; seed pending
+            } else {
+              const additions = diffAnnouncementSnapshot(seenAnnouncementIds, list);
+              if (additions.length > 0) {
+                fireBrowserNotifications(additions);
+              }
             }
         }
     }, (status) => {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -127,6 +127,29 @@ class ErrorBoundary extends React.Component {
   }
 }
 
+// mp-cw1: Fire browser Notification for each newly-added announcement.
+// Guards: Notification API available + permission granted + document hidden
+// + localStorage toggle on. Uses tag:id to coalesce duplicate fires.
+// Pure function; exported for unit testing.
+export function fireBrowserNotifications(additions) {
+  if (typeof Notification === "undefined") return;
+  if (Notification.permission !== "granted") return;
+  if (!document.hidden) return;
+  let enabled = false;
+  try {
+    enabled = window.localStorage.getItem("viewer.notifications.enabled") === "true";
+  } catch (_e) { /* storage unavailable */ }
+  if (!enabled) return;
+  for (const a of additions) {
+    if (!a || !a.id) continue;
+    new Notification("Tournament Announcement", {
+      tag: a.id,
+      body: a.message || "",
+      icon: "/favicon.jpeg",
+    });
+  }
+}
+
 function App() {
   const [tournament, setTournament] = useS(null);
   const [loading, setLoading] = useS(true);
@@ -202,6 +225,13 @@ function App() {
       ? crypto.randomUUID()
       : `c${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }
+  // mp-cw1: Set of announcement IDs already seen by this session.
+  // Seeded from the initial fetchAnnouncements snapshot so page-reload
+  // does NOT re-fire notifications for already-active announcements.
+  // Updated on every SSE snapshot: all current IDs are added so that
+  // remove/clear snapshots (smaller lists) never re-fire.
+  const seenAnnouncementIds = useR(null); // lazily initialised to a Set below
+
   // Auth-mode discovery (file vs. locked). Fetched once on App mount
   // from GET /api/auth-config. Starts as null ("loading") so that
   // CreateTournament can gate its submit until the mode is known —
@@ -320,7 +350,14 @@ function App() {
   useE(() => {
     window.API.fetchAnnouncements()
       .then(list => {
-        setAnnouncements(filterActiveAnnouncements(list || []));
+        const active = filterActiveAnnouncements(list || []);
+        setAnnouncements(active);
+        // Seed the seen-IDs set so a page reload does NOT re-fire
+        // notifications for already-active announcements.
+        if (!seenAnnouncementIds.current) {
+          seenAnnouncementIds.current = new Set();
+        }
+        (list || []).forEach(a => { if (a && a.id) seenAnnouncementIds.current.add(a.id); });
       })
       .catch(err => {
         console.error("Failed to fetch initial announcements:", err);
@@ -477,6 +514,22 @@ function App() {
             // Payload is now the full list snapshot.
             const list = Array.isArray(event.data) ? event.data : [];
             setAnnouncements(filterActiveAnnouncements(list));
+
+            // mp-cw1: diff against seen IDs to fire browser notifications
+            // ONLY for genuinely new announcements. Dismiss/clear snapshots
+            // (where the list shrinks) must never re-fire for removed IDs.
+            if (!seenAnnouncementIds.current) {
+              seenAnnouncementIds.current = new Set();
+            }
+            const seen = seenAnnouncementIds.current;
+            const additions = list.filter(a => a && a.id && !seen.has(a.id));
+            // Mark ALL current IDs as seen (additions + existing), so a
+            // later snapshot that still contains the same IDs won't re-fire.
+            list.forEach(a => { if (a && a.id) seen.add(a.id); });
+
+            if (additions.length > 0) {
+              fireBrowserNotifications(additions);
+            }
         }
     }, (status) => {
         // T063: track SSE connection status so /display surfaces can

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -259,12 +259,15 @@ function App() {
       ? crypto.randomUUID()
       : `c${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }
-  // mp-cw1: ISO timestamp of when this viewer session mounted. Used to
+  // mp-cw1: Unix-ms timestamp of when this viewer session mounted. Used to
   // distinguish pre-existing announcements (sentAt ≤ mount time) from
   // announcements created after the viewer opened the tab (sentAt > mount
   // time). Post-mount IDs are excluded from the HTTP seed so the buffered
-  // SSE replay still fires notifications for them.
-  const mountTimeRef = useR(new Date().toISOString());
+  // SSE replay still fires notifications for them. Stored as a number so
+  // the filter can use Date.parse() for correct cross-format comparison
+  // (Go RFC3339Nano may omit fractional seconds; lexicographic string
+  // comparison of "…Z" vs "….500Z" is incorrect — 'Z' > '.' in ASCII).
+  const mountTimeRef = useR(Date.now());
   // Set of announcement IDs already seen by this session. Seeded by the
   // initial HTTP fetchAnnouncements response (pre-mount IDs only) so a
   // page-reload does NOT re-fire for already-active announcements, and an
@@ -399,11 +402,16 @@ function App() {
         // the viewer mounted (sentAt > mount time) are intentionally excluded
         // so the buffered SSE replay below still fires notifications for them
         // even when the HTTP GET response happened to capture them too.
-        // Announcements without a sentAt field are treated conservatively as
-        // pre-existing (no spam risk).
-        const preMountList = (list || []).filter(
-          a => !a || !a.id || !a.sentAt || a.sentAt <= mountTimeRef.current
-        );
+        // Date.parse() is used for numeric comparison because Go's RFC3339Nano
+        // serialisation may omit fractional seconds ("…Z" vs "….500Z") and
+        // lexicographic string comparison would give the wrong order in that
+        // case ('Z' > '.' in ASCII). Missing/unparseable sentAt → pre-existing.
+        const preMountList = (list || []).filter(a => {
+          if (!a || !a.id) return false;
+          if (!a.sentAt) return true;
+          const ms = Date.parse(a.sentAt);
+          return isNaN(ms) || ms <= mountTimeRef.current;
+        });
         diffAnnouncementSnapshot(seenAnnouncementIds, preMountList);
         // Replay any SSE snapshot that beat the HTTP seed. These arrived
         // after mount and may contain genuinely new announcements added in

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -131,7 +131,9 @@ class ErrorBoundary extends React.Component {
 // mp-cw1: Fire browser Notification for each newly-added announcement.
 // Guards: Notification API available + permission granted + document hidden
 // + localStorage toggle on. Uses tag:id to coalesce duplicate fires.
-// Pure function; exported for unit testing.
+// NOT pure — reads Notification.permission, document.hidden and localStorage,
+// and constructs Notification instances. Exported for unit testing (tests stub
+// those globals). Callers must treat it as side-effecting.
 export function fireBrowserNotifications(additions) {
   if (typeof Notification === "undefined") return;
   if (Notification.permission !== "granted") return;

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -259,11 +259,16 @@ function App() {
       ? crypto.randomUUID()
       : `c${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }
-  // mp-cw1: Set of announcement IDs already seen by this session.
-  // Seeded by the initial HTTP fetchAnnouncements response (source of truth
-  // for pre-existing announcements). SSE snapshots that arrive before the HTTP
-  // seed are buffered in pendingSseAnnouncements and replayed after seeding to
-  // detect announcements added in the race window.
+  // mp-cw1: ISO timestamp of when this viewer session mounted. Used to
+  // distinguish pre-existing announcements (sentAt ≤ mount time) from
+  // announcements created after the viewer opened the tab (sentAt > mount
+  // time). Post-mount IDs are excluded from the HTTP seed so the buffered
+  // SSE replay still fires notifications for them.
+  const mountTimeRef = useR(new Date().toISOString());
+  // Set of announcement IDs already seen by this session. Seeded by the
+  // initial HTTP fetchAnnouncements response (pre-mount IDs only) so a
+  // page-reload does NOT re-fire for already-active announcements, and an
+  // announcement created in the mount→fetch race window still fires.
   const seenAnnouncementIds = useR(null); // lazily initialised to a Set below
   // Holds the latest SSE announcement snapshot received before the HTTP seed
   // has settled. Full snapshots are idempotent: only the latest matters.
@@ -389,9 +394,17 @@ function App() {
       .then(list => {
         const active = filterActiveAnnouncements(list || []);
         setAnnouncements(active);
-        // mp-cw1: Seed from the HTTP response — the canonical list of
-        // announcements that existed when the viewer mounted.
-        diffAnnouncementSnapshot(seenAnnouncementIds, list || []);
+        // mp-cw1: Seed from the HTTP response, but only for pre-mount
+        // announcements (sentAt ≤ mount time). Announcements created after
+        // the viewer mounted (sentAt > mount time) are intentionally excluded
+        // so the buffered SSE replay below still fires notifications for them
+        // even when the HTTP GET response happened to capture them too.
+        // Announcements without a sentAt field are treated conservatively as
+        // pre-existing (no spam risk).
+        const preMountList = (list || []).filter(
+          a => !a || !a.id || !a.sentAt || a.sentAt <= mountTimeRef.current
+        );
+        diffAnnouncementSnapshot(seenAnnouncementIds, preMountList);
         // Replay any SSE snapshot that beat the HTTP seed. These arrived
         // after mount and may contain genuinely new announcements added in
         // the race window; diff them to fire the appropriate notifications.

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -414,6 +414,9 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             onMatchClick={setSelectedMatch}
           />
 
+          {/* mp-cw1: Browser push notification opt-in toggle. */}
+          <NotificationSettings />
+
           {live.length > 0 && (
             <div className="hero-live">
               <div className="hero-live__lbl"><span className="dot dot--live"></span> LIVE NOW · {pluralize(live.length, "match", "matches")}</div>
@@ -2447,6 +2450,113 @@ function MatchViewerModal({ match, onClose }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// NotificationSettings — viewer settings panel for browser push notifications.
+// Exported for unit testing.
+// ---------------------------------------------------------------------------
+
+// LocalStorage key for the notification opt-in toggle.
+const LS_NOTIFICATIONS_ENABLED = "viewer.notifications.enabled";
+
+// Pure helper: detect Notification API support.
+// Exported for unit testing.
+export function notificationSupported() {
+  return typeof Notification !== "undefined";
+}
+
+// NotificationSettings — "Enable browser notifications" toggle for the
+// viewer home settings area. Phases:
+//   1) Secure-context warning (edge case, normally hidden in production).
+//   2) Notification API unavailable — hide the toggle.
+//   3) Permission "denied" — show blocked state.
+//   4) Permission "default" or "granted" — show the opt-in toggle.
+//
+// Requests permission ONLY on a user click (the gesture gate). Never
+// calls requestPermission() automatically. Exported for unit testing.
+export function NotificationSettings() {
+  // Compute the initial permission outside useState so tests using the
+  // static React mock (which passes the value through unmodified rather
+  // than calling function initialisers) see the correct starting value.
+  const initialPermission = (typeof Notification === "undefined")
+    ? "unavailable"
+    : Notification.permission;
+
+  // Read the current permission state reactively: re-query after the user
+  // interacts with the native permission prompt. We keep a local state so
+  // the UI stays responsive without relying on a global re-render.
+  const [permission, setPermission] = useState(initialPermission);
+
+  let initialEnabled = false;
+  try {
+    initialEnabled = window.localStorage.getItem(LS_NOTIFICATIONS_ENABLED) === "true";
+  } catch (_e) { /* storage unavailable */ }
+  const [enabled, setEnabled] = useState(initialEnabled);
+
+  // Phase 4: secure-context warning. Only show when the API would exist but
+  // the context is insecure (plain http:// non-localhost). In production the
+  // TLS proxy ensures this block is never reached.
+  const insecure = typeof window !== "undefined" && window.isSecureContext === false;
+
+  // Phase 3: API unavailable — hide entirely.
+  if (permission === "unavailable") return null;
+
+  const handleToggle = async () => {
+    if (enabled) {
+      // Turning off: just persist the preference.
+      try { window.localStorage.setItem(LS_NOTIFICATIONS_ENABLED, "false"); } catch (_e) { /* storage unavailable */ }
+      setEnabled(false);
+      return;
+    }
+    // Turning on: request permission first (this is the user-gesture gate).
+    if (Notification.permission === "default") {
+      const result = await Notification.requestPermission();
+      setPermission(result);
+      if (result !== "granted") return; // user denied — don't toggle on
+    } else {
+      setPermission(Notification.permission);
+    }
+    try { window.localStorage.setItem(LS_NOTIFICATIONS_ENABLED, "true"); } catch (_e) { /* storage unavailable */ }
+    setEnabled(true);
+  };
+
+  const denied = permission === "denied";
+
+  return (
+    <div className="card" data-testid="notification-settings" style={{ marginBottom: 16, padding: 14 }}>
+      <div className="section-title" style={{ marginTop: 0 }}>Notifications</div>
+      {insecure && (
+        <div style={{ fontSize: 12, color: "var(--amber, #b45309)", marginBottom: 8 }} data-testid="notification-insecure-warning">
+          Browser notifications require a secure connection (https or localhost).
+        </div>
+      )}
+      {denied ? (
+        <div style={{ fontSize: 12, color: "var(--ink-3)" }} data-testid="notification-denied">
+          Browser notifications are blocked. Allow them in your browser settings, then reload.
+        </div>
+      ) : (
+        <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer", fontSize: 13 }}>
+          <input
+            type="checkbox"
+            checked={enabled && permission === "granted"}
+            onChange={handleToggle}
+            data-testid="notification-toggle"
+            disabled={insecure}
+          />
+          <span>
+            Enable browser notifications for announcements
+            {permission === "granted" && enabled && (
+              <span style={{ marginLeft: 6, fontSize: 11, color: "var(--ink-3)" }}>(granted)</span>
+            )}
+            {permission === "default" && (
+              <span style={{ marginLeft: 6, fontSize: 11, color: "var(--ink-3)" }}>(permission not yet requested)</span>
+            )}
+          </span>
+        </label>
+      )}
+    </div>
+  );
+}
+
 // Shared formatter so the synchronous initializer and the useEffect tick
 // produce identical strings — keeps the first paint stable.
 function formatAnnouncementTimeLeft(expiresAtIso) {
@@ -2536,4 +2646,6 @@ window.competitionKindLabel = competitionKindLabel;
 window.compMatches = compMatches;
 window.tournamentMatches = tournamentMatches;
 window.currentMatchOf = currentMatchOf;
+window.NotificationSettings = NotificationSettings;
+window.LS_NOTIFICATIONS_ENABLED = LS_NOTIFICATIONS_ENABLED;
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2499,13 +2499,28 @@ export function NotificationSettings() {
   // handler branch aligned with the visible checkbox state.
   const [enabled, setEnabled] = useState(storedOptIn && initialPermission === "granted");
 
-  // Phase 4: secure-context warning. Only show when the API would exist but
-  // the context is insecure (plain http:// non-localhost). In production the
-  // TLS proxy ensures this block is never reached.
+  // Phase 4: secure-context warning. In production the TLS proxy makes this
+  // false; it only matters for bare http:// (no proxy) access.
   const insecure = typeof window !== "undefined" && window.isSecureContext === false;
 
-  // Phase 3: API unavailable — hide entirely.
-  if (permission === "unavailable") return null;
+  // Phase 3 / Phase 4 ordering: when the API is unavailable we normally hide
+  // the panel entirely. BUT some browsers expose `Notification` only in a
+  // secure context, so a bare http:// page can have BOTH no API AND
+  // isSecureContext === false — which is the exact situation this panel is
+  // meant to explain. In that case render the warning (no toggle) instead of
+  // hiding. Only hide outright when the API is unavailable for some OTHER
+  // reason (secure context but an old/unsupported browser).
+  if (permission === "unavailable") {
+    if (!insecure) return null;
+    return (
+      <div className="card" data-testid="notification-settings" style={{ marginBottom: 16, padding: 14 }}>
+        <div className="section-title" style={{ marginTop: 0 }}>Notifications</div>
+        <div style={{ fontSize: 12, color: "var(--amber, #b45309)" }} data-testid="notification-insecure-warning">
+          Browser notifications require a secure connection (https or localhost).
+        </div>
+      </div>
+    );
+  }
 
   const handleToggle = async () => {
     if (enabled) {
@@ -2522,8 +2537,17 @@ export function NotificationSettings() {
     } else {
       setPermission(Notification.permission);
     }
-    try { window.localStorage.setItem(LS_NOTIFICATIONS_ENABLED, "true"); } catch (_e) { /* storage unavailable */ }
-    setEnabled(true);
+    // Only mark the toggle ON if the preference actually persisted.
+    // fireBrowserNotifications() reads this localStorage flag at fire time, so
+    // an unpersisted "on" would render a checked box that never fires (storage
+    // throwing → flag missing → firing path reads opt-out). Keep the UI honest
+    // with the firing path: if persistence failed, leave the toggle off.
+    let persisted = false;
+    try {
+      window.localStorage.setItem(LS_NOTIFICATIONS_ENABLED, "true");
+      persisted = true;
+    } catch (_e) { /* storage unavailable — keep toggle off */ }
+    setEnabled(persisted);
   };
 
   const denied = permission === "denied";

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2486,11 +2486,18 @@ export function NotificationSettings() {
   // the UI stays responsive without relying on a global re-render.
   const [permission, setPermission] = useState(initialPermission);
 
-  let initialEnabled = false;
+  let storedOptIn = false;
   try {
-    initialEnabled = window.localStorage.getItem(LS_NOTIFICATIONS_ENABLED) === "true";
+    storedOptIn = window.localStorage.getItem(LS_NOTIFICATIONS_ENABLED) === "true";
   } catch (_e) { /* storage unavailable */ }
-  const [enabled, setEnabled] = useState(initialEnabled);
+  // Only treat the opt-in as enabled when the browser permission is ALSO
+  // still granted. If the user reset the site permission back to "default"
+  // (or "denied") since they last opted in, starting `enabled` at true would
+  // render the checkbox unchecked (checked={enabled && permission==="granted"})
+  // yet send the first click down the "turning off" branch — the user would
+  // have to click twice and never see the prompt. Gating on granted keeps the
+  // handler branch aligned with the visible checkbox state.
+  const [enabled, setEnabled] = useState(storedOptIn && initialPermission === "granted");
 
   // Phase 4: secure-context warning. Only show when the API would exist but
   // the context is insecure (plain http:// non-localhost). In production the


### PR DESCRIPTION
## Summary

- Adds opt-in browser push notifications for viewer-side announcements (mp-cw1). When a new announcement arrives via SSE while the viewer tab is hidden, a `Notification` fires — but only if the user explicitly enabled the toggle.
- Three design corrections applied versus a naive implementation:

**1. Snapshot-diff, not fire-on-event**
The SSE `announcement` event delivers a full-list snapshot, not a "new item" delta. A naive handler would fire on dismissals and clears too. The implementation maintains a `seenAnnouncementIds` Set (ref) in `app.jsx`: only IDs absent from the set are considered additions; ALL current snapshot IDs are added after every event so shrinking lists never re-fire. The set is seeded from the initial `fetchAnnouncements` response so a page-reload does not spam notifications for already-active announcements.

**2. TLS is provided by the hosting proxy, not this repo**
The Go server serves plain HTTP; production is fronted by a TLS-terminating reverse proxy so spectators are on https → `window.isSecureContext === true`. No TLS/cert code was added. A Phase 4 operator note in the viewer settings warns if `window.isSecureContext === false` (bare LAN access without a proxy — rare edge case).

**3. Opt-in only from a user gesture**
Browsers suppress `Notification.requestPermission()` without a user gesture. The toggle checkbox click is the only call site. The SSE arrival handler never calls `requestPermission()`.

## Changes

- **`web-mobile/js/app.jsx`**: `fireBrowserNotifications(additions)` helper (NOT pure — reads live browser state; exported for tests); `seenAnnouncementIds` ref seeded by HTTP fetch; `pendingSseAnnouncements` buffer — SSE snapshots that arrive before the HTTP seed are buffered and replayed after seeding so announcements added in the mount→fetch race window still fire; SSE handler diffs against seen IDs.
- **`web-mobile/js/viewer.jsx`**: `NotificationSettings` component with: toggle checkbox, denied/blocked state, insecure-context note (Phase 4), `notificationSupported()` pure helper. Rendered in `ViewerHome` below `WatchlistPanel`. Both exported for unit testing.
- **`web-mobile/js/__tests__/app_announcement.test.jsx`**: 20 new tests covering `fireBrowserNotifications` guards (Notification unavailable, permission not granted, document visible, toggle off), snapshot-diff logic (additions, dismissals, clears, idempotency), `NotificationSettings` render branches (null when unavailable, denied state, insecure-context warning), and localStorage round-trip.

## Test plan

- [x] All JS tests pass (964): `cd web-mobile && npm test`
- [x] JS lint passes: `make js/lint`
- [x] Go lint passes: `make go/lint`
- [x] Go tests pass (domain packages): `go test ./internal/...`
- [x] Binary builds: `make go/build`
- [x] Browser — viewer home shows a "Notifications" card below the watchlist
- [x] Toggle checkbox: clicking "Enable" triggers the browser permission prompt
- [x] After granting: toggle shows as checked; `localStorage` key `viewer.notifications.enabled` = `"true"`
- [x] With tab hidden + toggle on + permission granted: sending an announcement from admin fires a browser notification
- [x] Dismissing an announcement (shrinking the snapshot) does NOT fire a new notification
- [x] Page reload with active announcements: no notifications fired on reload
- [x] With `Notification.permission === "denied"`: toggle replaced by "Browser notifications are blocked" message
- [x] With browser lacking Notification API: settings panel hidden entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Verification evidence (2026-05-30)

**Automated:** 955 JS tests pass · `make js/lint` clean · `make go/lint` 0 issues · `go test ./internal/...` all green · `make go/build` OK.

**Manual browser** (real `mobile-app` binary on `http://localhost:8077`, live SSE, headless Chromium via Preview):
- Notifications card renders directly **below the Watchlist** card (screenshot confirmed); overlay renders additively top-right.
- `default` permission → toggle shown, unchecked, "(permission not yet requested)". Clicking it called `requestPermission()` exactly once; after grant `localStorage["viewer.notifications.enabled"] = "true"` and the box rendered **checked** with "(granted)".
- **Fire path (end-to-end SSE):** with permission granted + `document.hidden` + toggle on, a real `POST /api/tournament/announce` fired exactly **1** `Notification` with `tag` = the announcement id and the correct body; a second distinct announcement fired again (count→2).
- **Dismiss/clear:** `DELETE /api/announcements` did **not** fire (count unchanged); overlay removed.
- **Reload no-spam:** reloading with an active announcement fired **0** notifications (seed-on-load path).
- **Denied:** real headless permission is `denied` → card shows the "blocked" message, no toggle.
- **API unavailable:** with `Notification` undefined at mount, the settings card is hidden entirely (overlay still works).

Notes: headless Chromium locks the real `Notification.permission` to `denied`, so the granted/default flows above were driven with a stubbed `window.Notification` — `fireBrowserNotifications` reads the live global, so the SSE→fire path is exercised genuinely.

**Round-4/5 fixes (Copilot review):**
- `fireBrowserNotifications` doc-comment corrected: NOT pure (reads live browser state + constructs Notification instances).
- Insecure-context warning reachability fixed: `unavailable && isSecureContext===false` now renders the warning card instead of returning null.
- Persist-gated toggle: `setEnabled(true)` only fires when `localStorage.setItem` succeeds.
- SSE seeding race fixed (rounds 4-6): SSE snapshots buffered until HTTP seed (round 4); `sentAt` mount-time filter excludes post-mount IDs from the HTTP seed so announcements created in the mount→fetch race window still fire notifications via SSE replay (round 6).