### PR TITLE
feat(mp-ba3): self-reported match scores for self-run tournaments

### DIFF
--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -633,6 +633,9 @@ func (e *Engine) recordBracketMatchResult(compId string, matchId string, result 
 					bracket.Rounds[rIdx][mIdx].DecisionBy = result.DecisionBy
 					bracket.Rounds[rIdx][mIdx].DecisionReason = result.DecisionReason
 					bracket.Rounds[rIdx][mIdx].Encho = result.Encho
+					if result.ResultSource != "" {
+						bracket.Rounds[rIdx][mIdx].ResultSource = result.ResultSource
+					}
 					// nil = omitted (preserve stored data); non-nil [] = explicit clear.
 					if result.SubResults != nil {
 						bracket.Rounds[rIdx][mIdx].SubResults = result.SubResults

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -530,6 +530,37 @@ func TestRecordMatchResult_ConcurrentBracketScoresNotLost(t *testing.T) {
 	}
 }
 
+func TestRecordMatchResult_BracketResultSourcePropagated(t *testing.T) {
+	dir, err := os.MkdirTemp("", "engine-bracket-resultsource-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	eng := New(store)
+
+	compID := "rs-bracket"
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, Name: "RS Bracket"}))
+	require.NoError(t, store.SaveBracket(compID, &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{{ID: "SF1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled}},
+		},
+	}))
+
+	err = eng.RecordMatchResult(compID, "SF1", &state.MatchResult{
+		Winner:       "Alice",
+		IpponsA:      []string{"M", "K"},
+		Status:       state.MatchStatusCompleted,
+		ResultSource: "self-reported",
+	})
+	require.NoError(t, err)
+
+	stored, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	require.Len(t, stored.Rounds[0], 1)
+	assert.Equal(t, "self-reported", stored.Rounds[0][0].ResultSource)
+}
+
 // TestMaybeAutoCompletePools_ConcurrentInvalidateNotLost pins the
 // TOCTOU fix in engine.MaybeAutoCompletePools. Pre-atomic-primitive,
 // the LoadCompetition + status check + SaveCompetitionChanged

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -84,6 +84,9 @@ func (e *Engine) recordBracketMatchResultTx(tx state.StoreTx, compID, matchID st
 					bracket.Rounds[rIdx][mIdx].DecisionBy = result.DecisionBy
 					bracket.Rounds[rIdx][mIdx].DecisionReason = result.DecisionReason
 					bracket.Rounds[rIdx][mIdx].Encho = result.Encho
+					if result.ResultSource != "" {
+						bracket.Rounds[rIdx][mIdx].ResultSource = result.ResultSource
+					}
 					// nil = omitted (preserve stored data); non-nil [] = explicit clear.
 					if result.SubResults != nil {
 						bracket.Rounds[rIdx][mIdx].SubResults = result.SubResults

--- a/internal/mobileapp/concurrency_test.go
+++ b/internal/mobileapp/concurrency_test.go
@@ -78,7 +78,7 @@ func TestConcurrentScoresPreserveOrder(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	admin := r.Group("/api")
-	RegisterMatchHandlers(admin, eng, store, store, hub)
+	RegisterMatchHandlers(admin, eng, store, store, hub, NewFileVerifier(store), store)
 
 	// Goroutines all fire concurrently — each scores a different match
 	// so the per-comp lock is contended on every step (LoadCompetition

--- a/internal/mobileapp/deps.go
+++ b/internal/mobileapp/deps.go
@@ -46,11 +46,9 @@ type CompetitionStore interface {
 	// LoadCompetition returns the competition record, or (nil, nil) when
 	// no record exists for this ID. Mirrors state.Store.LoadCompetition.
 	LoadCompetition(id string) (*state.Competition, error)
-	// LoadPoolMatches returns the pool-match results for compID. Used by
-	// the score handler's finalized-result guard (mp-ba3).
+	// LoadPoolMatches returns the pool-match results for compID.
 	LoadPoolMatches(id string) ([]state.MatchResult, error)
-	// LoadBracket returns the elimination bracket for compID. Used by the
-	// score handler's finalized-result guard (mp-ba3).
+	// LoadBracket returns the elimination bracket for compID.
 	LoadBracket(id string) (*state.Bracket, error)
 }
 

--- a/internal/mobileapp/deps.go
+++ b/internal/mobileapp/deps.go
@@ -23,6 +23,14 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
+// TournamentLoader is the consumer-boundary view of state.Store used by
+// handlers that need to inspect the tournament-level configuration (e.g.
+// Mode) without taking a dependency on the full store. *state.Store
+// satisfies this interface by structural match.
+type TournamentLoader interface {
+	LoadTournament() (*state.Tournament, error)
+}
+
 // CompetitionStore is the consumer-boundary view of state.Store used by
 // handler families that need to read/write competition-level data
 // (config.md, pools, brackets, schedule). Methods are added here only as
@@ -38,6 +46,12 @@ type CompetitionStore interface {
 	// LoadCompetition returns the competition record, or (nil, nil) when
 	// no record exists for this ID. Mirrors state.Store.LoadCompetition.
 	LoadCompetition(id string) (*state.Competition, error)
+	// LoadPoolMatches returns the pool-match results for compID. Used by
+	// the score handler's finalized-result guard (mp-ba3).
+	LoadPoolMatches(id string) ([]state.MatchResult, error)
+	// LoadBracket returns the elimination bracket for compID. Used by the
+	// score handler's finalized-result guard (mp-ba3).
+	LoadBracket(id string) (*state.Bracket, error)
 }
 
 // ScoringEngine is the consumer-boundary view of engine.Engine used by

--- a/internal/mobileapp/deps_test.go
+++ b/internal/mobileapp/deps_test.go
@@ -19,6 +19,22 @@ func (stubCompetitionStore) LoadCompetition(string) (*state.Competition, error) 
 	return nil, nil
 }
 
+func (stubCompetitionStore) LoadPoolMatches(string) ([]state.MatchResult, error) {
+	return nil, nil
+}
+
+func (stubCompetitionStore) LoadBracket(string) (*state.Bracket, error) {
+	return nil, nil
+}
+
+// stubTournamentLoader is a no-op implementation of TournamentLoader. Same
+// rationale as stubCompetitionStore.
+type stubTournamentLoader struct{}
+
+func (stubTournamentLoader) LoadTournament() (*state.Tournament, error) {
+	return nil, nil
+}
+
 // stubScoringEngine is a no-op implementation of ScoringEngine. Same
 // rationale as stubCompetitionStore.
 type stubScoringEngine struct{}
@@ -142,6 +158,7 @@ func TestDepsInterfacesCompile(t *testing.T) {
 		_ Broadcaster           = stubBroadcaster{}
 		_ TeamLineupStore       = stubTeamLineupStore{}
 		_ CompetitionTransactor = stubCompetitionTransactor{}
+		_ TournamentLoader      = stubTournamentLoader{}
 	)
 
 	// Concrete types — proves the production types remain drop-in
@@ -159,5 +176,6 @@ func TestDepsInterfacesCompile(t *testing.T) {
 		// the lineup PUT migration uses. *state.Store satisfies it via
 		// the Slice 6 / T155 method.
 		_ CompetitionTransactor = (*state.Store)(nil)
+		_ TournamentLoader      = (*state.Store)(nil)
 	)
 }

--- a/internal/mobileapp/handlers_decision.go
+++ b/internal/mobileapp/handlers_decision.go
@@ -133,10 +133,9 @@ func RegisterDecisionHandlers(r *gin.RouterGroup, eng ScoringEngine, store Compe
 		)
 		txErr := tx.WithTransaction(id, func(stx state.StoreTx) error {
 			result, status, engErr = eng.RecordDecisionTx(stx, id, mid, req.Decision, req.DecisionBy, req.DecisionReason, req.Encho, req.Force)
-			// engine errors are normal failure modes (locked, ineligible,
-			// not-found, validation) — return nil here so the tx
-			// commits whatever partial writes K3-style rollback already
-			// landed; engErr is mapped to the right HTTP status below.
+			if result != nil && result.ResultSource == "" {
+				result.ResultSource = "admin"
+			}
 			return nil
 		})
 		if txErr != nil {

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -2,6 +2,7 @@ package mobileapp
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"sort"
@@ -494,9 +495,8 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 //
 // Called after ScoreRequest.Validate() so the request is structurally valid.
 //
-// In officiated mode (or when the tournament cannot be loaded), this is a
-// no-op that returns "admin", true — the auth middleware already gates those
-// endpoints, so setting the source is just provenance tracking.
+// In officiated mode this is a pass-through that returns "admin", true.
+// On LoadTournament error the function fails closed (500).
 func enforceSelfRunPolicy(c *gin.Context, tl TournamentLoader, verifier PasswordVerifier, store CompetitionStore, compID, matchID string, req *ScoreRequest) (string, bool) {
 	t, err := tl.LoadTournament()
 	if err != nil {
@@ -517,15 +517,25 @@ func enforceSelfRunPolicy(c *gin.Context, tl TournamentLoader, verifier Password
 		return "admin", true
 	}
 
-	// Anonymous caller in self-run mode: enforce decision allowlist.
+	// Anonymous caller in self-run mode: enforce decision allowlist on
+	// the top-level decision AND every sub-result decision.
 	if !IsSelfRunReportableDecision(req.Decision, req.DecidedByHantei) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "decision type not allowed in self-run mode without admin password"})
 		return "", false
 	}
+	for i := range req.SubResults {
+		sub := &req.SubResults[i]
+		if !IsSelfRunReportableSubDecision(sub.Decision, sub.DecidedByHantei, sub.Position) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("subResults[%d]: decision type not allowed in self-run mode without admin password", i)})
+			return "", false
+		}
+	}
 
