### PR TITLE
fix(mp-7x4n): show Report result button on Overview tab in self-run mode

### DIFF
--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -798,3 +798,118 @@ describe('PoolMatrix (mp-f4xo)', () => {
   });
 });
 
+// mp-7x4n: ViewerOverview opens MatchViewerModal in self-run mode,
+// MatchDetailCard in officiated mode.
+describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
+  const realReact = global.React;
+  let runtime;
+  let ViewerOverview;
+  const STUBBED = ['ipponsFromScore', 'formatIpponsScore', 'queueLabel', 'isHikiwake', 'useEscapeToClose', 'hasBothSides', 'StatusBadge', 'formatLabel', 'roundLabel', 'queueLabelCompact', 'pluralize'];
+  const savedGlobals = {};
+
+  const mkMatch = (id) => ({
+    id,
+    status: 'scheduled',
+    phase: 'pool',
+    poolName: 'Pool A',
+    court: 'A',
+    sideA: { id: 'a1', name: 'Alice' },
+    sideB: { id: 'b1', name: 'Bob' },
+    ipponsA: [],
+    ipponsB: [],
+  });
+
+  const mkComp = () => ({
+    id: 'c1',
+    name: 'Test',
+    format: 'mixed',
+    status: 'pools',
+    courts: ['A'],
+  });
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => { savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k) ? { had: true, val: global.window[k] } : { had: false }; });
+    global.window.ipponsFromScore = vi.fn(() => []);
+    global.window.formatIpponsScore = vi.fn(() => '');
+    global.window.queueLabel = vi.fn(() => '');
+    global.window.queueLabelCompact = vi.fn(() => '');
+    global.window.isHikiwake = vi.fn(() => false);
+    global.window.useEscapeToClose = vi.fn();
+    global.window.hasBothSides = vi.fn(() => true);
+    global.window.StatusBadge = vi.fn(() => null);
+    global.window.formatLabel = vi.fn((x) => x || '');
+    global.window.roundLabel = vi.fn((x) => x || '');
+    global.window.pluralize = vi.fn((n, s) => `${n} ${s}`);
+    vi.resetModules();
+    ({ ViewerOverview } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('self-run: clicking an upcoming match opens MatchViewerModal', () => {
+    const m = mkMatch('m1');
+    const tree = runtime.mount(ViewerOverview, {
+      c: mkComp(),
+      myPlayer: null,
+      myUpcoming: null,
+      currentMatch: null,
+      liveMatches: [],
+      upcomingMatches: [m],
+      recentMatches: [],
+      tweaks: {},
+      tournament: { mode: 'self-run' },
+      compId: 'c1',
+    });
+    // VSchedItem is a child component — the reactive shim stores it as a
+    // vnode {type: Function, props: {onClick, ...}} without executing it.
+    // Find it by its type being a function with an onClick prop.
+    const vsched = findInTree(tree, n => typeof n?.type === 'function' && n?.props?.onClick && n?.props?.m);
+    expect(vsched).toBeTruthy();
+    vsched.props.onClick();
+    const updated = runtime.currentTree();
+    // MatchViewerModal is a function component with tournament + compId props
+    const modal = findInTree(updated, n => typeof n?.type === 'function' && n?.props?.tournament && n?.props?.compId);
+    expect(modal).toBeTruthy();
+    expect(modal.props.match).toBeTruthy();
+    expect(modal.props.match.id).toBe('m1');
+  });
+
+  it('officiated: clicking an upcoming match expands inline MatchDetailCard', () => {
+    const m = mkMatch('m1');
+    const tree = runtime.mount(ViewerOverview, {
+      c: mkComp(),
+      myPlayer: null,
+      myUpcoming: null,
+      currentMatch: null,
+      liveMatches: [],
+      upcomingMatches: [m],
+      recentMatches: [],
+      tweaks: {},
+      tournament: { mode: 'officiated' },
+      compId: 'c1',
+    });
+    const vsched = findInTree(tree, n => typeof n?.type === 'function' && n?.props?.onClick && n?.props?.m);
+    expect(vsched).toBeTruthy();
+    vsched.props.onClick();
+    const updated = runtime.currentTree();
+    // MatchDetailCard should be rendered (function component with match + onClose props)
+    const detailCard = findInTree(updated, n => typeof n?.type === 'function' && n?.props?.match && n?.props?.onClose !== undefined && !n?.props?.tournament);
+    expect(detailCard).toBeTruthy();
+    // No modal-backdrop (no MatchViewerModal)
+    const modal = findInTree(updated, n => n?.props?.className === 'modal-backdrop');
+    expect(modal).toBeNull();
+  });
+});
+

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -879,8 +879,7 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
     expect(vsched).toBeTruthy();
     vsched.props.onClick();
     const updated = runtime.currentTree();
