### PR TITLE
feat(mp-c38): tournament sponsor logos on viewer, lobby, and TV displays

### DIFF
--- a/internal/mobileapp/handlers_sponsors.go
+++ b/internal/mobileapp/handlers_sponsors.go
@@ -120,9 +120,9 @@ func handleSponsorUpload(store *state.Store) gin.HandlerFunc {
 		defer func() { _ = src.Close() }()
 
 		// Sniff first 512 bytes per http.DetectContentType contract.
-		// Don't trust the Content-Type header. multipart.File is
-		// guaranteed by the net/textproto contract to be a ReadSeeker,
-		// so the Seek below cannot fail in practice.
+		// Don't trust the Content-Type header. fileHeader.Open() returns
+		// mime/multipart.File, which embeds io.ReadSeeker — so src.Seek
+		// below is part of the type and cannot fail at compile time.
 		sniffBuf := make([]byte, 512)
 		nRead, rerr := io.ReadFull(src, sniffBuf)
 		// ErrUnexpectedEOF on a short part is fine: DetectContentType
@@ -138,7 +138,7 @@ func handleSponsorUpload(store *state.Store) gin.HandlerFunc {
 			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "only PNG or JPEG accepted"})
 			return
 		}
-		if _, err := src.(io.Seeker).Seek(0, io.SeekStart); err != nil {
+		if _, err := src.Seek(0, io.SeekStart); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/mobileapp/handlers_sponsors.go
+++ b/internal/mobileapp/handlers_sponsors.go
@@ -1,0 +1,239 @@
+package mobileapp
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// sponsorsDirName is the subdirectory under the store root that holds
+// uploaded sponsor logo files. Created lazily on first upload.
+const sponsorsDirName = "sponsors"
+
+// sponsorFilePattern enforces the server-generated filename shape on the
+// public GET route: 16 lowercase hex chars + .png/.jpg/.jpeg. Any other
+// shape (path traversal, absent suffix, uppercase, longer/shorter) is
+// rejected before touching the filesystem.
+var sponsorFilePattern = regexp.MustCompile(`^[a-f0-9]{16}\.(png|jpe?g)$`)
+
+// validSponsorContentTypes is the allowlist for the http.DetectContentType
+// sniff result on POST. Header Content-Type is not trusted.
+var validSponsorContentTypes = map[string]string{
+	"image/png":  ".png",
+	"image/jpeg": ".jpg",
+}
+
+// maxSponsorNameLen and maxSponsorLinkLen bound the optional metadata
+// fields to keep YAML compact and prevent abuse.
+const (
+	maxSponsorNameLen = 80
+	maxSponsorLinkLen = 500
+)
+
+// RegisterPublicSponsorHandlers wires the unauthenticated GET route that
+// serves sponsor logo bytes. Public because the logos render on viewer
+// and TV/lobby surfaces that have no admin credentials.
+func RegisterPublicSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
+	r.GET("/sponsors/:file", func(c *gin.Context) {
+		name := c.Param("file")
+		if !sponsorFilePattern.MatchString(name) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid sponsor filename"})
+			return
+		}
+		path := filepath.Join(store.GetFolder(), sponsorsDirName, name)
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			c.JSON(http.StatusNotFound, gin.H{"error": "sponsor logo not found"})
+			return
+		}
+		// Content-hashed filenames are unique per upload, so the bytes a
+		// given URL refers to never change. immutable is correct here, not
+		// aspirational; see mp-c38 plan.
+		c.Header("Cache-Control", "public, max-age=31536000, immutable")
+		c.Header("ETag", `"`+strings.TrimSuffix(name, filepath.Ext(name))+`"`)
+		// Pick content-type from filename extension; we control the names
+		// so this is safe (no header-trust loop).
+		ext := strings.ToLower(filepath.Ext(name))
+		switch ext {
+		case ".png":
+			c.Header("Content-Type", "image/png")
+		case ".jpg", ".jpeg":
+			c.Header("Content-Type", "image/jpeg")
+		}
+		c.File(path)
+	})
+}
+
+// RegisterSponsorHandlers wires admin-gated mutation endpoints onto the
+// supplied admin router group (which already carries body-cap + auth
+// middleware). The caller must use a group whose body cap is at least
+// SponsorMaxBodyBytes (2 MB) — the in-handler file size check at
+// SponsorMaxFileBytes still applies separately.
+func RegisterSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
+	r.POST("/sponsors", func(c *gin.Context) {
+		t, err := store.LoadTournament()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if t == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "tournament not initialized"})
+			return
+		}
+		if len(t.Sponsors) >= state.MaxSponsors {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "maximum " + strconv.Itoa(state.MaxSponsors) + " sponsors per tournament",
+			})
+			return
+		}
+
+		name := strings.TrimSpace(c.PostForm("name"))
+		if name == "" || len([]rune(name)) > maxSponsorNameLen {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "name is required (1–80 chars)"})
+			return
+		}
+
+		link := strings.TrimSpace(c.PostForm("link"))
+		if link != "" {
+			if len(link) > maxSponsorLinkLen {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "link must be ≤500 chars"})
+				return
+			}
+			u, perr := url.Parse(link)
+			if perr != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "link must be a valid http(s) URL"})
+				return
+			}
+		}
+
+		fileHeader, err := c.FormFile("file")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
+			return
+		}
+		if fileHeader.Size > SponsorMaxFileBytes {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
+			return
+		}
+
+		src, err := fileHeader.Open()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer func() { _ = src.Close() }()
+
+		// Sniff the first 512 bytes per http.DetectContentType contract.
+		// Don't trust the Content-Type header; clients lie.
+		sniffBuf := make([]byte, 512)
+		nRead, _ := io.ReadFull(src, sniffBuf)
+		sniffed := http.DetectContentType(sniffBuf[:nRead])
+		ext, ok := validSponsorContentTypes[sniffed]
+		if !ok {
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "only PNG or JPEG accepted"})
+			return
+		}
+		// Rewind so we can copy the full file. fileHeader.Open returns a
+		// multipart.File which is always io.Seeker — but defend against
+		// future refactors with an explicit assertion.
+		seeker, ok := src.(io.Seeker)
+		if !ok {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal: file not seekable"})
+			return
+		}
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		// Server-generated random filename: 16 hex chars + sniffed-ext.
+		// Each upload gets a unique URL — see mp-c38 plan §2.
+		nameBytes := make([]byte, 8)
+		if _, err := rand.Read(nameBytes); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		fileName := hex.EncodeToString(nameBytes) + ext
+
+		sponsorsDir := filepath.Join(store.GetFolder(), sponsorsDirName)
+		if err := os.MkdirAll(sponsorsDir, 0o700); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// fileName is server-generated (16 random hex chars + sniffed image
+		// extension); the path joins under sponsorsDir which is itself
+		// derived from store.GetFolder. No user-controlled input reaches
+		// the OS call.
+		// #nosec G304 -- filename is server-generated, not from user input
+		dst, err := os.OpenFile(filepath.Join(sponsorsDir, fileName), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// Cap the file-write side at SponsorMaxFileBytes+1 so an envelope
+		// that lied about size can still be caught mid-stream.
+		written, copyErr := io.Copy(dst, io.LimitReader(src, SponsorMaxFileBytes+1))
+		cerr := dst.Close()
+		if copyErr != nil || cerr != nil {
+			_ = os.Remove(filepath.Join(sponsorsDir, fileName))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Join(copyErr, cerr).Error()})
+			return
+		}
+		if written > SponsorMaxFileBytes {
+			_ = os.Remove(filepath.Join(sponsorsDir, fileName))
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
+			return
+		}
+
+		// Persist the sponsor entry. Re-load under the store lock via
+		// SaveTournament — the brief window between LoadTournament above
+		// and Save below is bounded by the per-store mutex in Save.
+		sponsor := state.Sponsor{Name: name, File: fileName, Link: link}
+		t.Sponsors = append(t.Sponsors, sponsor)
+		if err := store.SaveTournament(t); err != nil {
+			_ = os.Remove(filepath.Join(sponsorsDir, fileName))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusCreated, sponsor)
+	})
+
+	r.DELETE("/sponsors/:index", func(c *gin.Context) {
+		idx, err := strconv.Atoi(c.Param("index"))
+		if err != nil || idx < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid index"})
+			return
+		}
+		t, err := store.LoadTournament()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if t == nil || idx >= len(t.Sponsors) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "sponsor not found"})
+			return
+		}
+		removed := t.Sponsors[idx]
+		t.Sponsors = append(t.Sponsors[:idx], t.Sponsors[idx+1:]...)
+		if err := store.SaveTournament(t); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// Unlink the file unconditionally — random filenames mean cross-
+		// references are effectively impossible at the 1–6 scale (mp-c38).
+		// Best-effort: log on failure but don't roll back the YAML write.
+		_ = os.Remove(filepath.Join(store.GetFolder(), sponsorsDirName, removed.File))
+		c.JSON(http.StatusOK, gin.H{"removed": removed})
+	})
+}

--- a/internal/mobileapp/handlers_sponsors.go
+++ b/internal/mobileapp/handlers_sponsors.go
@@ -252,7 +252,17 @@ func handleSponsorDelete(store *state.Store) gin.HandlerFunc {
 		// Best-effort unlink. Random filenames make collisions effectively
 		// impossible at the 1–6 scale, so a missing file (ENOENT from a
 		// concurrent delete) is harmless and silently ignored.
-		_ = os.Remove(filepath.Join(store.GetFolder(), sponsorsDirName, removed.File))
+		//
+		// Defense-in-depth: the filename in tournament.md was server-
+		// generated, but a hand-edited or corrupt YAML could supply a
+		// traversal path like "../../etc/passwd". Re-apply the same
+		// allowlist regex used by the GET handler before unlinking so
+		// this endpoint can never delete arbitrary files under the
+		// store root. Invalid → skip the unlink; the YAML entry is
+		// already removed.
+		if sponsorFilePattern.MatchString(removed.File) {
+			_ = os.Remove(filepath.Join(store.GetFolder(), sponsorsDirName, removed.File))
+		}
 		c.JSON(http.StatusOK, gin.H{"removed": removed})
 	}
 }

--- a/internal/mobileapp/handlers_sponsors.go
+++ b/internal/mobileapp/handlers_sponsors.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,11 +33,12 @@ var validSponsorContentTypes = map[string]string{
 	"image/jpeg": ".jpg",
 }
 
-// maxSponsorNameLen and maxSponsorLinkLen bound the optional metadata
-// fields to keep YAML compact and prevent abuse.
-const (
-	maxSponsorNameLen = 80
-	maxSponsorLinkLen = 500
+// Sentinel errors surfaced by the POST/DELETE transforms so the handler
+// can map them to specific status codes without inspecting strings.
+var (
+	errSponsorTournamentNotInit = errors.New("tournament not initialized")
+	errSponsorCapReached        = errors.New("sponsor cap reached")
+	errSponsorNotFound          = errors.New("sponsor not found")
 )
 
 // RegisterPublicSponsorHandlers wires the unauthenticated GET route that
@@ -52,19 +52,25 @@ func RegisterPublicSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
 			return
 		}
 		path := filepath.Join(store.GetFolder(), sponsorsDirName, name)
