### PR TITLE
chore: bump Go toolchain to 1.26.4 for stdlib CVEs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Init project
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: true
 
       - name: Init project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # Build stage
 FROM golang:${GO_VERSION} AS builder

--- a/Dockerfile.mobile
+++ b/Dockerfile.mobile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # Build stage
 FROM golang:${GO_VERSION} AS builder

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME := bracket-creator
 GH_REPOSITORY ?= gitrgoliveira/bracket-creator
 IMAGE_NAME := ghcr.io/$(GH_REPOSITORY)
 BIN_PATH := ./bin
-GO_VERSION := 1.26.3
+GO_VERSION := 1.26.4
 GO_SOURCES := $(shell find . -name "*.go" -type f)
 EMBEDDED_ASSETS := $(shell find ./web ./web-mobile -type f 2>/dev/null)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gitrgoliveira/bracket-creator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gin-gonic/gin v1.12.0


### PR DESCRIPTION
## Summary
- Bumps `go.mod` from `go 1.26.3` to `go 1.26.4`
- Updates `go-version` pin in `.github/workflows/validate.yaml` (×2) and `.github/workflows/release.yaml`

## Why
`govulncheck` reported two callable stdlib vulnerabilities, observed blocking the `make go/vuln` gate on every PR:

| CVE | Package | Description | Fixed in |
|---|---|---|---|
| GO-2026-5039 | `net/textproto` | Arbitrary inputs included in errors without escaping (call path: `internal/helper/excel.go` → excelize → `textproto.Reader.ReadMIMEHeader`) | go1.26.4 |
| GO-2026-5037 | `crypto/x509` | Inefficient candidate hostname parsing (call path: `internal/helper/excel.go` → `fmt.Fprintf` → `x509.Certificate.Verify`) | go1.26.4 |

Both are stdlib-level; neither vulnerability is introduced by this repo's code. The toolchain bump is the only fix.

## Validation
- `make go/vuln` after bump: **"No vulnerabilities found."**
- `make go/test` (lint + gosec + all test packages): **green**

## Test plan
- [x] `make go/vuln` — No vulnerabilities found
- [x] `make go/test` — All packages pass, lint clean, gosec 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)