-    // MatchViewerModal is a function component with tournament + compId props
-    const modal = findInTree(updated, n => typeof n?.type === 'function' && n?.props?.tournament && n?.props?.compId);
+    const modal = findInTree(updated, n => n?.type?.name === 'MatchViewerModal');
     expect(modal).toBeTruthy();
     expect(modal.props.match).toBeTruthy();
     expect(modal.props.match.id).toBe('m1');
@@ -908,8 +907,54 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
     const detailCard = findInTree(updated, n => typeof n?.type === 'function' && n?.props?.match && n?.props?.onClose !== undefined && !n?.props?.tournament);
     expect(detailCard).toBeTruthy();
     // No modal-backdrop (no MatchViewerModal)
-    const modal = findInTree(updated, n => n?.props?.className === 'modal-backdrop');
+    const modal = findInTree(updated, n => n?.type?.name === 'MatchViewerModal');
     expect(modal).toBeNull();
+  });
+
+  it('self-run: clicking the ON NOW current match opens MatchViewerModal', () => {
+    const running = { ...mkMatch('curr1'), status: 'running' };
+    runtime.mount(ViewerOverview, {
+      c: mkComp(),
+      myPlayer: null,
+      myUpcoming: null,
+      currentMatch: running,
+      liveMatches: [],
+      upcomingMatches: [],
+      recentMatches: [],
+      tweaks: {},
+      tournament: { mode: 'self-run' },
+      compId: 'c1',
+    });
+    const onNow = findInTree(runtime.currentTree(), n => n?.type === 'div' && n?.props?.role === 'button');
+    expect(onNow).toBeTruthy();
+    onNow.props.onClick();
+    const modal = findInTree(runtime.currentTree(), n => n?.type?.name === 'MatchViewerModal');
+    expect(modal).toBeTruthy();
+    expect(modal.props.match.id).toBe('curr1');
+  });
+
+  it('self-run: Enter key on ON NOW current match opens MatchViewerModal', () => {
+    const running = { ...mkMatch('curr2'), status: 'running' };
+    runtime.mount(ViewerOverview, {
+      c: mkComp(),
+      myPlayer: null,
+      myUpcoming: null,
+      currentMatch: running,
+      liveMatches: [],
+      upcomingMatches: [],
+      recentMatches: [],
+      tweaks: {},
+      tournament: { mode: 'self-run' },
+      compId: 'c1',
+    });
+    const onNow = findInTree(runtime.currentTree(), n => n?.type === 'div' && n?.props?.role === 'button');
+    expect(onNow).toBeTruthy();
+    const fakeEvent = { key: 'Enter', preventDefault: vi.fn() };
+    onNow.props.onKeyDown(fakeEvent);
+    expect(fakeEvent.preventDefault).toHaveBeenCalled();
+    const modal = findInTree(runtime.currentTree(), n => n?.type?.name === 'MatchViewerModal');
+    expect(modal).toBeTruthy();
+    expect(modal.props.match.id).toBe('curr2');
   });
 });
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1945,7 +1945,19 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
 
       {/* Current match — shown inline, before Up Next */}
       {currentMatch && currentMatch.status === "running" && (
-        <div style={{ marginBottom: 12, cursor: isSelfRun ? "pointer" : undefined }} role={isSelfRun ? "button" : undefined} tabIndex={isSelfRun ? 0 : undefined} onClick={isSelfRun ? () => handleMatchClick(currentMatch) : undefined} onKeyDown={isSelfRun ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleMatchClick(currentMatch); } } : undefined}>
+        <div
+          style={{ marginBottom: 12, cursor: isSelfRun ? "pointer" : undefined }}
+          role={isSelfRun ? "button" : undefined}
+          aria-label={isSelfRun ? "View current match details" : undefined}
+          tabIndex={isSelfRun ? 0 : undefined}
+          onClick={isSelfRun ? () => handleMatchClick(currentMatch) : undefined}
+          onKeyDown={isSelfRun ? (e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleMatchClick(currentMatch);
+            }
+          } : undefined}
+        >
           <div className="section-title" style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <span className="dot dot--live"></span> ON NOW
           </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1660,6 +1660,8 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
               upcomingMatches={upcomingMatches}
               recentMatches={recentMatches}
               tweaks={tweaks}