-		info, err := os.Stat(path)
-		if err != nil || info.IsDir() {
+		// Lstat (not Stat) so a symlink planted in the sponsors dir is
+		// rejected rather than followed. The filename regex prevents
+		// directory traversal, but a separate write path (operator,
+		// backup-restore, future feature) could drop a symlink into the
+		// dir; refusing to serve symlinks closes that gap regardless.
+		info, err := os.Lstat(path)
+		if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			c.JSON(http.StatusNotFound, gin.H{"error": "sponsor logo not found"})
 			return
 		}
-		// Content-hashed filenames are unique per upload, so the bytes a
-		// given URL refers to never change. immutable is correct here, not
-		// aspirational; see mp-c38 plan.
-		c.Header("Cache-Control", "public, max-age=31536000, immutable")
-		c.Header("ETag", `"`+strings.TrimSuffix(name, filepath.Ext(name))+`"`)
-		// Pick content-type from filename extension; we control the names
-		// so this is safe (no header-trust loop).
 		ext := strings.ToLower(filepath.Ext(name))
+		// Random-token filenames are unique per upload, so the bytes a
+		// given URL refers to never change. immutable is correct here,
+		// not aspirational; see mp-c38 plan.
+		c.Header("Cache-Control", "public, max-age=31536000, immutable")
+		c.Header("ETag", `"`+strings.TrimSuffix(name, ext)+`"`)
+		// Set Content-Type explicitly from extension; we control the
+		// names (regex-validated) so this is safe and avoids depending
+		// on the platform's MIME database via http.ServeFile.
 		switch ext {
 		case ".png":
 			c.Header("Content-Type", "image/png")
@@ -81,40 +87,19 @@ func RegisterPublicSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
 // SponsorMaxBodyBytes (2 MB) — the in-handler file size check at
 // SponsorMaxFileBytes still applies separately.
 func RegisterSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
-	r.POST("/sponsors", func(c *gin.Context) {
-		t, err := store.LoadTournament()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-		if t == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "tournament not initialized"})
-			return
-		}
-		if len(t.Sponsors) >= state.MaxSponsors {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "maximum " + strconv.Itoa(state.MaxSponsors) + " sponsors per tournament",
-			})
-			return
-		}
+	r.POST("/sponsors", handleSponsorUpload(store))
+	r.DELETE("/sponsors/:index", handleSponsorDelete(store))
+}
 
-		name := strings.TrimSpace(c.PostForm("name"))
-		if name == "" || len([]rune(name)) > maxSponsorNameLen {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "name is required (1–80 chars)"})
-			return
+func handleSponsorUpload(store *state.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		candidate := state.Sponsor{
+			Name: strings.TrimSpace(c.PostForm("name")),
+			Link: strings.TrimSpace(c.PostForm("link")),
 		}
-
-		link := strings.TrimSpace(c.PostForm("link"))
-		if link != "" {
-			if len(link) > maxSponsorLinkLen {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "link must be ≤500 chars"})
-				return
-			}
-			u, perr := url.Parse(link)
-			if perr != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "link must be a valid http(s) URL"})
-				return
-			}
+		if err := state.ValidateSponsor(candidate); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 
 		fileHeader, err := c.FormFile("file")
@@ -134,30 +119,31 @@ func RegisterSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
 		}
 		defer func() { _ = src.Close() }()
 
-		// Sniff the first 512 bytes per http.DetectContentType contract.
-		// Don't trust the Content-Type header; clients lie.
+		// Sniff first 512 bytes per http.DetectContentType contract.
+		// Don't trust the Content-Type header. multipart.File is
+		// guaranteed by the net/textproto contract to be a ReadSeeker,
+		// so the Seek below cannot fail in practice.
 		sniffBuf := make([]byte, 512)
-		nRead, _ := io.ReadFull(src, sniffBuf)
+		nRead, rerr := io.ReadFull(src, sniffBuf)
+		// ErrUnexpectedEOF on a short part is fine: DetectContentType
+		// sniffs whatever bytes are present. Any other read error is a
+		// real I/O failure and we cannot recover.
+		if rerr != nil && !errors.Is(rerr, io.ErrUnexpectedEOF) && !errors.Is(rerr, io.EOF) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": rerr.Error()})
+			return
+		}
 		sniffed := http.DetectContentType(sniffBuf[:nRead])
 		ext, ok := validSponsorContentTypes[sniffed]
 		if !ok {
 			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "only PNG or JPEG accepted"})
 			return
 		}
-		// Rewind so we can copy the full file. fileHeader.Open returns a
-		// multipart.File which is always io.Seeker — but defend against
-		// future refactors with an explicit assertion.
-		seeker, ok := src.(io.Seeker)
-		if !ok {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal: file not seekable"})
-			return
-		}
-		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+		if _, err := src.(io.Seeker).Seek(0, io.SeekStart); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
 
-		// Server-generated random filename: 16 hex chars + sniffed-ext.
+		// Server-generated random filename: 16 hex chars + sniffed ext.
 		// Each upload gets a unique URL — see mp-c38 plan §2.
 		nameBytes := make([]byte, 8)
 		if _, err := rand.Read(nameBytes); err != nil {
@@ -171,69 +157,102 @@ func RegisterSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		// fileName is server-generated (16 random hex chars + sniffed image
-		// extension); the path joins under sponsorsDir which is itself
-		// derived from store.GetFolder. No user-controlled input reaches
-		// the OS call.
+		fullPath := filepath.Join(sponsorsDir, fileName)
+		// fileName is server-generated (16 random hex chars + sniffed
+		// image extension); fullPath joins under sponsorsDir which is
+		// itself derived from store.GetFolder. No user-controlled input
+		// reaches the OS call.
 		// #nosec G304 -- filename is server-generated, not from user input
-		dst, err := os.OpenFile(filepath.Join(sponsorsDir, fileName), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		dst, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		// Cap the file-write side at SponsorMaxFileBytes+1 so an envelope
-		// that lied about size can still be caught mid-stream.
+		// LimitReader+1 catches an envelope that lied about its size.
 		written, copyErr := io.Copy(dst, io.LimitReader(src, SponsorMaxFileBytes+1))
 		cerr := dst.Close()
 		if copyErr != nil || cerr != nil {
-			_ = os.Remove(filepath.Join(sponsorsDir, fileName))
+			_ = os.Remove(fullPath)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Join(copyErr, cerr).Error()})
 			return
 		}
 		if written > SponsorMaxFileBytes {
-			_ = os.Remove(filepath.Join(sponsorsDir, fileName))
+			_ = os.Remove(fullPath)
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
 			return
 		}
 
-		// Persist the sponsor entry. Re-load under the store lock via
-		// SaveTournament — the brief window between LoadTournament above
-		// and Save below is bounded by the per-store mutex in Save.
-		sponsor := state.Sponsor{Name: name, File: fileName, Link: link}
-		t.Sponsors = append(t.Sponsors, sponsor)
-		if err := store.SaveTournament(t); err != nil {
-			_ = os.Remove(filepath.Join(sponsorsDir, fileName))
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		// Append the sponsor entry atomically under the store lock.
+		// UpdateTournamentChanged serialises load+modify+save so two
+		// concurrent uploads can't exceed the cap or clobber each
+		// other's appended entry. The transform copies all fields from
+		// current; we replace Sponsors with a fresh slice to avoid
+		// aliasing current's backing array.
+		candidate.File = fileName
+		_, err = store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
+			if current == nil {
+				return errSponsorTournamentNotInit
+			}
+			*desired = *current
+			if len(current.Sponsors) >= state.MaxSponsors {
+				return errSponsorCapReached
+			}
+			sponsors := make([]state.Sponsor, len(current.Sponsors)+1)
+			copy(sponsors, current.Sponsors)
+			sponsors[len(current.Sponsors)] = candidate
+			desired.Sponsors = sponsors
+			return nil
+		})
+		if err != nil {
+			_ = os.Remove(fullPath)
+			switch {
+			case errors.Is(err, errSponsorTournamentNotInit):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			case errors.Is(err, errSponsorCapReached):
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "maximum " + strconv.Itoa(state.MaxSponsors) + " sponsors per tournament",
+				})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
 			return
 		}
-		c.JSON(http.StatusCreated, sponsor)
-	})
+		c.JSON(http.StatusCreated, candidate)
+	}
+}
 
-	r.DELETE("/sponsors/:index", func(c *gin.Context) {
+func handleSponsorDelete(store *state.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
 		idx, err := strconv.Atoi(c.Param("index"))
 		if err != nil || idx < 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid index"})
 			return
 		}
-		t, err := store.LoadTournament()
+		var removed state.Sponsor
+		_, err = store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
+			if current == nil || idx >= len(current.Sponsors) {
+				return errSponsorNotFound
+			}
+			*desired = *current
+			sponsors := make([]state.Sponsor, 0, len(current.Sponsors)-1)
+			sponsors = append(sponsors, current.Sponsors[:idx]...)
+			sponsors = append(sponsors, current.Sponsors[idx+1:]...)
+			removed = current.Sponsors[idx]
+			desired.Sponsors = sponsors
+			return nil
+		})
 		if err != nil {
+			if errors.Is(err, errSponsorNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "sponsor not found"})
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		if t == nil || idx >= len(t.Sponsors) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "sponsor not found"})
-			return
-		}
-		removed := t.Sponsors[idx]
-		t.Sponsors = append(t.Sponsors[:idx], t.Sponsors[idx+1:]...)
-		if err := store.SaveTournament(t); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-		// Unlink the file unconditionally — random filenames mean cross-
-		// references are effectively impossible at the 1–6 scale (mp-c38).
-		// Best-effort: log on failure but don't roll back the YAML write.
+		// Best-effort unlink. Random filenames make collisions effectively
+		// impossible at the 1–6 scale, so a missing file (ENOENT from a
+		// concurrent delete) is harmless and silently ignored.
 		_ = os.Remove(filepath.Join(store.GetFolder(), sponsorsDirName, removed.File))
 		c.JSON(http.StatusOK, gin.H{"removed": removed})
-	})
+	}
 }

--- a/internal/mobileapp/handlers_sponsors_test.go
+++ b/internal/mobileapp/handlers_sponsors_test.go
@@ -301,6 +301,50 @@ func TestDeleteSponsor_RemovesEntryAndFile(t *testing.T) {
 	assert.Empty(t, tour.Sponsors)
 }
 
