### PR TITLE
feat(mp-ef3): public tournament info page

### DIFF
--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -335,6 +335,88 @@ func TestTournamentHandlers(t *testing.T) {
 			"PUT with empty Password against legacy empty-password tournament must reject")
 		assert.Contains(t, w.Body.String(), "tournament password is required")
 	}
+
+	// mp-ef3 Copilot round 2: public info field trimming, contacts-count
+	// validation, URL validation, and contacts field-length validation.
+
+	t.Run("PUT trims public info fields", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "Trim Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{
+			Name:         "Trim Test",
+			Password:     "secret",
+			Courts:       []string{"A"},
+			VenueAddress: "  123 Main St  ",
+			OpeningTime:  "  09:00  ",
+			Contacts:     []state.TournamentContact{{Label: "  Email  ", Value: "  test@example.com  "}},
+		}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		saved, _ := store.LoadTournament()
+		assert.Equal(t, "123 Main St", saved.VenueAddress)
+		assert.Equal(t, "09:00", saved.OpeningTime)
+		require.Len(t, saved.Contacts, 1)
+		assert.Equal(t, "Email", saved.Contacts[0].Label)
+		assert.Equal(t, "test@example.com", saved.Contacts[0].Value)
+	})
+
+	t.Run("PUT rejects contacts over MaxTournamentContacts", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "Max Contacts", Password: "secret", Courts: []string{"A"}}))
+		contacts := make([]state.TournamentContact, MaxTournamentContacts+1)
+		for i := range contacts {
+			contacts[i] = state.TournamentContact{Label: fmt.Sprintf("Label%d", i), Value: fmt.Sprintf("value%d@example.com", i)}
+		}
+		tour := state.Tournament{
+			Name:     "Max Contacts",
+			Password: "secret",
+			Courts:   []string{"A"},
+			Contacts: contacts,
+		}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "contacts")
+	})
+
+	t.Run("PUT rejects javascript: URL in venueMapURL", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "URL Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{
+			Name:        "URL Test",
+			Password:    "secret",
+			Courts:      []string{"A"},
+			VenueMapURL: "javascript:alert(1)",
+		}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PUT validates contacts field lengths", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "Field Len", Password: "secret", Courts: []string{"A"}}))
+		longLabel := strings.Repeat("x", MaxLenContactLabel+1)
+		tour := state.Tournament{
+			Name:     "Field Len",
+			Password: "secret",
+			Courts:   []string{"A"},
+			Contacts: []state.TournamentContact{{Label: longLabel, Value: "ok@example.com"}},
+		}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "contacts[0].label")
+	})
 }
 
 // TestTournamentHandlers_LockedMode_PUTRejectsPasswordChange pins the
@@ -1904,7 +1986,7 @@ func TestCheckInPreservedOnRosterReplace(t *testing.T) {
 	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "ci-pr"}))
 
 	// Seed an initial roster with Alice.
