### PR TITLE
fix(mp-1b7m): distribute league matches across multiple courts

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2040,6 +2040,78 @@ func TestStartCompetition_PreservesExplicitTeamSize(t *testing.T) {
 		"explicit TeamSize=7 must survive start (no auto-default applied)")
 }
 
+func TestStartCompetition_LeagueMultiCourt(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "league-multi-court"
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:         compID,
+		Name:       "League Multi Court",
+		Kind:       "individual",
+		Format:     state.CompFormatLeague,
+		PoolSize:   5,
+		RoundRobin: true,
+		Courts:     []string{"A", "B"},
+		StartTime:  "09:00",
+		Status:     "setup",
+	}))
+	saveTestParticipants(t, store, compID, []string{"Alice", "Bob", "Charlie", "Dave", "Eve"})
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	matches, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	assert.Len(t, matches, 10, "5-player round-robin must produce 10 matches")
+
+	courts := map[string]int{}
+	for _, m := range matches {
+		courts[m.Court]++
+	}
+	assert.Greater(t, courts["A"], 0, "court A should have matches")
+	assert.Greater(t, courts["B"], 0, "court B should have matches")
+	assert.Equal(t, 5, courts["A"], "court A should have 5 matches")
+	assert.Equal(t, 5, courts["B"], "court B should have 5 matches")
+
+	// Round-robin assignment: match i goes to court i%2
+	for i, m := range matches {
+		expected := []string{"A", "B"}[i%2]
+		assert.Equal(t, expected, m.Court, "match %d should be on court %s", i, expected)
+	}
+}
+
+func TestStartCompetition_LeagueMultiCourt_ThreeCourts(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "league-three-courts"
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:         compID,
+		Name:       "League Three Courts",
+		Kind:       "individual",
+		Format:     state.CompFormatLeague,
+		PoolSize:   6,
+		RoundRobin: true,
+		Courts:     []string{"A", "B", "C"},
+		StartTime:  "09:00",
+		Status:     "setup",
+	}))
+	saveTestParticipants(t, store, compID, []string{"P1", "P2", "P3", "P4", "P5", "P6"})
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	matches, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	assert.Len(t, matches, 15, "6-player round-robin must produce 15 matches")
+
+	courts := map[string]int{}
+	for _, m := range matches {
+		courts[m.Court]++
+	}
+	assert.Equal(t, 3, len(courts), "all 3 courts should be used")
+	assert.Equal(t, 5, courts["A"], "court A should have 5 matches")
+	assert.Equal(t, 5, courts["B"], "court B should have 5 matches")
+	assert.Equal(t, 5, courts["C"], "court C should have 5 matches")
+}
+
 // TestStartCompetition_PreservesNumberPrefix pins the NumberPrefix /
 // StartTime / RoundRobin additions to the StartCompetition transform's
 // field-mismatch validation. With these fields in the validation list,

--- a/internal/engine/pools.go
+++ b/internal/engine/pools.go
@@ -62,9 +62,15 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 
 	var results []state.MatchResult
 	for pi, p := range pools {
-		court := ""
+		poolCourts := []string{""}
 		if len(comp.Courts) > 0 {
-			court = comp.Courts[courtAssign[pi]]
+			poolCourts = []string{comp.Courts[courtAssign[pi]]}
+			// When there is only one pool (league format) and multiple
+			// courts, spread that pool's matches round-robin across all
+			// competition courts so no court sits idle.
+			if len(pools) == 1 && len(comp.Courts) > 1 {
+				poolCourts = comp.Courts
+			}
 		}
 		for i, m := range p.Matches {
 			results = append(results, state.MatchResult{
@@ -72,7 +78,7 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 				SideA:  m.SideA.Name,
 				SideB:  m.SideB.Name,
 				Status: state.MatchStatusScheduled,
-				Court:  court,
+				Court:  poolCourts[i%len(poolCourts)],
 				// ScheduledAt is populated below by
 				// assignPoolMatchSlots — uniform start times were
 				// retired in T150.


### PR DESCRIPTION
## Summary
- League format enforces a single pool, so `AssignPoolsToCourts(1, N)` mapped all matches to court index 0
- When only one pool exists and the competition has multiple courts, matches are now spread round-robin across all courts (`court = courts[i % len(courts)]`)
- Multi-pool competitions are unaffected — each pool still gets its assigned court block

Closes mp-1b7m

## Test plan
- [x] `TestStartCompetition_LeagueMultiCourt` — 5 players, 2 courts → 5 matches per court, round-robin pattern
- [x] `TestStartCompetition_LeagueMultiCourt_ThreeCourts` — 6 players, 3 courts → 5 matches per court
- [x] Existing `TestStartCompetition_LeagueFormat` (1 court) still passes
- [x] All `internal/engine`, `internal/helper`, `internal/state`, `internal/mobileapp` tests pass
- [x] Browser: create self-run tournament with 2 shiaijo, add League on courts A+B, register 5 players, start — matches appear on both courts in schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)