### PR TITLE
feat(mp-f4xo): make pool cross-table cells clickable in viewer

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4700,16 +4700,13 @@ button.my-match__opp {
 
 .pool-matrix__cell--self { color: var(--ink-4); background: var(--bg-2); }
 .pool-matrix__cell--empty { background: var(--bg-2); }
-.pool-matrix__cell--pending { color: var(--ink-3); cursor: pointer; }
-.pool-matrix__cell--live { color: var(--accent); cursor: pointer; }
-.pool-matrix__cell--win { background: rgba(22, 163, 74, 0.08); cursor: pointer; }
-.pool-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); cursor: pointer; }
-.pool-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); cursor: pointer; }
-.pool-matrix__cell--pending:hover,
-.pool-matrix__cell--live:hover,
-.pool-matrix__cell--win:hover,
-.pool-matrix__cell--loss:hover,
-.pool-matrix__cell--draw:hover { filter: brightness(0.92); }
+.pool-matrix__cell--pending { color: var(--ink-3); }
+.pool-matrix__cell--live { color: var(--accent); }
+.pool-matrix__cell--win { background: rgba(22, 163, 74, 0.08); }
+.pool-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); }
+.pool-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); }
+.pool-matrix__cell[role="button"] { cursor: pointer; }
+.pool-matrix__cell[role="button"]:hover { filter: brightness(0.92); }
 .pool-matrix__cell[role="button"]:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
 .pool-matrix__win { color: #16a34a; }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4700,11 +4700,17 @@ button.my-match__opp {
 
 .pool-matrix__cell--self { color: var(--ink-4); background: var(--bg-2); }
 .pool-matrix__cell--empty { background: var(--bg-2); }
-.pool-matrix__cell--pending { color: var(--ink-3); }
-.pool-matrix__cell--live { color: var(--accent); }
-.pool-matrix__cell--win { background: rgba(22, 163, 74, 0.08); }
-.pool-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); }
-.pool-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); }
+.pool-matrix__cell--pending { color: var(--ink-3); cursor: pointer; }
+.pool-matrix__cell--live { color: var(--accent); cursor: pointer; }
+.pool-matrix__cell--win { background: rgba(22, 163, 74, 0.08); cursor: pointer; }
+.pool-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); cursor: pointer; }
+.pool-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); cursor: pointer; }
+.pool-matrix__cell--pending:hover,
+.pool-matrix__cell--live:hover,
+.pool-matrix__cell--win:hover,
+.pool-matrix__cell--loss:hover,
+.pool-matrix__cell--draw:hover { filter: brightness(0.92); }
+.pool-matrix__cell[role="button"]:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
 .pool-matrix__win { color: #16a34a; }
 .pool-matrix__loss { color: #dc2626; }

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL } from '../viewer.jsx';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, PoolMatrix } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 
@@ -590,6 +590,179 @@ describe('TournamentInfo', () => {
     expect(isHttpURL('ftp://files.example.com')).toBe(false);
     expect(isHttpURL('')).toBe(false);
     expect(isHttpURL(undefined)).toBe(false);
+  });
+});
+
+// mp-f4xo: PoolMatrix — clickable cross-table cells
+describe('PoolMatrix (mp-f4xo)', () => {
+  const realReact = global.React;
+  let runtime;
+  let PM;
+  let savedIsHikiwake;
+
+  const pool = {
+    poolName: 'Pool A',
+    players: [
+      { name: 'Alice' },
+      { name: 'Bob' },
+      { name: 'Charlie' },
+    ],
+  };
+
+  const completedMatch = {
+    id: 'Pool A-1',
+    sideA: { id: 'pA', name: 'Alice' },
+    sideB: { id: 'pB', name: 'Bob' },
+    status: 'completed',
+    winner: { id: 'pA', name: 'Alice' },
+    ipponsA: ['M'],
+    ipponsB: [],
+    decision: 'fought',
+  };
+
+  const pendingMatch = {
+    id: 'Pool A-2',
+    sideA: { id: 'pA', name: 'Alice' },
+    sideB: { id: 'pC', name: 'Charlie' },
+    status: 'scheduled',
+    winner: null,
+    ipponsA: [],
+    ipponsB: [],
+  };
+
+  const runningMatch = {
+    id: 'Pool A-3',
+    sideA: { id: 'pB', name: 'Bob' },
+    sideB: { id: 'pC', name: 'Charlie' },
+    status: 'running',
+    winner: null,
+    ipponsA: [],
+    ipponsB: [],
+  };
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    savedIsHikiwake = global.window.isHikiwake;
+    global.window.isHikiwake = vi.fn(() => false);
+    vi.resetModules();
+    ({ PoolMatrix: PM } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    if (savedIsHikiwake === undefined) delete global.window.isHikiwake;
+    else global.window.isHikiwake = savedIsHikiwake;
+  });
+
+  function allCells(tree) {
+    const cells = [];
+    (function walk(n) {
+      if (!n || typeof n !== 'object') return;
+      if (Array.isArray(n)) { n.forEach(walk); return; }
+      if (n.type === 'td') cells.push(n);
+      const kids = n.children || n.props?.children || [];
+      [].concat(kids).forEach(walk);
+    })(tree);
+    return cells;
+  }
+
+  it('renders W/L cells for a completed match', () => {
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {} });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const lossCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--loss'));
+    expect(winCell).toBeTruthy();
+    expect(lossCell).toBeTruthy();
+  });
+
+  it('clicking a completed-match cell fires onMatchClick with enriched match', () => {
+    const spy = vi.fn();
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: spy });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    expect(winCell.props.onClick).toBeTypeOf('function');
+    winCell.props.onClick();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const enriched = spy.mock.calls[0][0];
+    expect(enriched.phase).toBe('pool');
+    expect(enriched.poolName).toBe('Pool A');
+    expect(enriched.phaseName).toBe('Pool A');
+    expect(enriched.compKind).toBe('');
+    expect(enriched.teamSize).toBe(0);
+    expect(enriched.id).toBe(completedMatch.id);
+  });
+
+  it('clicking a pending-match cell fires onMatchClick', () => {
+    const spy = vi.fn();
+    const tree = runtime.mount(PM, { pool, matches: [pendingMatch], tweaks: {}, onMatchClick: spy });
+    const cells = allCells(tree);
+    const pendingCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--pending'));
+    expect(pendingCell).toBeTruthy();
+    pendingCell.props.onClick();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking a live-match cell fires onMatchClick', () => {
+    const spy = vi.fn();
+    const tree = runtime.mount(PM, { pool, matches: [runningMatch], tweaks: {}, onMatchClick: spy });
+    const cells = allCells(tree);
+    const liveCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--live'));
+    expect(liveCell).toBeTruthy();
+    liveCell.props.onClick();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('self-diagonal and empty cells have no onClick', () => {
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: vi.fn() });
+    const cells = allCells(tree);
+    const selfCells = cells.filter(c => c.props?.className?.includes('pool-matrix__cell--self'));
+    const emptyCells = cells.filter(c => c.props?.className?.includes('pool-matrix__cell--empty'));
+    expect(selfCells.length).toBeGreaterThan(0);
+    selfCells.forEach(c => expect(c.props.onClick).toBeUndefined());
+    emptyCells.forEach(c => expect(c.props.onClick).toBeUndefined());
+  });
+
+  it('interactive cells have role=button and tabIndex=0 for a11y', () => {
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: vi.fn() });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    expect(winCell.props.role).toBe('button');
+    expect(winCell.props.tabIndex).toBe(0);
+  });
+
+  it('interactive cells have aria-label describing the matchup', () => {
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: vi.fn() });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    expect(winCell.props['aria-label']).toContain('Alice');
+    expect(winCell.props['aria-label']).toContain('Bob');
+    expect(winCell.props['aria-label']).toContain('Win');
+  });
+
+  it('Enter key on interactive cell fires onMatchClick', () => {
+    const spy = vi.fn();
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: spy });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const preventDefaultSpy = vi.fn();
+    winCell.props.onKeyDown({ key: 'Enter', preventDefault: preventDefaultSpy });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('cells are not interactive when onMatchClick is not provided', () => {
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {} });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    expect(winCell.props.onClick).toBeUndefined();
+    expect(winCell.props.role).toBeUndefined();
+  });
+
+  it('returns null for fewer than 2 players', () => {
+    const tree = runtime.mount(PM, { pool: { poolName: 'Pool X', players: [{ name: 'Solo' }] }, matches: [], tweaks: {} });
+    expect(tree).toBeNull();
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -643,6 +643,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
   beforeEach(async () => {
     runtime = makeReactive();
     global.React = runtime.React;
+    global.window = global.window || {};
     savedIsHikiwake = global.window.isHikiwake;
     global.window.isHikiwake = vi.fn(() => false);
     vi.resetModules();
@@ -748,6 +749,17 @@ describe('PoolMatrix (mp-f4xo)', () => {
     const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
     const preventDefaultSpy = vi.fn();
     winCell.props.onKeyDown({ key: 'Enter', preventDefault: preventDefaultSpy });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('Space key on interactive cell fires onMatchClick', () => {
+    const spy = vi.fn();
+    const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: spy });
+    const cells = allCells(tree);
+    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const preventDefaultSpy = vi.fn();
+    winCell.props.onKeyDown({ key: ' ', preventDefault: preventDefaultSpy });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(preventDefaultSpy).toHaveBeenCalled();
   });

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, PoolMatrix } from '../viewer.jsx';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2026,11 +2026,10 @@ PoolMatchRow.displayName = "PoolMatchRow";
 
 // Round-robin matrix for a single pool. Rows = players (AKA), cols = players (SHIRO).
 // Diagonal and upper triangle are empty; lower triangle shows result from match AKA vs SHIRO.
-function PoolMatrix({ pool, matches, tweaks }) {
+function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
 
-  // Build a lookup: (aName, bName) → match
   const matchMap = {};
   matches.forEach(m => {
     const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
@@ -2046,6 +2045,14 @@ function PoolMatrix({ pool, matches, tweaks }) {
     const parts = n.split(" ");
     return parts.length > 1 ? parts[0][0] + ". " + parts.slice(1).join(" ") : n;
   };
+
+  const enrichMatch = (m) => ({ ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compKind: "", teamSize: 0 });
+
+  const handleCellClick = (m) => { if (onMatchClick) onMatchClick(enrichMatch(m)); };
+
+  const handleCellKeyDown = (e, m) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleCellClick(m); } };
+
+  const cellLabel = (rowPlayer, colPlayer, result) => `Match: ${rowPlayer.name} vs ${colPlayer.name} — ${result}`;
 
   return (
     <div className="pool-matrix-wrap">
@@ -2066,7 +2073,7 @@ function PoolMatrix({ pool, matches, tweaks }) {
                 <span className="pool-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
               </td>
               {players.map((colPlayer, ci) => {
-                if (ri === ci) return <td key={colPlayer.name} className="pool-matrix__cell pool-matrix__cell--self">—</td>;
+                if (ri === ci) return <td key={colPlayer.name} className="pool-matrix__cell pool-matrix__cell--self">&mdash;</td>;
                 const m = matchMap[`${rowPlayer.name}||${colPlayer.name}`];
                 if (!m) return <td key={colPlayer.name} className="pool-matrix__cell pool-matrix__cell--empty"></td>;
 
@@ -2074,9 +2081,16 @@ function PoolMatrix({ pool, matches, tweaks }) {
                 const winnerName = typeof m.winner === "object" ? m.winner?.name : m.winner;
                 const rowIsAka = aName === rowPlayer.name;
 
+                const interactiveProps = onMatchClick ? {
+                  role: "button",
+                  tabIndex: 0,
+                  onClick: () => handleCellClick(m),
+                  onKeyDown: (e) => handleCellKeyDown(e, m),
+                } : {};
+
                 if (m.status !== "completed") {
-                  return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--pending ${m.status === "running" ? "pool-matrix__cell--live" : ""}`}>
-                    {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>●</span> : "–"}
+                  return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--pending ${m.status === "running" ? "pool-matrix__cell--live" : ""}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
+                    {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>&bull;</span> : "–"}
                   </td>;
                 }
 
@@ -2087,16 +2101,20 @@ function PoolMatrix({ pool, matches, tweaks }) {
                 const isDraw = window.isHikiwake(m.decision) || window.isHikiwake(m.score?.type);
 
                 let cellContent;
+                let resultLabel;
                 if (isDraw) {
                   cellContent = <span className="pool-matrix__draw">X</span>;
+                  resultLabel = "Draw";
                 } else if (rowWon) {
                   cellContent = <span className="pool-matrix__win">{rowIppons.join("") || "W"}</span>;
+                  resultLabel = "Win";
                 } else {
                   cellContent = <span className="pool-matrix__loss">{rowIppons.join("") || "L"}</span>;
+                  resultLabel = "Loss";
                 }
 
                 return (
-                  <td key={colPlayer.name} className={`pool-matrix__cell ${rowWon ? "pool-matrix__cell--win" : isDraw ? "pool-matrix__cell--draw" : "pool-matrix__cell--loss"}`}>
+                  <td key={colPlayer.name} className={`pool-matrix__cell ${rowWon ? "pool-matrix__cell--win" : isDraw ? "pool-matrix__cell--draw" : "pool-matrix__cell--loss"}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
                     {cellContent}
                   </td>
                 );
@@ -2109,7 +2127,7 @@ function PoolMatrix({ pool, matches, tweaks }) {
         <span className="pool-matrix__legend-item pool-matrix__legend-item--win">W = win</span>
         <span className="pool-matrix__legend-item pool-matrix__legend-item--loss">L = loss</span>
         <span className="pool-matrix__legend-item pool-matrix__legend-item--draw">X = draw</span>
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>Row plays AKA vs col SHIRO</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>Tap a cell to view match details</span>
       </div>
     </div>
   );
@@ -2203,7 +2221,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
             {/* Round-robin matrix — always visible */}
             {matches.length > 0 && !isTeam && (
               <div style={{ marginTop: 12 }}>
-                <PoolMatrix pool={pool} matches={matches} tweaks={tweaks} />
+                <PoolMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} />
               </div>
             )}
 
@@ -2359,7 +2377,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2127,7 +2127,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
         <span className="pool-matrix__legend-item pool-matrix__legend-item--win">W = win</span>
         <span className="pool-matrix__legend-item pool-matrix__legend-item--loss">L = loss</span>
         <span className="pool-matrix__legend-item pool-matrix__legend-item--draw">X = draw</span>
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>Tap a cell to view match details</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row plays AKA vs col SHIRO"}</span>
       </div>
     </div>
   );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2098,8 +2098,8 @@ const PoolMatchRow = React.memo(({ m, onClick }) => {
 });
 PoolMatchRow.displayName = "PoolMatchRow";
 
-// Round-robin matrix for a single pool. Rows = players (AKA), cols = players (SHIRO).
-// Diagonal and upper triangle are empty; lower triangle shows result from match AKA vs SHIRO.
+// Round-robin matrix for a single pool. Each off-diagonal cell shows the row
+// player's result (W/L/X) against the column player; diagonal cells are self.
 function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
@@ -2201,7 +2201,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
         <span className="pool-matrix__legend-item pool-matrix__legend-item--win">W = win</span>
         <span className="pool-matrix__legend-item pool-matrix__legend-item--loss">L = loss</span>
         <span className="pool-matrix__legend-item pool-matrix__legend-item--draw">X = draw</span>
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row plays AKA vs col SHIRO"}</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row player's result vs column player"}</span>
       </div>
     </div>
   );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2090,7 +2090,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
 
                 if (m.status !== "completed") {
                   return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--pending ${m.status === "running" ? "pool-matrix__cell--live" : ""}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
-                    {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>&bull;</span> : "–"}
+                    {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>●</span> : "–"}
                   </td>;
                 }
 


### PR DESCRIPTION
## Summary

- Cross-table matrix cells (W/L/X/pending/live) in the viewer Pools tab are now clickable, opening the `MatchViewerModal` with correct pool metadata (`phase: "pool"`, `poolName`, `compKind: ""`, `teamSize: 0`)
- Self-diagonal (`—`) and empty cells remain inert — no click handler, no cursor change
- Adds CSS affordance (`cursor: pointer`, hover highlight, `focus-visible` outline) gated on `[role="button"]` so non-interactive renders are unaffected
- a11y support: `role="button"`, `tabIndex`, Enter/Space keyboard handling, `aria-label` with matchup + result
- Legend text updated to "Tap a cell to view match details"

Closes mp-f4xo.

## Files changed

- `web-mobile/js/viewer.jsx` — `PoolMatrix` component: accept `onMatchClick`, enrich match before dispatch, a11y props on interactive cells; `PoolsViewer`: thread `onMatchClick` to `PoolMatrix`; export `PoolMatrix` for testing
- `web-mobile/css/styles.css` — cursor + hover + focus-visible styles gated on `[role="button"]` for interactive matrix cells
- `web-mobile/js/__tests__/viewer.test.jsx` — 9 new tests: click dispatch, enrichment fields, pending/live cells, self/empty non-interactive, a11y attributes, keyboard Enter, no-callback graceful degradation, <2 players null

## Test plan

- [x] All 1096 JS tests pass (41 files)
- [x] All Go tests pass (version test excluded — worktree embed artifact)
- [x] Browser verified: created tournament with 6 players, 2 pools, scored Pool A matches, clicked W cell in cross-table → `MatchViewerModal` opened with correct "Shiaijo · Pool A" header and ippon details
- [x] Verify pending cells open the modal — clicked Pool B pending cell, modal opened with "Pool B · scheduled · Diana Prince vs Bob Jones"
- [x] Verify keyboard navigation — focused win cell via Tab (tabIndex=0), pressed Enter → modal opened; focused loss cell, pressed Space → modal opened; defaultPrevented=true confirms handler ran
- [x] Verify self-diagonal and empty cells are NOT clickable — all 6 self cells have role=null, tabIndex=null, cursor=auto, no onclick; clicking produced no modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)