### PR TITLE
feat(mp-7h7): self-run tournament mode with destructive-only auth boundary

### DIFF
--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -137,6 +137,22 @@ func validateTournamentDurationDays(durationDays int) error {
 	return nil
 }
 
+// errModeImmutable is the sentinel the PUT /tournament transform returns
+// when the caller tries to change the tournament Mode field after creation
+// (mp-7h7). Mode is immutable — flipping it mid-event would either
+// suddenly expose the admin surface (officiated → self-run) or lock
+// participants out mid-scoring (self-run → officiated).
+var errModeImmutable = errors.New("tournament mode cannot be changed after creation")
+
+// errSelfRunRequiresAdminPassword is the sentinel returned when a caller
+// tries to create or save a self-run tournament in file mode without an
+// elevated (admin) password configured. In self-run mode the main-gate
+// is skipped, so if enforceElevated's GateActive()==false path (file mode,
+// no admin password) were reached the destructive routes would be fully
+// public — violating the self-run invariant that destructive calls still
+// require X-Admin-Password. (mp-7h7 fail-open fix)
+var errSelfRunRequiresAdminPassword = errors.New("self-run tournaments require an admin (destructive-ops) password to be set; configure it before switching to self-run mode or set it in the same request")
+
 // validateTournamentLengths enforces the persisted-string caps from
 // validation.go on every string field of t. Called after trim and
 // after the required-field checks so error messages report the
@@ -317,6 +333,25 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			if current != nil {
 				desired.AdminPassword = current.AdminPassword
 			}
+
+			// Immutability of Mode (mp-7h7): Mode is chosen once at creation
+			// and cannot be changed via PUT. Mirror the write-only AdminPassword
+			// preservation pattern: when the incoming body sends Mode == ""
+			// (omitempty), preserve the current stored value. When the body
+			// sends a non-empty Mode that differs from the stored Mode, reject.
+			if current != nil {
+				if desired.Mode == "" {
+					// Preserve on omit — backward-compat and "no change" intent.
+					desired.Mode = current.Mode
+				} else if desired.Mode != current.Mode {
+					return errModeImmutable
+				}
+			}
+			// Normalize empty Mode so new tournaments always have a canonical value.
+			if desired.Mode == "" {
+				desired.Mode = state.TournamentModeOfficiated
+			}
+
 			if locked {
 				// Reset passwordChanged to false defensively — the
 				// non-empty case is already rejected above, but keep
@@ -344,10 +379,37 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			if current == nil || current.Password != desired.Password {
 				passwordChanged = true
 			}
+
+			// Fail-open guard for self-run + file mode (mp-7h7): if the
+			// tournament is self-run, the main-gate is skipped, so
+			// destructive routes rely SOLELY on RequireElevatedPassword /
+			// enforceElevated. enforceElevated allows requests when
+			// GateActive()==false (file mode, no AdminPassword set). Without
+			// this guard, a self-run tournament with no admin password would
+			// leave destructive routes fully public. Locked mode always fails
+			// closed (GateActive always true → 503 when unconfigured) so we
+			// only need to guard file mode here.
+			//
+			// Note: we check desired.AdminPassword (the just-loaded value) not
+			// a freshly-loaded field since we are inside the locked transform.
+			// desired.AdminPassword was preserved from current above, so it
+			// reflects the current on-disk value.
+			if desired.Mode == state.TournamentModeSelfRun && desired.AdminPassword == "" {
+				return errSelfRunRequiresAdminPassword
+			}
+
 			return nil
 		})
 		if errors.Is(err, errPasswordRequired) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errPasswordRequired.Error()})
+			return
+		}
+		if errors.Is(err, errModeImmutable) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errModeImmutable.Error()})
+			return
+		}
+		if errors.Is(err, errSelfRunRequiresAdminPassword) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errSelfRunRequiresAdminPassword.Error()})
 			return
 		}
 		if err != nil {
@@ -433,6 +495,17 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			return
 		}
 
+		// Validate and normalize the Mode field (mp-7h7). POST is the creation
+		// endpoint — Mode is accepted here and becomes immutable thereafter.
+		// Empty maps to "officiated" (default, backward compat).
+		if err := state.ValidateTournamentMode(t.Mode); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if t.Mode == "" {
+			t.Mode = state.TournamentModeOfficiated
+		}
+
 		// Reject empty Password on POST (initial setup) in file mode.
 		// AuthMiddleware allows POST /api/tournament unauthenticated
 		// when the tournament is uninitialized — this is the bootstrap
@@ -489,6 +562,21 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		// nil) it stays "" — the operator sets it later via Settings.
 		if existingForPost != nil {
 			t.AdminPassword = existingForPost.AdminPassword
+		}
+
+		// Fail-open guard for self-run + file mode (mp-7h7).
+		// In self-run mode the main-gate is skipped, so destructive routes
+		// rely SOLELY on RequireElevatedPassword / enforceElevated.
+		// enforceElevated GateActive()==false (file mode, no admin password)
+		// means destructive routes would be fully public — violating the
+		// invariant. Reject creation of a self-run tournament in file mode
+		// unless an AdminPassword is already set (or was set in existingForPost).
+		// Locked mode always fails closed (GateActive always true → 503) so no
+		// guard needed there.
+		fileMode := verifier == nil || !verifier.RedactStoredPassword()
+		if fileMode && t.Mode == state.TournamentModeSelfRun && t.AdminPassword == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": errSelfRunRequiresAdminPassword.Error()})
+			return
 		}
 
 		if _, err := store.SaveTournamentChanged(&t); err != nil {

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -650,12 +650,23 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		// is transient (not in Tournament) so validateTournamentLengths never
 		// sees it; enforce MaxLenTournamentPassword here.
 		fileMode := verifier == nil || !verifier.RedactStoredPassword()
-		if fileMode && t.AdminPassword == "" && extra.AdminPassword != "" {
+		// Fix 3331061367: validate adminPassword length whenever the field is
+		// present in the body, regardless of mode or whether an existing
+		// credential is already stored. This enforces the OpenAPI maxLength:256
+		// contract consistently: locked mode and re-bootstrap with an existing
+		// password would otherwise accept and silently discard an oversized
+		// value, giving callers no feedback that their request violates the
+		// contract. Only persist the value when in file mode with no existing
+		// elevated credential (locked mode uses TOURNAMENT_ADMIN_PASSWORD_HASH;
+		// re-bootstrap preserves the existing credential).
+		if extra.AdminPassword != "" {
 			if err := validateMaxLen("adminPassword", extra.AdminPassword, MaxLenTournamentPassword); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
-			t.AdminPassword = extra.AdminPassword
+			if fileMode && t.AdminPassword == "" {
+				t.AdminPassword = extra.AdminPassword
+			}
 		}
 
 		// Fail-open guard for self-run + file mode (mp-7h7).

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -286,6 +286,18 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			return
 		}
 
+		// Validate Mode before entering the update transform. Mode is
+		// immutable after creation (mp-7h7) — the transform enforces that
+		// invariant — but it must also be a known value so an invalid string
+		// never lands on disk via a direct API call. Empty is accepted here
+		// (the transform normalises "" → preserved-stored-value or
+		// "officiated" for a new record). ValidateTournamentMode is the
+		// canonical check; POST already calls it for the same reason.
+		if err := state.ValidateTournamentMode(t.Mode); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
 		// Preserve the stored Password when the incoming body omits it
 		// or sends "". The frontend AdminEditTournament uses
 		// `password: pass || undefined` (admin_setup.jsx:89) so an

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -388,13 +388,16 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			// this guard, a self-run tournament with no admin password would
 			// leave destructive routes fully public. Locked mode always fails
 			// closed (GateActive always true → 503 when unconfigured) so we
-			// only need to guard file mode here.
+			// must NOT apply this guard in locked mode: there, the on-disk
+			// AdminPassword is always empty/inert (the env-var bcrypt hash is
+			// authoritative), so guarding on desired.AdminPassword == ""
+			// would wrongly reject every PUT to a locked-mode self-run
+			// tournament (e.g. a routine venue edit). The `locked` flag is
+			// captured from the enclosing handler scope.
 			//
-			// Note: we check desired.AdminPassword (the just-loaded value) not
-			// a freshly-loaded field since we are inside the locked transform.
 			// desired.AdminPassword was preserved from current above, so it
 			// reflects the current on-disk value.
-			if desired.Mode == state.TournamentModeSelfRun && desired.AdminPassword == "" {
+			if !locked && desired.Mode == state.TournamentModeSelfRun && desired.AdminPassword == "" {
 				return errSelfRunRequiresAdminPassword
 			}
 

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -352,12 +352,24 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			// preservation pattern: when the incoming body sends Mode == ""
 			// (omitempty), preserve the current stored value. When the body
 			// sends a non-empty Mode that differs from the stored Mode, reject.
+			//
+			// Fix 3329406568: normalize current.Mode="" to "officiated" before
+			// comparing so an idempotent PUT sending mode:"officiated" against a
+			// legacy tournament (empty Mode on disk) is accepted rather than
+			// rejected as a mutation ("" != "officiated").
 			if current != nil {
 				if desired.Mode == "" {
 					// Preserve on omit — backward-compat and "no change" intent.
 					desired.Mode = current.Mode
-				} else if desired.Mode != current.Mode {
-					return errModeImmutable
+				} else {
+					// Normalize legacy empty current mode before comparing.
+					currentMode := current.Mode
+					if currentMode == "" {
+						currentMode = state.TournamentModeOfficiated
+					}
+					if desired.Mode != currentMode {
+						return errModeImmutable
+					}
 				}
 			}
 			// Normalize empty Mode so new tournaments always have a canonical value.
@@ -604,6 +616,21 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			t.AdminPassword = existingForPost.AdminPassword
 		}
 
+		// Fix 3329416172: Mode is immutable after creation (mp-7h7). On a
+		// re-bootstrap POST (existingForPost != nil) preserve the stored Mode
+		// so a caller cannot flip an officiated tournament to self-run or vice
+		// versa via POST. Normalise legacy empty to "officiated" so the on-disk
+		// record gains the canonical value on the next write. On a true first
+		// bootstrap (existingForPost == nil), Mode was already validated and
+		// normalised above — no change needed.
+		if existingForPost != nil {
+			existingMode := existingForPost.Mode
+			if existingMode == "" {
+				existingMode = state.TournamentModeOfficiated
+			}
+			t.Mode = existingMode
+		}
+
 		// Atomic admin-password set at creation (mp-7h7). In file mode the
 		// admin (destructive-ops) password is stored as PLAINTEXT in
 		// Tournament.AdminPassword (fileElevatedVerifier.Verify does an
@@ -618,8 +645,16 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		// Locked mode: the env-var bcrypt hash is the authoritative elevated
 		// credential; any body adminPassword is inert, so ignore it (do not
 		// write a plaintext value that would never be consulted).
+		//
+		// Fix 3329406566: validate adminPassword length before copy. The field
+		// is transient (not in Tournament) so validateTournamentLengths never
+		// sees it; enforce MaxLenTournamentPassword here.
 		fileMode := verifier == nil || !verifier.RedactStoredPassword()
 		if fileMode && t.AdminPassword == "" && extra.AdminPassword != "" {
+			if err := validateMaxLen("adminPassword", extra.AdminPassword, MaxLenTournamentPassword); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 			t.AdminPassword = extra.AdminPassword
 		}
 

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
@@ -454,7 +455,31 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 
 	r.POST("/tournament", func(c *gin.Context) {
 		var t state.Tournament
-		if err := c.ShouldBindJSON(&t); err != nil {
+		// ShouldBindBodyWith caches the raw request body so we can bind it a
+		// SECOND time below into a separate struct. This lets us read a
+		// transient `adminPassword` field from the SAME POST body WITHOUT
+		// weakening the json:"-" invariant on Tournament.AdminPassword (which
+		// deliberately can never be populated by binding a request body).
+		// Creation is the one safe place to accept the elevated credential in
+		// the body: there is no existing credential to protect at bootstrap,
+		// and it lets self-run creation be atomic (the fail-open guard never
+		// sees a self-run tournament persisted without an admin password). PUT
+		// keeps the json:"-" preserve-only behaviour (rotation stays on
+		// PUT /api/auth/admin-password).
+		if err := c.ShouldBindBodyWith(&t, binding.JSON); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		// Second bind into a local struct to capture the transient admin
+		// (destructive-ops) password. Tournament.AdminPassword has json:"-"
+		// so it is never populated by the bind above — this is the only way
+		// to read it from the body at creation time. A bind failure here is
+		// impossible (the first bind already validated the JSON), but handle
+		// it for safety.
+		var extra struct {
+			AdminPassword string `json:"adminPassword"`
+		}
+		if err := c.ShouldBindBodyWith(&extra, binding.JSON); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -567,16 +592,35 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			t.AdminPassword = existingForPost.AdminPassword
 		}
 
+		// Atomic admin-password set at creation (mp-7h7). In file mode the
+		// admin (destructive-ops) password is stored as PLAINTEXT in
+		// Tournament.AdminPassword (fileElevatedVerifier.Verify does an
+		// exact-string compare). When the body carried an `adminPassword`
+		// (read into `extra` above) and no admin password is already on disk,
+		// set it now — BEFORE the fail-open guard and before
+		// SaveTournamentChanged — so a self-run tournament is persisted WITH
+		// the credential in a single request. This is what makes self-run
+		// creation possible via the real API (the json:"-" invariant blocks
+		// the field from being bound directly into Tournament).
+		//
+		// Locked mode: the env-var bcrypt hash is the authoritative elevated
+		// credential; any body adminPassword is inert, so ignore it (do not
+		// write a plaintext value that would never be consulted).
+		fileMode := verifier == nil || !verifier.RedactStoredPassword()
+		if fileMode && t.AdminPassword == "" && extra.AdminPassword != "" {
+			t.AdminPassword = extra.AdminPassword
+		}
+
 		// Fail-open guard for self-run + file mode (mp-7h7).
 		// In self-run mode the main-gate is skipped, so destructive routes
 		// rely SOLELY on RequireElevatedPassword / enforceElevated.
 		// enforceElevated GateActive()==false (file mode, no admin password)
 		// means destructive routes would be fully public — violating the
 		// invariant. Reject creation of a self-run tournament in file mode
-		// unless an AdminPassword is already set (or was set in existingForPost).
-		// Locked mode always fails closed (GateActive always true → 503) so no
-		// guard needed there.
-		fileMode := verifier == nil || !verifier.RedactStoredPassword()
+		// unless an AdminPassword is set: either already on disk (preserved
+		// from existingForPost) or supplied in this request's body (set just
+		// above). Locked mode always fails closed (GateActive always true →
+		// 503) so no guard needed there.
 		if fileMode && t.Mode == state.TournamentModeSelfRun && t.AdminPassword == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errSelfRunRequiresAdminPassword.Error()})
 			return

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -220,6 +220,7 @@ func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 		http.MethodPut + " /api/competitions/:id/matches/:mid/override-winner",         // Fix 3330080949: result correction — organiser, not participant play
 		http.MethodPut + " /api/competitions/:id/pools/:poolId/override-rank",          // Fix 3330080949: standings correction — organiser, not participant play
 		http.MethodPost + " /api/competitions/:id/competitor-status",                   // Fix 3331033814: eligibility mutation — organiser decision, not operational play
+		http.MethodGet + " /api/competitions/:id/export",                               // Fix 3332740291: xlsx export — admin/CPU-heavy, not operational play
 		http.MethodPut + " /api/competitions/:id/matches/:mid/court",                   // court assignment — organiser coordination
 		http.MethodPut + " /api/competitions/:id/matches/:mid/time",                    // match time — organiser coordination
 		http.MethodPut + " /api/competitions/:id/seeds",                                // seeding — organiser pre-draw setup

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -249,6 +249,29 @@ func AuthMiddleware(verifier PasswordVerifier, store *state.Store) gin.HandlerFu
 			return
 		}
 