-	// Finalized guard: if a result already exists and is finalized, block overwrites.
+	// Finalized guard: anonymous callers cannot write to a finalized match
+	// at all — any field change could alter the outcome through the
+	// engine's preserve-on-empty merge, so we reject unconditionally.
 	existing := loadExistingMatchResult(store, compID, matchID)
-	if existing != nil && isMatchFinalized(existing) && isChangingResult(existing, req) {
+	if existing != nil && isMatchFinalized(existing) {
 		c.JSON(http.StatusConflict, gin.H{
 			"error":   "result_finalized",
 			"message": "This match result has already been reported. Contact the tournament organizer to correct it.",
@@ -580,26 +590,6 @@ func bracketMatchToResult(bm *state.BracketMatch) *state.MatchResult {
 // winner has been recorded or the decision is hikiwake (a draw).
 func isMatchFinalized(r *state.MatchResult) bool {
 	return r.Status == state.MatchStatusCompleted && (r.Winner != "" || r.Decision == "hikiwake")
-}
-
-// isChangingResult reports whether the incoming score request would alter the
-// outcome of the existing finalized result. We check Winner, Decision,
-// IpponsA, IpponsB, and SubResults — the fields that constitute the match
-// outcome. Minor field changes (status update, scheduledAt) are allowed.
-func isChangingResult(existing *state.MatchResult, req *ScoreRequest) bool {
-	if req.Winner != "" && req.Winner != existing.Winner {
-		return true
-	}
-	if req.Decision != "" && req.Decision != existing.Decision {
-		return true
-	}
-	if len(req.IpponsA) > 0 || len(req.IpponsB) > 0 {
-		return true
-	}
-	if len(req.SubResults) > 0 {
-		return true
-	}
-	return false
 }
 
 // registerScoreHandler wires the `PUT /competitions/:id/matches/:mid/score`

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -230,7 +230,7 @@ func tryAutoCompletePools(c *gin.Context, eng ScoringEngine, hub Broadcaster, co
 // a time; the concrete `*engine.Engine` remains a drop-in
 // implementation of `ScoringEngine` so the `tryAutoCompletePools` and
 // score endpoint paths can already accept the interface today.
-func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store CompetitionStore, tx CompetitionTransactor, hub *Hub) {
+func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store CompetitionStore, tx CompetitionTransactor, hub *Hub, verifier PasswordVerifier, tl TournamentLoader) {
 	r.POST("/competitions/:id/matches/bulk-score", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
@@ -378,7 +378,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 	// behaviour as before. T156 added the CompetitionTransactor `tx`
 	// parameter so the match-write + ineligibility-write + lineup-freeze
 	// commit under one per-comp lock acquire.
-	registerScoreHandler(r, eng, store, tx, hub)
+	registerScoreHandler(r, eng, store, tx, hub, verifier, tl)
 
 	r.PUT("/competitions/:id/matches/:mid/court", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
@@ -486,6 +486,122 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 	})
 }
 
+// enforceSelfRunPolicy applies the self-run decision allowlist and
+// finalized-result guard when the tournament is in self-run mode and the
+// request carries no valid admin password. Returns the resultSource string
+// ("admin" or "self-reported") and true on success; writes the HTTP error
+// response and returns "", false when the request should be rejected.
+//
+// Called after ScoreRequest.Validate() so the request is structurally valid.
+//
+// In officiated mode (or when the tournament cannot be loaded), this is a
+// no-op that returns "admin", true — the auth middleware already gates those
+// endpoints, so setting the source is just provenance tracking.
+func enforceSelfRunPolicy(c *gin.Context, tl TournamentLoader, verifier PasswordVerifier, store CompetitionStore, compID, matchID string, req *ScoreRequest) (string, bool) {
+	t, err := tl.LoadTournament()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load tournament config"})
+		return "", false
+	}
+	if t == nil || t.Mode != "self-run" {
+		return "admin", true
+	}
+
+	// Self-run mode: check whether the caller has a valid admin password.
+	ok, verr := verifier.Verify(c.GetHeader("X-Tournament-Password"))
+	if verr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "auth verification failed"})
+		return "", false
+	}
+	if ok {
+		return "admin", true
+	}
+
+	// Anonymous caller in self-run mode: enforce decision allowlist.
+	if !IsSelfRunReportableDecision(req.Decision, req.DecidedByHantei) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "decision type not allowed in self-run mode without admin password"})
+		return "", false
+	}
+
+	// Finalized guard: if a result already exists and is finalized, block overwrites.
+	existing := loadExistingMatchResult(store, compID, matchID)
+	if existing != nil && isMatchFinalized(existing) && isChangingResult(existing, req) {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":   "result_finalized",
+			"message": "This match result has already been reported. Contact the tournament organizer to correct it.",
+		})
+		return "", false
+	}
+
+	return "self-reported", true
+}
+
+// loadExistingMatchResult looks up a match result by ID from pool matches or
+// the bracket. Returns nil when not found or on any load error (fail-open:
+// a load error should not block a legitimate score submission).
+func loadExistingMatchResult(store CompetitionStore, compID, matchID string) *state.MatchResult {
+	poolMatches, err := store.LoadPoolMatches(compID)
+	if err == nil {
+		for i := range poolMatches {
+			if poolMatches[i].ID == matchID {
+				m := poolMatches[i]
+				return &m
+			}
+		}
+	}
+	bracket, err := store.LoadBracket(compID)
+	if err == nil && bracket != nil {
+		for _, round := range bracket.Rounds {
+			for i := range round {
+				if round[i].ID == matchID {
+					bm := round[i]
+					return bracketMatchToResult(&bm)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// bracketMatchToResult projects the fields of a BracketMatch that the
+// finalized guard cares about into a MatchResult so the guard can use a
+// uniform type.
+func bracketMatchToResult(bm *state.BracketMatch) *state.MatchResult {
+	return &state.MatchResult{
+		ID:       bm.ID,
+		Winner:   bm.Winner,
+		Decision: bm.Decision,
+		Status:   bm.Status,
+	}
+}
+
+// isMatchFinalized reports whether the given result represents a concluded
+// match. A result is finalized when its status is "completed" AND either a
+// winner has been recorded or the decision is hikiwake (a draw).
+func isMatchFinalized(r *state.MatchResult) bool {
+	return r.Status == state.MatchStatusCompleted && (r.Winner != "" || r.Decision == "hikiwake")
+}
+
+// isChangingResult reports whether the incoming score request would alter the
+// outcome of the existing finalized result. We check Winner, Decision,
+// IpponsA, IpponsB, and SubResults — the fields that constitute the match
+// outcome. Minor field changes (status update, scheduledAt) are allowed.
+func isChangingResult(existing *state.MatchResult, req *ScoreRequest) bool {
+	if req.Winner != "" && req.Winner != existing.Winner {
+		return true
+	}
+	if req.Decision != "" && req.Decision != existing.Decision {
+		return true
+	}
+	if len(req.IpponsA) > 0 || len(req.IpponsB) > 0 {
+		return true
+	}
+	if len(req.SubResults) > 0 {
+		return true
+	}
+	return false
+}
+
 // registerScoreHandler wires the `PUT /competitions/:id/matches/:mid/score`
 // endpoint via the consumer-boundary interfaces (T014/T017) instead of
 // the concrete `*engine.Engine` / `*Hub`. This is the Slice 0
@@ -511,7 +627,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 // NOT migrated: the partial-success error array semantics need a
 // per-result tx (or a different commit shape) and that's out of scope
 // for this slice.
-func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store CompetitionStore, tx CompetitionTransactor, hub Broadcaster) {
+func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store CompetitionStore, tx CompetitionTransactor, hub Broadcaster, verifier PasswordVerifier, tl TournamentLoader) {
 	r.PUT("/competitions/:id/matches/:mid/score", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {
@@ -546,7 +662,16 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 			return
 		}
 
+		// mp-ba3: self-run decision allowlist + finalized guard + result
+		// provenance. Runs after Validate() so the request is structurally
+		// valid before Mode and password are inspected.
+		resultSource, ok := enforceSelfRunPolicy(c, tl, verifier, store, id, mid, &req)
+		if !ok {
+			return
+		}
+
 		result := req.AsMatchResult()
+		result.ResultSource = resultSource
 
 		// T156: run the score write + ineligibility update + lineup-freeze
 		// inside a single per-comp lock acquire via WithTransaction. The

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -487,17 +487,21 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 	})
 }
 
-// enforceSelfRunPolicy applies the self-run decision allowlist and
-// finalized-result guard when the tournament is in self-run mode and the
-// request carries no valid admin password. Returns the resultSource string
-// ("admin" or "self-reported") and true on success; writes the HTTP error
-// response and returns "", false when the request should be rejected.
+// enforceSelfRunPolicy applies the self-run decision allowlist when the
+// tournament is in self-run mode and the request carries no valid admin
+// password. Returns the resultSource string ("admin" or "self-reported")
+// and true on success; writes the HTTP error response and returns "",
+// false when the request should be rejected.
+//
+// The finalized-result guard is NOT checked here — it must run inside
+// WithTransaction to prevent TOCTOU races between concurrent anonymous
+// submissions. See checkFinalizedUnderTx.
 //
 // Called after ScoreRequest.Validate() so the request is structurally valid.
 //
 // In officiated mode this is a pass-through that returns "admin", true.
 // On LoadTournament error the function fails closed (500).
-func enforceSelfRunPolicy(c *gin.Context, tl TournamentLoader, verifier PasswordVerifier, store CompetitionStore, compID, matchID string, req *ScoreRequest) (string, bool) {
+func enforceSelfRunPolicy(c *gin.Context, tl TournamentLoader, verifier PasswordVerifier, req *ScoreRequest) (string, bool) {
 	t, err := tl.LoadTournament()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load tournament config"})
@@ -531,41 +535,35 @@ func enforceSelfRunPolicy(c *gin.Context, tl TournamentLoader, verifier Password
 		}
 	}
 
-	// Finalized guard: anonymous callers cannot write to a finalized match
-	// at all — any field change could alter the outcome through the
-	// engine's preserve-on-empty merge, so we reject unconditionally.
-	existing := loadExistingMatchResult(store, compID, matchID)
-	if existing != nil && isMatchFinalized(existing) {
-		c.JSON(http.StatusConflict, gin.H{
-			"error":   "result_finalized",
-			"message": "This match result has already been reported. Contact the tournament organizer to correct it.",
-		})
-		return "", false
-	}
-
 	return "self-reported", true
 }
 
-// loadExistingMatchResult looks up a match result by ID from pool matches or
-// the bracket. Returns nil when not found or on any load error (fail-open:
-// a load error should not block a legitimate score submission).
-func loadExistingMatchResult(store CompetitionStore, compID, matchID string) *state.MatchResult {
-	poolMatches, err := store.LoadPoolMatches(compID)
+// errResultFinalized is a sentinel returned by checkFinalizedUnderTx to
+// signal that the match is already finalized and the anonymous overwrite
+// should be rejected with 409.
+var errResultFinalized = errors.New("result_finalized")
+
+// checkFinalizedUnderTx runs inside WithTransaction (under the per-comp
+// lock) so it's safe from TOCTOU races. Returns errResultFinalized when
+// an anonymous caller tries to write to a completed match.
+func checkFinalizedUnderTx(stx state.StoreTx, compID, matchID string) error {
+	poolMatches, err := stx.LoadPoolMatches(compID)
 	if err == nil {
 		for i := range poolMatches {
-			if poolMatches[i].ID == matchID {
-				m := poolMatches[i]
-				return &m
+			if poolMatches[i].ID == matchID && isMatchFinalized(&poolMatches[i]) {
+				return errResultFinalized
 			}
 		}
 	}
-	bracket, err := store.LoadBracket(compID)
+	bracket, err := stx.LoadBracket(compID)
 	if err == nil && bracket != nil {
 		for _, round := range bracket.Rounds {
 			for i := range round {
 				if round[i].ID == matchID {
-					bm := round[i]
-					return bracketMatchToResult(&bm)
+					mr := bracketMatchToResult(&round[i])
+					if isMatchFinalized(mr) {
+						return errResultFinalized
+					}
 				}
 			}
 		}
@@ -652,10 +650,9 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 			return
 		}
 
-		// mp-ba3: self-run decision allowlist + finalized guard + result
-		// provenance. Runs after Validate() so the request is structurally
-		// valid before Mode and password are inspected.
-		resultSource, ok := enforceSelfRunPolicy(c, tl, verifier, store, id, mid, &req)
+		// mp-ba3: self-run decision allowlist + result provenance. Runs
+		// after Validate() so the request is structurally valid.
+		resultSource, ok := enforceSelfRunPolicy(c, tl, verifier, &req)
 		if !ok {
 			return
 		}
@@ -684,6 +681,14 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 			engErr    error
 		)
 		txErr := tx.WithTransaction(id, func(stx state.StoreTx) error {
+			// mp-ba3: finalized guard runs under the per-comp lock to
+			// prevent TOCTOU races between concurrent anonymous submissions.
+			if resultSource == "self-reported" {
+				if err := checkFinalizedUnderTx(stx, id, mid); err != nil {
+					engErr = err
+					return nil
+				}
+			}
 			isWithdrawal := domain.IsKikenDecisionStr(result.Decision) || result.Decision == "fusenpai"
 			if !isWithdrawal {
 				if err := eng.StartMatchTx(stx, id, mid); err != nil {
@@ -705,6 +710,13 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 			return
 		}
 		if engErr != nil {
+			if errors.Is(engErr, errResultFinalized) {
+				c.JSON(http.StatusConflict, gin.H{
+					"error":   "result_finalized",
+					"message": "This match result has already been reported. Contact the tournament organizer to correct it.",
+				})
+				return
+			}
 			var ineligErr *engine.IneligibleCompetitorError
 			if errors.As(engErr, &ineligErr) {
 				// U1: reasonHuman alongside the raw kendo-term reason

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -589,10 +589,10 @@ func bracketMatchToResult(bm *state.BracketMatch) *state.MatchResult {
 }
 
 // isMatchFinalized reports whether the given result represents a concluded
-// match. A result is finalized when its status is "completed" AND either a
-// winner has been recorded or the decision is hikiwake (a draw).
+// match. Any completed match is finalized — anonymous callers must not
+// overwrite it regardless of whether a winner was explicitly recorded.
 func isMatchFinalized(r *state.MatchResult) bool {
-	return r.Status == state.MatchStatusCompleted && (r.Winner != "" || r.Decision == "hikiwake")
+	return r.Status == state.MatchStatusCompleted
 }
 
 // registerScoreHandler wires the `PUT /competitions/:id/matches/:mid/score`

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -545,18 +545,23 @@ var errResultFinalized = errors.New("result_finalized")
 
 // checkFinalizedUnderTx runs inside WithTransaction (under the per-comp
 // lock) so it's safe from TOCTOU races. Returns errResultFinalized when
-// an anonymous caller tries to write to a completed match.
+// an anonymous caller tries to write to a completed match. Fails closed:
+// a load error rejects the request rather than allowing an overwrite.
 func checkFinalizedUnderTx(stx state.StoreTx, compID, matchID string) error {
 	poolMatches, err := stx.LoadPoolMatches(compID)
-	if err == nil {
-		for i := range poolMatches {
-			if poolMatches[i].ID == matchID && isMatchFinalized(&poolMatches[i]) {
-				return errResultFinalized
-			}
+	if err != nil {
+		return fmt.Errorf("finalized guard: load pool matches: %w", err)
+	}
+	for i := range poolMatches {
+		if poolMatches[i].ID == matchID && isMatchFinalized(&poolMatches[i]) {
+			return errResultFinalized
 		}
 	}
 	bracket, err := stx.LoadBracket(compID)
-	if err == nil && bracket != nil {
+	if err != nil {
+		return fmt.Errorf("finalized guard: load bracket: %w", err)
+	}
+	if bracket != nil {
 		for _, round := range bracket.Rounds {
 			for i := range round {
 				if round[i].ID == matchID {

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -630,6 +630,14 @@ func (f failingCompetitionStore) LoadCompetition(string) (*state.Competition, er
 	return nil, f.err
 }
 
+func (f failingCompetitionStore) LoadPoolMatches(string) ([]state.MatchResult, error) {
+	return nil, f.err
+}
+
+func (f failingCompetitionStore) LoadBracket(string) (*state.Bracket, error) {
+	return nil, f.err
+}
+
 // TestEnchoExceedsCap covers the pure predicate. Force, missing comp,
 // 0 cap, and within-cap all return false; only an over-cap count with
 // !force returns true.
@@ -701,7 +709,7 @@ func TestEnforceEnchoCap_ScoreHandler(t *testing.T) {
 		// cap check exercises the new fail-closed branch. The engine
 		// keeps the real store but never gets called — enforceEnchoCap
 		// aborts the request first.
-		registerScoreHandler(admin, eng, failingCompetitionStore{err: errors.New("disk on fire")}, realStore, hub)
+		registerScoreHandler(admin, eng, failingCompetitionStore{err: errors.New("disk on fire")}, realStore, hub, NewFileVerifier(realStore), realStore)
 
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(score(1)))
@@ -716,7 +724,7 @@ func TestEnforceEnchoCap_ScoreHandler(t *testing.T) {
 		gin.SetMode(gin.TestMode)
 		r := gin.New()
 		admin := r.Group("/api")
-		registerScoreHandler(admin, eng, realStore, realStore, hub)
+		registerScoreHandler(admin, eng, realStore, realStore, hub, NewFileVerifier(realStore), realStore)
 
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(score(3)))
@@ -737,7 +745,7 @@ func TestEnforceEnchoCap_ScoreHandler(t *testing.T) {
 		gin.SetMode(gin.TestMode)
 		r := gin.New()
 		admin := r.Group("/api")
-		registerScoreHandler(admin, eng, realStore, realStore, hub)
+		registerScoreHandler(admin, eng, realStore, realStore, hub, NewFileVerifier(realStore), realStore)
 
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score?force=true", bytes.NewBuffer(score(3)))
@@ -783,7 +791,7 @@ func TestEnforceEnchoCapWithSubs(t *testing.T) {
 		gin.SetMode(gin.TestMode)
 		r := gin.New()
 		admin := r.Group("/api")
-		registerScoreHandler(admin, eng, realStore, realStore, hub)
+		registerScoreHandler(admin, eng, realStore, realStore, hub, NewFileVerifier(realStore), realStore)
 
 		body, _ := json.Marshal(state.MatchResult{
 			ID: "PoolA-1", SideA: "TeamA", SideB: "TeamB",
@@ -809,7 +817,7 @@ func TestEnforceEnchoCapWithSubs(t *testing.T) {
 		gin.SetMode(gin.TestMode)
 		r := gin.New()
 		admin := r.Group("/api")
-		registerScoreHandler(admin, eng, realStore, realStore, hub)
+		registerScoreHandler(admin, eng, realStore, realStore, hub, NewFileVerifier(realStore), realStore)
 
 		body, _ := json.Marshal(state.MatchResult{
 			ID: "PoolA-1", SideA: "TeamA", SideB: "TeamB",
@@ -828,7 +836,7 @@ func TestEnforceEnchoCapWithSubs(t *testing.T) {
 		gin.SetMode(gin.TestMode)
 		r := gin.New()
 		admin := r.Group("/api")
-		RegisterMatchHandlers(admin, eng, realStore, realStore, hub)
+		RegisterMatchHandlers(admin, eng, realStore, realStore, hub, NewFileVerifier(realStore), realStore)
 
 		body, _ := json.Marshal([]state.MatchResult{
 			{
@@ -878,7 +886,7 @@ func TestBulkScore_FailsClosedOnLoadError(t *testing.T) {
 	// RegisterMatchHandlers takes the concrete *Hub; the cap check
 	// uses the CompetitionStore parameter (which we fault here) and
 	// returns 500 before any handler reaches the hub or engine.
-	RegisterMatchHandlers(admin, eng, failingCompetitionStore{err: errors.New("disk on fire")}, realStore, hub)
+	RegisterMatchHandlers(admin, eng, failingCompetitionStore{err: errors.New("disk on fire")}, realStore, hub, NewFileVerifier(realStore), realStore)
 
 	body, _ := json.Marshal([]state.MatchResult{
 		{ID: "PoolA-1", SideA: "P1", SideB: "P2", Winner: "P1", Status: state.MatchStatusCompleted},
@@ -1068,4 +1076,287 @@ func TestAnnotateBracketQueuePositions_EmptyScheduledAt(t *testing.T) {
 
 	assert.Equal(t, 1, b.Rounds[0][1].QueuePosition, "has-time = 1st")
 	assert.Equal(t, 2, b.Rounds[0][0].QueuePosition, "no-time = 2nd (sinks to end)")
+}
+
+// setupSelfRunScoreRouter creates a minimal gin router with just the score
+// endpoint, wired to a fresh store that has a self-run tournament and one
+// pool match pre-seeded.
+func setupSelfRunScoreRouter(t *testing.T, mainPw string) (*gin.Engine, *state.Store, string) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "selfrun-score-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	eng := engine.New(store)
+	hub := NewHub()
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:     "SelfRun",
+		Password: mainPw,
+		Courts:   []string{"A"},
+		Mode:     state.TournamentModeSelfRun,
+	}))
+	compID := "c1"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     compID,
+		Format: state.CompFormatMixed,
+		Status: state.CompStatusPools,
+	}))
+	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+		{Name: "Alice"}, {Name: "Bob"},
+	}))
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "PoolA-1", SideA: "Alice", SideB: "Bob"},
+	}))
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	admin := r.Group("/api")
+	verifier := NewFileVerifier(store)
+	RegisterMatchHandlers(admin, eng, store, store, hub, verifier, store)
+
+	return r, store, compID
+}
+
+// TestSelfRunScoreHandler verifies the decision allowlist, finalized guard,
+// and resultSource provenance for self-run tournaments.
+func TestSelfRunScoreHandler(t *testing.T) {
+	t.Run("anonymous PUT score with fought decision returns 200 and self-reported source", func(t *testing.T) {
+		r, store, compID := setupSelfRunScoreRouter(t, "secret")
+
+		body, _ := json.Marshal(state.MatchResult{
+			ID:      "PoolA-1",
+			SideA:   "Alice",
+			SideB:   "Bob",
+			Winner:  "Alice",
+			IpponsA: []string{"M", "K"},
+			Status:  state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var result state.MatchResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, "self-reported", result.ResultSource)
+
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		assert.Equal(t, "self-reported", stored[0].ResultSource)
+	})
+
+	t.Run("anonymous PUT score with hikiwake returns 200 and self-reported source", func(t *testing.T) {
+		r, _, compID := setupSelfRunScoreRouter(t, "secret")
+
+		body, _ := json.Marshal(state.MatchResult{
+			ID:     "PoolA-1",
+			SideA:  "Alice",
+			SideB:  "Bob",
+			Status: state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var result state.MatchResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, "self-reported", result.ResultSource)
+	})
+
+	t.Run("anonymous PUT score with kiken-voluntary returns 400", func(t *testing.T) {
+		r, _, compID := setupSelfRunScoreRouter(t, "secret")
+
+		body, _ := json.Marshal(state.MatchResult{
+			ID:         "PoolA-1",
+			SideA:      "Alice",
+			SideB:      "Bob",
+			Winner:     "Alice",
+			IpponsA:    []string{"M", "K"},
+			Status:     state.MatchStatusCompleted,
+			Decision:   "kiken-voluntary",
+			DecisionBy: "shiro",
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+		assert.Contains(t, w.Body.String(), "decision type not allowed")
+	})
+
+	t.Run("anonymous PUT score with fusenpai returns 400", func(t *testing.T) {
+		r, _, compID := setupSelfRunScoreRouter(t, "secret")
+
+		body, _ := json.Marshal(state.MatchResult{
+			ID:         "PoolA-1",
+			SideA:      "Alice",
+			SideB:      "Bob",
+			Winner:     "Alice",
+			IpponsA:    []string{"M", "K"},
+			Status:     state.MatchStatusCompleted,
+			Decision:   "fusenpai",
+			DecisionBy: "shiro",
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+		assert.Contains(t, w.Body.String(), "decision type not allowed")
+	})
+
+	t.Run("anonymous overwrite of finalized result returns 409", func(t *testing.T) {
+		r, store, compID := setupSelfRunScoreRouter(t, "secret")
+
+		// First, establish a finalized result.
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{
+				ID:      "PoolA-1",
+				SideA:   "Alice",
+				SideB:   "Bob",
+				Winner:  "Alice",
+				Status:  state.MatchStatusCompleted,
+				IpponsA: []string{"M", "K"},
+			},
+		}))
+
+		// Anonymous attempt to overwrite.
+		body, _ := json.Marshal(state.MatchResult{
+			ID:      "PoolA-1",
+			SideA:   "Alice",
+			SideB:   "Bob",
+			Winner:  "Bob",
+			IpponsB: []string{"M", "K"},
+			Status:  state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusConflict, w.Code, "body=%s", w.Body.String())
+		assert.Contains(t, w.Body.String(), "result_finalized")
+	})
+
+	t.Run("admin PUT score with valid password returns 200 and admin source", func(t *testing.T) {
+		r, store, compID := setupSelfRunScoreRouter(t, "secret")
+
+		body, _ := json.Marshal(state.MatchResult{
+			ID:      "PoolA-1",
+			SideA:   "Alice",
+			SideB:   "Bob",
+			Winner:  "Alice",
+			IpponsA: []string{"M", "K"},
+			Status:  state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Tournament-Password", "secret")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var result state.MatchResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, "admin", result.ResultSource)
+
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		assert.Equal(t, "admin", stored[0].ResultSource)
+	})
+
+	t.Run("admin can overwrite finalized result with valid password", func(t *testing.T) {
+		r, store, compID := setupSelfRunScoreRouter(t, "secret")
+
+		// First, establish a finalized result.
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{
+				ID:      "PoolA-1",
+				SideA:   "Alice",
+				SideB:   "Bob",
+				Winner:  "Alice",
+				Status:  state.MatchStatusCompleted,
+				IpponsA: []string{"M", "K"},
+			},
+		}))
+
+		// Admin overwrite with valid password succeeds.
+		body, _ := json.Marshal(state.MatchResult{
+			ID:      "PoolA-1",
+			SideA:   "Alice",
+			SideB:   "Bob",
+			Winner:  "Bob",
+			IpponsB: []string{"M", "K"},
+			Status:  state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Tournament-Password", "secret")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var result state.MatchResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, "admin", result.ResultSource)
+	})
+
+	t.Run("officiated mode PUT score sets resultSource admin", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "officiated-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(tempDir) })
+		store, err := state.NewStore(tempDir)
+		require.NoError(t, err)
+		eng := engine.New(store)
+		hub := NewHub()
+
+		require.NoError(t, store.SaveTournament(&state.Tournament{
+			Name:     "Officiated",
+			Password: "pw",
+			Courts:   []string{"A"},
+			Mode:     state.TournamentModeOfficiated,
+		}))
+		compID := "off1"
+		require.NoError(t, store.SaveCompetition(&state.Competition{
+			ID:     compID,
+			Format: state.CompFormatMixed,
+			Status: state.CompStatusPools,
+		}))
+		require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+			{Name: "Alice"}, {Name: "Bob"},
+		}))
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "PoolA-1", SideA: "Alice", SideB: "Bob"},
+		}))
+
+		gin.SetMode(gin.TestMode)
+		rr := gin.New()
+		admin := rr.Group("/api")
+		RegisterMatchHandlers(admin, eng, store, store, hub, NewFileVerifier(store), store)
+
+		body, _ := json.Marshal(state.MatchResult{
+			ID:      "PoolA-1",
+			SideA:   "Alice",
+			SideB:   "Bob",
+			Winner:  "Alice",
+			IpponsA: []string{"M", "K"},
+			Status:  state.MatchStatusCompleted,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/PoolA-1/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+		var result state.MatchResult
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+		assert.Equal(t, "admin", result.ResultSource)
+	})
 }

--- a/internal/mobileapp/handlers_match_tx_test.go
+++ b/internal/mobileapp/handlers_match_tx_test.go
@@ -67,7 +67,7 @@ func TestScoreHandler_NoDeadlockUnderConcurrentLoad(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	admin := r.Group("/api")
-	RegisterMatchHandlers(admin, eng, store, store, hub)
+	RegisterMatchHandlers(admin, eng, store, store, hub, NewFileVerifier(store), store)
 
 	var wg sync.WaitGroup
 	done := make(chan struct{})

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -51,7 +51,7 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *state.Store, *engine.Engine, *
 	RegisterImportHandlers(admin, store, hub, NewFileElevatedVerifier(store))
 	RegisterCompetitionHandlers(admin, store, eng, hub, NewFileElevatedVerifier(store))
 	RegisterParticipantHandlers(admin, store, hub, NewFileElevatedVerifier(store))
-	RegisterMatchHandlers(admin, eng, store, store, hub)
+	RegisterMatchHandlers(admin, eng, store, store, hub, NewFileVerifier(store), store)
 	RegisterDecisionHandlers(admin, eng, store, store, hub)
 	RegisterEligibilityHandlers(admin, store, hub)
 	RegisterLineupHandlers(admin, store, store, store)

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -229,7 +229,8 @@ func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 		http.MethodPut + " /api/competitions/:id/teams/:tid/lineups/:round",            // team lineup management — organiser
 		http.MethodDelete + " /api/competitions/:id/teams/:tid/lineups/:round",         // team lineup management — organiser
 		http.MethodPut + " /api/competitions/:id/teams/:tid/match-lineups/:matchId",    // team match lineup — organiser
-		http.MethodDelete + " /api/competitions/:id/teams/:tid/match-lineups/:matchId": // team match lineup — organiser
+		http.MethodDelete + " /api/competitions/:id/teams/:tid/match-lineups/:matchId", // team match lineup — organiser
+		http.MethodPost + " /api/competitions/:id/matches/:mid/decision":               // mp-ba3: kiken/fusenpai/daihyosen are admin-only decisions
 		return true
 	default:
 		return false

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -143,7 +143,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	RegisterAdminPasswordHandler(adminSmallBody, store, elevated)
 	RegisterCompetitionHandlers(adminSmallBody, store, eng, hub, elevated)
 	RegisterParticipantHandlers(adminSmallBody, store, hub, elevated)
-	RegisterMatchHandlers(adminSmallBody, eng, store, store, hub)
+	RegisterMatchHandlers(adminSmallBody, eng, store, store, hub, verifier, store)
 	RegisterDecisionHandlers(adminSmallBody, eng, store, store, hub)
 	RegisterEligibilityHandlers(adminSmallBody, store, hub)
 	RegisterReinstateHandler(adminSmallBody, eng, hub)

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -523,3 +523,27 @@ func (r *ScoreRequest) AsMatchResult() *state.MatchResult {
 	mr := state.MatchResult(*r)
 	return &mr
 }
+
+// IsSelfRunReportableDecision reports whether the given decision value is
+// permitted for participant self-reporting in self-run tournaments (i.e.
+// when no valid admin password is present on the request).
+//
+// Allowed: "" (none), "fought", "hikiwake", "fusensho" (per-bout default win
+// in team matches). These are factual observations a participant can make
+// without referee authority.
+//
+// Rejected: "kiken-voluntary", "kiken-injury", "fusenpai", "daihyosen",
+// "kachinuki-exhaustion" — referee/operator rulings with eligibility side-
+// effects or official designation requirements. Also rejected when
+// decidedByHantei is explicitly true (judges' panel decision).
+func IsSelfRunReportableDecision(decision string, decidedByHantei *bool) bool {
+	if decidedByHantei != nil && *decidedByHantei {
+		return false
+	}
+	switch decision {
+	case "", "fought", "hikiwake", "fusensho":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -528,16 +528,37 @@ func (r *ScoreRequest) AsMatchResult() *state.MatchResult {
 // permitted for participant self-reporting in self-run tournaments (i.e.
 // when no valid admin password is present on the request).
 //
-// Allowed: "" (none), "fought", "hikiwake", "fusensho" (per-bout default win
-// in team matches). These are factual observations a participant can make
-// without referee authority.
+// Allowed at the top level: "" (none), "fought", "hikiwake". These are
+// factual observations a participant can make without referee authority.
+// fusensho is only valid on sub-results (ScoreRequest.Validate rejects it
+// at the top level), so it's not listed here.
 //
 // Rejected: "kiken-voluntary", "kiken-injury", "fusenpai", "daihyosen",
-// "kachinuki-exhaustion" — referee/operator rulings with eligibility side-
-// effects or official designation requirements. Also rejected when
-// decidedByHantei is explicitly true (judges' panel decision).
+// "kachinuki-exhaustion", "fusensho" — referee/operator rulings with
+// eligibility side-effects or official designation requirements. Also
+// rejected when decidedByHantei is explicitly true (judges' panel decision).
 func IsSelfRunReportableDecision(decision string, decidedByHantei *bool) bool {
 	if decidedByHantei != nil && *decidedByHantei {
+		return false
+	}
+	switch decision {
+	case "", "fought", "hikiwake":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSelfRunReportableSubDecision validates a sub-bout decision for self-run
+// anonymous callers. Allowed: "" (none), "fought", "hikiwake", "fusensho"
+// (per-bout forfeiture is a factual observation). Rejected: kiken variants,
+// fusenpai, daihyosen, kachinuki-exhaustion, decidedByHantei=true. Also
+// rejects position == -1 (daihyosen representative bout placeholder).
+func IsSelfRunReportableSubDecision(decision string, decidedByHantei bool, position int) bool {
+	if position == -1 {
+		return false
+	}
+	if decidedByHantei {
 		return false
 	}
 	switch decision {

--- a/internal/mobileapp/validation_test.go
+++ b/internal/mobileapp/validation_test.go
@@ -1177,7 +1177,7 @@ func TestIsSelfRunReportableDecision(t *testing.T) {
 		{name: "empty decision allowed", decision: "", want: true},
 		{name: "fought allowed", decision: "fought", want: true},
 		{name: "hikiwake allowed", decision: "hikiwake", want: true},
-		{name: "fusensho allowed (team per-bout)", decision: "fusensho", want: true},
+		{name: "fusensho rejected at top level", decision: "fusensho", want: false},
 		{name: "kiken-voluntary rejected", decision: "kiken-voluntary", want: false},
 		{name: "kiken-injury rejected", decision: "kiken-injury", want: false},
 		{name: "fusenpai rejected", decision: "fusenpai", want: false},
@@ -1191,6 +1191,32 @@ func TestIsSelfRunReportableDecision(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := IsSelfRunReportableDecision(tc.decision, tc.decidedByHantei)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsSelfRunReportableSubDecision(t *testing.T) {
+	tests := []struct {
+		name            string
+		decision        string
+		decidedByHantei bool
+		position        int
+		want            bool
+	}{
+		{name: "empty sub-decision allowed", decision: "", position: 1, want: true},
+		{name: "fought sub-decision allowed", decision: "fought", position: 1, want: true},
+		{name: "hikiwake sub-decision allowed", decision: "hikiwake", position: 1, want: true},
+		{name: "fusensho sub-decision allowed", decision: "fusensho", position: 1, want: true},
+		{name: "kiken-voluntary sub rejected", decision: "kiken-voluntary", position: 1, want: false},
+		{name: "daihyosen sub rejected", decision: "daihyosen", position: 1, want: false},
+		{name: "position -1 (daihyosen slot) rejected", decision: "", position: -1, want: false},
+		{name: "decidedByHantei true sub rejected", decision: "fought", decidedByHantei: true, position: 1, want: false},
+		{name: "position 0 allowed", decision: "fought", position: 0, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsSelfRunReportableSubDecision(tc.decision, tc.decidedByHantei, tc.position)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/internal/mobileapp/validation_test.go
+++ b/internal/mobileapp/validation_test.go
@@ -1161,3 +1161,37 @@ func TestValidateBulkScoreLengths_SubBoutDecidedByHantei(t *testing.T) {
 		assert.Equal(t, "subResults[0].decidedByHantei", verr.(*ValidationError).Field)
 	})
 }
+
+// TestIsSelfRunReportableDecision covers the allowlist and rejection cases
+// for participant self-reporting in self-run tournaments.
+func TestIsSelfRunReportableDecision(t *testing.T) {
+	f := false
+	tr := true
+
+	tests := []struct {
+		name            string
+		decision        string
+		decidedByHantei *bool
+		want            bool
+	}{
+		{name: "empty decision allowed", decision: "", want: true},
+		{name: "fought allowed", decision: "fought", want: true},
+		{name: "hikiwake allowed", decision: "hikiwake", want: true},
+		{name: "fusensho allowed (team per-bout)", decision: "fusensho", want: true},
+		{name: "kiken-voluntary rejected", decision: "kiken-voluntary", want: false},
+		{name: "kiken-injury rejected", decision: "kiken-injury", want: false},
+		{name: "fusenpai rejected", decision: "fusenpai", want: false},
+		{name: "daihyosen rejected", decision: "daihyosen", want: false},
+		{name: "kachinuki-exhaustion rejected", decision: "kachinuki-exhaustion", want: false},
+		{name: "unknown decision rejected", decision: "magic", want: false},
+		{name: "decidedByHantei=true rejects even allowed decision", decision: "fought", decidedByHantei: &tr, want: false},
+		{name: "decidedByHantei=false is ok (nil-vs-false are the same signal)", decision: "fought", decidedByHantei: &f, want: true},
+		{name: "decidedByHantei nil is ok", decision: "fought", decidedByHantei: nil, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsSelfRunReportableDecision(tc.decision, tc.decidedByHantei)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -386,6 +386,10 @@ type MatchResult struct {
 	// allow it in pool play) that the gap is acceptable. The yaml tag
 	// is retained for future YAML-serialised contexts.
 	DecidedByHantei *bool `json:"decidedByHantei,omitempty" yaml:"decided_by_hantei,omitempty"`
+	// ResultSource records how the result was submitted: "admin" (operator with
+	// password), "self-reported" (participant in self-run mode), or "" (legacy/
+	// unset). Set by the score handler; omitted from wire when empty.
+	ResultSource string `json:"resultSource,omitempty" yaml:"result_source,omitempty"`
 }
 
 // HanteiPtr returns &b when b is true, nil otherwise. Use on READ paths
@@ -491,6 +495,8 @@ type BracketMatch struct {
 	// SubResults persists per-bout results for team bracket matches so the
 	// score editor can restore hantei state and bout-level detail on re-open.
 	SubResults []SubMatchResult `json:"subResults,omitempty"`
+	// ResultSource mirrors MatchResult.ResultSource for bracket matches.
+	ResultSource string `json:"resultSource,omitempty"`
 }
 
 type Bracket struct {

--- a/internal/state/pools.go
+++ b/internal/state/pools.go
@@ -282,6 +282,9 @@ func parsePoolMatchesRecords(records [][]string) []MatchResult {
 		if len(rec) > 13 {
 			m.ScheduledAt = rec[13]
 		}
+		if len(rec) > 14 {
+			m.ResultSource = rec[14]
+		}
 
 		results = append(results, m)
 	}
@@ -318,7 +321,7 @@ func (s *Store) savePoolMatchesLocked(compID string, results []MatchResult, writ
 	// the previous os.Create + streaming pattern lacked.
 	var buf bytes.Buffer
 	writer := csv.NewWriter(&buf)
-	if err := writer.Write([]string{"PoolName", "MatchIdx", "SideA", "SideB", "Winner", "IpponsA", "IpponsB", "HansokuA", "HansokuB", "Decision", "Status", "Court", "SubResults", "ScheduledAt"}); err != nil {
+	if err := writer.Write([]string{"PoolName", "MatchIdx", "SideA", "SideB", "Winner", "IpponsA", "IpponsB", "HansokuA", "HansokuB", "Decision", "Status", "Court", "SubResults", "ScheduledAt", "ResultSource"}); err != nil {
 		return err
 	}
 
@@ -351,6 +354,7 @@ func (s *Store) savePoolMatchesLocked(compID string, results []MatchResult, writ
 			r.Court,
 			subJSON,
 			r.ScheduledAt,
+			r.ResultSource,
 		}); err != nil {
 			return err
 		}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -147,7 +147,7 @@ function levenshtein(a, b) {
   return prev[n];
 }
 
-function AdminParticipants({ c, tournament, onUpdate, password, showToast, onSection }) {
+function AdminParticipants({ c, tournament: _tournament, onUpdate, password, showToast, onSection }) {
   const [showOnlyUnchecked, setShowOnlyUnchecked] = useStateA(false);
   const [replaceTarget, setReplaceTarget] = useStateA(null);
   const [showAddForm, setShowAddForm] = useStateA(false);

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -508,7 +508,7 @@ function FoulCounter({ label, fouls, setFouls, onIncrement, color, disabled }) {
   );
 }
 
-function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch, nextMatch, onPrev, onNext, password }) {
+function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch, nextMatch, onPrev, onNext, password, selfReport }) {
   const m = match;
   const isComplete = m.status === "completed";
   // Canonical team check (matches admin_pools.jsx and the lineup panel):
@@ -518,7 +518,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
   // correctly stay on the individual editor.
   const isTeam = m.compKind === "team" || (m.teamSize || 0) > 0;
   const teamSize = m.teamSize || 5;
-  if (isTeam) return <TeamScoreEditorModal match={m} teamSize={teamSize} onClose={onClose} onSubmit={onSubmit} onSubmitAndNext={onSubmitAndNext} prevMatch={prevMatch} nextMatch={nextMatch} onPrev={onPrev} onNext={onNext} password={password} />;
+  if (isTeam) return <TeamScoreEditorModal match={m} teamSize={teamSize} onClose={onClose} onSubmit={onSubmit} onSubmitAndNext={onSubmitAndNext} prevMatch={prevMatch} nextMatch={nextMatch} onPrev={onPrev} onNext={onNext} password={password} selfReport={selfReport} />;
 
   const seedAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
   const seedBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
@@ -1039,7 +1039,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
               follow-up. Sits between the scoring board and the footer so the
               flow is: enter score OR record a decision → either way the modal
               closes (or surfaces the remaining-matches list for kiken). */}
-          {!withdrawnPlayer && !decisionPromptKind && (
+          {!withdrawnPlayer && !decisionPromptKind && !selfReport && (
             <div className="decision-controls" style={{ display: "flex", gap: 8, marginTop: 12, fontSize: 12, alignItems: "center" }}>
               <span style={{ color: "var(--ink-3)", fontWeight: 600 }}>Decision:</span>
               <div className="decision-btn-group">
@@ -1202,7 +1202,7 @@ function resolveLineupTeamId(sideKey, players) {
   return (p && (p.id || p.ID)) || sideKey;
 }
 
-function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndNext, prevMatch, nextMatch, onPrev, onNext, password }) {
+function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndNext, prevMatch, nextMatch, onPrev, onNext, password, selfReport }) {
   const m = match;
   const isComplete = m.status === "completed";
   const numberedPositions = TEAM_POSITIONS.slice(0, teamSize);
@@ -1984,7 +1984,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
           {/* T093–T098: decision (kiken/fusenpai) controls for the overall
               team match. Per-bout Fusensho lives on each sub-match row
               (see the row-level "Fusensho" button per side, T096). */}
-          {!withdrawnPlayer && !decisionPromptKind && (
+          {!withdrawnPlayer && !decisionPromptKind && !selfReport && (
             <div className="decision-controls" style={{ display: "flex", gap: 8, marginTop: 12, fontSize: 12, alignItems: "center" }}>
               <span style={{ color: "var(--ink-3)", fontWeight: 600 }}>Team decision:</span>
               <div className="decision-btn-group">

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1614,7 +1614,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
           )}
         </div>
       </div>
-      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} />}
+      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} compId={c.id} />}
     </div>
   );
 }
@@ -2727,7 +2727,7 @@ function ViewerSchedule({ tournament, onBack, tweaks }) {
   );
 }
 
-function MatchViewerModal({ match, onClose, tournament }) {
+function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId }) {
   window.useEscapeToClose(onClose);
   const [scoringMatch, setScoringMatch] = useState(null);
   if (!match) return null;
@@ -2751,7 +2751,7 @@ function MatchViewerModal({ match, onClose, tournament }) {
       onClose: () => setScoringMatch(null),
       onSubmit: async (patch) => {
         try {
-          await window.API.recordScore(scoringMatch.compId, scoringMatch.id, patch, "", scoringMatch);
+          await window.API.recordScore(scoringMatch.compId || defaultCompId, scoringMatch.id, patch, "", scoringMatch);
           setScoringMatch(null);
           onClose();
         } catch (_err) {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2742,8 +2742,7 @@ function MatchViewerModal({ match, onClose, tournament }) {
   const mvmIpponsB = match.ipponsB || window.ipponsFromScore(match.scoreB);
 
   const isSelfRun = tournament && tournament.mode === "self-run";
-  const hasBothSides = !!(match.sideA && match.sideA.name && match.sideB && match.sideB.name &&
-    match.sideA.name !== "TBD" && match.sideB.name !== "TBD");
+  const bothSidesReady = window.hasBothSides ? window.hasBothSides(match) : false;
   const isFinalized = match.status === "completed" && (match.winner?.name || match.winner?.id || match.decision === "hikiwake");
 
   if (scoringMatch && window.ScoreEditorModal) {
@@ -2841,7 +2840,7 @@ function MatchViewerModal({ match, onClose, tournament }) {
           </div>
         )}
 
-        {isSelfRun && hasBothSides && (
+        {isSelfRun && bothSidesReady && (
           <div style={{ marginTop: 16, paddingTop: 12, borderTop: "1px solid var(--line)" }}>
             {isFinalized ? (
               <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "var(--ink-3)" }}>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2743,7 +2743,7 @@ function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId })
 
   const isSelfRun = tournament && tournament.mode === "self-run";
   const bothSidesReady = window.hasBothSides ? window.hasBothSides(match) : false;
-  const isFinalized = match.status === "completed" && (match.winner?.name || match.winner?.id || match.decision === "hikiwake");
+  const isFinalized = match.status === "completed";
 
   if (scoringMatch && window.ScoreEditorModal) {
     return React.createElement(window.ScoreEditorModal, {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -796,7 +796,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
           </div>
         </div>
       </div>
-      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} />}
+      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={t} />}
     </div>
   );
 }
@@ -1614,7 +1614,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
           )}
         </div>
       </div>
-      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} />}
+      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} />}
     </div>
   );
 }
@@ -2722,13 +2722,14 @@ function ViewerSchedule({ tournament, onBack, tweaks }) {
           <ScheduleViewer tournament={tournament} tweaks={extendedTweaks} />
         </div>
       </div>
-      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} />}
+      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} />}
     </div>
   );
 }
 
-function MatchViewerModal({ match, onClose }) {
+function MatchViewerModal({ match, onClose, tournament }) {
   window.useEscapeToClose(onClose);
+  const [scoringMatch, setScoringMatch] = useState(null);
   if (!match) return null;
   const isTeam = match.compKind === "team" || match.teamSize > 0;
   const aName = match.sideA?.name || "TBD";
@@ -2739,6 +2740,29 @@ function MatchViewerModal({ match, onClose }) {
   // same fallback used in MatchDetailCard and VSchedItem.
   const mvmIpponsA = match.ipponsA || window.ipponsFromScore(match.scoreA);
   const mvmIpponsB = match.ipponsB || window.ipponsFromScore(match.scoreB);
+
+  const isSelfRun = tournament && tournament.mode === "self-run";
+  const hasBothSides = !!(match.sideA && match.sideA.name && match.sideB && match.sideB.name &&
+    match.sideA.name !== "TBD" && match.sideB.name !== "TBD");
+  const isFinalized = match.status === "completed" && (match.winner?.name || match.winner?.id || match.decision === "hikiwake");
+
+  if (scoringMatch && window.ScoreEditorModal) {
+    return React.createElement(window.ScoreEditorModal, {
+      match: scoringMatch,
+      onClose: () => setScoringMatch(null),
+      onSubmit: async (patch) => {
+        try {
+          await window.API.recordScore(scoringMatch.compId, scoringMatch.id, patch, "", scoringMatch);
+          setScoringMatch(null);
+          onClose();
+        } catch (_err) {
+          // leave modal open so the error is visible
+        }
+      },
+      password: "",
+      selfReport: true,
+    });
+  }
 
   return (
     <div className="modal-backdrop" onClick={onClose} style={{ zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -2814,6 +2838,24 @@ function MatchViewerModal({ match, onClose }) {
             {match.decidedByHantei && <div style={{ marginTop: 16, fontSize: 14, fontWeight: 600 }}>Decision (Hantei)</div>}
             {match.score?.type === "hikiwake" && <div style={{ marginTop: 16, fontSize: 14, fontWeight: 600 }}>Draw (<TermV name="hikiwake">Hikiwake</TermV>)</div>}
             {match.score?.type === "bye" && <div style={{ marginTop: 16, fontSize: 14, fontWeight: 600 }}>BYE</div>}
+          </div>
+        )}
+
+        {isSelfRun && hasBothSides && (
+          <div style={{ marginTop: 16, paddingTop: 12, borderTop: "1px solid var(--line)" }}>
+            {isFinalized ? (
+              <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "var(--ink-3)" }}>
+                <span style={{ background: "var(--bg-2)", padding: "4px 10px", borderRadius: 4, fontSize: 12 }}>Result reported</span>
+                <span>Contact the organizer to correct this result.</span>
+              </div>
+            ) : (
+              <button
+                className="btn btn--primary btn--sm"
+                onClick={() => setScoringMatch({ ...match, id: match.id })}
+              >
+                Report result
+              </button>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Participants in self-run tournaments can now report their own match results from the viewer UI — no operator needed
- Decision allowlist enforces that anonymous reporters can only submit `fought`, `hikiwake`, and `fusensho` (per-bout forfeit); admin-only decisions like kiken, fusenpai, and daihyosen are rejected with 400
- Finalized-result guard returns 409 when an anonymous user tries to overwrite a completed match — directs them to contact the organizer
- Provenance tracking via `ResultSource` field ("self-reported" / "admin") on `MatchResult` and `BracketMatch`, persisted in pool-matches.csv and bracket.json

### Backend (Phase 1)
- `TournamentLoader` interface in deps.go for mode inspection
- `IsSelfRunReportableDecision()` allowlist in validation.go
- `enforceSelfRunPolicy()` gate in the score handler (after Validate, before tx)
- `ResultSource` CSV column with backward-compat (missing column → empty)
- 8 new test cases covering anonymous/admin/officiated paths + decision filtering + finalized guard

### Frontend (Phase 2)
- `MatchViewerModal` shows "Report result" button in self-run mode (both sides assigned, not finalized)
- Shows "Result reported" badge with organizer hint when finalized
- `ScoreEditorModal` / `TeamScoreEditorModal` accept `selfReport` prop to hide kiken/fusenpai decision buttons

## Test plan

- [x] `make go/test` passes (lint + security + 1059 JS tests + all Go packages)
- [x] Anonymous PUT /score with fought → 200 + resultSource "self-reported"
- [x] Anonymous PUT /score with hikiwake → 200 + resultSource "self-reported"
- [x] Anonymous PUT /score with kiken-voluntary → 400 decision not allowed
- [x] Anonymous PUT /score with fusenpai → 400 decision not allowed
- [x] Anonymous overwrite finalized result → 409 result_finalized
- [x] Admin PUT /score with password → 200 + resultSource "admin"
- [x] Admin can overwrite finalized → 200
- [x] Officiated mode → resultSource "admin"
- [x] IsSelfRunReportableDecision unit tests (13 cases)
- [x] ResultSource persists in pool-matches.csv and survives reload
- [x] Browser: create self-run tournament → start competition → open viewer → click match → "Report result" visible → submit → match updates live
- [x] Browser: after reporting → "Result reported" badge shown, no "Report result" button
- [x] Browser: officiated tournament → no "Report result" in viewer

Closes mp-ba3

🤖 Generated with [Claude Code](https://claude.com/claude-code)