+// TestDeleteSponsor_HandEditedTraversalFilenameRejected pins the
+// defense-in-depth check on DELETE: if tournament.md was hand-edited to
+// carry a traversal-shaped file value, the os.Remove must NOT fire and
+// the bystander file must survive. The YAML entry is still removed
+// (the index check stays intact).
+func TestDeleteSponsor_HandEditedTraversalFilenameRejected(t *testing.T) {
+	router, tempDir, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	// Plant a bystander file outside the sponsors dir that a traversal
+	// would target. If the unlink fires, we'll catch it.
+	bystander := filepath.Join(tempDir, "secret.txt")
+	require.NoError(t, os.WriteFile(bystander, []byte("must survive"), 0o600))
+
+	// Save a tournament with a Sponsors entry whose File is a traversal
+	// path. Simulates a hand-edit / corrupt YAML.
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:     "Traversal Test",
+		Password: "secret",
+		Sponsors: []state.Sponsor{{Name: "Evil", File: "../secret.txt"}},
+	}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/sponsors/0", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "YAML entry still gets removed; only the file unlink is suppressed")
+
+	// Bystander file must still exist — the unlink was suppressed by
+	// the filename allowlist check.
+	_, err = os.Stat(bystander)
+	assert.NoError(t, err, "traversal-shaped sponsor filename must not trigger an arbitrary file delete")
+
+	// YAML entry is gone (the safe part of delete still ran).
+	store2, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	tour, err := store2.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, tour)
+	assert.Empty(t, tour.Sponsors)
+}
+
 func TestDeleteSponsor_InvalidIndex(t *testing.T) {
 	router, _, cleanup := sponsorTestSetup(t)
 	defer cleanup()

--- a/internal/mobileapp/handlers_sponsors_test.go
+++ b/internal/mobileapp/handlers_sponsors_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -156,15 +157,22 @@ func TestPostSponsor_RejectsBadLink(t *testing.T) {
 		"javascript:alert(1)",
 		"ftp://files.example",
 		"no-scheme.example",
-		"",
+		"https://user:pass@example.com", // userinfo rejected — would leak credentials in href
+		"https://",                      // missing host
 	} {
-		if badLink == "" {
-			continue // empty link is allowed (optional field)
-		}
 		body, ct := buildSponsorUpload(t, "Bad Link", badLink, "x.png", tinyPNG)
 		w := postSponsor(t, router, body, ct, "secret")
 		assert.Equal(t, http.StatusBadRequest, w.Code, "link %q must be rejected", badLink)
 	}
+}
+
+func TestPostSponsor_RejectsOversizedName(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	body, ct := buildSponsorUpload(t, strings.Repeat("a", state.MaxSponsorNameLen+1), "", "x.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestPostSponsor_RejectsEmptyName(t *testing.T) {
@@ -193,7 +201,7 @@ func TestPostSponsor_CapEnforced(t *testing.T) {
 	router, _, cleanup := sponsorTestSetup(t)
 	defer cleanup()
 
-	for i := 0; i < state.MaxSponsors; i++ {
+	for i := range state.MaxSponsors {
 		body, ct := buildSponsorUpload(t, "Sponsor", "", "s.png", tinyPNG)
 		w := postSponsor(t, router, body, ct, "secret")
 		require.Equal(t, http.StatusCreated, w.Code, "upload %d should succeed", i+1)
@@ -304,4 +312,96 @@ func TestDeleteSponsor_InvalidIndex(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusOK, w.Code, "path %q must not return 200", path)
 	}
+}
+
+// TestPostSponsor_NoTournament covers the rare-but-real path where the
+// admin somehow hits the upload route before tournament.md exists. The
+// transform must return errSponsorTournamentNotInit → 404, not 500.
+func TestPostSponsor_NoTournament(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "sponsor-no-tournament-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{"web-mobile/index.html": {Data: []byte("<html/>")}}
+	res := resources.NewResources(nil, mockFS)
+	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
+
+	body, ct := buildSponsorUpload(t, "Acme", "", "x.png", tinyPNG)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/sponsors", body)
+	req.Header.Set("Content-Type", ct)
+	// No tournament password set (no tournament exists). AuthMiddleware
+	// permits unauth POST /api/tournament on a virgin install, but
+	// /api/sponsors is NOT on that allowlist. The middleware should
+	// reject (4xx, not 200 or 404 from the handler), proving the auth
+	// layer fires before the handler can leak the not-init state.
+	router.ServeHTTP(w, req)
+	assert.True(t, w.Code >= 400 && w.Code < 500,
+		"no-tournament + no-password must reject at the auth layer (got %d)", w.Code)
+	assert.NotEqual(t, http.StatusOK, w.Code)
+	assert.NotEqual(t, http.StatusCreated, w.Code)
+}
+
+// TestPostSponsor_SelfRunMode_RejectsAnonymous and Delete equivalent
+// pin the self-run authorization contract — sponsor management is
+// organiser setup, not operational play, and must not become anonymously
+// writable when the tournament is in self-run mode. The route is added
+// to isSelfRunMainGatedConfigRoute alongside the other config routes.
+func TestPostSponsor_SelfRunMode_RejectsAnonymous(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "sponsor-selfrun-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:          "Self-Run Cup",
+		Password:      "main-pw",
+		AdminPassword: "admin-pw",
+		Mode:          state.TournamentModeSelfRun,
+	}))
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{"web-mobile/index.html": {Data: []byte("<html/>")}}
+	res := resources.NewResources(nil, mockFS)
+	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
+
+	body, ct := buildSponsorUpload(t, "Acme", "", "x.png", tinyPNG)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/sponsors", body)
+	req.Header.Set("Content-Type", ct)
+	// No password header. In self-run mode the main-pw gate is bypassed
+	// for operational routes — but sponsor mutation is config, so 401.
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "self-run sponsor upload must require main-password")
+
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest(http.MethodDelete, "/api/sponsors/0", nil)
+	router.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusUnauthorized, w2.Code, "self-run sponsor delete must require main-password")
+}
+
+// TestGetSponsor_RejectsSymlink hardens the GET path against a symlink
+// planted in the sponsors dir (e.g. by a shared-host operator or a
+// future feature). The strict filename regex already blocks the most
+// common traversal vectors, but a valid-looking name pointing at /etc/
+// would still be served by c.File. os.Lstat + symlink check closes that.
+func TestGetSponsor_RejectsSymlink(t *testing.T) {
+	router, tempDir, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	sponsorsDir := filepath.Join(tempDir, "sponsors")
+	require.NoError(t, os.MkdirAll(sponsorsDir, 0o700))
+	// Create a target file outside the sponsors dir.
+	target := filepath.Join(tempDir, "secret.txt")
+	require.NoError(t, os.WriteFile(target, []byte("not for sharing"), 0o600))
+	// Plant a symlink that matches the strict filename regex.
+	linkName := "abcdef0123456789.png"
+	require.NoError(t, os.Symlink(target, filepath.Join(sponsorsDir, linkName)))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/sponsors/"+linkName, nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code, "symlinked sponsor file must 404, not serve target")
+	assert.NotContains(t, w.Body.String(), "not for sharing")
 }

--- a/internal/mobileapp/handlers_sponsors_test.go
+++ b/internal/mobileapp/handlers_sponsors_test.go
@@ -1,0 +1,307 @@
+package mobileapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/engine"
+	"github.com/gitrgoliveira/bracket-creator/internal/resources"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Smallest valid PNG: 8-byte signature + IHDR + IDAT + IEND. 1×1 white.
+// Source: hand-crafted; verified by `file` reporting "PNG image data, 1×1".
+var tinyPNG = []byte{
+	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+	0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+	0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41,
+	0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+	0x00, 0x00, 0x03, 0x00, 0x01, 0x5B, 0x3F, 0x18,
+	0xBD, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E,
+	0x44, 0xAE, 0x42, 0x60, 0x82,
+}
+
+// Smallest valid JPEG: SOI + APP0 + EOI. Enough for DetectContentType to
+// classify as image/jpeg (it sniffs the FFD8FF prefix).
+var tinyJPEG = []byte{
+	0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46,
+	0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+	0x00, 0x01, 0x00, 0x00, 0xFF, 0xD9,
+}
+
+func sponsorTestSetup(t *testing.T) (*gin.Engine, string, func()) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "sponsor-test-*")
+	require.NoError(t, err)
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "Sponsor Test Cup", Password: "secret",
+	}))
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{"web-mobile/index.html": {Data: []byte("<html/>")}}
+	res := resources.NewResources(nil, mockFS)
+	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
+	return router, tempDir, func() { _ = os.RemoveAll(tempDir) }
+}
+
+func buildSponsorUpload(t *testing.T, name, link, filename string, content []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if name != "" {
+		require.NoError(t, mw.WriteField("name", name))
+	}
+	if link != "" {
+		require.NoError(t, mw.WriteField("link", link))
+	}
+	if filename != "" {
+		fw, err := mw.CreateFormFile("file", filename)
+		require.NoError(t, err)
+		_, err = fw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, mw.Close())
+	return body, mw.FormDataContentType()
+}
+
+func postSponsor(t *testing.T, router *gin.Engine, body *bytes.Buffer, ct string, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/sponsors", body)
+	req.Header.Set("Content-Type", ct)
+	if password != "" {
+		req.Header.Set("X-Tournament-Password", password)
+	}
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestPostSponsor_HappyPath_PNG(t *testing.T) {
+	router, tempDir, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	body, ct := buildSponsorUpload(t, "Acme Corp", "https://acme.example", "acme.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	var got state.Sponsor
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "Acme Corp", got.Name)
+	assert.Equal(t, "https://acme.example", got.Link)
+	assert.Regexp(t, `^[a-f0-9]{16}\.png$`, got.File)
+
+	// File written to disk under tempDir/sponsors/.
+	on, err := os.ReadFile(filepath.Join(tempDir, "sponsors", got.File))
+	require.NoError(t, err)
+	assert.Equal(t, tinyPNG, on)
+}
+
+func TestPostSponsor_HappyPath_JPEG(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	body, ct := buildSponsorUpload(t, "BetaCo", "", "beta.jpg", tinyJPEG)
+	w := postSponsor(t, router, body, ct, "secret")
+
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	var got state.Sponsor
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Regexp(t, `^[a-f0-9]{16}\.jpg$`, got.File)
+	assert.Empty(t, got.Link, "omitempty link round-trips as empty")
+}
+
+func TestPostSponsor_RejectsOversized(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	// Build a "PNG" larger than 1 MB. First bytes are valid signature so
+	// the type sniff passes; subsequent garbage trips the size cap.
+	big := make([]byte, SponsorMaxFileBytes+1024)
+	copy(big, tinyPNG)
+	body, ct := buildSponsorUpload(t, "Huge Co", "", "huge.png", big)
+	w := postSponsor(t, router, body, ct, "secret")
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestPostSponsor_RejectsBadType(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	// PDF magic bytes — sniffer classifies as application/pdf.
+	pdfBytes := append([]byte("%PDF-1.4\n"), bytes.Repeat([]byte("\x00"), 100)...)
+	body, ct := buildSponsorUpload(t, "PDF Inc", "", "doc.pdf", pdfBytes)
+	w := postSponsor(t, router, body, ct, "secret")
+	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+}
+
+func TestPostSponsor_RejectsBadLink(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	for _, badLink := range []string{
+		"javascript:alert(1)",
+		"ftp://files.example",
+		"no-scheme.example",
+		"",
+	} {
+		if badLink == "" {
+			continue // empty link is allowed (optional field)
+		}
+		body, ct := buildSponsorUpload(t, "Bad Link", badLink, "x.png", tinyPNG)
+		w := postSponsor(t, router, body, ct, "secret")
+		assert.Equal(t, http.StatusBadRequest, w.Code, "link %q must be rejected", badLink)
+	}
+}
+
+func TestPostSponsor_RejectsEmptyName(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	body, ct := buildSponsorUpload(t, "   ", "", "x.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostSponsor_AdminGated(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	body, ct := buildSponsorUpload(t, "Acme", "", "x.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "" /* no password */)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	body2, ct2 := buildSponsorUpload(t, "Acme", "", "x.png", tinyPNG)
+	w2 := postSponsor(t, router, body2, ct2, "wrong-password")
+	assert.Equal(t, http.StatusUnauthorized, w2.Code)
+}
+
+func TestPostSponsor_CapEnforced(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	for i := 0; i < state.MaxSponsors; i++ {
+		body, ct := buildSponsorUpload(t, "Sponsor", "", "s.png", tinyPNG)
+		w := postSponsor(t, router, body, ct, "secret")
+		require.Equal(t, http.StatusCreated, w.Code, "upload %d should succeed", i+1)
+	}
+	body, ct := buildSponsorUpload(t, "One Too Many", "", "s.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "maximum")
+}
+
+func TestGetSponsor_NotFound(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/sponsors/abcdef0123456789.png", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetSponsor_RejectsTraversal(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	for _, bad := range []string{
+		"../../etc/passwd",
+		"not-hex.png",
+		"abcdef0123456789.gif",   // unsupported extension
+		"abcdef0123456789",       // no extension
+		"ABCDEF0123456789.png",   // uppercase rejected
+		"abcdef0123456789.png.x", // double extension
+	} {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/sponsors/"+bad, nil)
+		router.ServeHTTP(w, req)
+		// Path traversal with .. resolves at the URL layer — Gin returns
+		// 301 or 404. The filename regex covers everything that reaches
+		// the handler. Either way, no file is served. 200 must never
+		// appear.
+		assert.NotEqual(t, http.StatusOK, w.Code, "must not serve %q", bad)
+	}
+}
+
+func TestGetSponsor_ServesPNG_WithCacheHeaders(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	// Upload first so we have a known filename.
+	body, ct := buildSponsorUpload(t, "Acme", "", "x.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+	require.Equal(t, http.StatusCreated, w.Code)
+	var s state.Sponsor
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &s))
+
+	// Now GET it.
+	g := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/sponsors/"+s.File, nil)
+	router.ServeHTTP(g, req)
+
+	require.Equal(t, http.StatusOK, g.Code)
+	assert.Equal(t, "image/png", g.Header().Get("Content-Type"))
+	assert.Contains(t, g.Header().Get("Cache-Control"), "immutable")
+	assert.NotEmpty(t, g.Header().Get("ETag"))
+	bodyBytes, err := io.ReadAll(g.Body)
+	require.NoError(t, err)
+	assert.Equal(t, tinyPNG, bodyBytes)
+}
+
+func TestDeleteSponsor_RemovesEntryAndFile(t *testing.T) {
+	router, tempDir, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	// Upload one.
+	body, ct := buildSponsorUpload(t, "Acme", "", "x.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+	require.Equal(t, http.StatusCreated, w.Code)
+	var s state.Sponsor
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &s))
+
+	// Delete index 0.
+	d := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/sponsors/0", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	router.ServeHTTP(d, req)
+	require.Equal(t, http.StatusOK, d.Code, "body: %s", d.Body.String())
+
+	// File is gone.
+	_, err := os.Stat(filepath.Join(tempDir, "sponsors", s.File))
+	assert.True(t, os.IsNotExist(err), "file should be unlinked")
+
+	// YAML entry is gone.
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	tour, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, tour)
+	assert.Empty(t, tour.Sponsors)
+}
+
+func TestDeleteSponsor_InvalidIndex(t *testing.T) {
+	router, _, cleanup := sponsorTestSetup(t)
+	defer cleanup()
+
+	for _, path := range []string{"/api/sponsors/-1", "/api/sponsors/abc", "/api/sponsors/99"} {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodDelete, path, nil)
+		req.Header.Set("X-Tournament-Password", "secret")
+		router.ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusOK, w.Code, "path %q must not return 200", path)
+	}
+}

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -242,7 +242,9 @@ func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 		http.MethodDelete + " /api/competitions/:id/teams/:tid/lineups/:round",         // team lineup management — organiser
 		http.MethodPut + " /api/competitions/:id/teams/:tid/match-lineups/:matchId",    // team match lineup — organiser
 		http.MethodDelete + " /api/competitions/:id/teams/:tid/match-lineups/:matchId", // team match lineup — organiser
