### PR TITLE
feat(mp-ehf): multi-day tournaments (start date + DurationDays) + competition day constraint

### DIFF
--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -112,6 +112,31 @@ func extractSeeds(players []domain.Player) []domain.SeedAssignment {
 	return out
 }
 
+// validateCompetitionDateInTournament checks that the competition's Date
+// falls within the tournament's day range [Day 1 .. Day N]. When:
+//   - comp.Date is empty (optional field) → skip, return nil.
+//   - tourn is nil or tourn.Date is empty → skip (can't derive day list yet).
+//   - comp.Date is in the derived day list → return nil.
+//   - comp.Date is NOT in the derived day list → return a descriptive error.
+//
+// errcheck: no bare ignored returns — always propagated by callers.
+func validateCompetitionDateInTournament(comp *state.Competition, tourn *state.Tournament) error {
+	if comp.Date == "" || tourn == nil || tourn.Date == "" {
+		return nil
+	}
+	days := tourn.Days()
+	if len(days) == 0 {
+		// Tournament date unparseable or DurationDays < 1 — skip range check.
+		return nil
+	}
+	for _, d := range days {
+		if d == comp.Date {
+			return nil
+		}
+	}
+	return fmt.Errorf("date must be one of the tournament days (%s to %s)", days[0], days[len(days)-1])
+}
+
 // validateCompetitionFormat returns an HTTP status code + error
 // message for invalid Format / PoolFormat values. Empty values are
 // accepted (defaults applied on load). Unknown values return 400.
@@ -272,6 +297,31 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 
+		// Load the tournament to (a) default the competition date to Day 1
+		// and (b) enforce the date-in-range constraint. Tournament load can
+		// return nil when no tournament.md exists yet (new setup); both steps
+		// skip gracefully in that case.
+		createTourn, err := store.LoadTournament()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// Default the competition date to the tournament's Day 1 when the
+		// client sends an empty date. Pre-fix: the frontend seeded the date
+		// from tournament.date directly (JS), but the backend defaulted to
+		// today when it was empty — using Day 1 is the correct multi-day
+		// behaviour and also keeps server and client in sync.
+		if comp.Date == "" && createTourn != nil && createTourn.Date != "" {
+			comp.Date = createTourn.Date
+		}
+
+		// Reject a competition date that falls outside the tournament's day
+		// range. Skipped when tournament has no date configured.
+		if err := validateCompetitionDateInTournament(&comp, createTourn); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
 		// Cross-file guard symmetry with POST/PUT /tournament: same
 		// label + cap check via validateCompetitionCourts (looser than
 		// the tournament version — empty courts is allowed because the
@@ -348,7 +398,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// overwrote the existing competition. POST is documented as
 		// CREATE, so an existing ID is a 409 / 400 case.
 		var nameErr, idErr error
