### PR TITLE
feat(mp-w7x): exclude non-checked-in participants from the draw

### DIFF
--- a/internal/engine/checkin_filter_test.go
+++ b/internal/engine/checkin_filter_test.go
@@ -243,3 +243,96 @@ func TestGenerateSwissRound_ExcludesNonCheckedIn(t *testing.T) {
 	assert.NotContains(t, seen, "Frank", "non-checked-in player must not be paired")
 	assert.Contains(t, seen, "Alice")
 }
+
+// TestStartCompetition_SeededNonCheckedIn_Drawable is the regression guard for
+// PR #199 review comment 1: a seeded participant who is not checked in must not
+// break the draw. Their seed assignment is dropped alongside the player so
+// ApplySeeds doesn't fail with "seeded participant not found in main list".
+func TestStartCompetition_SeededNonCheckedIn_Drawable(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "seeded-checkin"
+
+	createTestCompetition(t, store, compID, "mixed", 4)
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve"},
+		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
+	)
+	// Eve is seeded #1 but NOT checked in; Alice is seeded #2 and checked in.
+	require.NoError(t, store.SaveSeeds(compID, []domain.SeedAssignment{
+		{Name: "Eve", SeedRank: 1},
+		{Name: "Alice", SeedRank: 2},
+	}))
+
+	// Pre-fix this returned "applying seeds: seeded participant not found in
+	// main list: Eve" and the draw failed entirely.
+	require.NoError(t, eng.StartCompetition(compID), "draw must succeed despite a non-checked-in seeded player")
+
+	pools, err := store.LoadPools(compID)
+	require.NoError(t, err)
+	names := poolPlayerNames(pools)
+	assert.Len(t, names, 4, "only the 4 checked-in players should be drawn")
+	assert.NotContains(t, names, "Eve", "non-checked-in seeded player must be excluded")
+	assert.Contains(t, names, "Alice")
+}
+
+// TestGenerateSwissRound_FrozenFieldIgnoresLateCheckIn is the regression guard
+// for PR #199 review comment 2: once round 1 is drawn, the Swiss field is
+// frozen. A participant excluded from round 1 (not checked in) must not appear
+// in a later round just because they were checked in afterwards.
+func TestGenerateSwissRound_FrozenFieldIgnoresLateCheckIn(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "swiss-frozen"
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:          compID,
+		Name:        "Swiss Frozen Field",
+		Kind:        "individual",
+		Format:      state.CompFormatSwiss,
+		SwissRounds: 3,
+		Courts:      []string{"A"},
+		StartTime:   "09:00",
+		Status:      "setup",
+	}))
+	// Round 1: P1–P4 checked in, P5/P6 not.
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"P1", "P2", "P3", "P4", "P5", "P6"},
+		map[string]bool{"P1": true, "P2": true, "P3": true, "P4": true},
+	)
+
+	r1, err := eng.GenerateSwissRound(compID, 1)
+	require.NoError(t, err)
+	require.NoError(t, store.SavePoolMatches(compID, r1))
+
+	r1Field := map[string]bool{}
+	for _, m := range r1 {
+		r1Field[m.SideA] = true
+		if m.SideB != "" {
+			r1Field[m.SideB] = true
+		}
+	}
+	require.NotContains(t, r1Field, "P5")
+	require.NotContains(t, r1Field, "P6")
+
+	// Complete round 1 so a next round can be generated (SideA wins each).
+	for _, m := range r1 {
+		if m.SideB != "" {
+			completeSwissMatch(t, store, compID, m.ID, m.SideA)
+		}
+	}
+
+	// P5 is checked in AFTER round 1 — a late toggle of mutable state.
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"P1", "P2", "P3", "P4", "P5", "P6"},
+		map[string]bool{"P1": true, "P2": true, "P3": true, "P4": true, "P5": true},
+	)
+
+	r2, err := eng.GenerateSwissRound(compID, 2)
+	require.NoError(t, err)
+
+	for _, m := range r2 {
+		assert.NotEqual(t, "P5", m.SideA, "late check-in must not inject P5 into round 2")
+		assert.NotEqual(t, "P5", m.SideB, "late check-in must not inject P5 into round 2")
+		assert.NotEqual(t, "P6", m.SideA, "P6 was never in the field")
+		assert.NotEqual(t, "P6", m.SideB, "P6 was never in the field")
+	}
+}

--- a/internal/engine/checkin_filter_test.go
+++ b/internal/engine/checkin_filter_test.go
@@ -25,6 +25,16 @@ func saveParticipantsWithCheckIn(t *testing.T, store *state.Store, compID string
 	require.NoError(t, store.SaveParticipants(compID, players))
 }
 