-		http.MethodPost + " /api/competitions/:id/matches/:mid/decision":               // mp-ba3: kiken/fusenpai/daihyosen are admin-only decisions
+		http.MethodPost + " /api/competitions/:id/matches/:mid/decision",               // mp-ba3: kiken/fusenpai/daihyosen are admin-only decisions
+		http.MethodPost + " /api/sponsors",                                             // mp-c38: sponsor logo upload — organiser setup, not operational play
+		http.MethodDelete + " /api/sponsors/:index":                                    // mp-c38: sponsor deletion — organiser setup, not operational play
 		return true
 	default:
 		return false

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -45,7 +45,19 @@ const (
 	// to disk. 64 MB is sized for a worst-case full-roster CSV plus
 	// metadata; raise here if real tournaments outgrow it.
 	MaxImportBodyBytes int64 = 64 << 20 // 64 MB
+
+	// SponsorMaxBodyBytes caps POST /api/sponsors (multipart logo upload).
+	// The sponsor logo file itself is capped at 1 MB by in-handler check;
+	// this envelope cap (2 MB) gives generous headroom for the multipart
+	// boundary, form-field overhead, and the optional link/name fields
+	// without letting a client stream gigabytes through the parser.
+	SponsorMaxBodyBytes int64 = 2 << 20 // 2 MB
 )