+		// Self-run mode (mp-7h7): skip the main-password gate entirely.
+		// Constructive admin routes (scoring, check-in, start, complete,
+		// generate draw, etc.) become public — there is no table operator.
+		// Destructive routes (delete competition, invalidate, draw, overrides,
+		// participant roster mutations, import) remain gated by the
+		// EXISTING RequireElevatedPassword / enforceElevated decorators that
+		// already fire downstream on those specific routes. No new allowlist
+		// is needed — the elevated-decorator set IS the allowlist (DRY).
+		//
+		// Officiated mode (the default) skips this block entirely → no regression.
+		//
+		// Note: LoadTournament returns tournament data with the Mode field. For
+		// older files where Mode is empty, ApplyTournamentDefaults normalises it
+		// to TournamentModeOfficiated before this comparison — but we don't call
+		// ApplyTournamentDefaults on the loaded record here to avoid unexpected
+		// mutations. Comparing explicitly against TournamentModeSelfRun is safe:
+		// the empty string (old files) and "officiated" both fall through to the
+		// standard auth path below.
+		if t.Mode == state.TournamentModeSelfRun {
+			c.Next()
+			return
+		}
+
 		// Defense-in-depth for the F4 sentinel-into-auth-field scenario
 		// (file mode only). The plaintext comparison done by the file
 		// verifier is satisfied vacuously when both sides are "" — an

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -189,6 +189,32 @@ func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
 	return true
 }
 
+// isSelfRunMainGatedConfigRoute reports whether the given (method, route)
+// is an organiser-owned configuration/setup mutation that must remain behind
+// the main-password gate even in self-run mode (mp-7h7 / Copilot #203).
+//
+// Self-run makes the OPERATIONAL play surface public (scoring, check-in,
+// start/complete, draw generation) because there is no table operator. But
+// configuration mutations are NOT operational play and are NOT elevated-gated,
+// so the self-run pass-through would otherwise let an anonymous client tamper
+// with setup. The routes below mutate: tournament setup (name/password/courts/
+// check-in windows) and competition setup (creation + config). They are keyed
+// by the param-free FullPath so the match is stable across path parameters.
+//
+// IMPORTANT: any NEW admin route that mutates organiser-owned setup (rather
+// than operational play) and is not already elevated-gated MUST be added here,
+// otherwise it becomes anonymously writable in self-run mode.
+func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
+	switch method + " " + fullPath {
+	case http.MethodPut + " /api/tournament", // tournament name/password/courts/check-in windows
+		http.MethodPost + " /api/competitions",    // create a competition (category) — setup
+		http.MethodPut + " /api/competitions/:id": // edit competition config — setup
+		return true
+	default:
+		return false
+	}
+}
+
 // AuthMiddleware gates admin endpoints behind the X-Tournament-Password
 // header. The actual credential check is delegated to the PasswordVerifier
 // so file-based and locked (bcrypt-env-var) modes share a single middleware.
@@ -258,13 +284,16 @@ func AuthMiddleware(verifier PasswordVerifier, store *state.Store) gin.HandlerFu
 		// already fire downstream on those specific routes. No new allowlist
 		// needed — the elevated-decorator set IS the allowlist (DRY).
 		//
-		// Exception — tournament configuration routes (PUT /api/tournament):
-		// these mutate setup data including the main password, courts, and
-		// check-in windows. In self-run mode there is no separate main-password
-		// gate, so these routes fall through to the standard auth path below.
-		// The SPA always sends the main password as X-Tournament-Password on
-		// PUT /api/tournament even in self-run mode, so this is transparent to
-		// existing clients.
+		// Exception — configuration/setup mutations stay main-gated even in
+		// self-run mode (see isSelfRunMainGatedConfigRoute). These routes
+		// mutate organiser-owned setup (tournament name/password/courts/
+		// check-in windows; competition creation and competition config) as
+		// opposed to the operational play surface participants drive. They are
+		// NOT elevated-gated, so without this carve-out the pass-through would
+		// expose them to anonymous callers in self-run (Copilot #203). The SPA
+		// always sends the main password as X-Tournament-Password on admin
+		// mutations, so for the organiser who created the tournament this is
+		// transparent; only an anonymous client (no main password) is blocked.
 		//
 		// Officiated mode (the default) skips this block entirely → no regression.
 		//
@@ -275,8 +304,7 @@ func AuthMiddleware(verifier PasswordVerifier, store *state.Store) gin.HandlerFu
 		// mutations. Comparing explicitly against TournamentModeSelfRun is safe:
 		// the empty string (old files) and "officiated" both fall through to the
 		// standard auth path below.
-		isTournamentConfigMutation := c.Request.Method == http.MethodPut && c.FullPath() == "/api/tournament"
-		if t.Mode == state.TournamentModeSelfRun && !isTournamentConfigMutation {
+		if t.Mode == state.TournamentModeSelfRun && !isSelfRunMainGatedConfigRoute(c.Request.Method, c.FullPath()) {
 			c.Next()
 			return
 		}

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -219,6 +219,7 @@ func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 		http.MethodPost + " /api/competitions/:id/playoffs",                            // Fix 3330063192: organiser playoff seeding, not operational play
 		http.MethodPut + " /api/competitions/:id/matches/:mid/override-winner",         // Fix 3330080949: result correction — organiser, not participant play
 		http.MethodPut + " /api/competitions/:id/pools/:poolId/override-rank",          // Fix 3330080949: standings correction — organiser, not participant play
+		http.MethodPost + " /api/competitions/:id/competitor-status",                   // Fix 3331033814: eligibility mutation — organiser decision, not operational play
 		http.MethodPut + " /api/competitions/:id/matches/:mid/court",                   // court assignment — organiser coordination
 		http.MethodPut + " /api/competitions/:id/matches/:mid/time",                    // match time — organiser coordination
 		http.MethodPut + " /api/competitions/:id/seeds",                                // seeding — organiser pre-draw setup

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -249,14 +249,22 @@ func AuthMiddleware(verifier PasswordVerifier, store *state.Store) gin.HandlerFu
 			return
 		}
 
-		// Self-run mode (mp-7h7): skip the main-password gate entirely.
-		// Constructive admin routes (scoring, check-in, start, complete,
-		// generate draw, etc.) become public — there is no table operator.
-		// Destructive routes (delete competition, invalidate, draw, overrides,
-		// participant roster mutations, import) remain gated by the
+		// Self-run mode (mp-7h7): skip the main-password gate for operational
+		// routes (scoring, check-in, start, complete, generate draw, etc.) —
+		// there is no dedicated table operator, so participants drive their own
+		// flow. Destructive routes (delete competition, invalidate, draw,
+		// overrides, participant roster mutations, import) remain gated by the
 		// EXISTING RequireElevatedPassword / enforceElevated decorators that
 		// already fire downstream on those specific routes. No new allowlist
-		// is needed — the elevated-decorator set IS the allowlist (DRY).
+		// needed — the elevated-decorator set IS the allowlist (DRY).
+		//
+		// Exception — tournament configuration routes (PUT /api/tournament):
+		// these mutate setup data including the main password, courts, and
+		// check-in windows. In self-run mode there is no separate main-password
+		// gate, so these routes fall through to the standard auth path below.
+		// The SPA always sends the main password as X-Tournament-Password on
+		// PUT /api/tournament even in self-run mode, so this is transparent to
+		// existing clients.
 		//
 		// Officiated mode (the default) skips this block entirely → no regression.
 		//
@@ -267,7 +275,8 @@ func AuthMiddleware(verifier PasswordVerifier, store *state.Store) gin.HandlerFu
 		// mutations. Comparing explicitly against TournamentModeSelfRun is safe:
 		// the empty string (old files) and "officiated" both fall through to the
 		// standard auth path below.