+// enableCheckIn flips a competition's check-in tracking flag on. The draw
+// filter (mp-w7x) only excludes non-checked-in players when this is set.
+func enableCheckIn(t *testing.T, store *state.Store, compID string) {
+	t.Helper()
+	comp, err := store.LoadCompetition(compID)
+	require.NoError(t, err)
+	comp.CheckInEnabled = true
+	require.NoError(t, store.SaveCompetition(comp))
+}
+
 // poolPlayerNames collects every player name across all generated pools.
 func poolPlayerNames(pools []helper.Pool) map[string]bool {
 	names := map[string]bool{}
@@ -93,6 +103,7 @@ func TestStartCompetition_MixedFormat_ExcludesNonCheckedIn(t *testing.T) {
 	compID := "checkin-pools"
 
 	createTestCompetition(t, store, compID, "mixed", 3)
+	enableCheckIn(t, store, compID)
 	saveParticipantsWithCheckIn(t, store, compID,
 		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
 		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
@@ -120,6 +131,7 @@ func TestStartCompetition_NoneCheckedIn_IncludesAll(t *testing.T) {
 	compID := "no-checkin-pools"
 
 	createTestCompetition(t, store, compID, "mixed", 3)
+	enableCheckIn(t, store, compID)
 	saveParticipantsWithCheckIn(t, store, compID,
 		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
 		map[string]bool{}, // nobody checked in
@@ -132,6 +144,29 @@ func TestStartCompetition_NoneCheckedIn_IncludesAll(t *testing.T) {
 	assert.Len(t, poolPlayerNames(pools), 6, "with no check-in, all participants are drawn")
 }
 
+// TestStartCompetition_CheckInDisabled_IgnoresStaleMarkers is the regression
+// guard for PR #199 review round 2: when check-in tracking is DISABLED for the
+// competition, stale/imported checked_in markers must be ignored so they cannot
+// shrink the field. The rest of the stack masks checkedIn behind CheckInEnabled.
+func TestStartCompetition_CheckInDisabled_IgnoresStaleMarkers(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "checkin-disabled"
+
+	// NOTE: enableCheckIn is deliberately NOT called — CheckInEnabled stays false.
+	createTestCompetition(t, store, compID, "mixed", 3)
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
+		map[string]bool{"Alice": true, "Bob": true}, // stale markers on 2 players
+	)
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	pools, err := store.LoadPools(compID)
+	require.NoError(t, err)
+	assert.Len(t, poolPlayerNames(pools), 6,
+		"check-in disabled: stale markers must be ignored and all participants drawn")
+}
+
 // TestStartCompetition_PlayoffsFormat_ExcludesNonCheckedIn verifies the filter
 // reaches the elimination-bracket path too.
 func TestStartCompetition_PlayoffsFormat_ExcludesNonCheckedIn(t *testing.T) {
@@ -139,6 +174,7 @@ func TestStartCompetition_PlayoffsFormat_ExcludesNonCheckedIn(t *testing.T) {
 	compID := "checkin-playoffs"
 
 	createTestCompetition(t, store, compID, "playoffs", 0)
+	enableCheckIn(t, store, compID)
 	saveParticipantsWithCheckIn(t, store, compID,
 		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve"},
 		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
@@ -184,14 +220,15 @@ func TestStartCompetition_PlayoffsFromSource_FinalistsNotExcluded(t *testing.T) 
 
 	playoffID := "src-mixed-playoffs"
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:           playoffID,
-		Name:         "Source Mixed - Playoffs",
-		Kind:         "individual",
-		Format:       state.CompFormatPlayoffs,
-		SourceCompID: srcID,
-		Courts:       []string{"A"},
-		StartTime:    "09:00",
-		Status:       "setup",
+		ID:             playoffID,
+		Name:           "Source Mixed - Playoffs",
+		Kind:           "individual",
+		Format:         state.CompFormatPlayoffs,
+		SourceCompID:   srcID,
+		Courts:         []string{"A"},
+		StartTime:      "09:00",
+		Status:         "setup",
+		CheckInEnabled: true,
 	}))
 
 	require.NoError(t, eng.StartCompetition(playoffID))
@@ -213,14 +250,15 @@ func TestGenerateSwissRound_ExcludesNonCheckedIn(t *testing.T) {
 	compID := "checkin-swiss"
 
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:          compID,
-		Name:        "Swiss Check-in",
-		Kind:        "individual",
-		Format:      state.CompFormatSwiss,
-		SwissRounds: 3,
-		Courts:      []string{"A"},
-		StartTime:   "09:00",
-		Status:      "setup",
+		ID:             compID,
+		Name:           "Swiss Check-in",
+		Kind:           "individual",
+		Format:         state.CompFormatSwiss,
+		SwissRounds:    3,
+		Courts:         []string{"A"},
+		StartTime:      "09:00",
+		Status:         "setup",
+		CheckInEnabled: true,
 	}))
 	saveParticipantsWithCheckIn(t, store, compID,
 		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
@@ -244,6 +282,44 @@ func TestGenerateSwissRound_ExcludesNonCheckedIn(t *testing.T) {
 	assert.Contains(t, seen, "Alice")
 }
 
+// TestGenerateSwissRound_CheckInDisabled_IgnoresStaleMarkers mirrors the pools
+// guard for the Swiss path: with check-in tracking disabled, stale markers must
+// not shrink the round-1 field (PR #199 review round 2, swiss.go).
+func TestGenerateSwissRound_CheckInDisabled_IgnoresStaleMarkers(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "swiss-checkin-disabled"
+
+	// CheckInEnabled deliberately left false.
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:          compID,
+		Name:        "Swiss No Check-in",
+		Kind:        "individual",
+		Format:      state.CompFormatSwiss,
+		SwissRounds: 3,
+		Courts:      []string{"A"},
+		StartTime:   "09:00",
+		Status:      "setup",
+	}))
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
+		map[string]bool{"Alice": true, "Bob": true}, // stale markers
+	)
+
+	matches, err := eng.GenerateSwissRound(compID, 1)
+	require.NoError(t, err)
+
+	seen := map[string]bool{}
+	for _, m := range matches {
+		if m.SideA != "" {
+			seen[m.SideA] = true
+		}
+		if m.SideB != "" {
+			seen[m.SideB] = true
+		}
+	}
+	assert.Len(t, seen, 6, "check-in disabled: all participants must be in the field")
+}
+
 // TestStartCompetition_SeededNonCheckedIn_Drawable is the regression guard for
 // PR #199 review comment 1: a seeded participant who is not checked in must not
 // break the draw. Their seed assignment is dropped alongside the player so