+
+// SponsorMaxFileBytes is the in-handler cap on the logo file itself
+// (the multipart `file` field), distinct from the envelope cap above.
+// See mp-c38 plan.
+const SponsorMaxFileBytes int64 = 1 << 20 // 1 MB
 
 // MaxBodyBytes returns a Gin middleware that rejects requests whose
 // body exceeds n bytes. Two checks, in order of cost:

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -903,4 +904,61 @@ func TestSelfRun_POST_NoMode_DefaultsToOfficiated(t *testing.T) {
 	require.NotNil(t, t2)
 	assert.Equal(t, state.TournamentModeOfficiated, t2.Mode,
 		"missing mode must default to officiated")
+}
+
+// ---------------------------------------------------------------------------
+// §sponsors: Self-run auth gate for sponsor management (mp-c38)
+// ---------------------------------------------------------------------------
+//
+// Sponsor POST/DELETE are organiser-owned setup routes (like PUT /api/tournament)
+// and must NOT become anonymously writable in self-run mode. Both are added to
+// isSelfRunMainGatedConfigRoute. This test pins that contract in the centralised
+// self-run auth matrix (the dedicated handler tests in handlers_sponsors_test.go
+// cover the full authentication story; these tests ensure the middleware-level
+// carve-out wiring is correct for self-run mode specifically).
+
+func TestSelfRun_Sponsors_RequireMainPassword(t *testing.T) {
+	store := newTempStore(t)
+	seedSelfRunTournament(t, store, "admin-pw")
+	r := setupSelfRunRouter(t, store, NewFileVerifier(store))
+
+	buildMultipart := func() (*bytes.Buffer, string) {
+		buf := &bytes.Buffer{}
+		mw := multipart.NewWriter(buf)
+		_ = mw.WriteField("name", "Acme Corp")
+		fw, _ := mw.CreateFormFile("file", "logo.png")
+		_, _ = fw.Write(tinyPNG) // reuse tinyPNG defined in handlers_sponsors_test.go
+		_ = mw.Close()
+		return buf, mw.FormDataContentType()
+	}
+
+	t.Run("POST_without_password_returns_401", func(t *testing.T) {
+		body, ct := buildMultipart()
+		req := httptest.NewRequest(http.MethodPost, "/api/sponsors", body)
+		req.Header.Set("Content-Type", ct)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"POST /api/sponsors must be main-gated in self-run mode")
+	})
+
+	t.Run("DELETE_without_password_returns_401", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/api/sponsors/0", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code,
+			"DELETE /api/sponsors/:index must be main-gated in self-run mode")
+	})
+
+	t.Run("GET_sponsor_logo_is_public", func(t *testing.T) {
+		// GET /api/sponsors/:file is a public asset endpoint (serves logo to
+		// viewer/TV/lobby). It must NOT require authentication in self-run mode.
+		// A 400 (invalid filename) is fine — the route is reachable without a
+		// password.
+		req := httptest.NewRequest(http.MethodGet, "/api/sponsors/abcdef0123456789.png", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.NotEqual(t, http.StatusUnauthorized, w.Code,
+			"GET /api/sponsors/:file must be public — logo is served to unauthenticated viewer/TV surfaces")
+	})
 }

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -925,10 +925,12 @@ func TestSelfRun_Sponsors_RequireMainPassword(t *testing.T) {
 	buildMultipart := func() (*bytes.Buffer, string) {
 		buf := &bytes.Buffer{}
 		mw := multipart.NewWriter(buf)
-		_ = mw.WriteField("name", "Acme Corp")
-		fw, _ := mw.CreateFormFile("file", "logo.png")
-		_, _ = fw.Write(tinyPNG) // reuse tinyPNG defined in handlers_sponsors_test.go
-		_ = mw.Close()
+		require.NoError(t, mw.WriteField("name", "Acme Corp"))
+		fw, err := mw.CreateFormFile("file", "logo.png")
+		require.NoError(t, err)
+		_, err = fw.Write(tinyPNG) // reuse tinyPNG defined in handlers_sponsors_test.go
+		require.NoError(t, err)
+		require.NoError(t, mw.Close())
 		return buf, mw.FormDataContentType()
 	}
 

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -115,6 +115,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	RegisterPublicSwissHandlers(api, store, eng)
 	RegisterPublicAnnouncementHandlers(api, store)
 	RegisterPublicRegistrationHandlers(api, store, hub)
+	RegisterPublicSponsorHandlers(api, store)
 
 	// Public password-reset + auth-config endpoints. Both must live
 	// outside the admin group: /reset is the recovery path for a
@@ -154,6 +155,13 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 
 	adminLargeBody := adminGroup(r, MaxImportBodyBytes, verifier, store)
 	RegisterImportHandlers(adminLargeBody, store, hub, elevated)
+
+	// Sponsor uploads (mp-c38) — multipart logo upload needs envelope
+	// headroom for the file plus boundary/form-field overhead, so it gets
+	// its own 2 MB group separate from the 1 MB JSON tier. DELETE rides
+	// on the same group (DELETE skips the cap by method anyway).
+	adminSponsorBody := adminGroup(r, SponsorMaxBodyBytes, verifier, store)
+	RegisterSponsorHandlers(adminSponsorBody, store)
 
 	// Static files & SPA Fallback
 	mobileFS := res.GetMobileWebFS()

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -84,6 +84,12 @@ type Tournament struct {
 	AwardsNote   string              `yaml:"awards_note,omitempty" json:"awardsNote,omitempty"`
 	InfoNotes    string              `yaml:"info_notes,omitempty" json:"infoNotes,omitempty"`
 	Contacts     []TournamentContact `yaml:"contacts,omitempty" json:"contacts,omitempty"`
+
+	// Sponsors is the ordered list of sponsor logos to display on the
+	// public viewer home and the /display TV/lobby surfaces (mp-c38).
+	// Stored as omitempty so legacy tournament.md files without sponsors
+	// round-trip cleanly (no `sponsors: []` key emitted).
+	Sponsors []Sponsor `yaml:"sponsors,omitempty" json:"sponsors,omitempty"`
 }
 
 // TournamentContact is a single contact entry for attendees (mp-ef3).
@@ -93,6 +99,20 @@ type TournamentContact struct {
 	Label string `yaml:"label" json:"label"`
 	Value string `yaml:"value" json:"value"`
 }
+
+// Sponsor is a single sponsor logo entry. File is the server-generated
+// random filename under tournament-data/sponsors/; Name is the alt text;
+// Link is optional and, when set, makes the logo clickable on the viewer
+// surface only (display surfaces never render anchors). See mp-c38.
+type Sponsor struct {
+	Name string `yaml:"name" json:"name"`
+	File string `yaml:"file" json:"file"`
+	Link string `yaml:"link,omitempty" json:"link,omitempty"`
+}
+
+// MaxSponsors is the per-tournament sponsor count cap (mp-c38). Realistic
+// count is 1–4; 6 leaves headroom without enabling abuse.
+const MaxSponsors = 6
 
 // Tournament mode constants (mp-7h7).
 const (

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -1,7 +1,9 @@
 package state
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -113,6 +115,44 @@ type Sponsor struct {
 // MaxSponsors is the per-tournament sponsor count cap (mp-c38). Realistic
 // count is 1–4; 6 leaves headroom without enabling abuse.
 const MaxSponsors = 6
+
+// MaxSponsorNameLen and MaxSponsorLinkLen bound the metadata fields.
+const (
+	MaxSponsorNameLen = 80
+	MaxSponsorLinkLen = 500
+)
+
+// Sentinel errors returned by ValidateSponsor so handlers can map them
+// to specific HTTP status codes without string-matching.
+var (
+	ErrSponsorNameRequired = errors.New("name is required (1–80 chars)")
+	ErrSponsorNameTooLong  = errors.New("name must be ≤80 chars")
+	ErrSponsorLinkTooLong  = errors.New("link must be ≤500 chars")
+	ErrSponsorLinkInvalid  = errors.New("link must be a valid http(s) URL")
+)
+
+// ValidateSponsor checks name length and link format. Centralises the
+// rules so handlers, tests, and future import paths agree. Name/link
+// must already be trimmed by the caller.
+func ValidateSponsor(s Sponsor) error {
+	if s.Name == "" {
+		return ErrSponsorNameRequired
+	}
+	if len([]rune(s.Name)) > MaxSponsorNameLen {
+		return ErrSponsorNameTooLong
+	}
+	if s.Link == "" {
+		return nil
+	}
+	if len(s.Link) > MaxSponsorLinkLen {
+		return ErrSponsorLinkTooLong
+	}
+	u, err := url.Parse(s.Link)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.User != nil {
+		return ErrSponsorLinkInvalid
+	}
+	return nil
+}
 
 // Tournament mode constants (mp-7h7).
 const (

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -229,9 +230,24 @@ func TestTournament_SponsorsRoundTrip(t *testing.T) {
 	}
 	b, err := yaml.Marshal(&original)
 	require.NoError(t, err)
-	// omitempty on Link → second sponsor must not emit a `link:` key.
-	assert.Contains(t, string(b), "name: Acme Corp")
-	assert.Contains(t, string(b), "link: https://acme.example")
+	yamlStr := string(b)
+	// Assert first sponsor fields are present.
+	assert.Contains(t, yamlStr, "name: Acme Corp")
+	assert.Contains(t, yamlStr, "link: https://acme.example")
+	// Structural omitempty check: the second sponsor has no link, so the
+	// `link:` key must be entirely absent from the YAML — not `link: ""`
+	// or `link: null`. This is what `yaml:"link,omitempty"` guarantees.
+	assert.Contains(t, yamlStr, "name: BetaCo")
+	assert.NotContains(t, yamlStr, "link: \"\"\nname: BetaCo",
+		"YAML must not emit link: \"\" for sponsors with no link")
+	// Parse the second sponsor block to confirm the key is truly absent,
+	// not just empty. We look for a "link:" line between the two name lines.
+	acmeIdx := strings.Index(yamlStr, "name: Acme Corp")
+	betaIdx := strings.Index(yamlStr, "name: BetaCo")
+	require.True(t, acmeIdx >= 0 && betaIdx > acmeIdx, "both sponsor entries must be present")
+	betaBlock := yamlStr[betaIdx:]
+	assert.NotContains(t, betaBlock[:strings.Index(betaBlock+"\n---", "\n---")], "link:",
+		"omitempty: link key must be absent from the no-link sponsor's YAML block")
 
 	var got Tournament
 	require.NoError(t, yaml.Unmarshal(b, &got))

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -212,3 +212,56 @@ func TestValidateTeamMatchType(t *testing.T) {
 		})
 	}
 }
+
+// --- Sponsors (mp-c38) ---
+
+// TestTournament_SponsorsRoundTrip pins the YAML round-trip contract:
+// populated sponsors must survive marshal/unmarshal with name, file, and
+// link preserved. omitempty on Link must omit the key for sponsors with
+// no link set.
+func TestTournament_SponsorsRoundTrip(t *testing.T) {
+	original := Tournament{
+		Name: "Round-Trip Cup",
+		Sponsors: []Sponsor{
+			{Name: "Acme Corp", File: "8a3f9c12d7b6e041.png", Link: "https://acme.example"},
+			{Name: "BetaCo", File: "1f2e3d4c5b6a7080.jpg"}, // no link
+		},
+	}
+	b, err := yaml.Marshal(&original)
+	require.NoError(t, err)
+	// omitempty on Link → second sponsor must not emit a `link:` key.
+	assert.Contains(t, string(b), "name: Acme Corp")
+	assert.Contains(t, string(b), "link: https://acme.example")
+
+	var got Tournament
+	require.NoError(t, yaml.Unmarshal(b, &got))
+	require.Len(t, got.Sponsors, 2)
+	assert.Equal(t, "Acme Corp", got.Sponsors[0].Name)
+	assert.Equal(t, "8a3f9c12d7b6e041.png", got.Sponsors[0].File)
+	assert.Equal(t, "https://acme.example", got.Sponsors[0].Link)
+	assert.Equal(t, "BetaCo", got.Sponsors[1].Name)
+	assert.Empty(t, got.Sponsors[1].Link, "omitempty link must round-trip as empty")
+}
+
+// TestTournament_NoSponsorsKey_LegacyParse ensures legacy tournament.md
+// files (predating mp-c38) deserialize with an empty/nil Sponsors slice
+// rather than failing. Strict-mode unmarshal would break older configs.
+func TestTournament_NoSponsorsKey_LegacyParse(t *testing.T) {
+	legacy := []byte(`name: Legacy Cup
+date: "01-06-2026"
+courts: ["A", "B"]
+`)
+	var got Tournament
+	require.NoError(t, yaml.Unmarshal(legacy, &got))
+	assert.Empty(t, got.Sponsors, "missing sponsors key must deserialize as empty slice")
+}
+
+// TestTournament_EmptySponsors_OmitsKey pins the reverse direction: a
+// tournament with no sponsors must NOT emit `sponsors: []` so existing
+// files round-trip byte-for-equivalent when no sponsors are configured.
+func TestTournament_EmptySponsors_OmitsKey(t *testing.T) {
+	tour := Tournament{Name: "No-Sponsor Cup"}
+	b, err := yaml.Marshal(&tour)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "sponsors:", "empty Sponsors must be omitted from YAML")
+}

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -615,6 +615,132 @@ paths:
                             `parse participants: ...`. Empty when the row
                             imported successfully.
 
+  # ── Sponsors ───────────────────────────────────────────────────────────────
+
+  /api/sponsors/{file}:
+    get:
+      tags: [tournament]
+      summary: Serve a sponsor logo file
+      description: |
+        Public (no auth). Returns the raw PNG or JPEG bytes for a previously
+        uploaded sponsor logo. The filename is server-generated (16 random hex
+        chars + `.png` or `.jpg`); any other shape returns `400`.
+
+        Response carries `Cache-Control: public, max-age=31536000, immutable`
+        because the filename is unique per upload — the bytes at a given URL
+        never change.
+      parameters:
+        - in: path
+          name: file
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-f0-9]{16}\.(png|jpe?g)$'
+          description: Server-generated sponsor logo filename (16 hex chars + .png/.jpg).
+      responses:
+        '200':
+          description: Sponsor logo image bytes.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid filename (pattern mismatch or traversal attempt).
+        '404':
+          description: File not found.
+
+  /api/sponsors:
+    post:
+      tags: [tournament]
+      summary: Upload a sponsor logo
+      description: |
+        Admin-gated (`X-Tournament-Password`). Accepts `multipart/form-data`
+        with fields `name` (required, ≤80 chars), `link` (optional, must be
+        an `http(s)://` URL with no user-info), and `file` (required PNG or
+        JPEG, ≤1 MB detected by content sniff — not the `Content-Type` header).
+
+        Up to **6** sponsors per tournament. The server generates the on-disk
+        filename from `crypto/rand` hex; the client-supplied filename is ignored.
+      security:
+        - TournamentPassword: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [name, file]
+              properties:
+                name:
+                  type: string
+                  maxLength: 80
+                  description: Sponsor name (used as alt text on logo images).
+                link:
+                  type: string
+                  format: uri
+                  maxLength: 500
+                  description: Optional clickable URL (must be http or https, no user-info).
+                file:
+                  type: string
+                  format: binary
+                  description: PNG or JPEG logo, ≤1 MB.
+      responses:
+        '201':
+          description: Sponsor created. Returns the Sponsor object including the server-generated filename.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sponsor'
+        '400':
+          description: Validation error (name missing/too long, link invalid, cap reached).
+        '401':
+          description: Missing or incorrect tournament password.
+        '413':
+          description: Logo file exceeds 1 MB.
+        '415':
+          description: Unsupported media type (only PNG and JPEG accepted).
+
+  /api/sponsors/{index}:
+    delete:
+      tags: [tournament]
+      summary: Delete a sponsor logo
+      description: |
+        Admin-gated (`X-Tournament-Password`). Removes the sponsor at the given
+        zero-based index from `tournament.sponsors` and unlinks the on-disk file
+        (file unlink is skipped if the stored filename does not match the
+        server-generated pattern, guarding against corrupt YAML).
+      security:
+        - TournamentPassword: []
+      parameters:
+        - in: path
+          name: index
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+          description: Zero-based index into the tournament's sponsors array.
+      responses:
+        '200':
+          description: Sponsor removed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed:
+                    $ref: '#/components/schemas/Sponsor'
+        '400':
+          description: Invalid index (negative or non-integer).
+        '401':
+          description: Missing or incorrect tournament password.
+        '404':
+          description: Index out of range or tournament not initialized.
+
   # ── Announcements ──────────────────────────────────────────────────────────
 
   /api/tournament/announcement:
@@ -2062,6 +2188,26 @@ components:
       properties:
         error:
           type: string