-		err := store.WithCompetitionRenameLock(func() error {
+		lockErr := store.WithCompetitionRenameLock(func() error {
 			if existing, _ := store.LoadCompetition(comp.ID); existing != nil {
 				idErr = fmt.Errorf("competition ID %q already exists", comp.ID)
 				return nil
@@ -359,6 +409,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			_, saveErr := saveCompetitionWithPlayers(&comp, store)
 			return saveErr
 		})
+		err = lockErr
 		if idErr != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": idErr.Error()})
 			return
@@ -490,6 +541,23 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 
 			// Reject non-canonical Date format.
 			if err := validateDateDMY(comp.Date); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+
+			// Enforce the competition-date-in-tournament-range constraint.
+			// Load tournament outside the rename lock to avoid holding the
+			// lock during I/O. Tournament load is read-only and idempotent,
+			// so the window between load and the lock acquisition is safe
+			// (the worst case is a missed tournament date update, which
+			// would just skip the range check — a harmless skip vs. a
+			// deadlock is the right trade-off).
+			putTourn, putTournErr := store.LoadTournament()
+			if putTournErr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": putTournErr.Error()})
+				return
+			}
+			if err := validateCompetitionDateInTournament(&comp, putTourn); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}

--- a/internal/mobileapp/handlers_import.go
+++ b/internal/mobileapp/handlers_import.go
@@ -200,6 +200,21 @@ func importCompetition(store *state.Store, entry ImportManifestComp, files map[s
 		return res
 	}
 
+	// Cross-file guard symmetry with POST/PUT /competitions: reject a
+	// competition date that falls outside the tournament's day range.
+	// Load the tournament once per row; the cost is a file stat + cache
+	// hit after the first row. Failures are soft (res.Error, not HTTP
+	// abort) matching all other per-row validation patterns.
+	importTourn, importTournErr := store.LoadTournament()
+	if importTournErr != nil {
+		res.Error = "load tournament: " + importTournErr.Error()
+		return res
+	}
+	if err := validateCompetitionDateInTournament(comp, importTourn); err != nil {
+		res.Error = err.Error()
+		return res
+	}
+
 	// Cross-file guard symmetry with POST /competitions and PUT
 	// /competitions/:id (handlers_competition.go): reject unknown formats
 	// (400) so a manifest cannot persist a Competition whose format would

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -3,6 +3,7 @@ package mobileapp
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2249,4 +2250,210 @@ func TestStartCompetition_BroadcastContract(t *testing.T) {
 
 	_, extra := receiveEvent(10 * time.Millisecond)
 	assert.False(t, extra, "start must emit exactly 1 broadcast for the common case")
+}
+
+// --- Tournament DurationDays validation ---
+
+func TestTournamentHandlers_DurationDays_Validation(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	// Seed a valid tournament so PUT has something to update.
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:     "Base Tournament",
+		Password: "secret",
+		Courts:   []string{"A"},
+		Date:     "01-06-2026",
+	}))
+
+	tests := []struct {
+		name         string
+		method       string // "PUT" or "POST"
+		durationDays int
+		wantStatus   int
+		wantErrFrag  string
+	}{
+		{"PUT valid 1", "PUT", 1, http.StatusOK, ""},
+		{"PUT valid 30", "PUT", 30, http.StatusOK, ""},
+		{"PUT zero accepted defaults to 1", "PUT", 0, http.StatusOK, ""},
+		{"PUT negative rejected", "PUT", -1, http.StatusBadRequest, "durationDays must be between"},
+		{"PUT over 30 rejected", "PUT", 31, http.StatusBadRequest, "durationDays must be between"},
+		{"POST valid 1", "POST", 1, http.StatusCreated, ""},
+		{"POST zero accepted", "POST", 0, http.StatusCreated, ""},
+		{"POST negative rejected", "POST", -1, http.StatusBadRequest, "durationDays must be between"},
+		{"POST over 30 rejected", "POST", 31, http.StatusBadRequest, "durationDays must be between"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tour := state.Tournament{
+				Name:         "Duration Test",
+				Password:     "secret",
+				Courts:       []string{"A"},
+				Date:         "01-06-2026",
+				DurationDays: tc.durationDays,
+			}
+			body, _ := json.Marshal(tour)
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(tc.method, "/api/tournament", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code, "method=%s durationDays=%d", tc.method, tc.durationDays)
+			if tc.wantErrFrag != "" {
+				assert.Contains(t, w.Body.String(), tc.wantErrFrag)
+			}
+		})
+	}
+}
+
+func TestTournamentHandlers_DurationDays_PersistsAndLoads(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	tour := state.Tournament{
+		Name:         "Multi-day Tournament",
+		Password:     "secret",
+		Courts:       []string{"A"},
+		Date:         "05-06-2026",
+		DurationDays: 3,
+	}
+	body, _ := json.Marshal(tour)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/tournament", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	loaded, err := store.LoadTournament()
+	require.NoError(t, err)
+	assert.Equal(t, 3, loaded.DurationDays)
+	assert.Equal(t, []string{"05-06-2026", "06-06-2026", "07-06-2026"}, loaded.Days())
+}
+
+// --- Competition date range validation ---
+
+func TestCompetitionHandlers_DateRangeValidation(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	// Three-day tournament starting June 5.
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:         "Multi-day",
+		Password:     "secret",
+		Courts:       []string{"A"},
+		Date:         "05-06-2026",
+		DurationDays: 3,
+	}))
+
+	tests := []struct {
+		name        string
+		compDate    string
+		wantStatus  int
+		wantErrFrag string
+	}{
+		{"Day 1 accepted", "05-06-2026", http.StatusCreated, ""},
+		{"Day 2 accepted", "06-06-2026", http.StatusCreated, ""},
+		{"Day 3 accepted", "07-06-2026", http.StatusCreated, ""},
+		{"before Day 1 rejected", "04-06-2026", http.StatusBadRequest, "date must be one of the tournament days"},
+		{"after Day 3 rejected", "08-06-2026", http.StatusBadRequest, "date must be one of the tournament days"},
+		{"empty date defaults to Day 1", "", http.StatusCreated, ""},
+	}
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			comp := state.Competition{
+				ID:     fmt.Sprintf("c-range-%d", i),
+				Name:   fmt.Sprintf("Range Test %d", i),
+				Courts: []string{"A"},
+				Date:   tc.compDate,
+			}
+			body, _ := json.Marshal(comp)
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("POST", "/api/competitions", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code, "case %q: comp date=%q", tc.name, tc.compDate)
+			if tc.wantErrFrag != "" {
+				assert.Contains(t, w.Body.String(), tc.wantErrFrag, "case %q", tc.name)
+			}
+		})
+	}
+}
+
+func TestCompetitionHandlers_DateRangeValidation_PUT(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:         "Multi-day",
+		Password:     "secret",
+		Courts:       []string{"A"},
+		Date:         "05-06-2026",
+		DurationDays: 2,
+	}))
+
+	// Create an initial competition on Day 1.
+	initComp := state.Competition{ID: "c-put-range", Name: "Range PUT Test", Courts: []string{"A"}, Date: "05-06-2026"}
+	require.NoError(t, store.SaveCompetition(&initComp))
+
+	tests := []struct {
+		name        string
+		newDate     string
+		wantStatus  int
+		wantErrFrag string
+	}{
+		{"Day 1 accepted", "05-06-2026", http.StatusOK, ""},
+		{"Day 2 accepted", "06-06-2026", http.StatusOK, ""},
+		{"outside range rejected", "07-06-2026", http.StatusBadRequest, "date must be one of the tournament days"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			comp := state.Competition{
+				ID:     "c-put-range",
+				Name:   "Range PUT Test",
+				Courts: []string{"A"},
+				Date:   tc.newDate,
+			}
+			body, _ := json.Marshal(comp)
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("PUT", "/api/competitions/c-put-range", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantStatus, w.Code, "case %q: date=%q", tc.name, tc.newDate)
+			if tc.wantErrFrag != "" {
+				assert.Contains(t, w.Body.String(), tc.wantErrFrag)
+			}
+		})
+	}
+}
+
+func TestCompetitionHandlers_DefaultDate_IsDay1(t *testing.T) {
+	// When POST /competitions sends an empty date, the handler should
+	// default to the tournament's Day 1 (not today).
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:         "Multi-day",
+		Password:     "secret",
+		Courts:       []string{"A"},
+		Date:         "15-07-2026",
+		DurationDays: 3,
+	}))
+
+	comp := state.Competition{
+		ID:     "c-default-date",
+		Name:   "Default Date Test",
+		Courts: []string{"A"},
+		// Date intentionally empty — should default to tournament Day 1
+	}
+	body, _ := json.Marshal(comp)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/competitions", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Reload and check the date was set to Day 1.
+	loaded, err := store.LoadCompetition("c-default-date")
+	require.NoError(t, err)
+	assert.Equal(t, "15-07-2026", loaded.Date, "empty competition date should default to tournament Day 1")
 }

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -125,6 +125,18 @@ func validateCompetitionCourts(courts []string) error {
 // keeps the handler's errors.Is check stable across refactors.
 var errPasswordRequired = errors.New("tournament password is required")
 
+// validateTournamentDurationDays returns an error when durationDays is
+// outside the accepted range. 0 is allowed (treated as "default to 1" by
+// ApplyTournamentDefaults); values 1–MaxTournamentDurationDays are
+// accepted; negative values and values > MaxTournamentDurationDays are
+// rejected with a clear 400-bound error.
+func validateTournamentDurationDays(durationDays int) error {
+	if durationDays < 0 || durationDays > MaxTournamentDurationDays {
+		return fmt.Errorf("durationDays must be between 1 and %d", MaxTournamentDurationDays)
+	}
+	return nil
+}
+
 // validateTournamentLengths enforces the persisted-string caps from
 // validation.go on every string field of t. Called after trim and
 // after the required-field checks so error messages report the
@@ -241,6 +253,15 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		if err := validateTournamentLengths(&t); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
+		}
+
+		if err := validateTournamentDurationDays(t.DurationDays); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		// Default 0 → 1 before persisting so round-trips are consistent.
+		if t.DurationDays == 0 {
+			t.DurationDays = 1
 		}
 
 		if err := validateCourts(t.Courts); err != nil {
@@ -396,6 +417,15 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		if err := validateDateDMY(t.Date); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
+		}
+
+		// Same DurationDays guard as the PUT handler.
+		if err := validateTournamentDurationDays(t.DurationDays); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if t.DurationDays == 0 {
+			t.DurationDays = 1
 		}
 
 		if err := validateCourts(t.Courts); err != nil {

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -37,6 +37,10 @@ const (
 	MaxLenTournamentPassword = 256 // not trimmed; cap prevents megabyte payloads
 	MaxLenCeremonyBlock      = 16  // "1h30m" etc.
 
+	// MaxTournamentDurationDays is the upper bound on Tournament.DurationDays.
+	// 30 days covers the longest conceivable multi-day open tournament.
+	MaxTournamentDurationDays = 30
+
 	MaxLenCompetitionName         = 200
 	MaxLenCompetitionNumberPrefix = 3 // matches admin UI maxLength="3"
 	MaxLenCompetitionStartTime    = 8 // "HH:MM"

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -14,6 +14,14 @@ type Tournament struct {
 	Courts   []string `yaml:"courts" json:"courts"`
 	Password string   `yaml:"password" json:"password"`
 
+	// DurationDays is the number of consecutive calendar days this
+	// tournament spans, starting from Date (Day 1). Default 1 (single-day).
+	// Maximum 30. Use Days() to obtain the derived per-day DD-MM-YYYY list.
+	// Stored as omitempty so single-day tournaments (value 1) written by
+	// older code read back cleanly via the zero-→-default migration in
+	// ApplyTournamentDefaults.
+	DurationDays int `yaml:"duration_days,omitempty" json:"durationDays,omitempty"`
+
 	// AdminPassword gates destructive operations (spec 004 / mp-e21):
 	// competition delete, draw/override/invalidate, and participant roster
 	// mutations. It is a SEPARATE, higher-privilege credential from
@@ -60,8 +68,9 @@ type Tournament struct {
 }
 
 // ApplyTournamentDefaults fills zero-valued schedule-estimator tuning
-// fields on t with their canonical defaults: ClockToElapsedMultiplier=1.5
-// and SlowestCourtBufferPct=10. Idempotent; safe to call repeatedly.
+// fields on t with their canonical defaults: ClockToElapsedMultiplier=1.5,
+// SlowestCourtBufferPct=10, and DurationDays=1. Idempotent; safe to call
+// repeatedly.
 // FR-055, FR-057, R9.
 func ApplyTournamentDefaults(t *Tournament) {
 	if t == nil {
@@ -73,6 +82,34 @@ func ApplyTournamentDefaults(t *Tournament) {
 	if t.SlowestCourtBufferPct == 0 {
 		t.SlowestCourtBufferPct = 10
 	}
+	if t.DurationDays == 0 {
+		t.DurationDays = 1
+	}
+}
+
+// Days returns the ordered list of DD-MM-YYYY calendar day strings
+// covered by the tournament, derived from Date + DurationDays. The list
+// has exactly DurationDays entries (Day 1 = Date, Day 2 = Date+1, …).
+//
+// Edge cases — never panics:
+//   - If Date is empty or unparseable, returns nil (no day list available).
+//   - If DurationDays < 1, returns nil.
+//
+// Consumers should call ApplyTournamentDefaults before Days() to ensure
+// DurationDays has its correct minimum of 1.
+func (t *Tournament) Days() []string {
+	if t == nil || t.DurationDays < 1 || t.Date == "" {
+		return nil
+	}
+	base, err := time.Parse("02-01-2006", t.Date)
+	if err != nil {
+		return nil
+	}
+	days := make([]string, t.DurationDays)
+	for i := range days {
+		days[i] = base.AddDate(0, 0, i).Format("02-01-2006")
+	}
+	return days
 }
 
 type Competition struct {

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -17,9 +17,13 @@ type Tournament struct {
 	// DurationDays is the number of consecutive calendar days this
 	// tournament spans, starting from Date (Day 1). Default 1 (single-day).
 	// Maximum 30. Use Days() to obtain the derived per-day DD-MM-YYYY list.
-	// Stored as omitempty so single-day tournaments (value 1) written by
-	// older code read back cleanly via the zero-→-default migration in
-	// ApplyTournamentDefaults.
+	//
+	// omitempty drops the field only when the value is 0 (Go's zero value),
+	// never when it is 1 — so tournaments saved by this code always persist
+	// an explicit duration_days. The omitempty matters in the reverse
+	// direction: legacy tournament.md files predating this field carry no
+	// duration_days key, so they deserialize to 0 and are migrated to 1 by
+	// the load path (and ApplyTournamentDefaults).
 	DurationDays int `yaml:"duration_days,omitempty" json:"durationDays,omitempty"`
 
 	// AdminPassword gates destructive operations (spec 004 / mp-e21):

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -97,6 +97,95 @@ func TestSubMatchResult_HanteiRoundTrip(t *testing.T) {
 	})
 }
 
+// --- Tournament.Days() ---
+
+func TestTournament_Days(t *testing.T) {
+	tests := []struct {
+		name         string
+		date         string
+		durationDays int
+		want         []string
+	}{
+		{
+			name:         "single day",
+			date:         "05-06-2026",
+			durationDays: 1,
+			want:         []string{"05-06-2026"},
+		},
+		{
+			name:         "three days",
+			date:         "05-06-2026",
+			durationDays: 3,
+			want:         []string{"05-06-2026", "06-06-2026", "07-06-2026"},
+		},
+		{
+			name:         "month boundary",
+			date:         "30-06-2026",
+			durationDays: 3,
+			want:         []string{"30-06-2026", "01-07-2026", "02-07-2026"},
+		},
+		{
+			name:         "year boundary",
+			date:         "31-12-2025",
+			durationDays: 2,
+			want:         []string{"31-12-2025", "01-01-2026"},
+		},
+		{
+			name:         "empty date returns nil",
+			date:         "",
+			durationDays: 3,
+			want:         nil,
+		},
+		{
+			name:         "unparseable date returns nil",
+			date:         "not-a-date",
+			durationDays: 1,
+			want:         nil,
+		},
+		{
+			name:         "durationDays zero returns nil",
+			date:         "05-06-2026",
+			durationDays: 0,
+			want:         nil,
+		},
+		{
+			name:         "durationDays negative returns nil",
+			date:         "05-06-2026",
+			durationDays: -1,
+			want:         nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tour := &Tournament{Date: tc.date, DurationDays: tc.durationDays}
+			got := tour.Days()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTournament_Days_NilReceiver(t *testing.T) {
+	var tour *Tournament
+	// Must not panic
+	got := tour.Days()
+	assert.Nil(t, got)
+}
+
+// --- ApplyTournamentDefaults DurationDays ---
+
+func TestApplyTournamentDefaults_DurationDays(t *testing.T) {
+	t.Run("zero defaults to 1", func(t *testing.T) {
+		tour := &Tournament{}
+		ApplyTournamentDefaults(tour)
+		assert.Equal(t, 1, tour.DurationDays)
+	})
+	t.Run("non-zero preserved", func(t *testing.T) {
+		tour := &Tournament{DurationDays: 5}
+		ApplyTournamentDefaults(tour)
+		assert.Equal(t, 5, tour.DurationDays)
+	})
+}
+
 func TestValidateTeamMatchType(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -91,6 +91,85 @@ func TestStore_TournamentYAML(t *testing.T) {
 	assert.Equal(t, tourney.Password, loaded.Password)
 }
 
+func TestStore_TournamentYAML_DurationDaysRoundTrip(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-test-durationdays-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		durationDays int
+		wantDuration int
+	}{
+		{"three days persisted and loaded", 3, 3},
+		{"max days", 30, 30},
+		{"one day", 1, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tourney := &Tournament{
+				Name:         "Round-trip Tournament",
+				Date:         "05-06-2026",
+				Venue:        "Test Venue",
+				Courts:       []string{"A"},
+				Password:     "pass",
+				DurationDays: tc.durationDays,
+			}
+			require.NoError(t, store.SaveTournament(tourney))
+
+			loaded, err := store.LoadTournament()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantDuration, loaded.DurationDays)
+		})
+	}
+}
+
+func TestStore_TournamentYAML_DurationDays_MigratesFromZero(t *testing.T) {
+	// A tournament.md that predates the DurationDays field will not have
+	// duration_days in its YAML (omitempty). When loaded, the zero value
+	// must be promoted to 1 (single-day default).
+	dir, err := os.MkdirTemp("", "state-test-migrate-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	// Write a tournament.md that looks like an old file (no duration_days).
+	path := filepath.Join(dir, "tournament.md")
+	data := "---\nname: Legacy Tournament\ndate: 01-05-2026\nvenue: Venue\npassword: pass\ncourts:\n  - A\n---\n"
+	require.NoError(t, os.WriteFile(path, []byte(data), 0600))
+
+	loaded, err := store.LoadTournament()
+	require.NoError(t, err)
+	assert.Equal(t, 1, loaded.DurationDays, "legacy tournament.md without duration_days must load as DurationDays=1")
+}
+
+func TestStore_TournamentYAML_CorruptParseFallback_DurationDays(t *testing.T) {
+	// When front matter fails to parse, the fallback record must also carry
+	// DurationDays=1 so Days() works correctly on the fallback.
+	dir, err := os.MkdirTemp("", "state-test-corrupt-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "tournament.md")
+	require.NoError(t, os.WriteFile(path, []byte("invalid content"), 0600))
+
+	loaded, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, 1, loaded.DurationDays, "corrupt-parse fallback must have DurationDays=1")
+	// Days() must return a non-nil single-element slice for the fallback.
+	days := loaded.Days()
+	assert.Len(t, days, 1, "corrupt-parse fallback must produce 1 day via Days()")
+}
+
 func TestStore_TournamentYAML_ReturnsNilWhenMissing(t *testing.T) {
 	dir, err := os.MkdirTemp("", "state-test-*")
 	require.NoError(t, err)

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -70,8 +70,8 @@ func (s *Store) LoadTournament() (*Tournament, error) {
 		}
 	} else if t.DurationDays == 0 {
 		// Migrate existing single-day tournament.md files that predate the
-		// DurationDays field: omitempty writes nothing for 1, so on load the
-		// zero value must be treated as 1.
+		// DurationDays field: with no duration_days key, the field
+		// deserializes to its zero value (0), which we treat as 1.
 		t.DurationDays = 1
 	}
 
@@ -193,8 +193,8 @@ func (s *Store) UpdateTournamentChanged(desired *Tournament, transform func(curr
 		var t Tournament
 		if perr := parseFrontMatter(data, &t); perr == nil {
 			if t.DurationDays == 0 {
-				// Migrate: omitempty means an existing file with no
-				// duration_days field deserialises to 0 — treat as 1.
+				// Migrate: a legacy file with no duration_days key
+				// deserialises to the zero value (0) — treat as 1.
 				t.DurationDays = 1
 			}
 			current = &t

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -63,10 +63,16 @@ func (s *Store) LoadTournament() (*Tournament, error) {
 	if err := parseFrontMatter(data, &t); err != nil {
 		// If it's not a front-matter file, return a default tournament
 		t = Tournament{
-			Name:  "New Tournament",
-			Date:  time.Now().Format("02-01-2006"),
-			Venue: "Venue TBA",
+			Name:         "New Tournament",
+			Date:         time.Now().Format("02-01-2006"),
+			Venue:        "Venue TBA",
+			DurationDays: 1,
 		}
+	} else if t.DurationDays == 0 {
+		// Migrate existing single-day tournament.md files that predate the
+		// DurationDays field: omitempty writes nothing for 1, so on load the
+		// zero value must be treated as 1.
+		t.DurationDays = 1
 	}
 
 	s.cachedTourn = &t
@@ -186,15 +192,21 @@ func (s *Store) UpdateTournamentChanged(desired *Tournament, transform func(curr
 	if data, rerr := os.ReadFile(path); rerr == nil { // #nosec G304
 		var t Tournament
 		if perr := parseFrontMatter(data, &t); perr == nil {
+			if t.DurationDays == 0 {
+				// Migrate: omitempty means an existing file with no
+				// duration_days field deserialises to 0 — treat as 1.
+				t.DurationDays = 1
+			}
 			current = &t
 		} else {
 			// Parse failure: fall back to the same default record
 			// LoadTournament constructs, so transform's view is
 			// consistent.
 			current = &Tournament{
-				Name:  "New Tournament",
-				Date:  time.Now().Format("02-01-2006"),
-				Venue: "Venue TBA",
+				Name:         "New Tournament",
+				Date:         time.Now().Format("02-01-2006"),
+				Venue:        "Venue TBA",
+				DurationDays: 1,
 			}
 		}
 	} else if !os.IsNotExist(rerr) {

--- a/web-mobile/js/__tests__/admin_helpers.test.jsx
+++ b/web-mobile/js/__tests__/admin_helpers.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sideName, hasBothSides, compMatchStats, normalizeDate, dmyToIso, isoToDmy, compareDmy, isValidDate, validateAndNormalizeDate, decideNumericUpdate, getScoreBtnClass, DATE_ERR_INVALID_FORMAT, DATE_ERR_YEAR_RANGE, MIN_YEAR, MAX_YEAR, MAX_TEAM_SIZE, MAX_COURTS, MAX_RANK } from '../admin_helpers.jsx';
+import { sideName, hasBothSides, compMatchStats, normalizeDate, dmyToIso, isoToDmy, compareDmy, isValidDate, validateAndNormalizeDate, decideNumericUpdate, getScoreBtnClass, deriveTournamentDays, DATE_ERR_INVALID_FORMAT, DATE_ERR_YEAR_RANGE, MIN_YEAR, MAX_YEAR, MAX_TEAM_SIZE, MAX_COURTS, MAX_RANK, MAX_TOURNAMENT_DURATION_DAYS } from '../admin_helpers.jsx';
 
 describe('sideName', () => {
   it('returns "" for null / undefined', () => {
@@ -632,5 +632,61 @@ describe('getScoreBtnClass', () => {
 
   it('returns correct variant for completed matches', () => {
     expect(getScoreBtnClass('completed')).toBe('score-btn score-btn--correct');
+  });
+});
+
+describe('deriveTournamentDays', () => {
+  // This mirrors Tournament.Days() in internal/state/models.go. These cases
+  // guard against frontend/backend drift in day derivation (mp-ehf).
+  it('single day → one entry equal to the start date', () => {
+    expect(deriveTournamentDays('05-06-2026', 1)).toEqual(['05-06-2026']);
+  });
+
+  it('multi-day → contiguous DD-MM-YYYY list starting at Day 1', () => {
+    expect(deriveTournamentDays('05-06-2026', 3)).toEqual(['05-06-2026', '06-06-2026', '07-06-2026']);
+  });
+
+  it('rolls over month boundary', () => {
+    expect(deriveTournamentDays('30-06-2026', 3)).toEqual(['30-06-2026', '01-07-2026', '02-07-2026']);
+  });
+
+  it('rolls over year boundary', () => {
+    expect(deriveTournamentDays('31-12-2026', 2)).toEqual(['31-12-2026', '01-01-2027']);
+  });
+
+  it('handles leap-year February correctly', () => {
+    // 2028 is a leap year: 28 Feb → 29 Feb → 1 Mar.
+    expect(deriveTournamentDays('28-02-2028', 3)).toEqual(['28-02-2028', '29-02-2028', '01-03-2028']);
+  });
+
+  it('normalizes a non-canonical (ISO) start date before deriving', () => {
+    // normalizeDate accepts ISO and converts to DD-MM-YYYY.
+    expect(deriveTournamentDays('2026-06-05', 2)).toEqual(['05-06-2026', '06-06-2026']);
+  });
+
+  it('derives across the full supported duration cap', () => {
+    const days = deriveTournamentDays('01-01-2026', MAX_TOURNAMENT_DURATION_DAYS);
+    expect(days).toHaveLength(MAX_TOURNAMENT_DURATION_DAYS);
+    expect(days[0]).toBe('01-01-2026');
+    expect(days[MAX_TOURNAMENT_DURATION_DAYS - 1]).toBe('30-01-2026');
+  });
+
+  it('returns [] for empty / missing start date', () => {
+    expect(deriveTournamentDays('', 3)).toEqual([]);
+    expect(deriveTournamentDays(null, 3)).toEqual([]);
+    expect(deriveTournamentDays(undefined, 3)).toEqual([]);
+  });
+
+  it('returns [] for an unparseable start date', () => {
+    expect(deriveTournamentDays('not-a-date', 3)).toEqual([]);
+    expect(deriveTournamentDays('31-02-2026', 3)).toEqual([]); // Feb 31 invalid
+  });
+
+  it('returns [] for invalid durations', () => {
+    expect(deriveTournamentDays('05-06-2026', 0)).toEqual([]);
+    expect(deriveTournamentDays('05-06-2026', -1)).toEqual([]);
+    expect(deriveTournamentDays('05-06-2026', 1.5)).toEqual([]); // non-integer
+    expect(deriveTournamentDays('05-06-2026', NaN)).toEqual([]);
+    expect(deriveTournamentDays('05-06-2026', '3')).toEqual([]); // non-number
   });
 });

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -11,6 +11,7 @@ const isoToDmy = window.isoToDmy;
 const isValidDate = window.isValidDate;
 const validateAndNormalizeDate = window.validateAndNormalizeDate;
 const decideNumericUpdate = window.decideNumericUpdate;
+const deriveTournamentDays = window.deriveTournamentDays;
 // Canonical numeric bounds (admin_helpers.jsx) so the team-size input cap
 // stays in lockstep with TEAM_POSITIONS in the scoring modal.
 const MIN_YEAR = window.MIN_YEAR;
@@ -610,13 +611,42 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       <div className="row">
         <div className="field"><label className="field__label">Display name</label><input className="input" value={local.name} onChange={(e) => update("name", e.target.value)} /></div>
         <div className="field">
-          <label className="field__label">Date</label>
-          {/* HTML <input type="date"> uses ISO YYYY-MM-DD; convert at the */}
-          {/* boundary so local state (and the saved payload) stays in the */}
-          {/* canonical DD-MM-YYYY format. Picker bounds match MIN_YEAR/ */}
-          {/* MAX_YEAR (admin_helpers.jsx) so a typed date can't pass */}
-          {/* validation but be unreachable via the picker. */}
-          <input className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(local.date)} onChange={(e) => update("date", isoToDmy(e.target.value))} />
+          <label className="field__label">Day</label>
+          {/* When the tournament has a start date + durationDays, constrain */}
+          {/* the competition date to the tournament's day list via a select. */}
+          {/* Falls back to a free date picker when the tournament has no date. */}
+          {(() => {
+            const days = deriveTournamentDays(tournament.date, tournament.durationDays || 1);
+            if (days.length > 0) {
+              // A previously-saved competition date can fall outside the
+              // current day list (e.g. the tournament duration was shortened
+              // after this competition was created). A controlled <select>
+              // whose value matches no <option> would silently display the
+              // first option while React state keeps the stale date — the
+              // operator would then "save" an out-of-range date the backend
+              // now rejects. Surface the stray value as an explicit, flagged
+              // option so the displayed value matches state and the mismatch
+              // is visible. Picking any real day clears it on save.
+              const outOfRange = local.date && !days.includes(local.date);
+              return (
+                <select
+                  className="input"
+                  value={local.date}
+                  onChange={(e) => update("date", e.target.value)}
+                >
+                  {outOfRange && (
+                    <option key={local.date} value={local.date}>{local.date} (outside tournament days)</option>
+                  )}
+                  {days.map((d, i) => (
+                    <option key={d} value={d}>Day {i + 1} — {d}</option>
+                  ))}
+                </select>
+              );
+            }
+            return (
+              <input className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(local.date)} onChange={(e) => update("date", isoToDmy(e.target.value))} />
+            );
+          })()}
           <div className="field__hint">Pick the competition day.</div>
         </div>
         <div className="field"><label className="field__label">Start time</label><input className="input" type="time" value={local.startTime} onChange={(e) => update("startTime", e.target.value)} /></div>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -618,15 +618,20 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           {(() => {
             const days = deriveTournamentDays(tournament.date, tournament.durationDays || 1);
             if (days.length > 0) {
-              // A previously-saved competition date can fall outside the
-              // current day list (e.g. the tournament duration was shortened
-              // after this competition was created). A controlled <select>
-              // whose value matches no <option> would silently display the
-              // first option while React state keeps the stale date — the
-              // operator would then "save" an out-of-range date the backend
-              // now rejects. Surface the stray value as an explicit, flagged
-              // option so the displayed value matches state and the mismatch
-              // is visible. Picking any real day clears it on save.
+              // A controlled <select> whose value matches no <option> would
+              // silently display the first option while React state keeps the
+              // real (stale or empty) value — the operator would then "save"
+              // a value the UI never showed. Two cases need an explicit
+              // matching option so the displayed value always tracks state:
+              //   - empty date (legacy/imported competition with no day set):
+              //     render a disabled "— Select a day —" placeholder so the
+              //     select shows "unset" and forces a deliberate pick rather
+              //     than persisting "" while appearing to show Day 1.
+              //   - out-of-range date (e.g. the tournament duration was
+              //     shortened after this competition was created): surface the
+              //     stray value as a flagged option so the mismatch is visible.
+              // Picking any real day clears either state on save.
+              const isEmpty = !local.date;
               const outOfRange = local.date && !days.includes(local.date);
               return (
                 <select
@@ -634,6 +639,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
                   value={local.date}
                   onChange={(e) => update("date", e.target.value)}
                 >
+                  {isEmpty && (
+                    <option value="" disabled>— Select a day —</option>
+                  )}
                   {outOfRange && (
                     <option key={local.date} value={local.date}>{local.date} (outside tournament days)</option>
                   )}

--- a/web-mobile/js/admin_helpers.jsx
+++ b/web-mobile/js/admin_helpers.jsx
@@ -252,6 +252,40 @@ function getScoreBtnClass(status) {
   return `score-btn ${status === "completed" ? "score-btn--correct" : "score-btn--active"}`;
 }
 
+// MAX_TOURNAMENT_DURATION_DAYS mirrors MaxTournamentDurationDays in
+// internal/mobileapp/validation.go. Keep both in sync.
+const MAX_TOURNAMENT_DURATION_DAYS = 30;
+
+// deriveTournamentDays returns an ordered array of DD-MM-YYYY strings
+// covering the tournament, mirroring Tournament.Days() on the Go side.
+//
+//   deriveTournamentDays("05-06-2026", 3) → ["05-06-2026", "06-06-2026", "07-06-2026"]
+//
+// Returns [] (empty) when:
+//   - startDate is empty / unparseable
+//   - durationDays < 1
+//
+// Exported for JSX components and vitest.
+function deriveTournamentDays(startDate, durationDays) {
+  if (!startDate || !Number.isInteger(durationDays) || durationDays < 1) return [];
+  const norm = normalizeDate(startDate);
+  if (!norm) return [];
+  // Parse from DD-MM-YYYY
+  const [dd, mm, yyyy] = norm.split('-').map(Number);
+  const base = new Date(Date.UTC(yyyy, mm - 1, dd));
+  if (isNaN(base.getTime())) return [];
+  const days = [];
+  for (let i = 0; i < durationDays; i++) {
+    const d = new Date(base);
+    d.setUTCDate(base.getUTCDate() + i);
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const year = d.getUTCFullYear();
+    days.push(`${day}-${month}-${year}`);
+  }
+  return days;
+}
+
 // Guard window assignments so this file stays safely importable in
 // non-browser test environments (matches the pattern in data.jsx / ui.jsx).
 if (typeof window !== "undefined") {
@@ -273,6 +307,8 @@ if (typeof window !== "undefined") {
   window.MAX_TEAM_SIZE = MAX_TEAM_SIZE;
   window.MAX_COURTS = MAX_COURTS;
   window.MAX_RANK = MAX_RANK;
+  window.MAX_TOURNAMENT_DURATION_DAYS = MAX_TOURNAMENT_DURATION_DAYS;
+  window.deriveTournamentDays = deriveTournamentDays;
   window.setCachedAuthConfig = setCachedAuthConfig;
   window.getCachedAuthConfig = getCachedAuthConfig;
   window.promptAdminPassword = promptAdminPassword;

--- a/web-mobile/js/admin_helpers.jsx
+++ b/web-mobile/js/admin_helpers.jsx
@@ -390,4 +390,6 @@ export {
   MAX_TEAM_SIZE,
   MAX_COURTS,
   MAX_RANK,
+  MAX_TOURNAMENT_DURATION_DAYS,
+  deriveTournamentDays,
 };

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -7,7 +7,9 @@ const validateAndNormalizeDate = window.validateAndNormalizeDate;
 const decideNumericUpdate = window.decideNumericUpdate;
 const dmyToIso = window.dmyToIso;
 const isoToDmy = window.isoToDmy;
+const deriveTournamentDays = window.deriveTournamentDays;
 const MAX_TEAM_SIZE = window.MAX_TEAM_SIZE;
+const MAX_TOURNAMENT_DURATION_DAYS = window.MAX_TOURNAMENT_DURATION_DAYS;
 const MIN_YEAR = window.MIN_YEAR;
 const MAX_YEAR = window.MAX_YEAR;
 // Canonical courts cap (admin_helpers.jsx) — mirrors helper.MaxCourts
@@ -96,6 +98,9 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [name, setName] = useStateA(tournament.name);
   const [venue, setVenue] = useStateA(tournament.venue);
   const [date, setDate] = useStateA(tournament.date);
+  // DurationDays: default 1 for tournaments that predate this field
+  // (tournament.durationDays is undefined / 0 for older records).
+  const [durationDays, setDurationDays] = useStateA(tournament.durationDays || 1);
   const [courts, setCourts] = useStateA(tournament.courts.length);
   const [checkInStart, setCheckInStart] = useStateA(tournament.checkInWindowStart || "");
   const [checkInEnd, setCheckInEnd] = useStateA(tournament.checkInWindowEnd || "");
@@ -141,6 +146,10 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     if (!trimmedName) { setError("Tournament name is required."); return; }
     const { norm, error: dateError } = validateAndNormalizeDate(date);
     if (dateError) { setError(dateError); return; }
+    if (!Number.isInteger(durationDays) || durationDays < 1 || durationDays > MAX_TOURNAMENT_DURATION_DAYS) {
+      setError(`Number of days must be a whole number between 1 and ${MAX_TOURNAMENT_DURATION_DAYS}.`);
+      return;
+    }
     if (!Number.isInteger(courts) || courts < 1 || courts > MAX_COURTS) { setError(`Number of courts must be a whole number between 1 and ${MAX_COURTS}.`); return; }
     if ((checkInStart && !checkInEnd) || (!checkInStart && checkInEnd)) { setError("Both check-in start and end must be set together, or both must be empty."); return; }
     if (checkInStart && checkInEnd && checkInStart >= checkInEnd) { setError("Check-in start must be before check-in end."); return; }
@@ -149,6 +158,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       name: trimmedName,
       venue: venue.trim(),
       date: norm,
+      durationDays,
       password: pass || undefined,
       courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i)),
       checkInWindowStart: checkInStart || undefined,
@@ -170,14 +180,30 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           <div className="row">
             <div className="field"><label className="field__label">Name</label><input className="input" value={name} onChange={(e) => { setName(e.target.value); setError(""); }} /></div>
             <div className="field">
-              <label className="field__label">Date</label>
+              <label className="field__label">Start date (Day 1)</label>
               {/* Picker bounds mirror AdminSettings's date input in */}
               {/* admin_competition.jsx and the MIN_YEAR/MAX_YEAR range */}
               {/* that validateAndNormalizeDate enforces at handleSave — */}
               {/* keeps the picker from offering years the validator */}
               {/* will then reject on submit. */}
               <input className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(date)} onChange={(e) => { setDate(isoToDmy(e.target.value)); setError(""); }} />
-              <div className="field__hint">Pick the tournament day.</div>
+              <div className="field__hint">Pick the first day of the tournament.</div>
+            </div>
+            <div className="field">
+              <label className="field__label">Number of days</label>
+              {/* decideNumericUpdate stores NaN for cleared input so render */}
+              {/* side can use Number.isFinite check (same pattern as courts). */}
+              <input
+                className="input"
+                type="number"
+                min="1"
+                max={MAX_TOURNAMENT_DURATION_DAYS}
+                step="1"
+                value={Number.isFinite(durationDays) ? durationDays : ""}
+                onChange={(e) => { setDurationDays(decideNumericUpdate(e.target.value, 1).value); setError(""); }}
+                style={{ maxWidth: 100 }}
+              />
+              <div className="field__hint">{`Duration in days (1–${MAX_TOURNAMENT_DURATION_DAYS}). Multi-day tournaments constrain competitions to their day.`}</div>
             </div>
           </div>
           <div className="field"><label className="field__label">Venue</label><input className="input" value={venue} onChange={(e) => { setVenue(e.target.value); setError(""); }} /></div>
@@ -459,12 +485,32 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
 
           <div className="row">
             <div className="field">
-              <label className="field__label">Date</label>
-              {/* Picker bounds match validateAndNormalizeDate at create() — */}
-              {/* see the equivalent comment on AdminEditTournament's date */}
-              {/* field above and AdminSettings's date input in */}
-              {/* admin_competition.jsx. */}
-              <input className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(date)} onChange={(e) => setDate(isoToDmy(e.target.value))} />
+              <label className="field__label">Day</label>
+              {/* When the tournament has a start date and durationDays, offer */}
+              {/* a select over the derived day list so the competition date */}
+              {/* is always within the tournament's range. For a single-day */}
+              {/* tournament (or when the tournament has no date yet) a single- */}
+              {/* option select is shown so the label matches the day. */}
+              {(() => {
+                const days = deriveTournamentDays(tournament.date, tournament.durationDays || 1);
+                if (days.length > 0) {
+                  return (
+                    <select
+                      className="input"
+                      value={date}
+                      onChange={(e) => setDate(e.target.value)}
+                    >
+                      {days.map((d, i) => (
+                        <option key={d} value={d}>Day {i + 1} — {d}</option>
+                      ))}
+                    </select>
+                  );
+                }
+                // Fallback: tournament has no date yet — free date picker.
+                return (
+                  <input className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(date)} onChange={(e) => setDate(isoToDmy(e.target.value))} />
+                );
+              })()}
               <div className="field__hint">For multi-day tournaments, specify which day this competition takes place.</div>
             </div>
             <div className="field">


### PR DESCRIPTION
## Summary

Adds multi-day tournament support using a **start date + duration** model, and makes each competition's date default to / be constrained within the tournament's day range. Consolidates the former **mp-1ws** (multi-day data model) into **mp-ehf** (its only consumer) per YAGNI — the field ships with the behavior that uses it, not as a standalone no-op scaffold.

### Model
- `Tournament.Date` (existing, DD-MM-YYYY) = **start / Day 1**, unchanged.
- New `Tournament.DurationDays int` — default 1, min 1, max 30 (`MaxTournamentDurationDays`).
- The per-day list is **derived in code**, never stored: `Tournament.Days()` returns `DurationDays` contiguous DD-MM-YYYY strings (`Date + i`). Nil-safe on empty/unparseable date or duration < 1.
- Decision: contiguous range via start+count — **not** an arbitrary `Days[]` list, **not** a dual `Date`+`Days` model (avoids drift; matches the operator's "starts X, lasts N days" mental model).

### Behavior
- **Tournament PUT/POST**: validate `DurationDays` (0 → default 1; negative or >30 → 400). Migrates legacy single-day `tournament.md` transparently (zero → 1 on load, in `ApplyTournamentDefaults` and both corrupt-parse fallbacks).
- **Competition create**: empty date defaults to tournament **Day 1** (was: today).
- **Competition create/update/import**: reject a date outside `[Day 1 .. Day N]` with `date must be one of the tournament days (… to …)`. Skipped when the tournament has no date configured.
- **Admin UI**: "Start date (Day 1)" + new "Number of days" input; competition date becomes a `<select>` over the derived days. An already-saved competition date that falls outside the (possibly shrunk) range is surfaced as a flagged `… (outside tournament days)` option so the displayed value matches state instead of silently submitting a stale date.

## Files
- `internal/state/models.go` — `DurationDays` field, `Days()` helper, `ApplyTournamentDefaults` default.
- `internal/state/tournament.go` — YAML round-trip + zero→1 migration in load path and both fallbacks.
- `internal/mobileapp/validation.go` — `MaxTournamentDurationDays = 30`.
- `internal/mobileapp/handlers_tournament.go` — `validateTournamentDurationDays` on PUT + POST.
- `internal/mobileapp/handlers_competition.go` — `validateCompetitionDateInTournament`; Day-1 default + range check on POST/PUT.
- `internal/mobileapp/handlers_import.go` — same range check (per-row soft error).
- `web-mobile/js/{admin_helpers,admin_setup,admin_competition}.jsx` — `deriveTournamentDays` (mirrors `Days()`), number-of-days input, day `<select>`.
- Tests: `internal/state/{models_test,state_test}.go`, `internal/mobileapp/handlers_test.go`.

## Test plan
- [x] `make go/build` (compiles JSX via esbuild) — passes
- [x] `golangci-lint` — 0 issues; gosec 0; govulncheck clean
- [x] `go test ./internal/...` — all 12 packages pass (incl. new `Days()`, YAML round-trip, migration, range, default-date, duration-bounds tests)
- [x] **HTTP round-trip**: POST 3-day tournament → `duration_days: 3` persists + reads back; `durationDays:31`/`-1` → 400; `durationDays:0` → 200 (defaults to 1)
- [x] **HTTP range check**: empty competition date → defaults to Day 1; in-range + last-day (inclusive) accepted; before-start + after-range → 400 with day-range message
- [x] **Browser (mobile-app)**: admin edit shows "Start date (Day 1)" + "Number of days"; setting days=3 + Save persists `duration_days: 3`; "Add competition" day `<select>` lists Day 1–3 with Day 1 pre-selected; no console errors
- [x] CI green — all 9 checks pass (codeql, gosec, cmd/integration/internal test shards, validate, GitGuardian, Vault Radar)
- [x] `cmd/TestDiagnoseFolderError_OwnerInfo` failure was **local sandbox-only** (gid `503:0` vs expected `503:20`); reproduced on clean `origin/main` and touches no files in this PR — **passes in CI** (`test (cmd, ./cmd/...)` green), confirming environmental cause

Closes mp-ehf. (mp-1ws closed as folded-in.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
