### PR TITLE
fix(mp-xd5g): schedule player filter now matches by UUID and name

### DIFF
--- a/web-mobile/js/__tests__/api.test.jsx
+++ b/web-mobile/js/__tests__/api.test.jsx
@@ -229,6 +229,24 @@ describe('API Utils', () => {
       expect(map['Alice']).toEqual({ id: 'Alice', name: 'Alice', dojo: 'Dojo A', seed: 1 });
       expect(map['Bob']).toEqual({ id: 'Bob', name: 'Bob', dojo: 'Dojo B', seed: 0 });
     });
+
+    it('preserves UUID id when player has one (camelCase input)', () => {
+      const comp = {
+        players: [
+          { id: 'uuid-aaa', name: 'Alice', dojo: 'Dojo A', seed: 1 },
+          { id: 'uuid-bbb', name: 'Bob', dojo: 'Dojo B' }
+        ]
+      };
+      const map = buildPlayerMap(comp);
+      expect(map['Alice'].id).toBe('uuid-aaa');
+      expect(map['Bob'].id).toBe('uuid-bbb');
+    });
+
+    it('falls back to name as id when no id field', () => {
+      const comp = { players: [{ name: 'Carol', dojo: 'Dojo C' }] };
+      const map = buildPlayerMap(comp);
+      expect(map['Carol'].id).toBe('Carol');
+    });
   });
 
   describe('normalizePlayer', () => {

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -88,6 +88,21 @@ describe('Viewer Utils', () => {
       const filtered = applyFilters(matches, [], 'Dojo A', 'all');
       expect(filtered.length).toBe(2);
     });
+
+    it('matches by name when picked id differs from match side id (UUID vs name)', () => {
+      const uuidMatches = [
+        { id: 'm1', compId: 'c1', sideA: { id: 'Alice', name: 'Alice' }, sideB: { id: 'Bob', name: 'Bob' } },
+      ];
+      const picked = [{ id: 'uuid-aaa', name: 'Alice' }];
+      const filtered = applyFilters(uuidMatches, picked, '', 'all');
+      expect(filtered.length).toBe(1);
+    });
+
+    it('matches by name on sideB', () => {
+      const m = [{ id: 'm1', compId: 'c1', sideA: { id: 'x', name: 'X' }, sideB: { id: 'Bob', name: 'Bob' } }];
+      const filtered = applyFilters(m, [{ id: 'uuid-bbb', name: 'Bob' }], '', 'all');
+      expect(filtered.length).toBe(1);
+    });
   });
 
   describe('matchHighlightedBy', () => {
@@ -101,6 +116,11 @@ describe('Viewer Utils', () => {
     it('should return true if dojo matches', () => {
       expect(matchHighlightedBy(match, [], 'Dojo B')).toBe(true);
       expect(matchHighlightedBy(match, [], 'Dojo C')).toBe(false);
+    });
+
+    it('highlights by name when picked id differs from match side id', () => {
+      expect(matchHighlightedBy(match, [{ id: 'uuid-xxx', name: 'Alice' }], '')).toBe(true);
+      expect(matchHighlightedBy(match, [{ id: 'uuid-xxx', name: 'Nobody' }], '')).toBe(false);
     });
   });
 

--- a/web-mobile/js/api_serializers.jsx
+++ b/web-mobile/js/api_serializers.jsx
@@ -146,7 +146,7 @@ function buildPlayerMap(comp) {
     const map = {};
     const add = (p) => {
         const norm = normalizePlayer(p);
-        if (norm.name) map[norm.name] = { id: norm.name, name: norm.name, dojo: norm.dojo || "", seed: norm.seed ?? 0 };
+        if (norm.name) map[norm.name] = { id: norm.id || norm.name, name: norm.name, dojo: norm.dojo || "", seed: norm.seed ?? 0 };
     };
     if (comp?.config?.players) comp.config.players.forEach(add);
     if (comp?.players) comp.players.forEach(add);

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2336,11 +2336,12 @@ function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, setDojoTex
 
 function applyFilters(matches, picked, dojoText, compFilter) {
   const ids = new Set(picked.map((p) => p.id));
+  const names = new Set(picked.map((p) => p.name).filter(Boolean));
   const dt = (dojoText || "").trim().toLowerCase();
   return matches.filter((m) => {
     if (compFilter !== "all" && m.compId !== compFilter) return false;
     if (ids.size > 0) {
-      const hit = (m.sideA && ids.has(m.sideA.id)) || (m.sideB && ids.has(m.sideB.id));
+      const hit = (m.sideA && (ids.has(m.sideA.id) || names.has(m.sideA.name))) || (m.sideB && (ids.has(m.sideB.id) || names.has(m.sideB.name)));
       if (!hit) return false;
     }
     if (dt) {
@@ -2353,7 +2354,8 @@ function applyFilters(matches, picked, dojoText, compFilter) {
 
 function matchHighlightedBy(m, picked, dojoText) {
   const ids = new Set(picked.map((p) => p.id));
-  if (ids.size > 0 && ((m.sideA && ids.has(m.sideA.id)) || (m.sideB && ids.has(m.sideB.id)))) return true;
+  const names = new Set(picked.map((p) => p.name).filter(Boolean));
+  if (ids.size > 0 && ((m.sideA && (ids.has(m.sideA.id) || names.has(m.sideA.name))) || (m.sideB && (ids.has(m.sideB.id) || names.has(m.sideB.name))))) return true;
   const dt = (dojoText || "").trim().toLowerCase();
   if (dt && [m.sideA?.name, m.sideB?.name, m.sideA?.dojo, m.sideB?.dojo].some((s) => (s || "").toLowerCase().includes(dt))) return true;
   return false;


### PR DESCRIPTION
## Summary

- **Root cause**: `buildPlayerMap` (api_serializers.jsx) hardcoded match-side `id` fields to the player's display name, while `PlayerMultiFilter` populated the filter with UUID-based IDs from `c.players`. The `applyFilters` check `ids.has(m.sideA.id)` compared UUIDs against display names — always false.
- **Fix**: `buildPlayerMap` now uses `norm.id || norm.name` to preserve UUIDs when available. Added name-based fallback matching in `applyFilters` and `matchHighlightedBy` for resilience.
- Affects the Schedule page filter and match highlighting on both viewer and admin schedule views.

## Test plan

- [x] Create a competition with UUID-enabled participants
- [x] Start competition, complete several matches
- [x] Open Schedule page, filter by a player name → verify their completed + scheduled matches appear
- [x] Verify match highlighting works (rows highlighted when player filter is active)
- [x] Test with legacy data (no UUIDs) — filter should still work via name fallback (covered by unit tests: `buildPlayerMap` falls back to name as id, `applyFilters`/`matchHighlightedBy` name-based matching)
- [x] Verify no regressions in admin schedule page filtering (all 11 matches display correctly unfiltered; admin code shares same `applyFilters` function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)