+              tournament={tournament}
+              compId={c.id}
             />
           )}
           {tab === "bracket" && derivedBracket && (
@@ -1790,8 +1792,10 @@ function MatchDetailCard({ match, onClose }) {
   );
 }
 
-function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks }) {
+function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks, tournament, compId }) {
   const [expandedMatchId, setExpandedMatchId] = useState(null);
+  const [selectedMatch, setSelectedMatch] = useState(null);
+  const isSelfRun = tournament && tournament.mode === "self-run";
 
   // setup: no draw yet — plain "not started" message.
   if (!c.status || c.status === "setup") {
@@ -1825,7 +1829,11 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
   }
 
   const handleMatchClick = (m) => {
-    setExpandedMatchId(prev => prev === m.id ? null : m.id);
+    if (isSelfRun) {
+      setSelectedMatch(m);
+    } else {
+      setExpandedMatchId(prev => prev === m.id ? null : m.id);
+    }
   };
 
   return (
@@ -1863,7 +1871,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
 
       {/* Current match — shown inline, before Up Next */}
       {currentMatch && currentMatch.status === "running" && (
-        <div style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: 12, cursor: isSelfRun ? "pointer" : undefined }} onClick={isSelfRun ? () => handleMatchClick(currentMatch) : undefined}>
           <div className="section-title" style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <span className="dot dot--live"></span> ON NOW
           </div>
@@ -1881,7 +1889,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
             {liveMatches.filter(m => !currentMatch || m.id !== currentMatch.id).map((m) => (
               <React.Fragment key={m.id}>
                 <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
-                {expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
+                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
           </div>
@@ -1896,7 +1904,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
             {upcomingMatches.map((m) => (
               <React.Fragment key={m.id}>
                 <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
-                {expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
+                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
           </div>
@@ -1914,13 +1922,14 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {recentMatches.map((m) => (
               <React.Fragment key={m.id}>
-                <VSchedItem m={m} tweaks={tweaks} onClick={() => setExpandedMatchId(prev => prev === m.id ? null : m.id)} />
-                {expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
+                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
+                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
           </div>
         </>
       )}
+      {isSelfRun && selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} compId={compId} />}
     </div>
   );
 }

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1945,7 +1945,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
 
       {/* Current match — shown inline, before Up Next */}
       {currentMatch && currentMatch.status === "running" && (
-        <div style={{ marginBottom: 12, cursor: isSelfRun ? "pointer" : undefined }} onClick={isSelfRun ? () => handleMatchClick(currentMatch) : undefined}>
+        <div style={{ marginBottom: 12, cursor: isSelfRun ? "pointer" : undefined }} role={isSelfRun ? "button" : undefined} tabIndex={isSelfRun ? 0 : undefined} onClick={isSelfRun ? () => handleMatchClick(currentMatch) : undefined} onKeyDown={isSelfRun ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleMatchClick(currentMatch); } } : undefined}>
           <div className="section-title" style={{ display: "flex", alignItems: "center", gap: 6 }}>
             <span className="dot dot--live"></span> ON NOW
           </div>


### PR DESCRIPTION
## Summary

- In self-run tournaments, clicking a match on the viewer's **Overview tab** (the default landing page) now opens \`MatchViewerModal\` with the "Report result" button — previously it only showed an inline \`MatchDetailCard\` with no scoring affordance
- Non-self-run tournaments retain the existing inline expansion behavior (no UX change)
- Threads \`tournament\` and \`compId\` props from \`ViewerCompetition\` → \`ViewerOverview\` to enable the self-run detection

## Test plan

- [x] **Self-run tournament, Overview tab**: tap a match → modal opens with "Report result" button
- [x] **Self-run tournament, scoring flow**: tap "Report result" → ScoreEditorModal opens → submit result → modal closes
- [x] **Self-run tournament, completed match**: tap a completed match → modal shows "Result reported" text, no button
- [x] **Non-self-run tournament, Overview tab**: tap a match → inline \`MatchDetailCard\` expands (unchanged behavior)
- [x] **Pools tab in self-run**: verify existing modal + "Report result" still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)