@@ -253,6 +329,7 @@ func TestStartCompetition_SeededNonCheckedIn_Drawable(t *testing.T) {
 	compID := "seeded-checkin"
 
 	createTestCompetition(t, store, compID, "mixed", 4)
+	enableCheckIn(t, store, compID)
 	saveParticipantsWithCheckIn(t, store, compID,
 		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve"},
 		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
@@ -284,14 +361,15 @@ func TestGenerateSwissRound_FrozenFieldIgnoresLateCheckIn(t *testing.T) {
 	compID := "swiss-frozen"
 
 	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:          compID,
-		Name:        "Swiss Frozen Field",
-		Kind:        "individual",
-		Format:      state.CompFormatSwiss,
-		SwissRounds: 3,
-		Courts:      []string{"A"},
-		StartTime:   "09:00",
-		Status:      "setup",
+		ID:             compID,
+		Name:           "Swiss Frozen Field",
+		Kind:           "individual",
+		Format:         state.CompFormatSwiss,
+		SwissRounds:    3,
+		Courts:         []string{"A"},
+		StartTime:      "09:00",
+		Status:         "setup",
+		CheckInEnabled: true,
 	}))
 	// Round 1: P1–P4 checked in, P5/P6 not.
 	saveParticipantsWithCheckIn(t, store, compID,

--- a/internal/engine/checkin_filter_test.go
+++ b/internal/engine/checkin_filter_test.go
@@ -1,0 +1,245 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saveParticipantsWithCheckIn writes participants where names listed in
+// checkedIn are flagged CheckedIn=true. Used by the mp-w7x exclusion tests.
+func saveParticipantsWithCheckIn(t *testing.T, store *state.Store, compID string, names []string, checkedIn map[string]bool) {
+	t.Helper()
+	players := make([]domain.Player, len(names))
+	for i, n := range names {
+		players[i] = domain.Player{
+			Name:      n,
+			Dojo:      "Dojo" + string(rune('A'+i%5)),
+			CheckedIn: checkedIn[n],
+		}
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+}
+
+// poolPlayerNames collects every player name across all generated pools.
+func poolPlayerNames(pools []helper.Pool) map[string]bool {
+	names := map[string]bool{}
+	for _, p := range pools {
+		for _, pl := range p.Players {
+			names[pl.Name] = true
+		}
+	}
+	return names
+}
+
+// bracketLeafNames collects the real (non-bye) competitor names seeded into
+// the first round of a bracket. Byes are the empty string (bracket.go).
+func bracketLeafNames(b *state.Bracket) map[string]bool {
+	names := map[string]bool{}
+	if b == nil || len(b.Rounds) == 0 {
+		return names
+	}
+	for _, m := range b.Rounds[0] {
+		if m.SideA != "" {
+			names[m.SideA] = true
+		}
+		if m.SideB != "" {
+			names[m.SideB] = true
+		}
+	}
+	return names
+}
+
+// TestFilterCheckedIn pins the opt-in semantics of the mp-w7x helper directly.
+func TestFilterCheckedIn(t *testing.T) {
+	mk := func(name string, in bool) domain.Player {
+		return domain.Player{Name: name, CheckedIn: in}
+	}
+
+	t.Run("nobody checked in returns the roster unchanged (opt-in)", func(t *testing.T) {
+		in := []domain.Player{mk("A", false), mk("B", false), mk("C", false)}
+		got := filterCheckedIn(in)
+		require.Len(t, got, 3)
+	})
+
+	t.Run("mixed returns only the checked-in players", func(t *testing.T) {
+		in := []domain.Player{mk("A", true), mk("B", false), mk("C", true)}
+		got := filterCheckedIn(in)
+		require.Len(t, got, 2)
+		assert.Equal(t, "A", got[0].Name)
+		assert.Equal(t, "C", got[1].Name)
+	})
+
+	t.Run("all checked in returns everyone", func(t *testing.T) {
+		in := []domain.Player{mk("A", true), mk("B", true)}
+		got := filterCheckedIn(in)
+		require.Len(t, got, 2)
+	})
+
+	t.Run("empty roster is a no-op", func(t *testing.T) {
+		got := filterCheckedIn(nil)
+		assert.Empty(t, got)
+	})
+}
+
+// TestStartCompetition_MixedFormat_ExcludesNonCheckedIn verifies that when
+// check-in is in use, only checked-in participants reach the pool draw.
+func TestStartCompetition_MixedFormat_ExcludesNonCheckedIn(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "checkin-pools"
+
+	createTestCompetition(t, store, compID, "mixed", 3)
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
+		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
+	)
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	pools, err := store.LoadPools(compID)
+	require.NoError(t, err)
+	names := poolPlayerNames(pools)
+
+	assert.Len(t, names, 4, "only the 4 checked-in players should be drawn")
+	for _, want := range []string{"Alice", "Bob", "Charlie", "Dave"} {
+		assert.Contains(t, names, want)
+	}
+	for _, dropped := range []string{"Eve", "Frank"} {
+		assert.NotContains(t, names, dropped, "non-checked-in player must be excluded")
+	}
+}
+
+// TestStartCompetition_NoneCheckedIn_IncludesAll pins the opt-in fallback:
+// a competition that never used check-in draws everyone.
+func TestStartCompetition_NoneCheckedIn_IncludesAll(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "no-checkin-pools"
+
+	createTestCompetition(t, store, compID, "mixed", 3)
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
+		map[string]bool{}, // nobody checked in
+	)
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	pools, err := store.LoadPools(compID)
+	require.NoError(t, err)
+	assert.Len(t, poolPlayerNames(pools), 6, "with no check-in, all participants are drawn")
+}
+
+// TestStartCompetition_PlayoffsFormat_ExcludesNonCheckedIn verifies the filter
+// reaches the elimination-bracket path too.
+func TestStartCompetition_PlayoffsFormat_ExcludesNonCheckedIn(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "checkin-playoffs"
+
+	createTestCompetition(t, store, compID, "playoffs", 0)
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve"},
+		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
+	)
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	bracket, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	names := bracketLeafNames(bracket)
+
+	assert.Len(t, names, 4, "only the 4 checked-in players should seed the bracket")
+	assert.NotContains(t, names, "Eve", "non-checked-in player must be excluded")
+}
+
+// TestStartCompetition_PlayoffsFromSource_FinalistsNotExcluded is the critical
+// regression guard for mp-w7x GAP 1: a playoffs competition whose roster is
+// resolved from a source's pool winners must NOT have those finalists dropped.
+// resolvePoolWinners builds them with CheckedIn=false, so a filter placed after
+// resolution would empty the bracket. The filter must run on the (empty) disk
+// roster BEFORE resolution, leaving the finalists untouched.
+func TestStartCompetition_PlayoffsFromSource_FinalistsNotExcluded(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+
+	srcID := "src-mixed"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     srcID,
+		Name:   "Source Mixed",
+		Format: state.CompFormatMixed,
+		Status: state.CompStatusComplete,
+	}))
+	require.NoError(t, store.SaveParticipants(srcID, []domain.Player{
+		{Name: "Alice", Dojo: "DojoA"},
+		{Name: "Bob", Dojo: "DojoB"},
+	}))
+	require.NoError(t, store.SavePools(srcID, []helper.Pool{
+		{PoolName: "Pool A", Players: []helper.Player{{Name: "Alice"}, {Name: "Bob"}}},
+	}))
+	require.NoError(t, store.SavePoolMatches(srcID, []state.MatchResult{
+		{ID: "Pool A-0", SideA: "Alice", SideB: "Bob", Winner: "Alice",
+			IpponsA: []string{"M"}, Status: state.MatchStatusCompleted},
+	}))
+
+	playoffID := "src-mixed-playoffs"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:           playoffID,
+		Name:         "Source Mixed - Playoffs",
+		Kind:         "individual",
+		Format:       state.CompFormatPlayoffs,
+		SourceCompID: srcID,
+		Courts:       []string{"A"},
+		StartTime:    "09:00",
+		Status:       "setup",
+	}))
+
+	require.NoError(t, eng.StartCompetition(playoffID))
+
+	bracket, err := store.LoadBracket(playoffID)
+	require.NoError(t, err)
+	names := bracketLeafNames(bracket)
+
+	assert.Len(t, names, 2, "both resolved finalists must seed the bracket despite CheckedIn=false")
+	assert.Contains(t, names, "Alice")
+	assert.Contains(t, names, "Bob")
+}
+
+// TestGenerateSwissRound_ExcludesNonCheckedIn is the regression guard for
+// mp-w7x GAP 2: the Swiss path reloads the roster from disk, so the filter
+// must live inside GenerateSwissRound, not only in runDrawPipeline.
+func TestGenerateSwissRound_ExcludesNonCheckedIn(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "checkin-swiss"
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:          compID,
+		Name:        "Swiss Check-in",
+		Kind:        "individual",
+		Format:      state.CompFormatSwiss,
+		SwissRounds: 3,
+		Courts:      []string{"A"},
+		StartTime:   "09:00",
+		Status:      "setup",
+	}))
+	saveParticipantsWithCheckIn(t, store, compID,
+		[]string{"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank"},
+		map[string]bool{"Alice": true, "Bob": true, "Charlie": true, "Dave": true},
+	)
+
+	matches, err := eng.GenerateSwissRound(compID, 1)
+	require.NoError(t, err)
+
+	seen := map[string]bool{}
+	for _, m := range matches {
+		if m.SideA != "" {
+			seen[m.SideA] = true
+		}
+		if m.SideB != "" {
+			seen[m.SideB] = true
+		}
+	}
+	assert.NotContains(t, seen, "Eve", "non-checked-in player must not be paired")
+	assert.NotContains(t, seen, "Frank", "non-checked-in player must not be paired")
+	assert.Contains(t, seen, "Alice")
+}