-		if t.Mode == state.TournamentModeSelfRun {
+		isTournamentConfigMutation := c.Request.Method == http.MethodPut && c.FullPath() == "/api/tournament"
+		if t.Mode == state.TournamentModeSelfRun && !isTournamentConfigMutation {
 			c.Next()
 			return
 		}

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -318,13 +318,10 @@ func AuthMiddleware(verifier PasswordVerifier, store *state.Store) gin.HandlerFu
 		//
 		// Officiated mode (the default) skips this block entirely → no regression.
 		//
-		// Note: LoadTournament returns tournament data with the Mode field. For
-		// older files where Mode is empty, ApplyTournamentDefaults normalises it
-		// to TournamentModeOfficiated before this comparison — but we don't call
-		// ApplyTournamentDefaults on the loaded record here to avoid unexpected
-		// mutations. Comparing explicitly against TournamentModeSelfRun is safe:
-		// the empty string (old files) and "officiated" both fall through to the
-		// standard auth path below.
+		// Note: LoadTournament already calls ApplyTournamentDefaults and
+		// normalises unknown values, so t.Mode is always a canonical value
+		// ("officiated" or "self-run") at this point. Comparing explicitly
+		// against TournamentModeSelfRun is both necessary and sufficient.
 		if t.Mode == state.TournamentModeSelfRun && !isSelfRunMainGatedConfigRoute(c.Request.Method, c.FullPath()) {
 			c.Next()
 			return

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -206,9 +206,14 @@ func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
 // otherwise it becomes anonymously writable in self-run mode.
 func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 	switch method + " " + fullPath {
-	case http.MethodPut + " /api/tournament", // tournament name/password/courts/check-in windows
+	case http.MethodGet + " /api/tournament", // Fix 3329406556: password field in full Tournament struct; viewer uses /api/viewer/tournament
+		http.MethodPost + " /api/tournament",      // Fix 3329416167: re-bootstrap overwrite when tournament already exists
+		http.MethodPut + " /api/tournament",       // tournament name/password/courts/check-in windows
 		http.MethodPost + " /api/competitions",    // create a competition (category) — setup
-		http.MethodPut + " /api/competitions/:id": // edit competition config — setup
+		http.MethodPut + " /api/competitions/:id", // edit competition config — setup
+		http.MethodPost + " /api/tournament/announce",    // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements/:id",    // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements":        // Fix 3329416176: organiser config, not operational play
 		return true
 	default:
 		return false

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -207,13 +207,13 @@ func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
 func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 	switch method + " " + fullPath {
 	case http.MethodGet + " /api/tournament", // Fix 3329406556: password field in full Tournament struct; viewer uses /api/viewer/tournament
-		http.MethodPost + " /api/tournament",      // Fix 3329416167: re-bootstrap overwrite when tournament already exists
-		http.MethodPut + " /api/tournament",       // tournament name/password/courts/check-in windows
-		http.MethodPost + " /api/competitions",    // create a competition (category) — setup
-		http.MethodPut + " /api/competitions/:id", // edit competition config — setup
-		http.MethodPost + " /api/tournament/announce",    // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements/:id",    // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements":        // Fix 3329416176: organiser config, not operational play
+		http.MethodPost + " /api/tournament",          // Fix 3329416167: re-bootstrap overwrite when tournament already exists
+		http.MethodPut + " /api/tournament",           // tournament name/password/courts/check-in windows
+		http.MethodPost + " /api/competitions",        // create a competition (category) — setup
+		http.MethodPut + " /api/competitions/:id",     // edit competition config — setup
+		http.MethodPost + " /api/tournament/announce", // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements/:id", // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements":     // Fix 3329416176: organiser config, not operational play
 		return true
 	default:
 		return false

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -207,13 +207,16 @@ func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
 func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 	switch method + " " + fullPath {
 	case http.MethodGet + " /api/tournament", // Fix 3329406556: password field in full Tournament struct; viewer uses /api/viewer/tournament
-		http.MethodPost + " /api/tournament",          // Fix 3329416167: re-bootstrap overwrite when tournament already exists
-		http.MethodPut + " /api/tournament",           // tournament name/password/courts/check-in windows
-		http.MethodPost + " /api/competitions",        // create a competition (category) — setup
-		http.MethodPut + " /api/competitions/:id",     // edit competition config — setup
-		http.MethodPost + " /api/tournament/announce", // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements/:id", // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements":     // Fix 3329416176: organiser config, not operational play
+		http.MethodPost + " /api/tournament",                // Fix 3329416167: re-bootstrap overwrite when tournament already exists
+		http.MethodPut + " /api/tournament",                 // tournament name/password/courts/check-in windows
+		http.MethodPost + " /api/competitions",              // create a competition (category) — setup
+		http.MethodPut + " /api/competitions/:id",           // edit competition config — setup
+		http.MethodPost + " /api/tournament/announce",       // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements/:id",       // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements",           // Fix 3329416176: organiser config, not operational play
+		http.MethodPut + " /api/auth/admin-password",        // Fix 3330063192: relies on AuthMiddleware main-pw verification; not elevated-gated
+		http.MethodPut + " /api/competitions/:id/schedule",  // Fix 3330063192: organiser schedule setup, not operational play
+		http.MethodPost + " /api/competitions/:id/playoffs": // Fix 3330063192: organiser playoff seeding, not operational play
 		return true
 	default:
 		return false

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -207,16 +207,27 @@ func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
 func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 	switch method + " " + fullPath {
 	case http.MethodGet + " /api/tournament", // Fix 3329406556: password field in full Tournament struct; viewer uses /api/viewer/tournament
-		http.MethodPost + " /api/tournament",                // Fix 3329416167: re-bootstrap overwrite when tournament already exists
-		http.MethodPut + " /api/tournament",                 // tournament name/password/courts/check-in windows
-		http.MethodPost + " /api/competitions",              // create a competition (category) — setup
-		http.MethodPut + " /api/competitions/:id",           // edit competition config — setup
-		http.MethodPost + " /api/tournament/announce",       // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements/:id",       // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements",           // Fix 3329416176: organiser config, not operational play
-		http.MethodPut + " /api/auth/admin-password",        // Fix 3330063192: relies on AuthMiddleware main-pw verification; not elevated-gated
-		http.MethodPut + " /api/competitions/:id/schedule",  // Fix 3330063192: organiser schedule setup, not operational play
-		http.MethodPost + " /api/competitions/:id/playoffs": // Fix 3330063192: organiser playoff seeding, not operational play
+		http.MethodPost + " /api/tournament",                                           // Fix 3329416167: re-bootstrap overwrite when tournament already exists
+		http.MethodPut + " /api/tournament",                                            // tournament name/password/courts/check-in windows
+		http.MethodPost + " /api/competitions",                                         // create a competition (category) — setup
+		http.MethodPut + " /api/competitions/:id",                                      // edit competition config — setup
+		http.MethodPost + " /api/tournament/announce",                                  // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements/:id",                                  // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements",                                      // Fix 3329416176: organiser config, not operational play
+		http.MethodPut + " /api/auth/admin-password",                                   // Fix 3330063192: relies on AuthMiddleware main-pw verification; not elevated-gated
+		http.MethodPut + " /api/competitions/:id/schedule",                             // Fix 3330063192: organiser schedule setup, not operational play
+		http.MethodPost + " /api/competitions/:id/playoffs",                            // Fix 3330063192: organiser playoff seeding, not operational play
+		http.MethodPut + " /api/competitions/:id/matches/:mid/override-winner",         // Fix 3330080949: result correction — organiser, not participant play
+		http.MethodPut + " /api/competitions/:id/pools/:poolId/override-rank",          // Fix 3330080949: standings correction — organiser, not participant play
+		http.MethodPut + " /api/competitions/:id/matches/:mid/court",                   // court assignment — organiser coordination
+		http.MethodPut + " /api/competitions/:id/matches/:mid/time",                    // match time — organiser coordination
+		http.MethodPut + " /api/competitions/:id/seeds",                                // seeding — organiser pre-draw setup
+		http.MethodPost + " /api/competitions/:id/competitors/:pid/reinstate",          // kiken-injury reinstatement — organiser decision
+		http.MethodDelete + " /api/competitions/:id/participants/:pid/checkin",         // check-in reversal — organiser correction
+		http.MethodPut + " /api/competitions/:id/teams/:tid/lineups/:round",            // team lineup management — organiser
+		http.MethodDelete + " /api/competitions/:id/teams/:tid/lineups/:round",         // team lineup management — organiser
+		http.MethodPut + " /api/competitions/:id/teams/:tid/match-lineups/:matchId",    // team match lineup — organiser
+		http.MethodDelete + " /api/competitions/:id/teams/:tid/match-lineups/:matchId": // team match lineup — organiser
 		return true
 	default:
 		return false

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -88,7 +88,7 @@ func newTempStore(t *testing.T) *state.Store {
 }
 
 // jsonReq builds a JSON request.
-func jsonReq(method, path string, body interface{}) *http.Request {
+func jsonReq(method, path string, body any) *http.Request {
 	var buf *bytes.Reader
 	if body != nil {
 		b, _ := json.Marshal(body)
@@ -226,7 +226,7 @@ func TestSelfRun_SelfRunMode_ParticipantPOST_StillElevatedGated(t *testing.T) {
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
 	// No X-Admin-Password → 401 even in self-run.
-	req := jsonReq(http.MethodPost, "/api/competitions/any-id/participants", map[string]interface{}{})
+	req := jsonReq(http.MethodPost, "/api/competitions/any-id/participants", map[string]any{})
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code,
@@ -245,7 +245,7 @@ func TestSelfRun_FailOpenGuard_CreationWithoutAdminPw_Rejected(t *testing.T) {
 	// File mode verifier.
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"name":     "Self-Run Tournament",
 		"date":     "01-06-2026",
 		"venue":    "Dojo",
@@ -285,7 +285,7 @@ func TestSelfRun_FailOpenGuard_CreationWithExistingAdminPw_Allowed(t *testing.T)
 
 	// Re-POST (bootstrap) with self-run but no admin password in the body —
 	// the preserve step in the handler copies existingForPost.AdminPassword.
-	body := map[string]interface{}{
+	body := map[string]any{
 		"name":     "Self-Run Tournament",
 		"date":     "01-06-2026",
 		"venue":    "Dojo",
@@ -321,7 +321,7 @@ func TestSelfRun_Immutability_POSTPreservesMode(t *testing.T) {
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
 	// Step 1: fresh bootstrap as officiated (no auth header needed — bootstrap).
-	postBody := map[string]interface{}{
+	postBody := map[string]any{
 		"name":     "My Officiated",
 		"date":     "01-06-2026",
 		"venue":    "Dojo",
@@ -340,7 +340,7 @@ func TestSelfRun_Immutability_POSTPreservesMode(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 	require.Equal(t, http.StatusOK, w2.Code)
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &result))
 	assert.Equal(t, "officiated", result["mode"],
 		"GET must return mode=officiated after officiated POST")
@@ -361,7 +361,7 @@ func TestSelfRun_Immutability_POSTPreservesMode(t *testing.T) {
 	}))
 	r2 := setupSelfRunRouter(t, store2, NewFileVerifier(store2))
 
-	postSelfRun := map[string]interface{}{
+	postSelfRun := map[string]any{
 		"name":     "My Self-Run",
 		"date":     "01-06-2026",
 		"venue":    "Dojo",
@@ -381,7 +381,7 @@ func TestSelfRun_Immutability_POSTPreservesMode(t *testing.T) {
 	w4 := httptest.NewRecorder()
 	r2.ServeHTTP(w4, req4)
 	require.Equal(t, http.StatusOK, w4.Code)
-	var result2 map[string]interface{}
+	var result2 map[string]any
 	require.NoError(t, json.Unmarshal(w4.Body.Bytes(), &result2))
 	assert.Equal(t, "self-run", result2["mode"],
 		"GET /api/tournament must return mode=self-run after self-run POST")
@@ -395,7 +395,7 @@ func TestSelfRun_Immutability_PUT_SwitchModeRejected(t *testing.T) {
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
 	// Try to change mode from officiated to self-run via PUT.
-	putBody := map[string]interface{}{
+	putBody := map[string]any{
 		"name":   "Officiated Test",
 		"date":   "01-06-2026",
 		"venue":  "Dojo",
@@ -419,7 +419,7 @@ func TestSelfRun_Immutability_PUT_OmittingModePreservesIt(t *testing.T) {
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
 	// PUT without mode field — should preserve self-run.
-	putBody := map[string]interface{}{
+	putBody := map[string]any{
 		"name":   "SelfRun Test",
 		"date":   "01-06-2026",
 		"venue":  "Dojo Updated",
@@ -447,7 +447,7 @@ func TestSelfRun_Immutability_PUT_SameModeIsIdempotent(t *testing.T) {
 	seedSelfRunTournament(t, store, "admin-pw")
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
-	putBody := map[string]interface{}{
+	putBody := map[string]any{
 		"name":   "SelfRun Test",
 		"date":   "01-06-2026",
 		"venue":  "Dojo",
@@ -576,6 +576,60 @@ func TestSelfRun_LockedMode_DestructiveRoutes_StillRequireAdminPw(t *testing.T) 
 		"locked+self-run constructive route must be public (not 401)")
 }
 
+// Regression (mp-7h7): a locked-mode self-run tournament has an empty on-disk
+// AdminPassword (the env-var bcrypt hash is authoritative). The self-run
+// fail-open guard applies to FILE MODE ONLY — in locked mode the elevated
+// gate already fails closed via GateActive(). A routine PUT that edits
+// venue/name MUST therefore succeed. Before the fix the PUT transform guard
+// fired unconditionally on desired.AdminPassword == "", returning 400
+// errSelfRunRequiresAdminPassword and making locked self-run tournaments
+// permanently uneditable.
+func TestSelfRun_LockedMode_PUTEdit_NotRejectedByFailOpenGuard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+
+	hashBytes, err := bcrypt.GenerateFromPassword([]byte("main-pw"), bcrypt.MinCost)
+	require.NoError(t, err)
+	lockedV, err := NewBcryptVerifier(string(hashBytes))
+	require.NoError(t, err)
+
+	// Locked-mode self-run tournament: empty on-disk Password AND empty
+	// on-disk AdminPassword (both inert; credentials come from env vars).
+	err = store.SaveTournament(&state.Tournament{
+		Name:     "LockedSelfRun",
+		Date:     "01-06-2026",
+		Venue:    "Old Dojo",
+		Courts:   []string{"A"},
+		Password: "",
+		Mode:     state.TournamentModeSelfRun,
+	})
+	require.NoError(t, err)
+
+	r := setupSelfRunRouter(t, store, lockedV)
+
+	// PUT editing the venue. Self-run skips the main gate, so no header is
+	// needed; password rotation is omitted (disabled in locked mode); mode is
+	// omitted (preserved). This must NOT be rejected by the file-mode-only
+	// fail-open guard.
+	putBody := map[string]any{
+		"name":   "LockedSelfRun",
+		"date":   "01-06-2026",
+		"venue":  "New Dojo",
+		"courts": []string{"A"},
+	}
+	req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code,
+		"locked self-run PUT venue edit must succeed, not be rejected by the file-mode fail-open guard: %s", w.Body.String())
+
+	t2, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, t2)
+	assert.Equal(t, "New Dojo", t2.Venue, "venue edit must persist")
+	assert.Equal(t, state.TournamentModeSelfRun, t2.Mode, "mode must remain self-run")
+}
+
 // ---------------------------------------------------------------------------
 // §6 POST mode validation
 // ---------------------------------------------------------------------------
@@ -586,7 +640,7 @@ func TestSelfRun_POST_InvalidMode_Rejected(t *testing.T) {
 	store := newTempStore(t)
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"name":     "T",
 		"date":     "01-06-2026",
 		"venue":    "V",
@@ -607,7 +661,7 @@ func TestSelfRun_POST_NoMode_DefaultsToOfficiated(t *testing.T) {
 	store := newTempStore(t)
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"name":     "T",
 		"date":     "01-06-2026",
 		"venue":    "V",

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -847,6 +847,38 @@ func TestSelfRun_POST_InvalidMode_Rejected(t *testing.T) {
 		"POST with invalid mode must return 400")
 }
 
+// POST with an oversized adminPassword returns 400 even in locked mode
+// (where the field is never persisted). Fix 3331061367: validate the
+// transient field whenever present, regardless of server mode.
+func TestSelfRun_POST_OversizedAdminPassword_Rejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+
+	// Build a bcrypt verifier (locked mode).
+	hashBytes, err := bcrypt.GenerateFromPassword([]byte("main-pw"), bcrypt.MinCost)
+	require.NoError(t, err)
+	lockedV, err := NewBcryptVerifier(string(hashBytes))
+	require.NoError(t, err)
+
+	r := setupSelfRunRouter(t, store, lockedV)
+
+	body := map[string]any{
+		"name":          "T",
+		"date":          "01-06-2026",
+		"venue":         "V",
+		"courts":        []string{"A"},
+		"password":      "main-pw",
+		"adminPassword": string(make([]byte, MaxLenTournamentPassword+1)), // 257 chars
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", body)
+	req.Header.Set("X-Tournament-Password", "main-pw")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"oversized adminPassword must return 400 even in locked mode")
+	assert.Contains(t, w.Body.String(), "adminPassword")
+}
+
 // POST with no mode → defaults to officiated.
 func TestSelfRun_POST_NoMode_DefaultsToOfficiated(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -204,6 +204,45 @@ func TestSelfRun_SelfRunMode_PUTTournament_RequiresMainPassword(t *testing.T) {
 	})
 }
 
+// Competition configuration mutations (create a competition, edit competition
+// config) are organiser setup, NOT operational play — like PUT /api/tournament
+// they stay main-gated in self-run mode (mp-7h7 / Copilot #203 sibling audit).
+// Without this an anonymous client could create or reconfigure competitions in
+// a self-run tournament. These routes are not elevated-gated, so the main gate
+// is the protection. The organiser's SPA always sends X-Tournament-Password.
+func TestSelfRun_SelfRunMode_CompetitionConfigRoutes_RequireMainPassword(t *testing.T) {
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	configRoutes := []struct{ method, path string }{
+		{http.MethodPost, "/api/competitions"},
+		{http.MethodPut, "/api/competitions/some-id"},
+	}
+
+	for _, tc := range configRoutes {
+		t.Run("no_pw_401_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := jsonReq(tc.method, tc.path, map[string]any{"name": "X"})
+			// No X-Tournament-Password: a config mutation must be rejected.
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"self-run config route %s %s must return 401 without main password", tc.method, tc.path)
+		})
+
+		t.Run("with_pw_not_401_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := jsonReq(tc.method, tc.path, map[string]any{"name": "X"})
+			req.Header.Set("X-Tournament-Password", "main-pw")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			// Past the main gate — downstream may 400/404 on the body/id, but
+			// never 401 (the invariant under test).
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"correct main password must clear the gate on %s %s (got %d)", tc.method, tc.path, w.Code)
+		})
+	}
+}
+
 // Destructive routes still require X-Admin-Password in self-run mode.
 // The main gate is skipped but RequireElevatedPassword still fires.
 func TestSelfRun_SelfRunMode_DestructiveRoutes_Require_AdminPassword(t *testing.T) {

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -262,6 +262,76 @@ func TestSelfRun_FailOpenGuard_CreationWithoutAdminPw_Rejected(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "admin")
 }
 
+// Creating a self-run tournament via the REAL API body path: the POST carries
+// a transient `adminPassword` field (the only way the credential can reach the
+// server, since Tournament.AdminPassword is json:"-"). The handler must set it
+// atomically with creation so the fail-open guard passes, the tournament is
+// persisted WITH the credential, and the destructive routes are gated by it.
+//
+// This exercises the path the browser/SPA actually uses — the prior
+// store-seeding test bypassed it, which is why the "creation impossible via
+// real API" bug slipped through.
+func TestSelfRun_FailOpenGuard_CreationWithBodyAdminPw_Atomic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// Fresh file-mode bootstrap POST: self-run + main password + a transient
+	// adminPassword in the SAME body. No header (file-mode bootstrap).
+	body := map[string]any{
+		"name":          "Self-Run Tournament",
+		"date":          "01-06-2026",
+		"venue":         "Dojo",
+		"courts":        []string{"A"},
+		"password":      "main-pw",
+		"mode":          "self-run",
+		"adminPassword": "destructive-pw",
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code,
+		"self-run creation with adminPassword in body must succeed: %s", w.Body.String())
+
+	// The persisted tournament must have mode=self-run AND a non-empty
+	// (correct) admin password on disk.
+	stored, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, state.TournamentModeSelfRun, stored.Mode,
+		"stored mode must be self-run")
+	assert.Equal(t, "destructive-pw", stored.AdminPassword,
+		"admin password must be persisted atomically with creation")
+
+	// Verify the destructive-route gate now uses the stored admin password:
+	// no X-Admin-Password → 401; correct X-Admin-Password → passes the gate.
+	t.Run("destructive route requires admin pw", func(t *testing.T) {
+		reqNoPw := httptest.NewRequest(http.MethodDelete, "/api/competitions/some-id", nil)
+		wNoPw := httptest.NewRecorder()
+		r.ServeHTTP(wNoPw, reqNoPw)
+		assert.Equal(t, http.StatusUnauthorized, wNoPw.Code,
+			"destructive route must 401 without X-Admin-Password")
+	})
+
+	t.Run("destructive route passes gate with correct admin pw", func(t *testing.T) {
+		reqWithPw := httptest.NewRequest(http.MethodDelete, "/api/competitions/some-id", nil)
+		reqWithPw.Header.Set("X-Admin-Password", "destructive-pw")
+		wWithPw := httptest.NewRecorder()
+		r.ServeHTTP(wWithPw, reqWithPw)
+		// Not 401: the elevated gate passed (downstream handler may 204/404).
+		assert.NotEqual(t, http.StatusUnauthorized, wWithPw.Code,
+			"destructive route must pass the elevated gate with correct X-Admin-Password (got %d)", wWithPw.Code)
+	})
+
+	t.Run("constructive route is public", func(t *testing.T) {
+		reqPub := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+		wPub := httptest.NewRecorder()
+		r.ServeHTTP(wPub, reqPub)
+		assert.NotEqual(t, http.StatusUnauthorized, wPub.Code,
+			"constructive route must be public in self-run (no main password)")
+	})
+}
+
 // Creating a self-run tournament IS allowed when the existing record already
 // has an AdminPassword on disk (from a prior setAdminPassword call or
 // direct store write). This exercises the preserveFromExisting path where

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -152,8 +152,13 @@ func TestSelfRun_SelfRunMode_ConstructiveRoutesArePublic(t *testing.T) {
 	// Routes that are main-gated-only today (no elevated decorator) become
 	// public in self-run. We test a subset because full competition state
 	// is complex to seed. The key invariant is: no 401 from the main gate.
+	//
+	// Note: GET /api/tournament is intentionally NOT in this list. In file
+	// mode it returns the Tournament struct including the Password field. If
+	// it were public in self-run, an anonymous caller could read the main
+	// password and use it to bypass the main gate on gated config routes
+	// (Copilot #203 finding 3329406556). It is kept in isSelfRunMainGatedConfigRoute.
 	constructiveRoutes := []struct{ method, path string }{
-		{http.MethodGet, "/api/tournament"},
 		{http.MethodGet, "/api/competitions"},
 	}
 
@@ -166,6 +171,34 @@ func TestSelfRun_SelfRunMode_ConstructiveRoutesArePublic(t *testing.T) {
 				"self-run constructive route %s %s must not return 401 (public)", tc.method, tc.path)
 		})
 	}
+}
+
+// GET /api/tournament is in the main-gated carve-out for self-run because in
+// file mode it returns the Tournament struct including the Password field
+// (Copilot #203 fix 3329406556). An anonymous read would leak the credential
+// and allow the caller to bypass the PUT /api/tournament gate.
+func TestSelfRun_SelfRunMode_GETTournament_RequiresMainPassword(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	t.Run("no_pw_returns_401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"GET /api/tournament must return 401 without main password in self-run mode (file-mode password leak prevention)")
+	})
+
+	t.Run("correct_pw_succeeds", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+		req.Header.Set("X-Tournament-Password", "main-pw")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code,
+			"GET /api/tournament must succeed with the main password in self-run mode")
+	})
 }
 
 // PUT /api/tournament is a tournament-configuration mutation (password, courts,
@@ -399,7 +432,9 @@ func TestSelfRun_FailOpenGuard_CreationWithBodyAdminPw_Atomic(t *testing.T) {
 	})
 
 	t.Run("constructive route is public", func(t *testing.T) {
-		reqPub := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+		// Use GET /api/competitions — GET /api/tournament is main-gated in
+		// self-run (file-mode password leak prevention, fix 3329406556).
+		reqPub := httptest.NewRequest(http.MethodGet, "/api/competitions", nil)
 		wPub := httptest.NewRecorder()
 		r.ServeHTTP(wPub, reqPub)
 		assert.NotEqual(t, http.StatusUnauthorized, wPub.Code,
@@ -490,39 +525,34 @@ func TestSelfRun_Immutability_POSTPreservesMode(t *testing.T) {
 	assert.Equal(t, "officiated", result["mode"],
 		"GET must return mode=officiated after officiated POST")
 
-	// Step 2: verify self-run mode persists when created fresh.
-	// Use a separate store for a clean slate — the mode we just bootstrapped
-	// is officiated and immutable; a fresh store exercises the self-run path.
+	// Step 2: verify self-run mode persists when created as a FRESH tournament
+	// (no prior record — true first bootstrap). Use a clean store with no
+	// existing tournament so POST acts as first-create (not re-bootstrap).
+	// Fix 3329416172 makes re-bootstrap preserve the existing mode (immutability),
+	// so we must use a fresh store to actually create a self-run tournament via POST.
 	store2 := newTempStore(t)
-	// Pre-seed admin pw directly (simulates operator having set it
-	// before the self-run re-bootstrap, which is required by fail-open guard).
-	require.NoError(t, store2.SaveTournament(&state.Tournament{
-		Name:          "Prev",
-		Date:          "01-01-2026",
-		Venue:         "V",
-		Courts:        []string{"A"},
-		Password:      "pw",
-		AdminPassword: "admin-pw",
-	}))
 	r2 := setupSelfRunRouter(t, store2, NewFileVerifier(store2))
 
 	postSelfRun := map[string]any{
-		"name":     "My Self-Run",
-		"date":     "01-06-2026",
-		"venue":    "Dojo",
-		"courts":   []string{"A"},
-		"password": "main-pw",
-		"mode":     "self-run",
+		"name":          "My Self-Run",
+		"date":          "01-06-2026",
+		"venue":         "Dojo",
+		"courts":        []string{"A"},
+		"password":      "main-pw",
+		"mode":          "self-run",
+		"adminPassword": "admin-pw", // required for self-run in file mode
 	}
+	// Fresh bootstrap — no X-Tournament-Password needed (file mode, no record).
 	req3 := jsonReq(http.MethodPost, "/api/tournament", postSelfRun)
-	req3.Header.Set("X-Tournament-Password", "pw") // re-POST requires main auth
 	w3 := httptest.NewRecorder()
 	r2.ServeHTTP(w3, req3)
 	require.Equal(t, http.StatusCreated, w3.Code, "self-run POST must succeed: %s", w3.Body.String())
 
 	// GET the tournament and verify mode = self-run.
+	// GET /api/tournament is main-gated in self-run (file-mode password leak
+	// prevention — fix 3329406556), so send the main password.
 	req4 := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
-	// self-run: main gate skipped, GET is public
+	req4.Header.Set("X-Tournament-Password", "main-pw")
 	w4 := httptest.NewRecorder()
 	r2.ServeHTTP(w4, req4)
 	require.Equal(t, http.StatusOK, w4.Code)
@@ -713,8 +743,9 @@ func TestSelfRun_LockedMode_DestructiveRoutes_StillRequireAdminPw(t *testing.T) 
 		"locked+self-run destructive route must return 401 or 503, got %d: %s", w.Code, w.Body.String())
 
 	// Constructive route without any header must NOT be 401 in self-run
-	// (main gate is skipped).
-	req2 := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+	// (main gate is skipped). Use GET /api/competitions — GET /api/tournament
+	// is main-gated in self-run to prevent file-mode password leaks (fix 3329406556).
+	req2 := httptest.NewRequest(http.MethodGet, "/api/competitions", nil)
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 	assert.NotEqual(t, http.StatusUnauthorized, w2.Code,

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -33,7 +33,7 @@ import (
 // ---------------------------------------------------------------------------
 
 // setupSelfRunRouter creates a full NewRouterWithHub with the given verifier
-// and a tournament pre-seeded in the store. Returns the router and store.
+// and a tournament pre-seeded in the store. Returns the router.
 func setupSelfRunRouter(t *testing.T, store *state.Store, verifier PasswordVerifier) *gin.Engine {
 	t.Helper()
 	eng := engine.New(store)

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -1,0 +1,628 @@
+package mobileapp
+
+// Tests for the self-run tournament mode auth boundary (mp-7h7).
+//
+// Three categories:
+//  1. Auth matrix: officiated vs self-run × constructive vs destructive routes
+//  2. Fail-open guard: self-run + file mode + no admin pw → 400 at creation
+//  3. Immutability: POST persists mode; PUT switch → 400; PUT omitting mode → preserved
+//  4. ValidateTournamentMode + ApplyTournamentDefaults unit tests
+//  5. Locked + self-run: elevated gate still fires on destructive routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/engine"
+	"github.com/gitrgoliveira/bracket-creator/internal/resources"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// setupSelfRunRouter creates a full NewRouterWithHub with the given verifier
+// and a tournament pre-seeded in the store. Returns the router and store.
+func setupSelfRunRouter(t *testing.T, store *state.Store, verifier PasswordVerifier) *gin.Engine {
+	t.Helper()
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{
+		"web-mobile/index.html": {Data: []byte("<html>test</html>")},
+	}
+	res := resources.NewResources(nil, mockFS)
+	r, _ := NewRouterWithHub(store, eng, res, verifier, NewHub())
+	return r
+}
+
+// seedSelfRunTournament saves a self-run tournament with a main password
+// AND sets an admin password via the store directly (since we need the
+// adminPassword on disk before we can call enforceElevated).
+func seedSelfRunTournament(t *testing.T, store *state.Store, adminPw string) {
+	t.Helper()
+	err := store.SaveTournament(&state.Tournament{
+		Name:          "SelfRun Test",
+		Date:          "01-06-2026",
+		Venue:         "Dojo",
+		Courts:        []string{"A"},
+		Password:      "main-pw",
+		AdminPassword: adminPw,
+		Mode:          state.TournamentModeSelfRun,
+	})
+	require.NoError(t, err)
+}
+
+// seedOfficiatedTournament saves a standard officiated tournament.
+func seedOfficiatedTournament(t *testing.T, store *state.Store) {
+	t.Helper()
+	err := store.SaveTournament(&state.Tournament{
+		Name:          "Officiated Test",
+		Date:          "01-06-2026",
+		Venue:         "Dojo",
+		Courts:        []string{"A"},
+		Password:      "main-pw",
+		AdminPassword: "admin-pw",
+		Mode:          state.TournamentModeOfficiated,
+	})
+	require.NoError(t, err)
+}
+
+func newTempStore(t *testing.T) *state.Store {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "selfrun-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	return store
+}
+
+// jsonReq builds a JSON request.
+func jsonReq(method, path string, body interface{}) *http.Request {
+	var buf *bytes.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		buf = bytes.NewReader(b)
+	} else {
+		buf = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, buf)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// ---------------------------------------------------------------------------
+// §1 Auth matrix: officiated mode (baseline — no regression)
+// ---------------------------------------------------------------------------
+
+// In officiated mode every admin route still requires X-Tournament-Password.
+func TestSelfRun_OfficiatedMode_RequiresMainPassword(t *testing.T) {
+	store := newTempStore(t)
+	seedOfficiatedTournament(t, store)
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	constructiveRoutes := []struct{ method, path string }{
+		{http.MethodGet, "/api/tournament"},
+		{http.MethodGet, "/api/competitions"},
+		{http.MethodPost, "/api/competitions"},
+	}
+
+	for _, tc := range constructiveRoutes {
+		t.Run("officiated_no_pw_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"officiated mode must require main password on %s %s", tc.method, tc.path)
+		})
+
+		t.Run("officiated_correct_pw_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("X-Tournament-Password", "main-pw")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			// Not checking for 200 because competition/tournament resources
+			// may not exist — just assert it's not a 401.
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"correct password must clear the main gate on %s %s", tc.method, tc.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// §1 Auth matrix: self-run mode
+// ---------------------------------------------------------------------------
+
+// Constructive routes are public (no main password needed) in self-run mode.
+func TestSelfRun_SelfRunMode_ConstructiveRoutesArePublic(t *testing.T) {
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// Routes that are main-gated-only today (no elevated decorator) become
+	// public in self-run. We test a subset because full competition state
+	// is complex to seed. The key invariant is: no 401 from the main gate.
+	constructiveRoutes := []struct{ method, path string }{
+		{http.MethodGet, "/api/tournament"},
+		{http.MethodGet, "/api/competitions"},
+	}
+
+	for _, tc := range constructiveRoutes {
+		t.Run("selfrun_no_pw_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"self-run constructive route %s %s must not return 401 (public)", tc.method, tc.path)
+		})
+	}
+}
+
+// Destructive routes still require X-Admin-Password in self-run mode.
+// The main gate is skipped but RequireElevatedPassword still fires.
+func TestSelfRun_SelfRunMode_DestructiveRoutes_Require_AdminPassword(t *testing.T) {
+	store := newTempStore(t)
+	// Need a competition to exercise DELETE /competitions/:id
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	destructiveRoutes := []struct{ method, path string }{
+		{http.MethodDelete, "/api/competitions/nonexistent-id"},
+		{http.MethodPost, "/api/competitions/nonexistent-id/invalidate"},
+		{http.MethodDelete, "/api/competitions/nonexistent-id/draw"},
+		{http.MethodDelete, "/api/competitions/nonexistent-id/overrides"},
+		{http.MethodPost, "/api/tournament/import"},
+	}
+
+	for _, tc := range destructiveRoutes {
+		t.Run("selfrun_no_pw_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			// No X-Tournament-Password and no X-Admin-Password
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"self-run destructive route %s %s must return 401 without admin pw", tc.method, tc.path)
+		})
+
+		t.Run("selfrun_wrong_admin_pw_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("X-Admin-Password", "wrong-admin-pw")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code,
+				"self-run destructive route %s %s must return 401 with wrong admin pw", tc.method, tc.path)
+		})
+
+		t.Run("selfrun_correct_admin_pw_"+tc.method+"_"+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("X-Admin-Password", "admin-pw")
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			// The gate passed (not 401); the downstream handler may return
+			// 400/404/422 because we're not providing valid payload / IDs.
+			// We only care that RequireElevatedPassword didn't reject it.
+			assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+				"self-run destructive route %s %s must not 401 with correct admin pw", tc.method, tc.path)
+		})
+	}
+}
+
+// POST /api/competitions/:id/participants is elevated-gated (Path A: mp-7h7
+// does NOT relax this endpoint; that's mp-e5j's job). Verify it still
+// requires the admin password in self-run mode.
+func TestSelfRun_SelfRunMode_ParticipantPOST_StillElevatedGated(t *testing.T) {
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// No X-Admin-Password → 401 even in self-run.
+	req := jsonReq(http.MethodPost, "/api/competitions/any-id/participants", map[string]interface{}{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code,
+		"POST /competitions/:id/participants must remain elevated-gated in self-run (Path A)")
+}
+
+// ---------------------------------------------------------------------------
+// §2 Fail-open guard: self-run + file mode without admin password
+// ---------------------------------------------------------------------------
+
+// Creating a self-run tournament in file mode without an admin password
+// must return 400. (Without the guard, destructive routes would be public.)
+func TestSelfRun_FailOpenGuard_CreationWithoutAdminPw_Rejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	// File mode verifier.
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	body := map[string]interface{}{
+		"name":     "Self-Run Tournament",
+		"date":     "01-06-2026",
+		"venue":    "Dojo",
+		"courts":   []string{"A"},
+		"password": "main-pw",
+		"mode":     "self-run",
+		// NO admin password set at all
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"self-run tournament without admin pw must be rejected in file mode")
+	assert.Contains(t, w.Body.String(), "admin")
+}
+
+// Creating a self-run tournament IS allowed when the existing record already
+// has an AdminPassword on disk (from a prior setAdminPassword call or
+// direct store write). This exercises the preserveFromExisting path where
+// t.AdminPassword != "" after the preserve step.
+func TestSelfRun_FailOpenGuard_CreationWithExistingAdminPw_Allowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+
+	// Seed a prior record with an admin password already set.
+	err := store.SaveTournament(&state.Tournament{
+		Name:          "Previous",
+		Date:          "01-01-2026",
+		Venue:         "Old",
+		Courts:        []string{"A"},
+		Password:      "old-pw",
+		AdminPassword: "existing-admin-pw",
+	})
+	require.NoError(t, err)
+
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// Re-POST (bootstrap) with self-run but no admin password in the body —
+	// the preserve step in the handler copies existingForPost.AdminPassword.
+	body := map[string]interface{}{
+		"name":     "Self-Run Tournament",
+		"date":     "01-06-2026",
+		"venue":    "Dojo",
+		"courts":   []string{"A"},
+		"password": "main-pw",
+		"mode":     "self-run",
+		// AdminPassword omitted from body (json:"-"); preserve step picks it up.
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", body)
+	req.Header.Set("X-Tournament-Password", "old-pw") // locked bootstrap test
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	// Should succeed (201) because the existing record has an admin password.
+	assert.Equal(t, http.StatusCreated, w.Code,
+		"self-run creation must succeed when admin pw exists in previous record")
+}
+
+// ---------------------------------------------------------------------------
+// §3 Immutability
+// ---------------------------------------------------------------------------
+
+// POST self-run → GET mode returns "self-run".
+// This test exercises a fresh bootstrap (no prior tournament.md) so the
+// AuthMiddleware bootstrap branch fires (anonymous POST allowed).
+// The fail-open guard for self-run requires an admin password, so we do a
+// two-step: (1) fresh bootstrap as officiated to create the record with an
+// admin password, (2) verify the store persisted mode=officiated, then
+// (3) verify that a self-run can be started fresh when admin pw is pre-set
+// directly via the store.
+func TestSelfRun_Immutability_POSTPreservesMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// Step 1: fresh bootstrap as officiated (no auth header needed — bootstrap).
+	postBody := map[string]interface{}{
+		"name":     "My Officiated",
+		"date":     "01-06-2026",
+		"venue":    "Dojo",
+		"courts":   []string{"A"},
+		"password": "main-pw",
+		"mode":     "officiated",
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", postBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "officiated POST must succeed: %s", w.Body.String())
+
+	// GET the tournament and verify mode = officiated.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+	req2.Header.Set("X-Tournament-Password", "main-pw")
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &result))
+	assert.Equal(t, "officiated", result["mode"],
+		"GET must return mode=officiated after officiated POST")
+
+	// Step 2: verify self-run mode persists when created fresh.
+	// Use a separate store for a clean slate — the mode we just bootstrapped
+	// is officiated and immutable; a fresh store exercises the self-run path.
+	store2 := newTempStore(t)
+	// Pre-seed admin pw directly (simulates operator having set it
+	// before the self-run re-bootstrap, which is required by fail-open guard).
+	require.NoError(t, store2.SaveTournament(&state.Tournament{
+		Name:          "Prev",
+		Date:          "01-01-2026",
+		Venue:         "V",
+		Courts:        []string{"A"},
+		Password:      "pw",
+		AdminPassword: "admin-pw",
+	}))
+	r2 := setupSelfRunRouter(t, store2, NewFileVerifier(store2))
+
+	postSelfRun := map[string]interface{}{
+		"name":     "My Self-Run",
+		"date":     "01-06-2026",
+		"venue":    "Dojo",
+		"courts":   []string{"A"},
+		"password": "main-pw",
+		"mode":     "self-run",
+	}
+	req3 := jsonReq(http.MethodPost, "/api/tournament", postSelfRun)
+	req3.Header.Set("X-Tournament-Password", "pw") // re-POST requires main auth
+	w3 := httptest.NewRecorder()
+	r2.ServeHTTP(w3, req3)
+	require.Equal(t, http.StatusCreated, w3.Code, "self-run POST must succeed: %s", w3.Body.String())
+
+	// GET the tournament and verify mode = self-run.
+	req4 := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+	// self-run: main gate skipped, GET is public
+	w4 := httptest.NewRecorder()
+	r2.ServeHTTP(w4, req4)
+	require.Equal(t, http.StatusOK, w4.Code)
+	var result2 map[string]interface{}
+	require.NoError(t, json.Unmarshal(w4.Body.Bytes(), &result2))
+	assert.Equal(t, "self-run", result2["mode"],
+		"GET /api/tournament must return mode=self-run after self-run POST")
+}
+
+// PUT that tries to switch officiated → self-run must return 400.
+func TestSelfRun_Immutability_PUT_SwitchModeRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	seedOfficiatedTournament(t, store)
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// Try to change mode from officiated to self-run via PUT.
+	putBody := map[string]interface{}{
+		"name":   "Officiated Test",
+		"date":   "01-06-2026",
+		"venue":  "Dojo",
+		"courts": []string{"A"},
+		"mode":   "self-run", // attempt to change
+	}
+	req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+	req.Header.Set("X-Tournament-Password", "main-pw")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"PUT switching mode must return 400")
+	assert.Contains(t, w.Body.String(), "mode cannot be changed")
+}
+
+// PUT that omits the mode field preserves the existing mode.
+func TestSelfRun_Immutability_PUT_OmittingModePreservesIt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	// PUT without mode field — should preserve self-run.
+	putBody := map[string]interface{}{
+		"name":   "SelfRun Test",
+		"date":   "01-06-2026",
+		"venue":  "Dojo Updated",
+		"courts": []string{"A"},
+		// mode omitted
+	}
+	req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+	req.Header.Set("X-Tournament-Password", "main-pw")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "PUT omitting mode must succeed: %s", w.Body.String())
+
+	// Reload and verify mode is still self-run.
+	t2, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, t2)
+	assert.Equal(t, state.TournamentModeSelfRun, t2.Mode,
+		"mode must be preserved when omitted from PUT body")
+}
+
+// PUT that sends the same mode as stored is a no-op (idempotent).
+func TestSelfRun_Immutability_PUT_SameModeIsIdempotent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	putBody := map[string]interface{}{
+		"name":   "SelfRun Test",
+		"date":   "01-06-2026",
+		"venue":  "Dojo",
+		"courts": []string{"A"},
+		"mode":   "self-run", // same as stored
+	}
+	req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+	req.Header.Set("X-Tournament-Password", "main-pw")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code,
+		"PUT with same mode must succeed (idempotent): %s", w.Body.String())
+}
+
+// ---------------------------------------------------------------------------
+// §4 ValidateTournamentMode + ApplyTournamentDefaults unit tests
+// ---------------------------------------------------------------------------
+
+func TestValidateTournamentMode(t *testing.T) {
+	cases := []struct {
+		mode  string
+		valid bool
+	}{
+		{"", true},               // empty → officiated (backward compat)
+		{"officiated", true},     // explicit default
+		{"self-run", true},       // self-run
+		{"OFFICIATED", false},    // case-sensitive
+		{"Self-Run", false},      // case-sensitive
+		{"peer-operated", false}, // unknown value
+		{"self_run", false},      // wrong separator
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("mode=%q", tc.mode), func(t *testing.T) {
+			err := state.ValidateTournamentMode(tc.mode)
+			if tc.valid {
+				assert.NoError(t, err, "expected %q to be valid", tc.mode)
+			} else {
+				assert.Error(t, err, "expected %q to be invalid", tc.mode)
+			}
+		})
+	}
+}
+
+func TestApplyTournamentDefaults_NormalizesEmptyMode(t *testing.T) {
+	t.Run("empty mode → officiated", func(t *testing.T) {
+		tour := &state.Tournament{
+			Name:     "T",
+			Password: "p",
+			Mode:     "",
+		}
+		state.ApplyTournamentDefaults(tour)
+		assert.Equal(t, state.TournamentModeOfficiated, tour.Mode)
+	})
+
+	t.Run("existing mode preserved", func(t *testing.T) {
+		tour := &state.Tournament{
+			Name:     "T",
+			Password: "p",
+			Mode:     state.TournamentModeSelfRun,
+		}
+		state.ApplyTournamentDefaults(tour)
+		assert.Equal(t, state.TournamentModeSelfRun, tour.Mode)
+	})
+
+	t.Run("nil tournament is a no-op", func(t *testing.T) {
+		// Must not panic.
+		state.ApplyTournamentDefaults(nil)
+	})
+
+	t.Run("idempotent: double apply keeps officiated", func(t *testing.T) {
+		tour := &state.Tournament{Name: "T", Password: "p"}
+		state.ApplyTournamentDefaults(tour)
+		state.ApplyTournamentDefaults(tour)
+		assert.Equal(t, state.TournamentModeOfficiated, tour.Mode)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// §5 Locked mode + self-run
+// ---------------------------------------------------------------------------
+
+// In locked mode the elevated gate is always active (GateActive==true);
+// destructive routes in self-run mode must still return 401/503.
+func TestSelfRun_LockedMode_DestructiveRoutes_StillRequireAdminPw(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+
+	// Build a bcrypt verifier (locked mode).
+	hashBytes, err := bcrypt.GenerateFromPassword([]byte("main-pw"), bcrypt.MinCost)
+	require.NoError(t, err)
+	lockedV, err := NewBcryptVerifier(string(hashBytes))
+	require.NoError(t, err)
+
+	// Seed a self-run tournament with empty on-disk Password (locked mode).
+	err = store.SaveTournament(&state.Tournament{
+		Name:     "LockedSelfRun",
+		Date:     "01-06-2026",
+		Venue:    "Dojo",
+		Courts:   []string{"A"},
+		Password: "", // irrelevant in locked mode
+		// No AdminPassword on disk — locked mode reads from env var only.
+		Mode: state.TournamentModeSelfRun,
+	})
+	require.NoError(t, err)
+
+	r := setupSelfRunRouter(t, store, lockedV)
+
+	// Destructive route without admin header → 503 (lockedUnconfigured elevated
+	// verifier: GateActive==true, Configured==false → 503).
+	req := httptest.NewRequest(http.MethodDelete, "/api/competitions/any-id", nil)
+	// Main password provided (required by locked verifier even in self-run? —
+	// no: self-run skips the main gate, so we send nothing).
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	// 401 (admin pw required but not provided) or 503 (no hash configured).
+	// Either is acceptable — both mean "destructive gate is active."
+	assert.True(t, w.Code == http.StatusUnauthorized || w.Code == http.StatusServiceUnavailable,
+		"locked+self-run destructive route must return 401 or 503, got %d: %s", w.Code, w.Body.String())
+
+	// Constructive route without any header must NOT be 401 in self-run
+	// (main gate is skipped).
+	req2 := httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	assert.NotEqual(t, http.StatusUnauthorized, w2.Code,
+		"locked+self-run constructive route must be public (not 401)")
+}
+
+// ---------------------------------------------------------------------------
+// §6 POST mode validation
+// ---------------------------------------------------------------------------
+
+// POST with invalid mode must return 400.
+func TestSelfRun_POST_InvalidMode_Rejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	body := map[string]interface{}{
+		"name":     "T",
+		"date":     "01-06-2026",
+		"venue":    "V",
+		"courts":   []string{"A"},
+		"password": "pw",
+		"mode":     "peer-operated", // invalid
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"POST with invalid mode must return 400")
+}
+
+// POST with no mode → defaults to officiated.
+func TestSelfRun_POST_NoMode_DefaultsToOfficiated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := newTempStore(t)
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	body := map[string]interface{}{
+		"name":     "T",
+		"date":     "01-06-2026",
+		"venue":    "V",
+		"courts":   []string{"A"},
+		"password": "pw",
+		// no mode field
+	}
+	req := jsonReq(http.MethodPost, "/api/tournament", body)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "POST without mode must succeed: %s", w.Body.String())
+
+	t2, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, t2)
+	assert.Equal(t, state.TournamentModeOfficiated, t2.Mode,
+		"missing mode must default to officiated")
+}

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -168,6 +168,42 @@ func TestSelfRun_SelfRunMode_ConstructiveRoutesArePublic(t *testing.T) {
 	}
 }
 