+
+    Sponsor:
+      type: object
+      description: A single sponsor logo entry in the tournament's sponsor list (mp-c38).
+      required: [name, file]
+      properties:
+        name:
+          type: string
+          maxLength: 80
+          description: Sponsor name used as alt text on logo images.
+          example: "Acme Corp"
+        file:
+          type: string
+          description: Server-generated filename (16 random hex chars + .png or .jpg). Serves as the path component in GET /api/sponsors/{file}.
+          example: "69a33e3dd2ebe03b.jpg"
+        link:
+          type: string
+          format: uri
+          description: Optional clickable URL shown on the viewer surface. Absent when not set (omitempty). Must be http(s) with no user-info.
+          example: "https://acme.example"
 
     Announcement:
       type: object

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -624,7 +624,10 @@ paths:
       description: |
         Public (no auth). Returns the raw PNG or JPEG bytes for a previously
         uploaded sponsor logo. The filename is server-generated (16 random hex
-        chars + `.png`, `.jpg`, or `.jpeg`); any other shape returns `400`.
+        chars + `.png`, `.jpg`, or `.jpeg`). Requests whose `file` parameter
+        reaches the handler but does not match the expected pattern return `400`;
+        multi-segment paths (e.g. containing `/`) do not match the route at all
+        and receive a router-level `404`.
 
         Response carries `Cache-Control: public, max-age=31536000, immutable`
         because the filename is unique per upload — the bytes at a given URL
@@ -650,9 +653,9 @@ paths:
                 type: string
                 format: binary
         '400':
-          description: Invalid filename (pattern mismatch or traversal attempt).
+          description: Filename reached the handler but does not match the expected pattern (not 16 hex chars + .png/.jpg/.jpeg).
         '404':
-          description: File not found.
+          description: File not found, or path did not match the route.
 
   /api/sponsors:
     post:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -624,7 +624,7 @@ paths:
       description: |
         Public (no auth). Returns the raw PNG or JPEG bytes for a previously
         uploaded sponsor logo. The filename is server-generated (16 random hex
-        chars + `.png` or `.jpg`); any other shape returns `400`.
+        chars + `.png`, `.jpg`, or `.jpeg`); any other shape returns `400`.
 
         Response carries `Cache-Control: public, max-age=31536000, immutable`
         because the filename is unique per upload — the bytes at a given URL
@@ -636,7 +636,7 @@ paths:
           schema:
             type: string
             pattern: '^[a-f0-9]{16}\.(png|jpe?g)$'
-          description: Server-generated sponsor logo filename (16 hex chars + .png/.jpg).
+          description: Server-generated sponsor logo filename (16 hex chars + .png/.jpg/.jpeg).
       responses:
         '200':
           description: Sponsor logo image bytes.
@@ -2201,7 +2201,7 @@ components:
           example: "Acme Corp"
         file:
           type: string
-          description: Server-generated filename (16 random hex chars + .png or .jpg). Serves as the path component in GET /api/sponsors/{file}.
+          description: Server-generated filename (16 random hex chars + .png, .jpg, or .jpeg). Serves as the path component in GET /api/sponsors/{file}.
           example: "69a33e3dd2ebe03b.jpg"
         link:
           type: string

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5876,3 +5876,75 @@ button.my-match__opp {
 
 /* up-next: tiny muted note in the header (NOT a big badge) */
 .tvd-upnext-note { font: 700 2.2vh/1 var(--font-strong); letter-spacing: 0.16em; text-transform: uppercase; color: rgba(255,209,102,0.85); }
+
+/* ---------- Sponsor strip (mp-c38) ----------
+   Used on viewer home, LobbyDisplay, and TvDisplay. Three variants
+   share the base styles; per-variant overrides handle the different
+   backdrops and logo heights of each surface. */
+.sponsor-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 16px 12px;
+  margin-top: 16px;
+}
+.sponsor-strip__logo {
+  height: 40px;
+  width: auto;
+  max-width: 160px;
+  object-fit: contain;
+  display: block;
+}
+.sponsor-strip__link,
+.sponsor-strip__item {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+.sponsor-strip__link:hover .sponsor-strip__logo {
+  filter: brightness(1.05);
+}
+
+/* Viewer variant — sits in the white viewer body, neutral framing. */
+.sponsor-strip--viewer {
+  border-top: 1px solid var(--line);
+  background: var(--surface);
+}
+
+/* Lobby variant — dark lobby board; logos need a touch more breathing
+   room and a subtle backdrop so they remain legible against the dark
+   gradient behind them. */
+.sponsor-strip--lobby {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 14px 24px;
+  margin-top: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.sponsor-strip--lobby .sponsor-strip__logo {
+  height: 48px;
+  filter: brightness(1.1);
+}
+
+/* TV variant — fullscreen per-court board; smaller strip so it stays
+   subordinate to match info. */
+.sponsor-strip--tv {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  padding: 1vh 2vw;
+  margin-top: 0;
+  background: rgba(0, 0, 0, 0.35);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 2vw;
+}
+.sponsor-strip--tv .sponsor-strip__logo {
+  height: 5vh;
+  max-width: 12vw;
+  filter: brightness(1.05);
+}
+
+@media (max-width: 480px) {
+  .sponsor-strip__logo { height: 32px; max-width: 120px; }
+  .sponsor-strip { gap: 12px; padding: 12px 8px; }
+}

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5930,10 +5930,13 @@ button.my-match__opp {
 /* TV variant — fullscreen per-court board; smaller strip so it stays
    subordinate to match info. */
 .sponsor-strip--tv {
-  position: absolute;
-  bottom: 0; left: 0; right: 0;
+  /* Normal flow — not absolute. position: absolute would take the strip
+     out of flow and overlay the upcoming-matches list below it (the tvd
+     container only has 4vh bottom padding, but the strip is ~6vh tall).
+     Keeping it in flow lets the flex column stack sponsor strip under the
+     queue cards without overlap. */
   padding: 1vh 2vw;
-  margin-top: 0;
+  margin-top: auto; /* push to bottom of the flex column when there's space */
   background: rgba(0, 0, 0, 0.35);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   gap: 2vw;

--- a/web-mobile/index.html
+++ b/web-mobile/index.html
@@ -54,6 +54,9 @@
     <script type="module" src="/dist/glossary.js?v=5"></script>
     <script type="module" src="/dist/reset.js?v=5"></script>
     <script type="module" src="/dist/registration.js?v=5"></script>
+    <!-- sponsor_strip.js exports SponsorStrip to window. Must load before
+         display.js and viewer.js — both consume window.SponsorStrip (mp-c38). -->
+    <script type="module" src="/dist/sponsor_strip.js?v=5"></script>
     <!-- display.js exports queueLabel / queueLabelCompact to window for the
          viewer pills. Must load *before* viewer.js so the first viewer render
          picks up the labels. -->
@@ -68,6 +71,9 @@
     <script type="module" src="/dist/admin_schedule.js?v=5"></script>
     <script type="module" src="/dist/admin_competition.js?v=5"></script>
     <script type="module" src="/dist/admin_announcement.js?v=5"></script>
+    <!-- admin_sponsors.js exports SponsorsManager. Loaded before admin_setup.js
+         (which embeds it inside the Edit Tournament page) — mp-c38. -->
+    <script type="module" src="/dist/admin_sponsors.js?v=5"></script>
     <script type="module" src="/dist/admin_setup.js?v=5"></script>
     <script type="module" src="/dist/admin.js?v=5"></script>
     <script type="module" src="/dist/app.js?v=5"></script>

--- a/web-mobile/js/__tests__/sponsor_strip.test.jsx
+++ b/web-mobile/js/__tests__/sponsor_strip.test.jsx
@@ -91,17 +91,23 @@ describe('SponsorStrip', () => {
     expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(1);
   });
 
-  it('every <img> has an onError handler to hide broken logos', () => {
-    // When a logo file is gone (e.g. YAML stale after manual delete),
-    // the handler must suppress the broken image rather than leaving a
-    // broken-image icon in the strip. Verify the onError prop is present
-    // on every rendered img regardless of variant.
+  it('every <img> onError hides the wrapper element, not just the img', () => {
+    // A broken logo that only hides the <img> still leaves its <a> or <span>
+    // wrapper as an empty flex item, which shows as a visible blank gap.
+    // The onError handler must climb to parentElement and hide the wrapper.
+    // We verify this by simulating the DOM event: stub parentElement with a
+    // spy, call the handler, and confirm style.display was set on the parent.
     for (const variant of ['viewer', 'lobby', 'tv']) {
       const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant });
       const imgs = findAll(tree, (n) => n.type === 'img');
       expect(imgs.length).toBeGreaterThan(0);
       imgs.forEach((img) => {
         expect(typeof img.props.onError).toBe('function');
+        // Simulate the browser onError event with a fake currentTarget.
+        const parentStyle = {};
+        const fakeEvent = { currentTarget: { parentElement: { style: parentStyle } } };
+        img.props.onError(fakeEvent);
+        expect(parentStyle.display).toBe('none');
       });
     }
   });

--- a/web-mobile/js/__tests__/sponsor_strip.test.jsx
+++ b/web-mobile/js/__tests__/sponsor_strip.test.jsx
@@ -90,4 +90,25 @@ describe('SponsorStrip', () => {
     expect(tree.props.className).toContain('sponsor-strip--viewer');
     expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(1);
   });
+
+  it('every <img> has an onError handler to hide broken logos', () => {
+    // When a logo file is gone (e.g. YAML stale after manual delete),
+    // the handler must suppress the broken image rather than leaving a
+    // broken-image icon in the strip. Verify the onError prop is present
+    // on every rendered img regardless of variant.
+    for (const variant of ['viewer', 'lobby', 'tv']) {
+      const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant });
+      const imgs = findAll(tree, (n) => n.type === 'img');
+      expect(imgs.length).toBeGreaterThan(0);
+      imgs.forEach((img) => {
+        expect(typeof img.props.onError).toBe('function');
+      });
+    }
+  });
+
+  it('root div has role=complementary and aria-label=Sponsors', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'viewer' });
+    expect(tree.props.role).toBe('complementary');
+    expect(tree.props['aria-label']).toBe('Sponsors');
+  });
 });