-	body, _ := json.Marshal(map[string]interface{}{
+	body, _ := json.Marshal(map[string]any{
 		"players": []map[string]string{{"name": "Alice", "dojo": "Dojo A"}},
 	})
 	w := httptest.NewRecorder()
@@ -1927,7 +2009,7 @@ func TestCheckInPreservedOnRosterReplace(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Replace the roster via POST (Alice still in the list, Bob added).
-	body, _ = json.Marshal(map[string]interface{}{
+	body, _ = json.Marshal(map[string]any{
 		"players": []map[string]string{
 			{"name": "Alice", "dojo": "Dojo A"},
 			{"name": "Bob", "dojo": "Dojo B"},

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -155,9 +155,10 @@ var errModeImmutable = errors.New("tournament mode cannot be changed after creat
 var errSelfRunRequiresAdminPassword = errors.New("self-run tournaments require an admin (destructive-ops) password to be set; configure it before switching to self-run mode or set it in the same request")
 
 // trimPublicInfoFields trims all optional public tournament info string fields
-// and normalises the Contacts slice: each entry's Label/Value is trimmed,
-// all-empty entries are dropped, and the slice is capped at MaxTournamentContacts.
-// Called identically by the PUT and POST /tournament handlers.
+// and normalises the Contacts slice: each entry's Label/Value is trimmed and
+// all-empty entries are dropped. Called identically by the PUT and POST
+// /tournament handlers. Count validation (>MaxTournamentContacts) is enforced
+// by validateTournamentLengths as a 400 error rather than silently truncating.
 func trimPublicInfoFields(t *state.Tournament) {
 	t.VenueAddress = strings.TrimSpace(t.VenueAddress)
 	t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
@@ -174,9 +175,6 @@ func trimPublicInfoFields(t *state.Tournament) {
 			if ct.Label != "" || ct.Value != "" {
 				filtered = append(filtered, ct)
 			}
-		}
-		if len(filtered) > MaxTournamentContacts {
-			filtered = filtered[:MaxTournamentContacts]
 		}
 		t.Contacts = filtered
 	}
@@ -236,6 +234,12 @@ func validateTournamentLengths(t *state.Tournament) error {
 	}
 	if err := validateMaxLen("infoNotes", t.InfoNotes, MaxLenInfoNotes); err != nil {
 		return err
+	}
+	if len(t.Contacts) > MaxTournamentContacts {
+		return &ValidationError{
+			Field:   "contacts",
+			Message: fmt.Sprintf("must contain <= %d entries", MaxTournamentContacts),
+		}
 	}
 	for i, ct := range t.Contacts {
 		prefix := fmt.Sprintf("contacts[%d]", i)

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -181,6 +181,37 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("closingBlock", t.ClosingBlock, MaxLenCeremonyBlock); err != nil {
 		return err
 	}
+	// mp-ef3: public tournament info fields.
+	if err := validateMaxLen("venueAddress", t.VenueAddress, MaxLenVenueAddress); err != nil {
+		return err
+	}
+	if err := validateMaxLen("venueMapURL", t.VenueMapURL, MaxLenVenueMapURL); err != nil {
+		return err
+	}
+	if err := validateMaxLen("openingTime", t.OpeningTime, MaxLenDisplayTime); err != nil {
+		return err
+	}
+	if err := validateMaxLen("closingTime", t.ClosingTime, MaxLenDisplayTime); err != nil {
+		return err
+	}
+	if err := validateMaxLen("rulesURL", t.RulesURL, MaxLenRulesURL); err != nil {
+		return err
+	}
+	if err := validateMaxLen("awardsNote", t.AwardsNote, MaxLenAwardsNote); err != nil {
+		return err
+	}
+	if err := validateMaxLen("infoNotes", t.InfoNotes, MaxLenInfoNotes); err != nil {
+		return err
+	}
+	for i, ct := range t.Contacts {
+		prefix := fmt.Sprintf("contacts[%d]", i)
+		if err := validateMaxLen(prefix+".label", ct.Label, MaxLenContactLabel); err != nil {
+			return err
+		}
+		if err := validateMaxLen(prefix+".value", ct.Value, MaxLenContactValue); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -227,6 +258,29 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		t.Name = strings.TrimSpace(t.Name)
 		t.Venue = strings.TrimSpace(t.Venue)
 		t.Date = strings.TrimSpace(t.Date)
+		// mp-ef3: trim public info fields.
+		t.VenueAddress = strings.TrimSpace(t.VenueAddress)
+		t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
+		t.OpeningTime = strings.TrimSpace(t.OpeningTime)
+		t.ClosingTime = strings.TrimSpace(t.ClosingTime)
+		t.RulesURL = strings.TrimSpace(t.RulesURL)
+		t.AwardsNote = strings.TrimSpace(t.AwardsNote)
+		t.InfoNotes = strings.TrimSpace(t.InfoNotes)
+		// Trim and filter contacts: remove entries where both label and value are empty.
+		if len(t.Contacts) > 0 {
+			filtered := make([]state.TournamentContact, 0, len(t.Contacts))
+			for _, ct := range t.Contacts {
+				ct.Label = strings.TrimSpace(ct.Label)
+				ct.Value = strings.TrimSpace(ct.Value)
+				if ct.Label != "" || ct.Value != "" {
+					filtered = append(filtered, ct)
+				}
+			}
+			if len(filtered) > MaxTournamentContacts {
+				filtered = filtered[:MaxTournamentContacts]
+			}
+			t.Contacts = filtered
+		}
 
 		// Reject non-empty Date that doesn't match the canonical DD-MM-YYYY
 		// shape (or semantically invalid days like Feb 31). The frontend
@@ -500,6 +554,28 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		t.Name = strings.TrimSpace(t.Name)
 		t.Venue = strings.TrimSpace(t.Venue)
 		t.Date = strings.TrimSpace(t.Date)
+		// mp-ef3: trim public info fields (mirrors the PUT handler).
+		t.VenueAddress = strings.TrimSpace(t.VenueAddress)
+		t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
+		t.OpeningTime = strings.TrimSpace(t.OpeningTime)
+		t.ClosingTime = strings.TrimSpace(t.ClosingTime)
+		t.RulesURL = strings.TrimSpace(t.RulesURL)
+		t.AwardsNote = strings.TrimSpace(t.AwardsNote)
+		t.InfoNotes = strings.TrimSpace(t.InfoNotes)
+		if len(t.Contacts) > 0 {
+			filtered := make([]state.TournamentContact, 0, len(t.Contacts))
+			for _, ct := range t.Contacts {
+				ct.Label = strings.TrimSpace(ct.Label)
+				ct.Value = strings.TrimSpace(ct.Value)
+				if ct.Label != "" || ct.Value != "" {
+					filtered = append(filtered, ct)
+				}
+			}
+			if len(filtered) > MaxTournamentContacts {
+				filtered = filtered[:MaxTournamentContacts]
+			}
+			t.Contacts = filtered
+		}
 
 		// Same empty-after-trim guard as the PUT handler.
 		if t.Name == "" {

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -216,6 +216,9 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("venueMapURL", t.VenueMapURL, MaxLenVenueMapURL); err != nil {
 		return err
 	}
+	if err := validateHTTPSURL("venueMapURL", t.VenueMapURL); err != nil {
+		return err
+	}
 	if err := validateMaxLen("openingTime", t.OpeningTime, MaxLenDisplayTime); err != nil {
 		return err
 	}
@@ -223,6 +226,9 @@ func validateTournamentLengths(t *state.Tournament) error {
 		return err
 	}
 	if err := validateMaxLen("rulesURL", t.RulesURL, MaxLenRulesURL); err != nil {
+		return err
+	}
+	if err := validateHTTPSURL("rulesURL", t.RulesURL); err != nil {
 		return err
 	}
 	if err := validateMaxLen("awardsNote", t.AwardsNote, MaxLenAwardsNote); err != nil {

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -172,7 +172,7 @@ func trimPublicInfoFields(t *state.Tournament) {
 		for _, ct := range t.Contacts {
 			ct.Label = strings.TrimSpace(ct.Label)
 			ct.Value = strings.TrimSpace(ct.Value)
-			if ct.Label != "" || ct.Value != "" {
+			if ct.Value != "" {
 				filtered = append(filtered, ct)
 			}
 		}
@@ -214,7 +214,7 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("venueMapURL", t.VenueMapURL, MaxLenVenueMapURL); err != nil {
 		return err
 	}
-	if err := validateHTTPSURL("venueMapURL", t.VenueMapURL); err != nil {
+	if err := validateHTTPURL("venueMapURL", t.VenueMapURL); err != nil {
 		return err
 	}
 	if err := validateMaxLen("openingTime", t.OpeningTime, MaxLenDisplayTime); err != nil {
@@ -226,7 +226,7 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("rulesURL", t.RulesURL, MaxLenRulesURL); err != nil {
 		return err
 	}
-	if err := validateHTTPSURL("rulesURL", t.RulesURL); err != nil {
+	if err := validateHTTPURL("rulesURL", t.RulesURL); err != nil {
 		return err
 	}
 	if err := validateMaxLen("awardsNote", t.AwardsNote, MaxLenAwardsNote); err != nil {

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -154,6 +154,34 @@ var errModeImmutable = errors.New("tournament mode cannot be changed after creat
 // require X-Admin-Password. (mp-7h7 fail-open fix)
 var errSelfRunRequiresAdminPassword = errors.New("self-run tournaments require an admin (destructive-ops) password to be set; configure it before switching to self-run mode or set it in the same request")
 
+// trimPublicInfoFields trims all optional public tournament info string fields
+// and normalises the Contacts slice: each entry's Label/Value is trimmed,
+// all-empty entries are dropped, and the slice is capped at MaxTournamentContacts.
+// Called identically by the PUT and POST /tournament handlers.
+func trimPublicInfoFields(t *state.Tournament) {
+	t.VenueAddress = strings.TrimSpace(t.VenueAddress)
+	t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
+	t.OpeningTime = strings.TrimSpace(t.OpeningTime)
+	t.ClosingTime = strings.TrimSpace(t.ClosingTime)
+	t.RulesURL = strings.TrimSpace(t.RulesURL)
+	t.AwardsNote = strings.TrimSpace(t.AwardsNote)
+	t.InfoNotes = strings.TrimSpace(t.InfoNotes)
+	if len(t.Contacts) > 0 {
+		filtered := make([]state.TournamentContact, 0, len(t.Contacts))
+		for _, ct := range t.Contacts {
+			ct.Label = strings.TrimSpace(ct.Label)
+			ct.Value = strings.TrimSpace(ct.Value)
+			if ct.Label != "" || ct.Value != "" {
+				filtered = append(filtered, ct)
+			}
+		}
+		if len(filtered) > MaxTournamentContacts {
+			filtered = filtered[:MaxTournamentContacts]
+		}
+		t.Contacts = filtered
+	}
+}
+
 // validateTournamentLengths enforces the persisted-string caps from
 // validation.go on every string field of t. Called after trim and
 // after the required-field checks so error messages report the
@@ -258,29 +286,7 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		t.Name = strings.TrimSpace(t.Name)
 		t.Venue = strings.TrimSpace(t.Venue)
 		t.Date = strings.TrimSpace(t.Date)
-		// mp-ef3: trim public info fields.
-		t.VenueAddress = strings.TrimSpace(t.VenueAddress)
-		t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
-		t.OpeningTime = strings.TrimSpace(t.OpeningTime)
-		t.ClosingTime = strings.TrimSpace(t.ClosingTime)
-		t.RulesURL = strings.TrimSpace(t.RulesURL)
-		t.AwardsNote = strings.TrimSpace(t.AwardsNote)
-		t.InfoNotes = strings.TrimSpace(t.InfoNotes)
-		// Trim and filter contacts: remove entries where both label and value are empty.
-		if len(t.Contacts) > 0 {
-			filtered := make([]state.TournamentContact, 0, len(t.Contacts))
-			for _, ct := range t.Contacts {
-				ct.Label = strings.TrimSpace(ct.Label)
-				ct.Value = strings.TrimSpace(ct.Value)
-				if ct.Label != "" || ct.Value != "" {
-					filtered = append(filtered, ct)
-				}
-			}
-			if len(filtered) > MaxTournamentContacts {
-				filtered = filtered[:MaxTournamentContacts]
-			}
-			t.Contacts = filtered
-		}
+		trimPublicInfoFields(&t)
 
 		// Reject non-empty Date that doesn't match the canonical DD-MM-YYYY
 		// shape (or semantically invalid days like Feb 31). The frontend
@@ -554,28 +560,7 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		t.Name = strings.TrimSpace(t.Name)
 		t.Venue = strings.TrimSpace(t.Venue)
 		t.Date = strings.TrimSpace(t.Date)
-		// mp-ef3: trim public info fields (mirrors the PUT handler).
-		t.VenueAddress = strings.TrimSpace(t.VenueAddress)
-		t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
-		t.OpeningTime = strings.TrimSpace(t.OpeningTime)
-		t.ClosingTime = strings.TrimSpace(t.ClosingTime)
-		t.RulesURL = strings.TrimSpace(t.RulesURL)
-		t.AwardsNote = strings.TrimSpace(t.AwardsNote)
-		t.InfoNotes = strings.TrimSpace(t.InfoNotes)
-		if len(t.Contacts) > 0 {
-			filtered := make([]state.TournamentContact, 0, len(t.Contacts))
-			for _, ct := range t.Contacts {
-				ct.Label = strings.TrimSpace(ct.Label)
-				ct.Value = strings.TrimSpace(ct.Value)
-				if ct.Label != "" || ct.Value != "" {
-					filtered = append(filtered, ct)
-				}
-			}
-			if len(filtered) > MaxTournamentContacts {
-				filtered = filtered[:MaxTournamentContacts]
-			}
-			t.Contacts = filtered
-		}
+		trimPublicInfoFields(&t)
 
 		// Same empty-after-trim guard as the PUT handler.
 		if t.Name == "" {

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -19,6 +19,7 @@ package mobileapp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
@@ -39,7 +40,7 @@ const (
 	// mp-ef3: public tournament info field caps.
 	MaxLenVenueAddress    = 300
 	MaxLenVenueMapURL     = 500
-	MaxLenDisplayTime     = 5 // "HH:MM"
+	MaxLenDisplayTime     = 8 // "HH:MM" or "HH:MM:SS"
 	MaxLenRulesURL        = 500
 	MaxLenAwardsNote      = 500
 	MaxLenInfoNotes       = 2000
@@ -90,6 +91,25 @@ func validateMaxLen(field, val string, max int) error {
 		return &ValidationError{
 			Field:   field,
 			Message: fmt.Sprintf("must be <= %d characters", max),
+		}
+	}
+	return nil
+}
+
+// validateHTTPSURL returns a ValidationError when val is non-empty and does not
+// start with "http://" or "https://". These URL fields are rendered as raw href
+// values in the viewer SPA; rejecting non-http(s) schemes at the write boundary
+// prevents javascript: or data: URIs from reaching the public viewer page.
+// Empty strings pass (the fields are optional).
+func validateHTTPSURL(field, val string) error {
+	if val == "" {
+		return nil
+	}
+	lower := strings.ToLower(val)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return &ValidationError{
+			Field:   field,
+			Message: "must start with http:// or https://",
 		}
 	}
 	return nil

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -36,6 +36,17 @@ const (
 	MaxLenTournamentPassword = 256 // not trimmed; cap prevents megabyte payloads
 	MaxLenCeremonyBlock      = 16  // "1h30m" etc.
 
+	// mp-ef3: public tournament info field caps.
+	MaxLenVenueAddress    = 300
+	MaxLenVenueMapURL     = 500
+	MaxLenDisplayTime     = 5 // "HH:MM"
+	MaxLenRulesURL        = 500
+	MaxLenAwardsNote      = 500
+	MaxLenInfoNotes       = 2000
+	MaxLenContactLabel    = 50
+	MaxLenContactValue    = 200
+	MaxTournamentContacts = 10
+
 	// MaxTournamentDurationDays is the upper bound on Tournament.DurationDays.
 	// 30 days covers the longest conceivable multi-day open tournament.
 	MaxTournamentDurationDays = 30

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -96,12 +96,12 @@ func validateMaxLen(field, val string, max int) error {
 	return nil
 }
 
-// validateHTTPSURL returns a ValidationError when val is non-empty and does not
+// validateHTTPURL returns a ValidationError when val is non-empty and does not
 // start with "http://" or "https://". These URL fields are rendered as raw href
 // values in the viewer SPA; rejecting non-http(s) schemes at the write boundary
 // prevents javascript: or data: URIs from reaching the public viewer page.
 // Empty strings pass (the fields are optional).
-func validateHTTPSURL(field, val string) error {
+func validateHTTPURL(field, val string) error {
 	if val == "" {
 		return nil
 	}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -73,6 +73,25 @@ type Tournament struct {
 	// still require X-Admin-Password. omitempty means older tournament.md
 	// files (Mode == "") normalise to "officiated" via ApplyTournamentDefaults.
 	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
+
+	// Public tournament info fields (mp-ef3). All optional (omitempty).
+	// Rendered read-only on the viewer home page; editable in the admin setup form.
+	VenueAddress string              `yaml:"venue_address,omitempty" json:"venueAddress,omitempty"`
+	VenueMapURL  string              `yaml:"venue_map_url,omitempty" json:"venueMapURL,omitempty"`
+	OpeningTime  string              `yaml:"opening_time,omitempty" json:"openingTime,omitempty"`
+	ClosingTime  string              `yaml:"closing_time,omitempty" json:"closingTime,omitempty"`
+	RulesURL     string              `yaml:"rules_url,omitempty" json:"rulesURL,omitempty"`
+	AwardsNote   string              `yaml:"awards_note,omitempty" json:"awardsNote,omitempty"`
+	InfoNotes    string              `yaml:"info_notes,omitempty" json:"infoNotes,omitempty"`
+	Contacts     []TournamentContact `yaml:"contacts,omitempty" json:"contacts,omitempty"`
+}
+
+// TournamentContact is a single contact entry for attendees (mp-ef3).
+// Label is a short description (e.g. "Email", "Phone") and Value is the
+// contact detail (email address, phone number, URL, etc.).
+type TournamentContact struct {
+	Label string `yaml:"label" json:"label"`
+	Value string `yaml:"value" json:"value"`
 }
 
 // Tournament mode constants (mp-7h7).

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -104,6 +104,10 @@ func (s *Store) copyTournament(t *Tournament) *Tournament {
 		cp.Courts = make([]string, len(t.Courts))
 		copy(cp.Courts, t.Courts)
 	}
+	if t.Contacts != nil {
+		cp.Contacts = make([]TournamentContact, len(t.Contacts))
+		copy(cp.Contacts, t.Contacts)
+	}
 	return &cp
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2302,6 +2302,69 @@ button.my-match__opp {
   color: var(--ink-3);
 }
 
+/* Tournament info card (mp-ef3) — public event details */
+.tournament-info {
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--r-lg);
+  padding: 14px 16px;
+  margin-bottom: 14px;
+}
+
+.tournament-info__title {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+
+.tournament-info__grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 12px;
+  align-items: baseline;
+  margin: 0;
+}
+
+.tournament-info__label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-3);
+  white-space: nowrap;
+}
+
+.tournament-info__value {
+  font-size: 13px;
+  color: var(--ink);
+  line-height: 1.4;
+  margin: 0;
+}
+
+.tournament-info__link {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: rgba(29, 53, 87, 0.3);
+  text-underline-offset: 2px;
+}
+
+.tournament-info__link:hover {
+  text-decoration-color: var(--accent);
+}
+
+.tournament-info__contact {
+  line-height: 1.6;
+}
+
+.tournament-info__contact-label {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--ink-2);
+}
+
 .hero-live {
   background: var(--surface);
   border: 1px solid var(--red);

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel } from '../viewer.jsx';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 
@@ -524,6 +524,72 @@ describe('MatchViewerModal header + team rendering (mp-116)', () => {
     };
     const tree = runtime.mount(MatchViewerModal, { match, onClose: () => {} });
     expect(collectText(tree)).toContain('Pool A');
+  });
+});
+
+// mp-ef3 Copilot round 2: TournamentInfo component and isHttpURL helper tests.
+describe('TournamentInfo', () => {
+  let runtime;
+  const realReact = global.React;
+
+  beforeEach(() => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+  });
+
+  it('returns null when all fields are empty', () => {
+    const tree = runtime.mount(TournamentInfo, { tournament: {} });
+    expect(tree).toBeNull();
+  });
+
+  it('renders venue, times, awards, and notes when provided', () => {
+    const tree = runtime.mount(TournamentInfo, {
+      tournament: {
+        venueAddress: '1 Main St',
+        openingTime: '09:00',
+        closingTime: '18:00',
+        awardsNote: 'Gold, Silver',
+        infoNotes: 'Bring your shinai',
+      },
+    });
+    const text = collectText(tree);
+    expect(text).toContain('1 Main St');
+    expect(text).toContain('09:00');
+    expect(text).toContain('18:00');
+    expect(text).toContain('Gold, Silver');
+    expect(text).toContain('Bring your shinai');
+  });
+
+  it('creates an anchor for http(s) rulesURL but renders plain text for non-http', () => {
+    // http URL → anchor element
+    const treeHttp = runtime.mount(TournamentInfo, {
+      tournament: { rulesURL: 'https://example.com/rules.pdf' },
+    });
+    const anchor = findInTree(treeHttp, n => n.type === 'a');
+    expect(anchor).not.toBeNull();
+
+    // Non-http value → plain text, no anchor
+    const treePlain = runtime.mount(TournamentInfo, {
+      tournament: { rulesURL: 'See the notice board' },
+    });
+    const anchorPlain = findInTree(treePlain, n => n.type === 'a');
+    expect(anchorPlain).toBeNull();
+    expect(collectText(treePlain)).toContain('See the notice board');
+  });
+
+  it('isHttpURL accepts http and https but rejects other schemes', () => {
+    expect(isHttpURL('http://example.com')).toBe(true);
+    expect(isHttpURL('https://example.com')).toBe(true);
+    expect(isHttpURL('HTTP://EXAMPLE.COM')).toBe(true);
+    expect(isHttpURL('javascript:alert(1)')).toBe(false);
+    expect(isHttpURL('ftp://files.example.com')).toBe(false);
+    expect(isHttpURL('')).toBe(false);
+    expect(isHttpURL(undefined)).toBe(false);
   });
 });
 

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -184,7 +184,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       rulesURL: rulesURL.trim() || undefined,
       awardsNote: awardsNote.trim() || undefined,
       infoNotes: infoNotes.trim() || undefined,
-      contacts: contacts.filter(c => (c.label || "").trim() || (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
+      contacts: contacts.filter(c => (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
     });
   };
 

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -118,7 +118,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [rulesURL, setRulesURL] = useStateA(tournament.rulesURL || "");
   const [awardsNote, setAwardsNote] = useStateA(tournament.awardsNote || "");
   const [infoNotes, setInfoNotes] = useStateA(tournament.infoNotes || "");
-  const [contacts, setContacts] = useStateA(tournament.contacts && tournament.contacts.length > 0 ? tournament.contacts : []);
+  const [contacts, setContacts] = useStateA(tournament.contacts || []);
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
 

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -118,7 +118,8 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [rulesURL, setRulesURL] = useStateA(tournament.rulesURL || "");
   const [awardsNote, setAwardsNote] = useStateA(tournament.awardsNote || "");
   const [infoNotes, setInfoNotes] = useStateA(tournament.infoNotes || "");
-  const [contacts, setContacts] = useStateA(tournament.contacts || []);
+  const [contacts, setContacts] = useStateA((tournament.contacts || []).map((ct, i) => ({ ...ct, _key: i })));
+  const nextKeyRef = useRefA((tournament.contacts || []).length);
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
 
@@ -323,14 +324,14 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               <label className="field__label">Contacts</label>
               <div className="field__hint" style={{ marginBottom: 8 }}>Add contact methods for attendees (max 10).</div>
               {contacts.map((ct, i) => (
-                <div key={i} style={{ display: "flex", gap: 8, marginBottom: 6 }}>
+                <div key={ct._key} style={{ display: "flex", gap: 8, marginBottom: 6 }}>
                   <input className="input" style={{ flex: "0 0 120px" }} value={ct.label} onChange={(e) => { const next = [...contacts]; next[i] = { ...next[i], label: e.target.value }; setContacts(next); }} placeholder="Label" />
                   <input className="input" style={{ flex: 1 }} value={ct.value} onChange={(e) => { const next = [...contacts]; next[i] = { ...next[i], value: e.target.value }; setContacts(next); }} placeholder="Value (email, phone, URL, etc.)" />
                   <button className="btn" style={{ padding: "4px 10px" }} onClick={() => setContacts(contacts.filter((_, j) => j !== i))}>✕</button>
                 </div>
               ))}
               {contacts.length < 10 && (
-                <button className="btn" style={{ fontSize: 12, marginTop: 4 }} onClick={() => setContacts([...contacts, { label: "", value: "" }])}>+ Add contact</button>
+                <button className="btn" style={{ fontSize: 12, marginTop: 4 }} onClick={() => setContacts([...contacts, { label: "", value: "", _key: nextKeyRef.current++ }])}>+ Add contact</button>
               )}
             </div>
           </div>

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -110,6 +110,15 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [openingBlock, setOpeningBlock] = useStateA(tournament.openingBlock || "");
   const [lunchBlock, setLunchBlock] = useStateA(tournament.lunchBlock || "");
   const [closingBlock, setClosingBlock] = useStateA(tournament.closingBlock || "");
+  // mp-ef3: public tournament info fields.
+  const [venueAddress, setVenueAddress] = useStateA(tournament.venueAddress || "");
+  const [venueMapURL, setVenueMapURL] = useStateA(tournament.venueMapURL || "");
+  const [openingTime, setOpeningTime] = useStateA(tournament.openingTime || "");
+  const [closingTime, setClosingTime] = useStateA(tournament.closingTime || "");
+  const [rulesURL, setRulesURL] = useStateA(tournament.rulesURL || "");
+  const [awardsNote, setAwardsNote] = useStateA(tournament.awardsNote || "");
+  const [infoNotes, setInfoNotes] = useStateA(tournament.infoNotes || "");
+  const [contacts, setContacts] = useStateA(tournament.contacts && tournament.contacts.length > 0 ? tournament.contacts : []);
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
 
@@ -167,6 +176,14 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       openingBlock: openingBlock.trim() || undefined,
       lunchBlock: lunchBlock.trim() || undefined,
       closingBlock: closingBlock.trim() || undefined,
+      venueAddress: venueAddress.trim() || undefined,
+      venueMapURL: venueMapURL.trim() || undefined,
+      openingTime: openingTime.trim() || undefined,
+      closingTime: closingTime.trim() || undefined,
+      rulesURL: rulesURL.trim() || undefined,
+      awardsNote: awardsNote.trim() || undefined,
+      infoNotes: infoNotes.trim() || undefined,
+      contacts: contacts.filter(c => (c.label || "").trim() || (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
     });
   };
 
@@ -263,6 +280,58 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               <label className="field__label">Closing ceremony <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
               <input className="input" value={closingBlock} onChange={(e) => setClosingBlock(e.target.value)} placeholder="e.g. 30m" />
               <div className="field__hint">Duration of the closing ceremony block. Leave blank if none.</div>
+            </div>
+          </div>
+          {/* mp-ef3: Tournament Information (Public) */}
+          <div style={{ borderTop: "1px solid var(--line)", marginTop: 20, paddingTop: 20 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--ink-3)", marginBottom: 12 }}>Tournament Information (Public)</div>
+            <div className="field">
+              <label className="field__label">Venue address</label>
+              <input className="input" value={venueAddress} onChange={(e) => setVenueAddress(e.target.value)} placeholder="123 Sport Centre Dr, City" />
+            </div>
+            <div className="field">
+              <label className="field__label">Map link</label>
+              <input className="input" value={venueMapURL} onChange={(e) => setVenueMapURL(e.target.value)} placeholder="https://maps.google.com/..." />
+              <div className="field__hint">Link to venue on Google Maps or similar.</div>
+            </div>
+            <div className="row">
+              <div className="field">
+                <label className="field__label">Opening time</label>
+                <input className="input" type="time" value={openingTime} onChange={(e) => setOpeningTime(e.target.value)} />
+                <div className="field__hint">Doors open / spectator arrival time.</div>
+              </div>
+              <div className="field">
+                <label className="field__label">Closing time</label>
+                <input className="input" type="time" value={closingTime} onChange={(e) => setClosingTime(e.target.value)} />
+                <div className="field__hint">Expected end time for the day.</div>
+              </div>
+            </div>
+            <div className="field">
+              <label className="field__label">Rules link</label>
+              <input className="input" value={rulesURL} onChange={(e) => setRulesURL(e.target.value)} placeholder="https://..." />
+              <div className="field__hint">Link to tournament rules document or PDF.</div>
+            </div>
+            <div className="field">
+              <label className="field__label">Awards</label>
+              <textarea className="input" rows={2} value={awardsNote} onChange={(e) => setAwardsNote(e.target.value)} placeholder="Gold, Silver, Bronze per competition" />
+            </div>
+            <div className="field">
+              <label className="field__label">Notes</label>
+              <textarea className="input" rows={3} value={infoNotes} onChange={(e) => setInfoNotes(e.target.value)} placeholder="General information for attendees" />
+            </div>
+            <div className="field">
+              <label className="field__label">Contacts</label>
+              <div className="field__hint" style={{ marginBottom: 8 }}>Add contact methods for attendees (max 10).</div>
+              {contacts.map((ct, i) => (
+                <div key={i} style={{ display: "flex", gap: 8, marginBottom: 6 }}>
+                  <input className="input" style={{ flex: "0 0 120px" }} value={ct.label} onChange={(e) => { const next = [...contacts]; next[i] = { ...next[i], label: e.target.value }; setContacts(next); }} placeholder="Label" />
+                  <input className="input" style={{ flex: 1 }} value={ct.value} onChange={(e) => { const next = [...contacts]; next[i] = { ...next[i], value: e.target.value }; setContacts(next); }} placeholder="Value (email, phone, URL, etc.)" />
+                  <button className="btn" style={{ padding: "4px 10px" }} onClick={() => setContacts(contacts.filter((_, j) => j !== i))}>✕</button>
+                </div>
+              ))}
+              {contacts.length < 10 && (
+                <button className="btn" style={{ fontSize: 12, marginTop: 4 }} onClick={() => setContacts([...contacts, { label: "", value: "" }])}>+ Add contact</button>
+              )}
             </div>
           </div>
           {locked ? (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -521,12 +521,15 @@ function MyMatchAlertBanner({ match, onView, onDismiss }) {
   );
 }
 
+// isHttpURL returns true when u starts with http:// or https://. Exported for
+// testing (mp-ef3 Copilot round 2).
+export const isHttpURL = (u) => /^https?:\/\//i.test(u);
+
 // TournamentInfo renders optional public tournament info (mp-ef3) as a
 // read-only card on the viewer home page. Returns null when no info fields
 // are set so the card is invisible for tournaments that haven't filled them in.
-function TournamentInfo({ tournament }) {
+export function TournamentInfo({ tournament }) {
   const t = tournament;
-  const isHttpURL = (u) => /^https?:\/\//i.test(u);
   if (!t.venueAddress && !t.venueMapURL && !t.openingTime && !t.closingTime && !t.awardsNote && !t.rulesURL && !t.infoNotes && !(t.contacts && t.contacts.length > 0)) return null;
 
   const contactLink = (value) => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -526,11 +526,12 @@ function MyMatchAlertBanner({ match, onView, onDismiss }) {
 // are set so the card is invisible for tournaments that haven't filled them in.
 function TournamentInfo({ tournament }) {
   const t = tournament;
-  if (!t.venueAddress && !t.openingTime && !t.closingTime && !t.awardsNote && !t.rulesURL && !t.infoNotes && !(t.contacts && t.contacts.length > 0)) return null;
+  const isHttpURL = (u) => /^https?:\/\//i.test(u);
+  if (!t.venueAddress && !t.venueMapURL && !t.openingTime && !t.closingTime && !t.awardsNote && !t.rulesURL && !t.infoNotes && !(t.contacts && t.contacts.length > 0)) return null;
 
   const contactLink = (value) => {
     if (!value) return value;
-    if (value.match(/^https?:\/\//i)) return <a href={value} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{value.replace(/^https?:\/\//i, "")}</a>;
+    if (isHttpURL(value)) return <a href={value} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{value.replace(/^https?:\/\//i, "")}</a>;
     if (value.includes("@")) return <a href={"mailto:" + value} className="tournament-info__link">{value}</a>;
     if (/^\+?[\d\s()-]+$/.test(value)) return <a href={"tel:" + value.replace(/[\s()-]/g, "")} className="tournament-info__link">{value}</a>;
     return value;
@@ -540,11 +541,11 @@ function TournamentInfo({ tournament }) {
     <div className="tournament-info">
       <div className="tournament-info__title">Tournament Info</div>
       <dl className="tournament-info__grid">
-        {t.venueAddress && <>
+        {(t.venueAddress || t.venueMapURL) && <>
           <dt className="tournament-info__label">Venue</dt>
           <dd className="tournament-info__value">
             {t.venueAddress}
-            {t.venueMapURL && <>{" "}<a href={t.venueMapURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">View map ↗</a></>}
+            {t.venueMapURL && isHttpURL(t.venueMapURL) && <>{t.venueAddress ? " " : ""}<a href={t.venueMapURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">View map ↗</a></>}
           </dd>
         </>}
         {(t.openingTime || t.closingTime) && <>
@@ -559,7 +560,7 @@ function TournamentInfo({ tournament }) {
         </>}
         {t.rulesURL && <>
           <dt className="tournament-info__label">Rules</dt>
-          <dd className="tournament-info__value"><a href={t.rulesURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{t.rulesURL.replace(/^https?:\/\//i, "")}</a></dd>
+          <dd className="tournament-info__value">{isHttpURL(t.rulesURL) ? <a href={t.rulesURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{t.rulesURL.replace(/^https?:\/\//i, "")}</a> : t.rulesURL}</dd>
         </>}
         {t.infoNotes && <>
           <dt className="tournament-info__label">Notes</dt>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -521,6 +521,73 @@ function MyMatchAlertBanner({ match, onView, onDismiss }) {
   );
 }
 
+// TournamentInfo renders optional public tournament info (mp-ef3) as a
+// read-only card on the viewer home page. Returns null when no info fields
+// are set so the card is invisible for tournaments that haven't filled them in.
+function TournamentInfo({ tournament }) {
+  const t = tournament;
+  const hasAddress = !!(t.venueAddress);
+  const hasTimes = !!(t.openingTime || t.closingTime);
+  const hasAwards = !!(t.awardsNote);
+  const hasRules = !!(t.rulesURL);
+  const hasNotes = !!(t.infoNotes);
+  const hasContacts = !!(t.contacts && t.contacts.length > 0);
+
+  if (!hasAddress && !hasTimes && !hasAwards && !hasRules && !hasNotes && !hasContacts) return null;
+
+  const contactLink = (value) => {
+    if (!value) return value;
+    if (value.match(/^https?:\/\//i)) return <a href={value} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{value.replace(/^https?:\/\//i, "")}</a>;
+    if (value.includes("@")) return <a href={"mailto:" + value} className="tournament-info__link">{value}</a>;
+    if (/^\+?[\d\s()-]+$/.test(value)) return <a href={"tel:" + value.replace(/[\s()-]/g, "")} className="tournament-info__link">{value}</a>;
+    return value;
+  };
+
+  return (
+    <div className="tournament-info">
+      <div className="tournament-info__title">Tournament Info</div>
+      <dl className="tournament-info__grid">
+        {hasAddress && <>
+          <dt className="tournament-info__label">Venue</dt>
+          <dd className="tournament-info__value">
+            {t.venueAddress}
+            {t.venueMapURL && <>{" "}<a href={t.venueMapURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">View map ↗</a></>}
+          </dd>
+        </>}
+        {hasTimes && <>
+          <dt className="tournament-info__label">Times</dt>
+          <dd className="tournament-info__value">
+            {t.openingTime && t.closingTime ? `${t.openingTime} – ${t.closingTime}` : t.openingTime ? `Opens ${t.openingTime}` : `Closes ${t.closingTime}`}
+          </dd>
+        </>}
+        {hasAwards && <>
+          <dt className="tournament-info__label">Awards</dt>
+          <dd className="tournament-info__value">{t.awardsNote}</dd>
+        </>}
+        {hasRules && <>
+          <dt className="tournament-info__label">Rules</dt>
+          <dd className="tournament-info__value"><a href={t.rulesURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{t.rulesURL.replace(/^https?:\/\//i, "")}</a></dd>
+        </>}
+        {hasNotes && <>
+          <dt className="tournament-info__label">Notes</dt>
+          <dd className="tournament-info__value">{t.infoNotes}</dd>
+        </>}
+        {hasContacts && <>
+          <dt className="tournament-info__label">Contact</dt>
+          <dd className="tournament-info__value">
+            {t.contacts.map((ct, i) => (
+              <div key={i} className="tournament-info__contact">
+                {ct.label && <span className="tournament-info__contact-label">{ct.label}:</span>}
+                {" "}{contactLink(ct.value)}
+              </div>
+            ))}
+          </dd>
+        </>}
+      </dl>
+    </div>
+  );
+}
+
 function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister }) {
   const t = tournament;
   const comps = t.competitions || [];
@@ -644,6 +711,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
         </div>
 
         <div className="viewer__body">
+          <TournamentInfo tournament={t} />
           <div style={{ marginBottom: 16, display: "flex", justifyContent: "flex-end" }}>
              <select className="input" style={{ width: "auto" }} value={courtFilter} onChange={(e) => setCourtFilter(e.target.value)}>
                <option value="all">All Shiaijo</option>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -526,14 +526,7 @@ function MyMatchAlertBanner({ match, onView, onDismiss }) {
 // are set so the card is invisible for tournaments that haven't filled them in.
 function TournamentInfo({ tournament }) {
   const t = tournament;
-  const hasAddress = !!(t.venueAddress);
-  const hasTimes = !!(t.openingTime || t.closingTime);
-  const hasAwards = !!(t.awardsNote);
-  const hasRules = !!(t.rulesURL);
-  const hasNotes = !!(t.infoNotes);
-  const hasContacts = !!(t.contacts && t.contacts.length > 0);
-
-  if (!hasAddress && !hasTimes && !hasAwards && !hasRules && !hasNotes && !hasContacts) return null;
+  if (!t.venueAddress && !t.openingTime && !t.closingTime && !t.awardsNote && !t.rulesURL && !t.infoNotes && !(t.contacts && t.contacts.length > 0)) return null;
 
   const contactLink = (value) => {
     if (!value) return value;
@@ -547,32 +540,32 @@ function TournamentInfo({ tournament }) {
     <div className="tournament-info">
       <div className="tournament-info__title">Tournament Info</div>
       <dl className="tournament-info__grid">
-        {hasAddress && <>
+        {t.venueAddress && <>
           <dt className="tournament-info__label">Venue</dt>
           <dd className="tournament-info__value">
             {t.venueAddress}
             {t.venueMapURL && <>{" "}<a href={t.venueMapURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">View map ↗</a></>}
           </dd>
         </>}
-        {hasTimes && <>
+        {(t.openingTime || t.closingTime) && <>
           <dt className="tournament-info__label">Times</dt>
           <dd className="tournament-info__value">
             {t.openingTime && t.closingTime ? `${t.openingTime} – ${t.closingTime}` : t.openingTime ? `Opens ${t.openingTime}` : `Closes ${t.closingTime}`}
           </dd>
         </>}
-        {hasAwards && <>
+        {t.awardsNote && <>
           <dt className="tournament-info__label">Awards</dt>
           <dd className="tournament-info__value">{t.awardsNote}</dd>
         </>}
-        {hasRules && <>
+        {t.rulesURL && <>
           <dt className="tournament-info__label">Rules</dt>
           <dd className="tournament-info__value"><a href={t.rulesURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{t.rulesURL.replace(/^https?:\/\//i, "")}</a></dd>
         </>}
-        {hasNotes && <>
+        {t.infoNotes && <>
           <dt className="tournament-info__label">Notes</dt>
           <dd className="tournament-info__value">{t.infoNotes}</dd>
         </>}
-        {hasContacts && <>
+        {t.contacts && t.contacts.length > 0 && <>
           <dt className="tournament-info__label">Contact</dt>
           <dd className="tournament-info__value">
             {t.contacts.map((ct, i) => (


### PR DESCRIPTION
## Summary
- Add 8 optional info fields to Tournament config: venue address, map URL, opening/closing times, rules URL, awards note, free-text notes, and a contacts list (label+value, max 10)
- Admin editor: new "Tournament Information (Public)" section in Edit Tournament with text/time/URL inputs and a contacts repeater
- Viewer home: `TournamentInfo` card renders below the hero header with a definition-list grid layout, auto-linked contacts (email/phone/URL detection), and hides entirely when no info fields are set

## Test plan
- [x] Admin: fill all info fields → Save → reload → verify values persisted
- [x] Viewer: see tournament info card with all rows (venue, times, awards, rules, notes, contacts)
- [x] Viewer: empty tournament (no info fields) → no info card visible
- [x] Viewer: partial fields (only venue address + 1 contact) → only those rows shown
- [x] Contact links: email renders as mailto, phone as tel, URL as anchor
- [x] Map link + Rules link: open in new tab
- [x] `make go/test` passes (lint + security + tests)

Bead: mp-ef3

🤖 Generated with [Claude Code](https://claude.com/claude-code)