+// PUT /api/tournament is a tournament-configuration mutation (password, courts,
+// check-in windows). In self-run mode the operational pass-through does NOT
+// apply to it — the main gate fires normally so anonymous callers cannot
+// tamper with tournament setup. The SPA always sends X-Tournament-Password
+// on PUT /api/tournament even in self-run mode, so this is transparent.
+func TestSelfRun_SelfRunMode_PUTTournament_RequiresMainPassword(t *testing.T) {
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	putBody := map[string]any{
+		"name":   "SelfRun Test",
+		"date":   "01-06-2026",
+		"venue":  "Dojo",
+		"courts": []string{"A"},
+	}
+
+	t.Run("no_pw_returns_401", func(t *testing.T) {
+		req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+		// No X-Tournament-Password — must be rejected (configuration mutation).
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"PUT /api/tournament must return 401 without main password even in self-run mode")
+	})
+
+	t.Run("correct_pw_succeeds", func(t *testing.T) {
+		req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+		req.Header.Set("X-Tournament-Password", "main-pw")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code,
+			"PUT /api/tournament must succeed with correct main password in self-run mode")
+	})
+}
+
 // Destructive routes still require X-Admin-Password in self-run mode.
 // The main gate is skipped but RequireElevatedPassword still fires.
 func TestSelfRun_SelfRunMode_DestructiveRoutes_Require_AdminPassword(t *testing.T) {
@@ -677,10 +713,12 @@ func TestSelfRun_LockedMode_PUTEdit_NotRejectedByFailOpenGuard(t *testing.T) {
 
 	r := setupSelfRunRouter(t, store, lockedV)
 
-	// PUT editing the venue. Self-run skips the main gate, so no header is
-	// needed; password rotation is omitted (disabled in locked mode); mode is
-	// omitted (preserved). This must NOT be rejected by the file-mode-only
-	// fail-open guard.
+	// PUT editing the venue. Tournament-configuration routes (PUT /api/tournament)
+	// require the main password even in self-run mode (mp-7h7: only operational
+	// scoring/check-in routes bypass the main gate). In locked mode the bcrypt
+	// verifier requires the env-var password. Password rotation is omitted
+	// (disabled in locked mode); mode is omitted (preserved). This must NOT be
+	// rejected by the file-mode-only fail-open guard.
 	putBody := map[string]any{
 		"name":   "LockedSelfRun",
 		"date":   "01-06-2026",
@@ -688,6 +726,7 @@ func TestSelfRun_LockedMode_PUTEdit_NotRejectedByFailOpenGuard(t *testing.T) {
 		"courts": []string{"A"},
 	}
 	req := jsonReq(http.MethodPut, "/api/tournament", putBody)
+	req.Header.Set("X-Tournament-Password", "main-pw") // required: PUT /tournament is always main-gated
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code,

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -463,8 +463,13 @@ func TestSelfRun_FailOpenGuard_CreationWithExistingAdminPw_Allowed(t *testing.T)
 
 	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
 
-	// Re-POST (bootstrap) with self-run but no admin password in the body —
-	// the preserve step in the handler copies existingForPost.AdminPassword.
+	// Re-POST (re-bootstrap) with mode:"self-run" in body, but no adminPassword
+	// in the body. The fail-open guard passes because the handler's preserve step
+	// copies existingForPost.AdminPassword from the prior record.
+	// NOTE: Mode is immutable — the preserve step also copies existingForPost.Mode
+	// (empty → "officiated"), so the stored record remains officiated regardless
+	// of what mode the body requests. This test exercises the fail-open path, not
+	// self-run creation; for first-create self-run see TestSelfRun_Immutability_POSTPreservesMode.
 	body := map[string]any{
 		"name":     "Self-Run Tournament",
 		"date":     "01-06-2026",
@@ -472,15 +477,23 @@ func TestSelfRun_FailOpenGuard_CreationWithExistingAdminPw_Allowed(t *testing.T)
 		"courts":   []string{"A"},
 		"password": "main-pw",
 		"mode":     "self-run",
-		// AdminPassword omitted from body (json:"-"); preserve step picks it up.
+		// adminPassword omitted from body (json:"-"); preserve step picks it up.
 	}
 	req := jsonReq(http.MethodPost, "/api/tournament", body)
-	req.Header.Set("X-Tournament-Password", "old-pw") // locked bootstrap test
+	req.Header.Set("X-Tournament-Password", "old-pw")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	// Should succeed (201) because the existing record has an admin password.
 	assert.Equal(t, http.StatusCreated, w.Code,
-		"self-run creation must succeed when admin pw exists in previous record")
+		"re-bootstrap must succeed when existing record has admin pw")
+
+	// The stored mode must be "officiated" — mode immutability preserves the
+	// existing record's mode (empty → officiated) and ignores the body's "self-run".
+	loaded, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, state.TournamentModeOfficiated, loaded.Mode,
+		"re-bootstrap must preserve existing mode (officiated), not adopt body mode")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -69,12 +69,43 @@ type Tournament struct {
 	// after the window closes.
 	CheckInWindowStart string `yaml:"check_in_window_start,omitempty" json:"checkInWindowStart,omitempty"`
 	CheckInWindowEnd   string `yaml:"check_in_window_end,omitempty" json:"checkInWindowEnd,omitempty"`
+
+	// Mode selects the auth posture for the whole tournament, chosen at
+	// creation and IMMUTABLE thereafter (mp-7h7). "officiated" (default)
+	// gates the full admin surface behind X-Tournament-Password.
+	// "self-run" inverts the boundary: constructive actions (scoring,
+	// check-in, start/complete) are public; only destructive actions
+	// (those already gated by RequireElevatedPassword / enforceElevated)
+	// still require X-Admin-Password. omitempty means older tournament.md
+	// files (Mode == "") normalise to "officiated" via ApplyTournamentDefaults.
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
+}
+
+// Tournament mode constants (mp-7h7).
+const (
+	TournamentModeOfficiated = "officiated" // default: main-gate on all admin routes
+	TournamentModeSelfRun    = "self-run"   // main-gate skipped; elevated gate stays
+)
+
+// ValidateTournamentMode reports whether the given mode value is acceptable.
+// Empty string is treated as "officiated" (backward compatibility). Only
+// the two defined constants are accepted; any other value returns an error.
+func ValidateTournamentMode(mode string) error {
+	switch mode {
+	case "", TournamentModeOfficiated, TournamentModeSelfRun:
+		return nil
+	default:
+		return fmt.Errorf("unknown tournament mode %q (expected %q or %q)",
+			mode, TournamentModeOfficiated, TournamentModeSelfRun)
+	}
 }
 
 // ApplyTournamentDefaults fills zero-valued schedule-estimator tuning
 // fields on t with their canonical defaults: ClockToElapsedMultiplier=1.5,
 // SlowestCourtBufferPct=10, and DurationDays=1. Idempotent; safe to call
 // repeatedly.
+// Also normalizes empty Mode to TournamentModeOfficiated so that
+// tournament.md files predating mp-7h7 behave as officiated tournaments.
 // FR-055, FR-057, R9.
 func ApplyTournamentDefaults(t *Tournament) {
 	if t == nil {
@@ -88,6 +119,9 @@ func ApplyTournamentDefaults(t *Tournament) {
 	}
 	if t.DurationDays == 0 {
 		t.DurationDays = 1
+	}
+	if t.Mode == "" {
+		t.Mode = TournamentModeOfficiated
 	}
 }
 

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -61,21 +61,24 @@ func (s *Store) LoadTournament() (*Tournament, error) {
 
 	var t Tournament
 	if err := parseFrontMatter(data, &t); err != nil {
-		// If it's not a front-matter file, return a default tournament
+		// If it's not a front-matter file, return a default tournament with
+		// well-known field values. ApplyTournamentDefaults below will
+		// normalise any remaining zero-valued fields (Mode, schedule tuning).
 		t = Tournament{
-			Name:         "New Tournament",
-			Date:         time.Now().Format("02-01-2006"),
-			Venue:        "Venue TBA",
-			DurationDays: 1,
+			Name:  "New Tournament",
+			Date:  time.Now().Format("02-01-2006"),
+			Venue: "Venue TBA",
 		}
-	} else {
-		// Apply canonical defaults so that tournament.md files predating
-		// any of these fields (DurationDays, ClockToElapsedMultiplier,
-		// SlowestCourtBufferPct, Mode) always return populated values.
-		// ApplyTournamentDefaults is idempotent so calling it here is safe
-		// even when the file already has explicit values for all fields.
-		ApplyTournamentDefaults(&t)
 	}
+	// Apply canonical defaults for both the successful-parse and fallback
+	// branches so the returned tournament is always fully normalised:
+	// Mode="officiated", DurationDays=1, ClockToElapsedMultiplier=1.5,
+	// SlowestCourtBufferPct=10. ApplyTournamentDefaults is idempotent and
+	// safe to call even when the fields already carry explicit values.
+	// Fix 3332701952: previously only the successful-parse branch called
+	// this, leaving the fallback tournament with Mode=="" and zero schedule
+	// fields that would omit mode from JSON responses.
+	ApplyTournamentDefaults(&t)
 
 	s.cachedTourn = &t
 	s.tournMtime = mtime

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -80,6 +80,15 @@ func (s *Store) LoadTournament() (*Tournament, error) {
 	// fields that would omit mode from JSON responses.
 	ApplyTournamentDefaults(&t)
 
+	// Normalize any unknown/invalid Mode value that may have been written to
+	// tournament.md outside the API (e.g. a manual edit). ApplyTournamentDefaults
+	// handles the empty-string case (→ "officiated"); this guard handles non-empty
+	// but unsupported values. Fix 3332772433: prevents unknown strings from leaking
+	// into JSON responses and violating the enum contract.
+	if t.Mode != TournamentModeOfficiated && t.Mode != TournamentModeSelfRun {
+		t.Mode = TournamentModeOfficiated
+	}
+
 	s.cachedTourn = &t
 	s.tournMtime = mtime
 

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -68,11 +68,13 @@ func (s *Store) LoadTournament() (*Tournament, error) {
 			Venue:        "Venue TBA",
 			DurationDays: 1,
 		}
-	} else if t.DurationDays == 0 {
-		// Migrate existing single-day tournament.md files that predate the
-		// DurationDays field: with no duration_days key, the field
-		// deserializes to its zero value (0), which we treat as 1.
-		t.DurationDays = 1
+	} else {
+		// Apply canonical defaults so that tournament.md files predating
+		// any of these fields (DurationDays, ClockToElapsedMultiplier,
+		// SlowestCourtBufferPct, Mode) always return populated values.
+		// ApplyTournamentDefaults is idempotent so calling it here is safe
+		// even when the file already has explicit values for all fields.
+		ApplyTournamentDefaults(&t)
 	}
 
 	s.cachedTourn = &t

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2096,10 +2096,10 @@ components:
             - **self-run**: there is no dedicated table operator. Operational actions
               (scoring, check-in, start, complete, swiss round generation) are public — no
               password required. Organiser-setup mutations (tournament/competition config,
-              seeds, overrides, announcements, schedule, court assignment) remain behind the
-              main password. Destructive actions (delete competition, draw, overrides, import,
-              participant roster mutations) require the separate `X-Admin-Password` elevated
-              credential.
+              seeds, override edits (set/change result), announcements, schedule, court
+              assignment, export) remain behind the main password. Destructive actions
+              (delete competition, discard draw, delete/discard overrides, import, participant
+              roster mutations) require the separate `X-Admin-Password` elevated credential.
 
             Always returned in GET/POST/PUT responses regardless of auth mode (unlike
             `password`, which is redacted in locked mode). Defaults to `officiated` when

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2083,6 +2083,41 @@ components:
         slowestCourtBufferPct:
           type: integer
           description: Buffer percentage applied to the slowest court when estimating overall duration.
+        mode:
+          type: string
+          enum: [officiated, self-run]
+          description: >
+            Tournament auth posture. Chosen once at creation and **immutable** thereafter
+            (mp-7h7) — PUT /tournament rejects a mode change with 400.
+
+            - **officiated** (default): the full admin surface requires `X-Tournament-Password`.
+              Constructive actions (scoring, check-in, start) and organiser-setup mutations
+              all require the main password.
+            - **self-run**: there is no dedicated table operator. Operational actions
+              (scoring, check-in, start, complete, swiss round generation) are public — no
+              password required. Organiser-setup mutations (tournament/competition config,
+              seeds, overrides, announcements, schedule, court assignment) remain behind the
+              main password. Destructive actions (delete competition, draw, overrides, import,
+              participant roster mutations) require the separate `X-Admin-Password` elevated
+              credential.
+
+            Omitted from the response in locked mode (same redaction rule as `password`).
+            Defaults to `officiated` when omitted on POST (backward-compatible with
+            pre-mp-7h7 tournaments whose `tournament.md` lacks the field).
+        adminPassword:
+          type: string
+          maxLength: 256
+          description: >
+            **Creation-only, file mode, self-run tournaments only.** Sets the elevated
+            (destructive-ops) credential atomically in the same POST that creates the
+            tournament. Required when `mode` is `"self-run"` in file mode — without it the
+            main gate is skipped and destructive routes would be unauthenticated.
+
+            This field is **write-only at the API boundary**: it is never returned in any
+            response (`json:"-"` on the server struct) and is ignored by PUT /tournament
+            (rotation is done via `PUT /api/auth/admin-password`). In locked mode this
+            field is accepted but silently ignored — the `TOURNAMENT_ADMIN_PASSWORD_HASH`
+            env var is the authoritative elevated credential.
 
     Competition:
       type: object

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2101,11 +2101,13 @@ components:
               participant roster mutations) require the separate `X-Admin-Password` elevated
               credential.
 
-            Omitted from the response in locked mode (same redaction rule as `password`).
-            Defaults to `officiated` when omitted on POST (backward-compatible with
-            pre-mp-7h7 tournaments whose `tournament.md` lacks the field).
+            Always returned in GET/POST/PUT responses regardless of auth mode (unlike
+            `password`, which is redacted in locked mode). Defaults to `officiated` when
+            omitted on POST (backward-compatible with pre-mp-7h7 tournaments whose
+            `tournament.md` lacks the field).
         adminPassword:
           type: string
+          writeOnly: true
           maxLength: 256
           description: >
             **Creation-only, file mode, self-run tournaments only.** Sets the elevated

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -104,6 +104,9 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [courts, setCourts] = useStateA(tournament.courts.length);
   const [checkInStart, setCheckInStart] = useStateA(tournament.checkInWindowStart || "");
   const [checkInEnd, setCheckInEnd] = useStateA(tournament.checkInWindowEnd || "");
+  // Tournament mode (mp-7h7): read-only after creation — shown for
+  // information only and NEVER included in the PUT payload.
+  const tournamentMode = tournament.mode || "officiated";
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
 
@@ -226,6 +229,20 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               onChange={(e) => { setCourts(decideNumericUpdate(e.target.value, 1).value); setError(""); }}
             />
             <div className="field__hint">{`Enter a number (1-${MAX_COURTS}). Courts will be automatically labeled A, B, C, etc.`}</div>
+          </div>
+          {/* Tournament type (mp-7h7): read-only after creation. Displayed
+              for information — it affects the auth boundary (officiated:
+              main password gates everything; self-run: only destructive
+              actions require a password). Never submitted on PUT. */}
+          <div className="field" style={{ marginTop: 16 }}>
+            <label className="field__label">Tournament type</label>
+            <div className="field__hint" style={{ marginTop: 4 }}>
+              <strong>{tournamentMode === "self-run" ? "Self-run" : "Officiated"}</strong>
+              {tournamentMode === "self-run"
+                ? " — Scoring, check-in and other constructive actions are public. Only destructive actions (delete, import, roster changes) require the destructive-ops password."
+                : " — All admin actions require the tournament password."}
+              {" "}This setting was fixed at creation and cannot be changed.
+            </div>
           </div>
           <div className="row" style={{ marginTop: 16 }}>
             <div className="field">

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1152,11 +1152,13 @@ function CreateTournament({ onCreated, authConfig }) {
               required
             />
             <div className="field__hint">
-              {locked
-                ? "This server is running in locked mode. Enter the password whose bcrypt hash is in TOURNAMENT_PASSWORD_HASH — it's used both to authorize this bootstrap and as your admin credential afterwards."
-                : isSelfRun
-                  ? "Used to authorise tournament setup. In self-run mode, scoring and check-in are public so participants don't need this."
-                  : "This password will be required to manage the tournament."}
+              {locked && isSelfRun
+                ? "This server is in locked mode. Enter the password whose bcrypt hash is in TOURNAMENT_PASSWORD_HASH — it authorises this bootstrap and organiser-setup mutations. Destructive actions (delete competition, discard draw, import) require the separate TOURNAMENT_ADMIN_PASSWORD_HASH credential."
+                : locked
+                  ? "This server is running in locked mode. Enter the password whose bcrypt hash is in TOURNAMENT_PASSWORD_HASH — it's used both to authorize this bootstrap and as your admin credential afterwards."
+                  : isSelfRun
+                    ? "Used to authorise tournament setup. In self-run mode, scoring and check-in are public so participants don't need this."
+                    : "This password will be required to manage the tournament."}
             </div>
           </div>
           {/* In self-run + file mode, require a destructive-ops password at

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -970,6 +970,15 @@ function CreateTournament({ onCreated, authConfig }) {
   const [venue, setVenue] = useS("");
   const [courts, setCourts] = useS(2);
   const [pass, setPass] = useS("");
+  // Tournament mode (mp-7h7): "officiated" (default) or "self-run".
+  // Chosen once at creation; read-only after that. Default officiated
+  // means existing deployments are unaffected.
+  const [mode, setMode] = useS("officiated");
+  // Destructive-ops (admin) password — required when creating a
+  // self-run tournament in file mode: the main auth gate is skipped in
+  // self-run, so destructive actions must fall back to this credential.
+  // Not shown in locked mode (the env-var hash is the credential).
+  const [adminPass, setAdminPass] = useS("");
   const [saving, setSaving] = useS(false);
   // submit's catch sets setSaving(false) post-await; on success the
   // parent calls onCreated which unmounts CreateTournament. The catch
@@ -978,6 +987,8 @@ function CreateTournament({ onCreated, authConfig }) {
   // fetch). Gate via mountedRef for symmetry with the admin sweep.
   const mountedRef = useR(true);
   useE(() => () => { mountedRef.current = false; }, []);
+
+  const isSelfRun = mode === "self-run";
 
   const submit = async (e) => {
     e.preventDefault();
@@ -990,6 +1001,14 @@ function CreateTournament({ onCreated, authConfig }) {
     const trimmedVenue = venue.trim();
     if (!trimmedName || !pass) {
       alert("Name and Password are required.");
+      return;
+    }
+    // Self-run in file mode requires a destructive-ops (admin) password
+    // so that destructive routes (delete, invalidate, etc.) are not
+    // left fully public. The backend enforces the same rule — this is
+    // client-side feedback only.
+    if (isSelfRun && !locked && !adminPass) {
+      alert("Self-run tournaments require a Destructive-ops password to protect delete and reset actions.");
       return;
     }
     // Match the admin-side handleSave guard from admin_setup.jsx.
@@ -1011,7 +1030,8 @@ function CreateTournament({ onCreated, authConfig }) {
       const config = {
         name: trimmedName, date, venue: trimmedVenue,
         password: pass,
-        courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i))
+        courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i)),
+        mode,
       };
       // In locked mode, the typed password IS the env-var admin
       // credential — pass it as authPassword so api_client sends
@@ -1020,6 +1040,18 @@ function CreateTournament({ onCreated, authConfig }) {
       // lets it through unauthenticated).
       const t = await window.API.createTournament(config, locked ? pass : undefined);
       if (!mountedRef.current) return;
+      // For self-run in file mode, set the admin (destructive-ops) password
+      // immediately after creating the tournament, using the main password
+      // for authentication (the tournament was just created, so the main
+      // password is the one we just set).
+      if (isSelfRun && !locked && adminPass) {
+        try {
+          await window.API.setAdminPassword(adminPass, "", pass);
+        } catch (adminErr) {
+          // Non-fatal: tournament is created; operator can set admin pw in Settings.
+          console.warn("Created self-run tournament but failed to set admin password:", adminErr.message);
+        }
+      }
       // Wait for backend to broadcast or just pass it up
       onCreated(t, pass);
     } catch (err) {
@@ -1067,6 +1099,34 @@ function CreateTournament({ onCreated, authConfig }) {
             />
             <div className="field__hint">{`Enter a number (1-${window.MAX_COURTS}). Courts will be automatically labeled A, B, C, etc.`}</div>
           </div>
+          {/* Tournament mode selector (mp-7h7). Chosen once at creation;
+              immutable after that. Default is officiated (existing behaviour). */}
+          <div className="field">
+            <label className="field__label">Tournament type</label>
+            <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                className={`btn${mode === "officiated" ? " btn--primary" : ""}`}
+                onClick={() => setMode("officiated")}
+                style={{ flex: 1 }}
+              >
+                Officiated
+              </button>
+              <button
+                type="button"
+                className={`btn${mode === "self-run" ? " btn--primary" : ""}`}
+                onClick={() => setMode("self-run")}
+                style={{ flex: 1 }}
+              >
+                Self-run
+              </button>
+            </div>
+            <div className="field__hint" style={{ marginTop: 6 }}>
+              {mode === "officiated"
+                ? "An operator manages scoring and bracket progression. All admin actions require the tournament password. This is the standard setup."
+                : "No dedicated operator. Participants self-report scores; all constructive actions (scoring, check-in, registration) are public. Destructive actions (delete, reset, import) still require a separate admin password. Cannot be changed after creation."}
+            </div>
+          </div>
           <div className="field">
             <label className="field__label">{locked ? "Admin Password (from TOURNAMENT_PASSWORD_HASH)" : "Admin Password"}</label>
             <input
@@ -1080,9 +1140,30 @@ function CreateTournament({ onCreated, authConfig }) {
             <div className="field__hint">
               {locked
                 ? "This server is running in locked mode. Enter the password whose bcrypt hash is in TOURNAMENT_PASSWORD_HASH — it's used both to authorize this bootstrap and as your admin credential afterwards."
-                : "This password will be required to manage the tournament."}
+                : isSelfRun
+                  ? "Used to authorise tournament setup. In self-run mode, scoring and check-in are public so participants don't need this."
+                  : "This password will be required to manage the tournament."}
             </div>
           </div>
+          {/* In self-run + file mode, require a destructive-ops password at
+              creation so delete/invalidate/import can't be called anonymously.
+              Locked mode uses TOURNAMENT_ADMIN_PASSWORD_HASH (no UI input). */}
+          {isSelfRun && !locked && (
+            <div className="field">
+              <label className="field__label">Destructive-ops password (required for self-run)</label>
+              <input
+                className="input"
+                type="password"
+                value={adminPass}
+                onChange={(e) => setAdminPass(e.target.value)}
+                placeholder="Password to protect delete / reset / import actions"
+                required
+              />
+              <div className="field__hint">
+                A separate password required for destructive actions (delete competition, discard draw, roster add/edit, import). Since this tournament is self-run, scoring is public — this password is the only thing protecting irreversible actions.
+              </div>
+            </div>
+          )}
           {/* Disable submit until authConfig is known (null = loading) so a
               locked-mode deployment doesn't submit without X-Tournament-Password.
               The null window lasts at most one HTTP round-trip on startup. */}

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1117,10 +1117,11 @@ function CreateTournament({ onCreated, authConfig }) {
               immutable after that. Default is officiated (existing behaviour). */}
           <div className="field">
             <label className="field__label">Tournament type</label>
-            <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+            <div role="group" aria-label="Tournament type" style={{ display: "flex", gap: 8, marginTop: 4 }}>
               <button
                 type="button"
                 className={`btn${mode === "officiated" ? " btn--primary" : ""}`}
+                aria-pressed={mode === "officiated"}
                 onClick={() => setMode("officiated")}
                 style={{ flex: 1 }}
               >
@@ -1129,6 +1130,7 @@ function CreateTournament({ onCreated, authConfig }) {
               <button
                 type="button"
                 className={`btn${mode === "self-run" ? " btn--primary" : ""}`}
+                aria-pressed={mode === "self-run"}
                 onClick={() => setMode("self-run")}
                 style={{ flex: 1 }}
               >

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1033,6 +1033,16 @@ function CreateTournament({ onCreated, authConfig }) {
         courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i)),
         mode,
       };
+      // Self-run in file mode: send the destructive-ops password as a
+      // transient `adminPassword` field on the SAME POST. The server reads
+      // it via a second body bind (Tournament.AdminPassword is json:"-" so
+      // it can't be bound directly) and persists it atomically with the
+      // tournament — so the self-run fail-open guard never sees a self-run
+      // tournament without an admin credential. In locked mode the server
+      // ignores this field (the env-var bcrypt hash is authoritative).
+      if (isSelfRun && !locked && adminPass) {
+        config.adminPassword = adminPass;
+      }
       // In locked mode, the typed password IS the env-var admin
       // credential — pass it as authPassword so api_client sends
       // X-Tournament-Password. In file mode authPassword is undefined
@@ -1040,18 +1050,6 @@ function CreateTournament({ onCreated, authConfig }) {
       // lets it through unauthenticated).
       const t = await window.API.createTournament(config, locked ? pass : undefined);
       if (!mountedRef.current) return;
-      // For self-run in file mode, set the admin (destructive-ops) password
-      // immediately after creating the tournament, using the main password
-      // for authentication (the tournament was just created, so the main
-      // password is the one we just set).
-      if (isSelfRun && !locked && adminPass) {
-        try {
-          await window.API.setAdminPassword(adminPass, "", pass);
-        } catch (adminErr) {
-          // Non-fatal: tournament is created; operator can set admin pw in Settings.
-          console.warn("Created self-run tournament but failed to set admin password:", adminErr.message);
-        }
-      }
       // Wait for backend to broadcast or just pass it up
       onCreated(t, pass);
     } catch (err) {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1138,7 +1138,7 @@ function CreateTournament({ onCreated, authConfig }) {
             <div className="field__hint" style={{ marginTop: 6 }}>
               {mode === "officiated"
                 ? "An operator manages scoring and bracket progression. All admin actions require the tournament password. This is the standard setup."
-                : "No dedicated operator. Participants self-report scores; all constructive actions (scoring, check-in, registration) are public. Destructive actions (delete, reset, import) still require a separate admin password. Cannot be changed after creation."}
+                : "No dedicated operator. Participants self-report scores; all constructive actions (scoring, check-in) are public. Destructive actions (delete, reset, import) still require a separate admin password. Cannot be changed after creation."}
             </div>
           </div>
           <div className="field">

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1050,7 +1050,23 @@ function CreateTournament({ onCreated, authConfig }) {
       // lets it through unauthenticated).
       const t = await window.API.createTournament(config, locked ? pass : undefined);
       if (!mountedRef.current) return;
-      // Wait for backend to broadcast or just pass it up
+      // Refresh the elevated-password auth config so promptAdminPassword()
+      // reads the correct gate state before the admin view mounts (mp-7h7).
+      // For a self-run tournament the admin password is set atomically in the
+      // same POST, so the /api/auth-config response changes: elevatedRequired
+      // flips from false to true. Without this refresh, the stale cached value
+      // would cause promptAdminPassword() to return "" and destructive actions
+      // would 401 without ever prompting the operator.
+      try {
+        const freshCfg = await window.API.fetchAuthConfig();
+        if (mountedRef.current && freshCfg && typeof freshCfg === "object") {
+          setCachedAuthConfig(freshCfg);
+        }
+      } catch (_) {
+        // Non-fatal: the cache update is best-effort; the operator can still
+        // retry destructive actions which will re-prompt after a 401.
+      }
+      if (!mountedRef.current) return;
       onCreated(t, pass);
     } catch (err) {
       alert(err.message);

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1008,7 +1008,7 @@ function CreateTournament({ onCreated, authConfig }) {
     // left fully public. The backend enforces the same rule — this is
     // client-side feedback only.
     if (isSelfRun && !locked && !adminPass) {
-      alert("Self-run tournaments require a Destructive-ops password to protect delete and reset actions.");
+      alert("Self-run tournaments require a Destructive-ops password to protect delete and import actions.");
       return;
     }
     // Match the admin-side handleSave guard from admin_setup.jsx.
@@ -1138,7 +1138,7 @@ function CreateTournament({ onCreated, authConfig }) {
             <div className="field__hint" style={{ marginTop: 6 }}>
               {mode === "officiated"
                 ? "An operator manages scoring and bracket progression. All admin actions require the tournament password. This is the standard setup."
-                : "No dedicated operator. Participants self-report scores; all constructive actions (scoring, check-in) are public. Destructive actions (delete, reset, import) still require a separate admin password. Cannot be changed after creation."}
+                : "No dedicated operator. Participants self-report scores; all constructive actions (scoring, check-in) are public. Destructive actions (delete competition, discard draw, import roster) still require a separate admin password. Cannot be changed after creation."}
             </div>
           </div>
           <div className="field">
@@ -1170,7 +1170,7 @@ function CreateTournament({ onCreated, authConfig }) {
                 type="password"
                 value={adminPass}
                 onChange={(e) => setAdminPass(e.target.value)}
-                placeholder="Password to protect delete / reset / import actions"
+                placeholder="Password to protect delete / import actions"
                 required
               />
               <div className="field__hint">


### PR DESCRIPTION
## Summary

Adds a new **immutable** tournament `Mode` (`officiated` default / `self-run`) chosen once at creation, which inverts the auth boundary for the self-run case: constructive admin actions (scoring, check-in, start/complete, generate-draw) become public, while destructive actions remain gated. Closes the foundation work for **mp-7h7** (blocks mp-e5j, mp-ba3).

## Design (reuses the existing destructive-ops tier — no duplicated route list)

The critical insight from review: a destructive-ops auth tier **already exists** (spec 004 / mp-e21) via `RequireElevatedPassword` / `enforceElevated` / `ElevatedVerifier` (the `X-Admin-Password` credential). So self-run does **not** introduce a new `destructiveRoutes` allowlist (which would duplicate that set and drift). Instead:

- **Officiated** (default, unchanged): main-gate (`AuthMiddleware`, `X-Tournament-Password`) on all admin routes + elevated-gate on the destructive subset.
- **Self-run**: `AuthMiddleware` becomes a pass-through; the **existing** elevated decorators are the sole gate on destructive routes. Scoring/check-in (main-gated-only today) become public automatically.

The destructive set IS the elevated-decorator set: DELETE competition, invalidate, delete draw, delete overrides, participant add/edit, import. New constructive routes need no change (auto-public in self-run); new destructive routes just add the existing elevated decorator.

## Key safety property — no fail-open

`enforceElevated` passes through when no admin password is set (file mode, opt-in). In officiated mode that's safe (main gate already passed), but in self-run there is no main gate. So **self-run requires an admin (destructive-ops) password**, enforced atomically at creation: the POST accepts the password in the body and persists it together with the tournament — a self-run tournament is never written to disk in a fail-open state. The guard is correctly scoped to file mode (locked mode fails closed via the elevated gate's `GateActive()`).

## Changes

- `internal/state/models.go` — immutable `Mode` field, `TournamentModeOfficiated`/`TournamentModeSelfRun` consts, `ValidateTournamentMode`, `ApplyTournamentDefaults` normalizes empty→officiated (back-compat for pre-existing `tournament.md`).
- `internal/mobileapp/middleware.go` — self-run pass-through branch in `AuthMiddleware` (officiated path untouched → no regression).
- `internal/mobileapp/handlers_tournament.go` — POST accepts a creation-only `adminPassword` body field (via `ShouldBindBodyWith`, preserving the `json:"-"` write-only invariant on PUT) and sets it atomically; Mode immutability on PUT (switch → 400, omit → preserved); fail-open guard scoped to file mode on both POST and PUT.
- `web-mobile/js/app.jsx` — `CreateTournament` mode radio-pill (default officiated) with trade-off copy; collects + sends the destructive-ops password in the same POST for self-run.
- `web-mobile/js/admin_setup.jsx` — `AdminEditTournament` shows the mode **read-only** ("fixed at creation"), never submitted.
- `internal/mobileapp/middleware_selfrun_test.go` — full auth matrix, fail-open guard (incl. atomic body-field creation), immutability, locked-mode (incl. the PUT-edit regression), and validation/defaults units.

## Test plan

- [x] `make go/build` (esbuild + go build)
- [x] golangci-lint — 0 issues; gosec — 0 issues (108 files); govulncheck — code calls 0 vulns
- [x] `go test ./internal/...` — all pass, incl. all `TestSelfRun_*`
- [x] **In-browser, end-to-end (file mode):** created a self-run tournament through the SPA → `POST /api/tournament` **201** (`mode: self-run`, `adminPassword` correctly absent from response); admin edit view shows mode read-only with no editable control.
- [x] **Live auth matrix** on the UI-created tournament: constructive `GET /api/competitions` no pw → **200**; destructive `DELETE` no pw → **401**; wrong admin pw → **401**; correct `X-Admin-Password` → **204** (passes gate). On-disk `admin_password` persisted atomically.
- [x] No-regression: officiated admin routes still 401 without main pw / 200 with it (handler tests; officiated code path unchanged).

Note: pre-existing, unrelated failures — `cmd/TestDiagnoseFolderError_OwnerInfo` (env uid/gid) and `js/lint` (eslint not installed in this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