--- a/web-mobile/js/__tests__/sponsor_strip.test.jsx
+++ b/web-mobile/js/__tests__/sponsor_strip.test.jsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { SponsorStrip } from '../sponsor_strip.jsx';
+
+// Walks a vnode tree (rendered by the global React stub in vitest.setup.js,
+// where React.createElement returns plain objects) and collects every
+// element with a given type. Mirrors the helper used in reset.test.jsx.
+function findAll(node, predicate) {
+  const out = [];
+  function walk(n) {
+    if (!n || typeof n !== 'object') return;
+    if (Array.isArray(n)) { n.forEach(walk); return; }
+    if (predicate(n)) out.push(n);
+    const kids = n.children || (n.props && n.props.children) || [];
+    [].concat(kids).forEach(walk);
+  }
+  walk(node);
+  return out;
+}
+
+describe('SponsorStrip', () => {
+  const sponsorsWithLink = [
+    { name: 'Acme', file: 'aa.png', link: 'https://acme.example' },
+  ];
+  const sponsorsNoLink = [
+    { name: 'BetaCo', file: 'bb.jpg' },
+  ];
+
+  it('returns null when sponsors is empty', () => {
+    expect(SponsorStrip({ sponsors: [], variant: 'viewer' })).toBeNull();
+  });
+
+  it('returns null when sponsors is undefined', () => {
+    expect(SponsorStrip({ sponsors: undefined, variant: 'viewer' })).toBeNull();
+  });
+
+  it('viewer variant wraps linked sponsors in <a target="_blank" rel="noopener noreferrer">', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'viewer' });
+    const anchors = findAll(tree, (n) => n.type === 'a');
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0].props.target).toBe('_blank');
+    expect(anchors[0].props.rel).toBe('noopener noreferrer');
+    expect(anchors[0].props.href).toBe('https://acme.example');
+  });
+
+  it('viewer variant: sponsor without link renders bare <img> (no anchor)', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsNoLink, variant: 'viewer' });
+    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(0);
+    expect(findAll(tree, (n) => n.type === 'img')).toHaveLength(1);
+  });
+
+  it('lobby variant never renders <a> even when link is set', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'lobby' });
+    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(0);
+    expect(findAll(tree, (n) => n.type === 'img')).toHaveLength(1);
+  });
+
+  it('tv variant never renders <a> even when link is set', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'tv' });
+    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(0);
+    expect(findAll(tree, (n) => n.type === 'img')).toHaveLength(1);
+  });
+
+  it('renders one <img> per sponsor with /api/sponsors/<file> src', () => {
+    const sponsors = [
+      { name: 'A', file: '1.png' },
+      { name: 'B', file: '2.jpg', link: 'https://b.example' },
+      { name: 'C', file: '3.png' },
+    ];
+    const tree = SponsorStrip({ sponsors, variant: 'viewer' });
+    const imgs = findAll(tree, (n) => n.type === 'img');
+    expect(imgs).toHaveLength(3);
+    expect(imgs.map((i) => i.props.src)).toEqual([
+      '/api/sponsors/1.png',
+      '/api/sponsors/2.jpg',
+      '/api/sponsors/3.png',
+    ]);
+  });
+
+  it('applies the variant suffix to the root className', () => {
+    expect(SponsorStrip({ sponsors: sponsorsWithLink, variant: 'viewer' }).props.className)
+      .toContain('sponsor-strip--viewer');
+    expect(SponsorStrip({ sponsors: sponsorsWithLink, variant: 'lobby' }).props.className)
+      .toContain('sponsor-strip--lobby');
+    expect(SponsorStrip({ sponsors: sponsorsWithLink, variant: 'tv' }).props.className)
+      .toContain('sponsor-strip--tv');
+  });
+
+  it('defaults variant to viewer when omitted', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink });
+    expect(tree.props.className).toContain('sponsor-strip--viewer');
+    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(1);
+  });
+});

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -379,6 +379,21 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
             <button className="btn btn--primary" onClick={handleSave}>Save changes</button>
           </div>
         </div>
+        {/* mp-c38: sponsor management lives on the same edit page so admins
+            don't need to navigate elsewhere. SponsorsManager is loaded from
+            admin_sponsors.js (window.SponsorsManager). Refresh tournament
+            after each upload/delete by calling onSave-equivalent through a
+            lightweight refetch — we use window.location.reload() as the
+            simplest correct invalidation since this page already re-fetches
+            tournament on mount. */}
+        {window.SponsorsManager && (
+          <window.SponsorsManager
+            tournament={tournament}
+            password={password}
+            showToast={showToast}
+            onChanged={async () => { window.location.reload(); }}
+          />
+        )}
       </div>
     </div>
   );

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -380,18 +380,15 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           </div>
         </div>
         {/* mp-c38: sponsor management lives on the same edit page so admins
-            don't need to navigate elsewhere. SponsorsManager is loaded from
-            admin_sponsors.js (window.SponsorsManager). Refresh tournament
-            after each upload/delete by calling onSave-equivalent through a
-            lightweight refetch — we use window.location.reload() as the
-            simplest correct invalidation since this page already re-fetches
-            tournament on mount. */}
+            don't need to navigate elsewhere. SponsorsManager owns its own
+            sponsors list (seeded from the tournament prop, updated locally
+            from the API response on upload/delete) so unsaved edits in the
+            tournament form above survive a sponsor change — no page reload. */}
         {window.SponsorsManager && (
           <window.SponsorsManager
             tournament={tournament}
             password={password}
             showToast={showToast}
-            onChanged={async () => { window.location.reload(); }}
           />
         )}
       </div>

--- a/web-mobile/js/admin_sponsors.jsx
+++ b/web-mobile/js/admin_sponsors.jsx
@@ -8,10 +8,18 @@
 
 const { useState: useStateSp, useRef: useRefSp } = React;
 