--- a/internal/engine/checkin_filter_test.go
+++ b/internal/engine/checkin_filter_test.go
@@ -96,6 +96,34 @@ func TestFilterCheckedIn(t *testing.T) {
 	})
 }
 
+// TestDropSeedAssignments_CaseSensitive is the regression guard for PR #199
+// review round 3: seed pruning must use the case-sensitive roster identity.
+// "Alice" (checked in) and "alice" (not) are distinct participants
+// (helper.CheckDuplicateEntries is case-sensitive), so the checked-in player's
+// seed must survive even though a case-variant peer is excluded.
+func TestDropSeedAssignments_CaseSensitive(t *testing.T) {
+	players := []domain.Player{
+		{Name: "Alice", CheckedIn: true},
+		{Name: "alice", CheckedIn: false},
+		{Name: "Bob", CheckedIn: true},
+	}
+	excluded := checkInExcludedNames(players)
+	require.Contains(t, excluded, "alice")
+	require.NotContains(t, excluded, "Alice", "checked-in Alice must not be in the excluded set")
+
+	seeds := []domain.SeedAssignment{
+		{Name: "Alice", SeedRank: 1},
+		{Name: "Bob", SeedRank: 2},
+	}
+	out := dropSeedAssignments(seeds, excluded)
+	require.Len(t, out, 2, "checked-in Alice's seed must survive an excluded case-variant 'alice'")
+	got := map[string]bool{}
+	for _, a := range out {
+		got[a.Name] = true
+	}
+	assert.True(t, got["Alice"] && got["Bob"])
+}
+
 // TestStartCompetition_MixedFormat_ExcludesNonCheckedIn verifies that when
 // check-in is in use, only checked-in participants reach the pool draw.
 func TestStartCompetition_MixedFormat_ExcludesNonCheckedIn(t *testing.T) {

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -534,11 +534,14 @@ func (e *Engine) runDrawPipeline(id string) error {
 	if err != nil {
 		return err
 	}
-	// Exclude participants who have not checked in (mp-w7x), but only when
-	// check-in is actually in use for this competition — i.e. at least one
-	// participant is checked in. If nobody is checked in, the operator never
-	// used the feature, so we include everyone (opt-in semantics: check-in
-	// can never silently empty the field).
+	// Exclude participants who have not checked in (mp-w7x) — but ONLY when the
+	// competition has check-in tracking enabled (comp.CheckInEnabled). The rest
+	// of the stack masks checkedIn behind this flag (the viewer derives
+	// checkedIn as `checkInEnabled && p.checkedIn`), so a stale/imported
+	// checked_in marker on a competition that doesn't use check-in must not
+	// silently shrink the field (PR #199 review). When enabled, opt-in
+	// semantics still apply (see filterCheckedIn): if nobody is checked in,
+	// everyone is included.
 	//
 	// Filter the DISK roster HERE — after load, BEFORE the playoffs
 	// source-resolution below. resolvePoolWinners builds promoted finalists
@@ -547,13 +550,16 @@ func (e *Engine) runDrawPipeline(id string) error {
 	// bracket. Source-resolved finalists are intentionally exempt and bypass
 	// this filter by virtue of placement.
 	//
-	// Capture the names check-in removes BEFORE filtering so we can drop their
-	// seed assignments too (PR #199 review): helper.ApplySeeds errors with
-	// "seeded participant not found in main list" for a seed whose player is
-	// absent, which would make a competition with a non-checked-in seeded
-	// player undrawable.
-	excludedByCheckIn := checkInExcludedNames(players)
-	players = filterCheckedIn(players)
+	// excludedByCheckIn captures the names check-in removes so we can drop
+	// their seed assignments too: helper.ApplySeeds errors with "seeded
+	// participant not found in main list" for a seed whose player is absent,
+	// which would make a competition with a non-checked-in seeded player
+	// undrawable.
+	var excludedByCheckIn map[string]bool
+	if comp.CheckInEnabled {
+		excludedByCheckIn = checkInExcludedNames(players)
+		players = filterCheckedIn(players)
+	}
 	// Playoffs competitions created from a mixed source (POST /playoffs)
 	// start with an empty roster on disk. Resolve the source's final pool
 	// winners into the roster now, BEFORE the empty-roster check. The

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -500,6 +500,7 @@ func (e *Engine) runDrawPipeline(id string) error {
 	loadedWithZekken := comp.WithZekkenName
 	loadedCourts := append([]string(nil), comp.Courts...)
 	loadedTeamSize := comp.TeamSize
+	loadedCheckInEnabled := comp.CheckInEnabled
 	// Note: PoolWinners is intentionally NOT snapshotted. The
 	// validation block below excludes it because it doesn't drive
 	// pool/bracket generation — admin's concurrent change is
@@ -705,6 +706,7 @@ func (e *Engine) runDrawPipeline(id string) error {
 		//   - StartTime (initial ScheduledAt for generated matches)
 		//   - Courts (court labels assigned to generated matches)
 		//   - Kind / WithZekkenName (participants loading)
+		//   - CheckInEnabled (decides which participants are included)
 		// Other config fields (TeamSize, PoolWinners, Name, Date, Venue,
 		// Mirror) are NOT validated — they don't drive generation, so
 		// admin's concurrent change to them doesn't invalidate the
@@ -719,8 +721,9 @@ func (e *Engine) runDrawPipeline(id string) error {
 			current.RoundRobin != loadedRoundRobin ||
 			current.Kind != loadedKind ||
 			current.WithZekkenName != loadedWithZekken ||
+			current.CheckInEnabled != loadedCheckInEnabled ||
 			!courtsEqual(current.Courts, loadedCourts) {
-			return nil, validationErrorf("competition %s configuration changed during start (Format/PoolSize/PoolSizeMode/NumberPrefix/StartTime/RoundRobin/Kind/WithZekkenName/Courts); regenerate by retrying", id)
+			return nil, validationErrorf("competition %s configuration changed during start (Format/PoolSize/PoolSizeMode/NumberPrefix/StartTime/RoundRobin/Kind/WithZekkenName/CheckInEnabled/Courts); regenerate by retrying", id)
 		}
 		// Participants / seeds drift: detected via file mtime captured
 		// at outer Load. A concurrent AdminParticipants PUT between our

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -423,10 +422,16 @@ func filterCheckedIn(players []domain.Player) []domain.Player {
 	return eligible
 }
 
-// checkInExcludedNames returns the normalized (lowercased, trimmed) names of
-// players that filterCheckedIn would remove under opt-in semantics: the
-// non-checked-in players when at least one is checked in, else nil. Used to
-// prune their seed assignments so ApplySeeds doesn't fail on an absent player.
+// checkInExcludedNames returns the names of players that filterCheckedIn would
+// remove under opt-in semantics: the non-checked-in players when at least one
+// is checked in, else nil. Used to prune their seed assignments so ApplySeeds
+// doesn't fail on an absent player.
+//
+// The key is the raw, case-sensitive player Name — matching the roster identity
+// the draw uses (helper.CheckDuplicateEntries and ApplySeeds' playerMap both key
+// on the exact Name, so "Alice" and "alice" are distinct participants).
+// Normalizing case here would let an excluded "alice" drop the seed of a
+// checked-in "Alice" (PR #199 review round 3).
 func checkInExcludedNames(players []domain.Player) map[string]bool {
 	anyCheckedIn := false
 	for _, p := range players {
@@ -441,23 +446,24 @@ func checkInExcludedNames(players []domain.Player) map[string]bool {
 	excluded := make(map[string]bool)
 	for _, p := range players {
 		if !p.CheckedIn {
-			excluded[strings.ToLower(strings.TrimSpace(p.Name))] = true
+			excluded[p.Name] = true
 		}
 	}
 	return excluded
 }
 
 // dropSeedAssignments removes seed assignments whose participant name is in the
-// excluded set (case-insensitive). A nil/empty excluded set returns the input
-// unchanged, so a seed for a name that was never a participant still flows
-// through to ApplySeeds and surfaces the same error as before.
+// excluded set, matched case-sensitively on the exact Name (same key as
+// checkInExcludedNames / the roster identity). A nil/empty excluded set returns
+// the input unchanged, so a seed for a name that was never a participant still
+// flows through to ApplySeeds and surfaces the same error as before.
 func dropSeedAssignments(seeds []domain.SeedAssignment, excluded map[string]bool) []domain.SeedAssignment {
 	if len(excluded) == 0 {
 		return seeds
 	}
 	out := make([]domain.SeedAssignment, 0, len(seeds))
 	for _, a := range seeds {
-		if excluded[strings.ToLower(strings.TrimSpace(a.Name))] {
+		if excluded[a.Name] {
 			continue
 		}
 		out = append(out, a)

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -422,6 +423,48 @@ func filterCheckedIn(players []domain.Player) []domain.Player {
 	return eligible
 }
 
+// checkInExcludedNames returns the normalized (lowercased, trimmed) names of
+// players that filterCheckedIn would remove under opt-in semantics: the
+// non-checked-in players when at least one is checked in, else nil. Used to
+// prune their seed assignments so ApplySeeds doesn't fail on an absent player.
+func checkInExcludedNames(players []domain.Player) map[string]bool {
+	anyCheckedIn := false
+	for _, p := range players {
+		if p.CheckedIn {
+			anyCheckedIn = true
+			break
+		}
+	}
+	if !anyCheckedIn {
+		return nil
+	}
+	excluded := make(map[string]bool)
+	for _, p := range players {
+		if !p.CheckedIn {
+			excluded[strings.ToLower(strings.TrimSpace(p.Name))] = true
+		}
+	}
+	return excluded
+}
+
+// dropSeedAssignments removes seed assignments whose participant name is in the
+// excluded set (case-insensitive). A nil/empty excluded set returns the input
+// unchanged, so a seed for a name that was never a participant still flows
+// through to ApplySeeds and surfaces the same error as before.
+func dropSeedAssignments(seeds []domain.SeedAssignment, excluded map[string]bool) []domain.SeedAssignment {
+	if len(excluded) == 0 {
+		return seeds
+	}
+	out := make([]domain.SeedAssignment, 0, len(seeds))
+	for _, a := range seeds {
+		if excluded[strings.ToLower(strings.TrimSpace(a.Name))] {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
 func (e *Engine) runDrawPipeline(id string) error {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {
@@ -503,6 +546,13 @@ func (e *Engine) runDrawPipeline(id string) error {
 	// so filtering after resolution would wrongly drop the entire playoff
 	// bracket. Source-resolved finalists are intentionally exempt and bypass
 	// this filter by virtue of placement.
+	//
+	// Capture the names check-in removes BEFORE filtering so we can drop their
+	// seed assignments too (PR #199 review): helper.ApplySeeds errors with
+	// "seeded participant not found in main list" for a seed whose player is
+	// absent, which would make a competition with a non-checked-in seeded
+	// player undrawable.
+	excludedByCheckIn := checkInExcludedNames(players)
 	players = filterCheckedIn(players)
 	// Playoffs competitions created from a mixed source (POST /playoffs)
 	// start with an empty roster on disk. Resolve the source's final pool
@@ -535,6 +585,10 @@ func (e *Engine) runDrawPipeline(id string) error {
 	if err != nil {
 		return err
 	}
+	// Drop seed assignments for participants removed by check-in (PR #199
+	// review) so ApplySeeds doesn't fail on an absent seeded player. Remaining
+	// seeds keep their ranks; sparse ranks are handled by the seeding pass.
+	seeds = dropSeedAssignments(seeds, excludedByCheckIn)
 
 	// League format: enforce the single-pool invariant so that
 	// generatePools always produces exactly one pool containing all

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -396,6 +396,32 @@ func (e *Engine) transitionDrawToRunning(id string) error {
 //     commit serializes them. Left as a follow-up.
 //   - SaveParticipants (source-linked playoffs roster path) also has its own
 //     lock acquisition. A failure mid-pipeline leaves partial state on disk.
+//
+// filterCheckedIn applies the mp-w7x check-in filter with opt-in semantics:
+// if at least one player is checked in, return only the checked-in players;
+// if nobody is checked in, the operator never used check-in for this
+// competition, so return the roster unchanged. This guarantees the filter can
+// never silently empty the field. The input slice is not mutated.
+func filterCheckedIn(players []domain.Player) []domain.Player {
+	anyCheckedIn := false
+	for _, p := range players {
+		if p.CheckedIn {
+			anyCheckedIn = true
+			break
+		}
+	}
+	if !anyCheckedIn {
+		return players
+	}
+	eligible := make([]domain.Player, 0, len(players))
+	for _, p := range players {
+		if p.CheckedIn {
+			eligible = append(eligible, p)
+		}
+	}
+	return eligible
+}
+
 func (e *Engine) runDrawPipeline(id string) error {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {
@@ -465,6 +491,19 @@ func (e *Engine) runDrawPipeline(id string) error {
 	if err != nil {
 		return err
 	}
+	// Exclude participants who have not checked in (mp-w7x), but only when
+	// check-in is actually in use for this competition — i.e. at least one
+	// participant is checked in. If nobody is checked in, the operator never
+	// used the feature, so we include everyone (opt-in semantics: check-in
+	// can never silently empty the field).
+	//
+	// Filter the DISK roster HERE — after load, BEFORE the playoffs
+	// source-resolution below. resolvePoolWinners builds promoted finalists
+	// with CheckedIn=false (ranking.go: only Name/DisplayName/Dojo are set),
+	// so filtering after resolution would wrongly drop the entire playoff
+	// bracket. Source-resolved finalists are intentionally exempt and bypass
+	// this filter by virtue of placement.
+	players = filterCheckedIn(players)
 	// Playoffs competitions created from a mixed source (POST /playoffs)
 	// start with an empty roster on disk. Resolve the source's final pool
 	// winners into the roster now, BEFORE the empty-roster check. The

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -384,19 +384,6 @@ func (e *Engine) transitionDrawToRunning(id string) error {
 	return err
 }
 
-// runDrawPipeline runs the full draw-generation pipeline for a Setup
-// competition and commits CompStatusDrawReady. It does NOT generate the
-// schedule; callers must call GenerateSchedule after transitioning to a
-// running status.
-//
-// Pipeline limitations (pre-existing):
-//   - Pool/bracket generation (writes pools.csv / bracket.json) runs
-//     OUTSIDE the comp-config lock. Two concurrent GenerateDraw calls
-//     could overwrite each other's pools.csv before the atomic Status
-//     commit serializes them. Left as a follow-up.
-//   - SaveParticipants (source-linked playoffs roster path) also has its own
-//     lock acquisition. A failure mid-pipeline leaves partial state on disk.
-//
 // filterCheckedIn applies the mp-w7x check-in filter with opt-in semantics:
 // if at least one player is checked in, return only the checked-in players;
 // if nobody is checked in, the operator never used check-in for this
@@ -471,6 +458,18 @@ func dropSeedAssignments(seeds []domain.SeedAssignment, excluded map[string]bool
 	return out
 }
 
+// runDrawPipeline runs the full draw-generation pipeline for a Setup
+// competition and commits CompStatusDrawReady. It does NOT generate the
+// schedule; callers must call GenerateSchedule after transitioning to a
+// running status.
+//
+// Pipeline limitations (pre-existing):
+//   - Pool/bracket generation (writes pools.csv / bracket.json) runs
+//     OUTSIDE the comp-config lock. Two concurrent GenerateDraw calls
+//     could overwrite each other's pools.csv before the atomic Status
+//     commit serializes them. Left as a follow-up.
+//   - SaveParticipants (source-linked playoffs roster path) also has its own
+//     lock acquisition. A failure mid-pipeline leaves partial state on disk.
 func (e *Engine) runDrawPipeline(id string) error {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {

--- a/internal/engine/swiss.go
+++ b/internal/engine/swiss.go
@@ -155,8 +155,10 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 	// Determine the Swiss field for this round (mp-w7x; PR #199 review).
 	//
 	// Round 1 (the initial draw): exclude participants who have not checked
-	// in, with opt-in semantics (see filterCheckedIn) — if nobody is checked
-	// in, check-in is unused and everyone is drawn.
+	// in, but ONLY when check-in tracking is enabled (comp.CheckInEnabled) —
+	// otherwise a stale/imported checked_in marker would shrink the field even
+	// though the competition doesn't use check-in (PR #199 review). When
+	// enabled, opt-in semantics still apply (see filterCheckedIn).
 	//
 	// Round N > 1: the field is FROZEN to whoever was part of the initial
 	// draw. We derive it from the names already present in prior Swiss matches
@@ -165,7 +167,9 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 	// player into a later round nor silently drop one. Withdrawals are handled
 	// separately by the eligibility (kiken/fusenpai) filter below.
 	if roundNumber == 1 {
-		participants = filterCheckedIn(participants)
+		if comp.CheckInEnabled {
+			participants = filterCheckedIn(participants)
+		}
 	} else {
 		field := swissFieldNamesFromMatches(priorMatches)
 		frozen := make([]domain.Player, 0, len(participants))

--- a/internal/engine/swiss.go
+++ b/internal/engine/swiss.go
@@ -128,6 +128,14 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 	// After T154, store.LoadParticipants returns []domain.Player
 	// directly, so the Swiss pipeline doesn't need a conversion at the
 	// boundary (NFR-007).
+	// Exclude participants who have not checked in (mp-w7x), opt-in semantics
+	// (see filterCheckedIn). Unlike the pools/playoffs draw (filtered once in
+	// runDrawPipeline), every Swiss round reloads the roster from disk here, so
+	// the filter lives at this shared point — it applies to round 1
+	// (StartCompetition) AND every AdvanceSwissRound, preventing a
+	// non-checked-in player from being paired mid-tournament.
+	participants = filterCheckedIn(participants)
+
 	active := make([]domain.Player, 0, len(participants))
 	for _, p := range participants {
 		if p.ID != "" {
@@ -138,7 +146,7 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 		active = append(active, p)
 	}
 	if len(active) < 2 {
-		return nil, validationErrorf("swiss round requires at least 2 eligible participants, got %d", len(active))
+		return nil, validationErrorf("swiss round requires at least 2 eligible (checked-in) participants, got %d", len(active))
 	}
 
 	priorMatches, err := e.store.LoadPoolMatches(compID)

--- a/internal/engine/swiss.go
+++ b/internal/engine/swiss.go
@@ -195,7 +195,7 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 		active = append(active, p)
 	}
 	if len(active) < 2 {
-		return nil, validationErrorf("swiss round requires at least 2 eligible (checked-in) participants, got %d", len(active))
+		return nil, validationErrorf("swiss round requires at least 2 eligible participants, got %d", len(active))
 	}
 
 	// Build the prior-pairings set (for rematch avoidance) and the

--- a/internal/engine/swiss.go
+++ b/internal/engine/swiss.go
@@ -60,6 +60,28 @@ func parseSwissMatchRound(id string) (int, bool) {
 	return n, true
 }
 
+// swissFieldNamesFromMatches returns the set of competitor names that have
+// appeared in prior Swiss matches (players and bye recipients alike) — i.e.
+// the frozen round-1 field. Used by GenerateSwissRound for rounds > 1 to keep
+// the field stable across rounds regardless of later check-in toggles
+// (mp-w7x; PR #199 review). Names are unique per competition
+// (helper.CheckDuplicateEntries), so a name key is an unambiguous identity.
+func swissFieldNamesFromMatches(matches []state.MatchResult) map[string]bool {
+	field := make(map[string]bool)
+	for _, m := range matches {
+		if _, ok := parseSwissMatchRound(m.ID); !ok {
+			continue
+		}
+		if m.SideA != "" {
+			field[m.SideA] = true
+		}
+		if m.SideB != "" {
+			field[m.SideB] = true
+		}
+	}
+	return field
+}
+
 // GenerateSwissRound builds the matches for round `roundNumber` of the
 // Swiss-format competition identified by compID. Returns only the
 // new round's matches — the caller is responsible for merging them
@@ -125,17 +147,40 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 	if err != nil {
 		return nil, err
 	}
-	// After T154, store.LoadParticipants returns []domain.Player
-	// directly, so the Swiss pipeline doesn't need a conversion at the
-	// boundary (NFR-007).
-	// Exclude participants who have not checked in (mp-w7x), opt-in semantics
-	// (see filterCheckedIn). Unlike the pools/playoffs draw (filtered once in
-	// runDrawPipeline), every Swiss round reloads the roster from disk here, so
-	// the filter lives at this shared point — it applies to round 1
-	// (StartCompetition) AND every AdvanceSwissRound, preventing a
-	// non-checked-in player from being paired mid-tournament.
-	participants = filterCheckedIn(participants)
+	priorMatches, err := e.store.LoadPoolMatches(compID)
+	if err != nil {
+		return nil, err
+	}
 
+	// Determine the Swiss field for this round (mp-w7x; PR #199 review).
+	//
+	// Round 1 (the initial draw): exclude participants who have not checked
+	// in, with opt-in semantics (see filterCheckedIn) — if nobody is checked
+	// in, check-in is unused and everyone is drawn.
+	//
+	// Round N > 1: the field is FROZEN to whoever was part of the initial
+	// draw. We derive it from the names already present in prior Swiss matches
+	// rather than re-reading mutable check-in state, so toggling a
+	// participant's check-in after round 1 can neither inject a zero-history
+	// player into a later round nor silently drop one. Withdrawals are handled
+	// separately by the eligibility (kiken/fusenpai) filter below.
+	if roundNumber == 1 {
+		participants = filterCheckedIn(participants)
+	} else {
+		field := swissFieldNamesFromMatches(priorMatches)
+		frozen := make([]domain.Player, 0, len(participants))
+		for _, p := range participants {
+			if field[p.Name] {
+				frozen = append(frozen, p)
+			}
+		}
+		participants = frozen
+	}
+
+	// After T154, store.LoadParticipants returns []domain.Player directly, so
+	// the Swiss pipeline doesn't need a conversion at the boundary (NFR-007).
+	// Drop kiken/fusenpai players (FR-050f); LoadCompetitorStatus returns an
+	// empty map when the file is missing (== "all eligible").
 	active := make([]domain.Player, 0, len(participants))
 	for _, p := range participants {
 		if p.ID != "" {
@@ -147,11 +192,6 @@ func (e *Engine) GenerateSwissRound(compID string, roundNumber int) ([]state.Mat
 	}
 	if len(active) < 2 {
 		return nil, validationErrorf("swiss round requires at least 2 eligible (checked-in) participants, got %d", len(active))
-	}
-
-	priorMatches, err := e.store.LoadPoolMatches(compID)
-	if err != nil {
-		return nil, err
 	}
 
 	// Build the prior-pairings set (for rematch avoidance) and the

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1123,14 +1123,16 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   const isDateValid = isValidDate;
 
   // mp-w7x: surface how many participants will be excluded from the draw
-  // because they have not checked in. Mirror the engine's opt-in rule
-  // (filterCheckedIn in internal/engine/competition.go): only exclude when at
-  // least one participant is checked in; if nobody is, check-in is unused for
-  // this competition and everyone is included. Empty roster (e.g. a
-  // playoffs-from-source competition resolved server-side) yields 0.
+  // because they have not checked in. Mirror the engine's rule
+  // (filterCheckedIn in internal/engine/competition.go): only applies when the
+  // competition has check-in tracking enabled (c.checkInEnabled) — consistent
+  // with the rest of the UI, which masks checkedIn behind that flag. Within an
+  // enabled competition, opt-in semantics apply: only exclude when at least one
+  // participant is checked in. Empty roster (e.g. a playoffs-from-source
+  // competition resolved server-side) yields 0.
   const drawPlayers = c.players || [];
   const anyCheckedIn = drawPlayers.some(p => p.checkedIn);
-  const excludedFromDraw = anyCheckedIn ? drawPlayers.filter(p => !p.checkedIn).length : 0;
+  const excludedFromDraw = (c.checkInEnabled && anyCheckedIn) ? drawPlayers.filter(p => !p.checkedIn).length : 0;
 
   // Confirm before a draw/start that would drop non-checked-in participants.
   // Returns false when the operator cancels.

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1122,7 +1122,30 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   // with a date that can't be saved back.
   const isDateValid = isValidDate;
 
+  // mp-w7x: surface how many participants will be excluded from the draw
+  // because they have not checked in. Mirror the engine's opt-in rule
+  // (filterCheckedIn in internal/engine/competition.go): only exclude when at
+  // least one participant is checked in; if nobody is, check-in is unused for
+  // this competition and everyone is included. Empty roster (e.g. a
+  // playoffs-from-source competition resolved server-side) yields 0.
+  const drawPlayers = c.players || [];
+  const anyCheckedIn = drawPlayers.some(p => p.checkedIn);
+  const excludedFromDraw = anyCheckedIn ? drawPlayers.filter(p => !p.checkedIn).length : 0;
+
+  // Confirm before a draw/start that would drop non-checked-in participants.
+  // Returns false when the operator cancels.
+  const confirmCheckInExclusion = () => {
+    if (excludedFromDraw === 0) return true;
+    const plural = excludedFromDraw === 1 ? "" : "s";
+    const verb = excludedFromDraw === 1 ? "is" : "are";
+    return confirm(
+      `${excludedFromDraw} participant${plural} ${verb} not checked in and will be excluded from the draw.\n\n` +
+      `Only checked-in participants will be drawn. Continue?`
+    );
+  };
+
   const generateDraw = async () => {
+    if (!confirmCheckInExclusion()) return;
     setGenerating(true);
     try {
       await window.API.generateDraw(c.id, password);
@@ -1160,6 +1183,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const regenerateDraw = async () => {
+    if (!confirmCheckInExclusion()) return;
     // Regenerate discards the existing draw first (DELETE /draw is gated),
     // so collect the elevated password up front before any work begins.
     const admin = window.promptAdminPassword();
@@ -1188,6 +1212,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const start = async () => {
+    if (!confirmCheckInExclusion()) return;
     showToast(`Starting ${c.name}…`);
 
     setStarting(true);
@@ -1291,6 +1316,11 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 {!isDateValid(c.date) && (
                   <div style={{ color: "var(--red)", fontSize: 11, fontWeight: 600 }}>
                     ⚠ Cannot start: invalid date in Settings tab (e.g. "{c.date}")
+                  </div>
+                )}
+                {excludedFromDraw > 0 && (
+                  <div style={{ color: "var(--ink-3)", fontSize: 11, fontWeight: 600 }}>
+                    {excludedFromDraw} not checked in — will be excluded from the draw
                   </div>
                 )}
               </>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1214,7 +1214,9 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const start = async () => {
-    if (!confirmCheckInExclusion()) return;
+    // draw-ready → running does not regenerate the draw; skip the confirmation
+    // there to avoid showing stale exclusion counts against an already-fixed draw.
+    if (c.status !== "draw-ready" && !confirmCheckInExclusion()) return;
     showToast(`Starting ${c.name}…`);
 
     setStarting(true);


### PR DESCRIPTION
## Summary

When a competition uses the check-in feature, the draw (pools, playoff bracket, and Swiss rounds) now includes **only checked-in participants**. Resolves **mp-w7x**.

**Opt-in semantics** (chosen over the bead's strict spec after weighing the blast radius): if *nobody* is checked in, check-in was never used for that competition, so everyone is drawn. The filter can never silently empty the field — and no existing tests/tournaments break.

## Critical-thinking findings (two gaps the original plan missed)

The bead's plan said "filter after load, before generation." Verifying against current code surfaced two bugs that wording would have shipped:

1. **GAP 1 — `resolvePoolWinners` finalists.** A playoffs-from-source competition resolves its roster from a source's pool winners, built with `CheckedIn=false` (`ranking.go`). Filtering right before the generator `switch` would drop the **entire** playoff bracket. Fix: filter the disk roster *before* `resolvePoolWinners` so source-resolved finalists are exempt by placement.
2. **GAP 2 — Swiss reload bypass.** `GenerateSwissRound` re-loads the roster from disk every round (`swiss.go`), ignoring the slice computed in `runDrawPipeline`. Filtering only there would leave Swiss unfiltered. Fix: apply the same filter inside `GenerateSwissRound`, so round 1 *and* every `AdvanceSwissRound` exclude non-checked-in players (preventing a player from materializing mid-tournament).

## Changes

- **`internal/engine/competition.go`** — `filterCheckedIn` helper (opt-in) applied after load, before `resolvePoolWinners`.
- **`internal/engine/swiss.go`** — same filter in the per-round Swiss draw.
- **`web-mobile/js/admin_competition.jsx`** — pre-start notice "N not checked in — will be excluded from the draw" + a confirmation dialog before Preview/Start/Regenerate when exclusions apply, mirroring the engine's opt-in rule client-side.
- **`internal/engine/checkin_filter_test.go`** — new tests.

## Test plan

- [x] `filterCheckedIn` unit table (none / mixed / all / empty)
- [x] Mixed format excludes non-checked-in; none-checked-in draws everyone
- [x] Playoffs format excludes non-checked-in
- [x] **Playoffs-from-source finalists NOT excluded** (GAP 1 regression guard)
- [x] **Swiss reload path excludes non-checked-in** (GAP 2 regression guard)
- [x] `make go/test` — Go lint, gosec, govulncheck, engine/state suites green
- [x] **Browser-verified** (mobile app): notice renders "2 not checked in…"; confirm dialog shows correct message and cancel aborts (status stays Pending); opt-in comp shows no notice and no confirm; on-disk draw contains only the 3 checked-in players (mixed) and all 3 (none-checked-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)