-function SponsorsManager({ tournament, password, onChanged, showToast, maxSponsors }) {
-  const sponsors = (tournament && tournament.sponsors) || [];
+function SponsorsManager({ tournament, password, showToast, maxSponsors }) {
   const cap = maxSponsors || 6;
 
+  // Manage the sponsor list in local state so upload/delete don't
+  // force window.location.reload() — that would wipe any unsaved edits
+  // in the tournament form above. We seed from the tournament prop on
+  // first render and update locally from the API response shape:
+  //   POST /api/sponsors → returns the created Sponsor
+  //   DELETE /api/sponsors/:index → returns {removed}
+  const [sponsors, setSponsors] = useStateSp(
+    (tournament && tournament.sponsors) || [],
+  );
   const [name, setName] = useStateSp("");
   const [link, setLink] = useStateSp("");
   const [busy, setBusy] = useStateSp(false);
@@ -32,12 +40,12 @@ function SponsorsManager({ tournament, password, onChanged, showToast, maxSponso
     }
     setBusy(true);
     try {
-      await window.API.uploadSponsor({ file, name: name.trim(), link: link.trim(), password });
+      const created = await window.API.uploadSponsor({ file, name: name.trim(), link: link.trim(), password });
+      setSponsors((prev) => [...prev, created]);
       setName("");
       setLink("");
       if (fileRef.current) fileRef.current.value = "";
       if (showToast) showToast("Sponsor added", "success");
-      if (onChanged) await onChanged();
     } catch (err) {
       if (showToast) showToast(err && err.message ? err.message : "Upload failed", "error");
     } finally {
@@ -50,8 +58,8 @@ function SponsorsManager({ tournament, password, onChanged, showToast, maxSponso
     setBusy(true);
     try {
       await window.API.deleteSponsor(idx, password);
+      setSponsors((prev) => prev.filter((_, i) => i !== idx));
       if (showToast) showToast("Sponsor removed", "success");
-      if (onChanged) await onChanged();
     } catch (err) {
       if (showToast) showToast(err && err.message ? err.message : "Delete failed", "error");
     } finally {

--- a/web-mobile/js/admin_sponsors.jsx
+++ b/web-mobile/js/admin_sponsors.jsx
@@ -1,0 +1,153 @@
+// Sponsors admin section — embedded in the Edit Tournament page (mp-c38).
+// Shows existing sponsor logos with delete controls and an upload form.
+//
+// Endpoints (via window.API.uploadSponsor / window.API.deleteSponsor):
+//   POST   /api/sponsors        multipart {name, link?, file}
+//   DELETE /api/sponsors/:index
+// Live list comes from the parent tournament prop (tournament.sponsors).
+
+const { useState: useStateSp, useRef: useRefSp } = React;
+
+function SponsorsManager({ tournament, password, onChanged, showToast, maxSponsors }) {
+  const sponsors = (tournament && tournament.sponsors) || [];
+  const cap = maxSponsors || 6;
+
+  const [name, setName] = useStateSp("");
+  const [link, setLink] = useStateSp("");
+  const [busy, setBusy] = useStateSp(false);
+  const fileRef = useRefSp(null);
+
+  const reachedCap = sponsors.length >= cap;
+
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    const file = fileRef.current && fileRef.current.files && fileRef.current.files[0];
+    if (!name.trim()) {
+      if (showToast) showToast("Sponsor name is required", "error");
+      return;
+    }
+    if (!file) {
+      if (showToast) showToast("Choose a PNG or JPEG file", "error");
+      return;
+    }
+    setBusy(true);
+    try {
+      await window.API.uploadSponsor({ file, name: name.trim(), link: link.trim(), password });
+      setName("");
+      setLink("");
+      if (fileRef.current) fileRef.current.value = "";
+      if (showToast) showToast("Sponsor added", "success");
+      if (onChanged) await onChanged();
+    } catch (err) {
+      if (showToast) showToast(err && err.message ? err.message : "Upload failed", "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (idx, label) => {
+    if (!window.confirm(`Remove sponsor "${label}"?`)) return;
+    setBusy(true);
+    try {
+      await window.API.deleteSponsor(idx, password);
+      if (showToast) showToast("Sponsor removed", "success");
+      if (onChanged) await onChanged();
+    } catch (err) {
+      if (showToast) showToast(err && err.message ? err.message : "Delete failed", "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="card card--pad-lg" style={{ marginTop: 16 }}>
+      <div className="card__title">Sponsors</div>
+      <div className="field__hint" style={{ marginBottom: 12 }}>
+        Logos shown on the viewer home and on the lobby/TV display surfaces. Up to {cap} sponsors;
+        PNG or JPEG up to 1 MB each.
+      </div>
+
+      {sponsors.length === 0 ? (
+        <div className="field__hint" style={{ marginBottom: 16, opacity: 0.7 }}>
+          No sponsors yet.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 16 }}>
+          {sponsors.map((s, i) => (
+            <div key={s.file} style={{
+              display: "flex", alignItems: "center", gap: 12,
+              padding: "8px 12px", border: "1px solid var(--line)", borderRadius: 8,
+            }}>
+              <img
+                src={"/api/sponsors/" + s.file}
+                alt={s.name}
+                style={{ height: 32, width: "auto", maxWidth: 64, objectFit: "contain" }}
+              />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontWeight: 600 }}>{s.name}</div>
+                {s.link && (
+                  <div style={{ fontSize: 12, color: "var(--ink-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {s.link}
+                  </div>
+                )}
+              </div>
+              <button
+                className="btn btn--danger"
+                disabled={busy}
+                onClick={() => handleDelete(i, s.name)}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {reachedCap ? (
+        <div className="field__hint" style={{ opacity: 0.7 }}>
+          Sponsor cap reached. Remove one to add another.
+        </div>
+      ) : (
+        <form onSubmit={handleUpload} style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <div className="field">
+            <label className="field__label">Sponsor name</label>
+            <input
+              className="input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Acme Corp"
+              maxLength={80}
+            />
+          </div>
+          <div className="field">
+            <label className="field__label">Link (optional)</label>
+            <input
+              className="input"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+              placeholder="https://acme.example"
+              maxLength={500}
+            />
+            <div className="field__hint">Opens in a new tab on the viewer surface.</div>
+          </div>
+          <div className="field">
+            <label className="field__label">Logo (PNG or JPEG, ≤1 MB)</label>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/png,image/jpeg"
+            />
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <button type="submit" className="btn btn--primary" disabled={busy}>
+              {busy ? "Uploading…" : "Add sponsor"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+window.SponsorsManager = SponsorsManager;
+export { SponsorsManager };

--- a/web-mobile/js/admin_sponsors.jsx
+++ b/web-mobile/js/admin_sponsors.jsx
@@ -4,7 +4,10 @@
 // Endpoints (via window.API.uploadSponsor / window.API.deleteSponsor):
 //   POST   /api/sponsors        multipart {name, link?, file}
 //   DELETE /api/sponsors/:index
-// Live list comes from the parent tournament prop (tournament.sponsors).
+// Live list is seeded from tournament.sponsors on first render and then
+// maintained in local state — updates come from API responses, not the
+// parent prop. This keeps unsaved tournament-form edits above intact
+// when a sponsor is added or deleted (no page reload needed).
 
 const { useState: useStateSp, useRef: useRefSp } = React;
 

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -760,6 +760,33 @@ const API = {
             const err = await res.json().catch(() => ({}));
             throw new Error(err.error || `Failed to clear announcements (Status ${res.status})`);
         }
+    },
+    // mp-c38: sponsor logo upload (multipart) and delete.
+    async uploadSponsor({ file, name, link, password }) {
+        const fd = new FormData();
+        fd.append('name', name);
+        if (link) fd.append('link', link);
+        fd.append('file', file);
+        const res = await fetch('/api/sponsors', {
+            method: 'POST',
+            headers: { 'X-Tournament-Password': password },
+            body: fd,
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to upload sponsor (Status ${res.status})`);
+        }
+        return res.json();
+    },
+    async deleteSponsor(index, password) {
+        const res = await fetch(`/api/sponsors/${index}`, {
+            method: 'DELETE',
+            headers: { 'X-Tournament-Password': password },
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to delete sponsor (Status ${res.status})`);
+        }
     }
 };
 

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -486,6 +486,8 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
                     })}
                 </div>
             )}
+            {/* mp-c38: sponsor strip — non-interactive on TV display. */}
+            {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="tv" />}
         </div>
     );
 }
@@ -907,6 +909,10 @@ function LobbyDisplay({ tournament, competitions, connected = true }) {
                             : `Shiaijo ${courts.join(' · ')}`
                 }
             </div>
+
+            {/* mp-c38: sponsor strip — non-interactive on lobby (no input
+                hardware to click; touchscreen lobbies should not focus-trap). */}
+            {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="lobby" />}
 
             {/* Keyframe for the cycle progress bar animation. Injected via a
                 <style> tag because inline styles cannot express @keyframes.

--- a/web-mobile/js/sponsor_strip.jsx
+++ b/web-mobile/js/sponsor_strip.jsx
@@ -1,0 +1,60 @@
+// SponsorStrip — renders a horizontal row of sponsor logos. Used on the
+// viewer home and on the /display TV / lobby surfaces. See mp-c38.
+//
+// Props:
+//   sponsors  Array<{name, file, link?}> from tournament.sponsors
+//   variant   "viewer" | "lobby" | "tv"
+//
+// The viewer variant wraps logos with a link in <a target="_blank"
+// rel="noopener noreferrer">. The lobby and tv variants are passive
+// (TVs have no mouse; lobby touch installs shouldn't focus-trap on a
+// sponsor logo) — they always render a bare <img>.
+//
+// Hidden when sponsors is empty or undefined.
+
+function SponsorStrip({ sponsors, variant }) {
+  if (!sponsors || sponsors.length === 0) return null;
+  const v = variant || "viewer";
+  const interactive = v === "viewer";
+
+  return React.createElement(
+    "div",
+    { className: "sponsor-strip sponsor-strip--" + v, role: "complementary", "aria-label": "Sponsors" },
+    sponsors.map((s, i) => {
+      const img = React.createElement("img", {
+        key: "img-" + i,
+        src: "/api/sponsors/" + s.file,
+        alt: s.name || "Sponsor",
+        className: "sponsor-strip__logo",
+        // Defensive: hide a broken logo rather than letting one missing
+        // file blow out the row layout. The handler returns 404 if the
+        // file is gone; the rest of the strip stays intact.
+        onError: (e) => { e.currentTarget.style.display = "none"; },
+      });
+      if (interactive && s.link) {
+        return React.createElement(
+          "a",
+          {
+            key: "a-" + i,
+            href: s.link,
+            target: "_blank",
+            rel: "noopener noreferrer",
+            className: "sponsor-strip__link",
+            title: s.name,
+          },
+          img,
+        );
+      }
+      return React.createElement(
+        "span",
+        { key: "span-" + i, className: "sponsor-strip__item", title: s.name },
+        img,
+      );
+    }),
+  );
+}
+
+window.SponsorStrip = SponsorStrip;
+
+// ES export for the vitest suite. Mirrors admin_announcement.jsx pattern.
+export { SponsorStrip };

--- a/web-mobile/js/sponsor_strip.jsx
+++ b/web-mobile/js/sponsor_strip.jsx
@@ -24,21 +24,27 @@ function SponsorStrip({ sponsors, variant }) {
       aria-label="Sponsors"
     >
       {sponsors.map((s) => {
-        // Defensive: hide a broken logo rather than letting one missing
-        // file blow out the row layout. The handler returns 404 if the
-        // file is gone; the rest of the strip stays intact.
+        // Key on s.file (server-generated, unique per upload) so React
+        // doesn't reuse the wrong DOM node when a sponsor is deleted —
+        // index keys would let sponsor N+1's image flash into sponsor
+        // N's slot before the next render flush.
+        //
+        // onError hides the *wrapper* element (a or span), not just the
+        // img. Hiding only the img leaves the wrapper as an empty flex
+        // item that still occupies a gap in the row layout. Climbing to
+        // the parentElement removes both the gap and the broken image.
+        const handleError = (e) => {
+          const wrapper = e.currentTarget.parentElement;
+          if (wrapper) wrapper.style.display = "none";
+        };
         const img = (
           <img
             src={"/api/sponsors/" + s.file}
             alt={s.name || "Sponsor"}
             className="sponsor-strip__logo"
-            onError={(e) => { e.currentTarget.style.display = "none"; }}
+            onError={handleError}
           />
         );
-        // Key on s.file (server-generated, unique per upload) so React
-        // doesn't reuse the wrong DOM node when a sponsor is deleted —
-        // index keys would let sponsor N+1's image flash into sponsor
-        // N's slot before the next render flush.
         if (interactive && s.link) {
           return (
             <a

--- a/web-mobile/js/sponsor_strip.jsx
+++ b/web-mobile/js/sponsor_strip.jsx
@@ -17,40 +17,45 @@ function SponsorStrip({ sponsors, variant }) {
   const v = variant || "viewer";
   const interactive = v === "viewer";
 
-  return React.createElement(
-    "div",
-    { className: "sponsor-strip sponsor-strip--" + v, role: "complementary", "aria-label": "Sponsors" },
-    sponsors.map((s, i) => {
-      const img = React.createElement("img", {
-        key: "img-" + i,
-        src: "/api/sponsors/" + s.file,
-        alt: s.name || "Sponsor",
-        className: "sponsor-strip__logo",
+  return (
+    <div
+      className={"sponsor-strip sponsor-strip--" + v}
+      role="complementary"
+      aria-label="Sponsors"
+    >
+      {sponsors.map((s, i) => {
         // Defensive: hide a broken logo rather than letting one missing
         // file blow out the row layout. The handler returns 404 if the
         // file is gone; the rest of the strip stays intact.
-        onError: (e) => { e.currentTarget.style.display = "none"; },
-      });
-      if (interactive && s.link) {
-        return React.createElement(
-          "a",
-          {
-            key: "a-" + i,
-            href: s.link,
-            target: "_blank",
-            rel: "noopener noreferrer",
-            className: "sponsor-strip__link",
-            title: s.name,
-          },
-          img,
+        const img = (
+          <img
+            src={"/api/sponsors/" + s.file}
+            alt={s.name || "Sponsor"}
+            className="sponsor-strip__logo"
+            onError={(e) => { e.currentTarget.style.display = "none"; }}
+          />
         );
-      }
-      return React.createElement(
-        "span",
-        { key: "span-" + i, className: "sponsor-strip__item", title: s.name },
-        img,
-      );
-    }),
+        if (interactive && s.link) {
+          return (
+            <a
+              key={i}
+              href={s.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="sponsor-strip__link"
+              title={s.name}
+            >
+              {img}
+            </a>
+          );
+        }
+        return (
+          <span key={i} className="sponsor-strip__item" title={s.name}>
+            {img}
+          </span>
+        );
+      })}
+    </div>
   );
 }
 

--- a/web-mobile/js/sponsor_strip.jsx
+++ b/web-mobile/js/sponsor_strip.jsx
@@ -23,7 +23,7 @@ function SponsorStrip({ sponsors, variant }) {
       role="complementary"
       aria-label="Sponsors"
     >
-      {sponsors.map((s, i) => {
+      {sponsors.map((s) => {
         // Defensive: hide a broken logo rather than letting one missing
         // file blow out the row layout. The handler returns 404 if the
         // file is gone; the rest of the strip stays intact.
@@ -35,10 +35,14 @@ function SponsorStrip({ sponsors, variant }) {
             onError={(e) => { e.currentTarget.style.display = "none"; }}
           />
         );
+        // Key on s.file (server-generated, unique per upload) so React
+        // doesn't reuse the wrong DOM node when a sponsor is deleted —
+        // index keys would let sponsor N+1's image flash into sponsor
+        // N's slot before the next render flush.
         if (interactive && s.link) {
           return (
             <a
-              key={i}
+              key={s.file}
               href={s.link}
               target="_blank"
               rel="noopener noreferrer"
@@ -50,7 +54,7 @@ function SponsorStrip({ sponsors, variant }) {
           );
         }
         return (
-          <span key={i} className="sponsor-strip__item" title={s.name}>
+          <span key={s.file} className="sponsor-strip__item" title={s.name}>
             {img}
           </span>
         );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -857,6 +857,9 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
               match can drop into the display mode they need. */}
           <DisplayModes tournament={t} />
 
+          {/* mp-c38: sponsor logos. Hidden when none configured. */}
+          {window.SponsorStrip && <window.SponsorStrip sponsors={t && t.sponsors} variant="viewer" />}
+
           {/* U1: link to the kendo glossary so volunteers (and
               spectators new to kendo) can browse the term register
               that the inline tooltips draw from. */}


### PR DESCRIPTION
# Description

Adds end-to-end tournament sponsor logo support (upload/manage on backend + render on viewer/lobby/TV) and incorporates follow-up hardening/fixes from review feedback.

In addition to the original feature scope, this PR now also includes:
- Admin UX fix: sponsor add/delete no longer reloads the page, so unsaved tournament form edits are preserved.
- Frontend rendering fixes: stable React keys (`s.file`), broken-logo handling now hides the full sponsor item (not just the `<img>`), and TV strip layout no longer overlays upcoming matches.
- Backend safety/test hardening: DELETE skips unlink when YAML contains an invalid/traversal filename; multipart test helper now checks writer errors with `require.NoError`.
- Spec/test accuracy updates: OpenAPI descriptions now include `.jpeg` where applicable; YAML `omitempty` behavior for sponsor `link` is structurally asserted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/gitrgoliveira/bracket-creator/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works