### PR TITLE
feat(mp-wvkh): global participant context across competition views

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5957,8 +5957,13 @@ button.my-match__opp {
 
 /* mp-wvkh: followed-player highlights */
 .pool__row--me { background: rgba(29,53,87,0.07); }
-.pool-matrix__row--me { background: rgba(29,53,87,0.07); }
-.pool-matrix__row--me .pool-matrix__row-head { font-weight: 700; }
-.pool-matrix__col--me { background: rgba(29,53,87,0.07); font-weight: 700; }
+/* Matrix row: top inset shadow on every cell so the highlight shows through win/loss/draw backgrounds */
+.pool-matrix__row--me td,
+.pool-matrix__row--me th { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35); }
+.pool-matrix__row--me .pool-matrix__row-head { background: rgba(29,53,87,0.07); font-weight: 700; }
+/* Matrix col: left inset shadow so it doesn't override win/loss/draw cell backgrounds */
+.pool-matrix__col--me { box-shadow: inset 2px 0 0 rgba(29,53,87,0.35); font-weight: 700; }
+/* Corner cell (row and col): combine both shadows */
+.pool-matrix__row--me .pool-matrix__col--me { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35), inset 2px 0 0 rgba(29,53,87,0.35); }
 .bc-match--my-match { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }
 .vsched-item--me { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5954,3 +5954,11 @@ button.my-match__opp {
   .sponsor-strip__logo { height: 32px; max-width: 120px; }
   .sponsor-strip { gap: 12px; padding: 12px 8px; }
 }
+
+/* mp-wvkh: followed-player highlights */
+.pool__row--me { background: rgba(29,53,87,0.07); }
+.pool-matrix__row--me { background: rgba(29,53,87,0.07); }
+.pool-matrix__row--me .pool-matrix__row-head { font-weight: 700; }
+.pool-matrix__col--me { background: rgba(29,53,87,0.07); font-weight: 700; }
+.bc-match--my-match { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }
+.vsched-item--me { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -165,3 +165,88 @@ describe('mymatchQueueLabel', () => {
     expect(mymatchQueueLabel(undefined)).toBeNull();
   });
 });
+
+// mp-wvkh: myUpcoming derivation logic — tested as a pure function that
+// mirrors the inline useMemo in ViewerCompetition. Exercises the three
+// behaviours Copilot flagged: running-match precedence, scheduledAt
+// ordering, and name-fallback when followed player has no UUID.
+function deriveMyUpcoming(followedPlayer, allMatches) {
+  if (!followedPlayer || (!followedPlayer.id && !followedPlayer.name)) return null;
+  const hasBothSides = (m) => m.sideA && m.sideB;
+  const mine = buildPlayerMatchHighlight(followedPlayer.id || "", allMatches, followedPlayer.name)
+    .filter(hasBothSides)
+    .filter((m) => m.status !== "completed");
+  mine.sort((a, b) => {
+    const ao = a.status === "running" ? 0 : 1;
+    const bo = b.status === "running" ? 0 : 1;
+    if (ao !== bo) return ao - bo;
+    return (a.scheduledAt || "99:99").localeCompare(b.scheduledAt || "99:99");
+  });
+  return mine[0] || null;
+}
+
+describe('deriveMyUpcoming (mp-wvkh)', () => {
+  const mkMatch = (id, sideA, sideB, status, scheduledAt) => ({
+    id, sideA, sideB, status, scheduledAt,
+  });
+  const player = { id: 'p1', name: 'Alice' };
+
+  it('returns null when followedPlayer is null or has no id/name', () => {
+    expect(deriveMyUpcoming(null, [])).toBeNull();
+    expect(deriveMyUpcoming({}, [])).toBeNull();
+    expect(deriveMyUpcoming({ id: '', name: '' }, [])).toBeNull();
+  });
+
+  it('returns the running match over a scheduled match', () => {
+    const matches = [
+      mkMatch('m1', { id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }, 'scheduled', '09:00'),
+      mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'running', '09:30'),
+    ];
+    const result = deriveMyUpcoming(player, matches);
+    expect(result.id).toBe('m2');
+  });
+
+  it('sorts scheduled matches by scheduledAt ascending', () => {
+    const matches = [
+      mkMatch('m1', { id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }, 'scheduled', '10:00'),
+      mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'scheduled', '09:00'),
+    ];
+    const result = deriveMyUpcoming(player, matches);
+    expect(result.id).toBe('m2');
+  });
+
+  it('excludes completed matches', () => {
+    const matches = [
+      mkMatch('m1', { id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }, 'completed', '08:00'),
+      mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'scheduled', '10:00'),
+    ];
+    const result = deriveMyUpcoming(player, matches);
+    expect(result.id).toBe('m2');
+  });
+
+  it('falls back to name match when followed player has no UUID', () => {
+    const nameOnly = { id: '', name: 'Alice' };
+    const matches = [
+      mkMatch('m1', { id: 'x1', name: 'Alice' }, { id: 'x2', name: 'Bob' }, 'scheduled', '09:00'),
+    ];
+    const result = deriveMyUpcoming(nameOnly, matches);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('m1');
+  });
+
+  it('returns null when no matches involve the followed player', () => {
+    const matches = [
+      mkMatch('m1', { id: 'p5', name: 'Eve' }, { id: 'p6', name: 'Frank' }, 'scheduled', '09:00'),
+    ];
+    expect(deriveMyUpcoming(player, matches)).toBeNull();
+  });
+
+  it('skips matches missing a side (hasBothSides guard)', () => {
+    const matches = [
+      mkMatch('m1', { id: 'p1', name: 'Alice' }, null, 'scheduled', '09:00'),
+      mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'scheduled', '10:00'),
+    ];
+    const result = deriveMyUpcoming(player, matches);
+    expect(result.id).toBe('m2');
+  });
+});

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -1,7 +1,7 @@
 // Pure-logic tests for buildPlayerMatchHighlight (FR-020, FR-022).
 // Slice 4 / T108–T109: drives "Find my matches" filtering on the viewer home.
 import { describe, it, expect } from 'vitest';
-import { buildPlayerMatchHighlight, isFollowedPlayer, mymatchQueueLabel } from '../viewer.jsx';
+import { buildPlayerMatchHighlight, buildFollowedNextMatch, isFollowedPlayer, mymatchQueueLabel } from '../viewer.jsx';
 
 describe('buildPlayerMatchHighlight', () => {
   it('returns matches where playerId is on SideA', () => {
@@ -166,35 +166,19 @@ describe('mymatchQueueLabel', () => {
   });
 });
 
-// mp-wvkh: myUpcoming derivation logic — tested as a pure function that
-// mirrors the inline useMemo in ViewerCompetition. Exercises the three
-// behaviours Copilot flagged: running-match precedence, scheduledAt
-// ordering, and name-fallback when followed player has no UUID.
-function deriveMyUpcoming(followedPlayer, allMatches) {
-  if (!followedPlayer || (!followedPlayer.id && !followedPlayer.name)) return null;
-  const hasBothSides = (m) => m.sideA && m.sideB;
-  const mine = buildPlayerMatchHighlight(followedPlayer.id || "", allMatches, followedPlayer.name)
-    .filter(hasBothSides)
-    .filter((m) => m.status !== "completed");
-  mine.sort((a, b) => {
-    const ao = a.status === "running" ? 0 : 1;
-    const bo = b.status === "running" ? 0 : 1;
-    if (ao !== bo) return ao - bo;
-    return (a.scheduledAt || "99:99").localeCompare(b.scheduledAt || "99:99");
-  });
-  return mine[0] || null;
-}
-
-describe('deriveMyUpcoming (mp-wvkh)', () => {
+// mp-wvkh: Tests for buildFollowedNextMatch — the extracted helper used by
+// ViewerCompetition to derive the followed player's next match. Covers:
+// running-match precedence, scheduledAt ordering, name-fallback (no UUID).
+describe('buildFollowedNextMatch (mp-wvkh)', () => {
   const mkMatch = (id, sideA, sideB, status, scheduledAt) => ({
     id, sideA, sideB, status, scheduledAt,
   });
   const player = { id: 'p1', name: 'Alice' };
 
   it('returns null when followedPlayer is null or has no id/name', () => {
-    expect(deriveMyUpcoming(null, [])).toBeNull();
-    expect(deriveMyUpcoming({}, [])).toBeNull();
-    expect(deriveMyUpcoming({ id: '', name: '' }, [])).toBeNull();
+    expect(buildFollowedNextMatch(null, [])).toBeNull();
+    expect(buildFollowedNextMatch({}, [])).toBeNull();
+    expect(buildFollowedNextMatch({ id: '', name: '' }, [])).toBeNull();
   });
 
   it('returns the running match over a scheduled match', () => {
@@ -202,7 +186,7 @@ describe('deriveMyUpcoming (mp-wvkh)', () => {
       mkMatch('m1', { id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }, 'scheduled', '09:00'),
       mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'running', '09:30'),
     ];
-    const result = deriveMyUpcoming(player, matches);
+    const result = buildFollowedNextMatch(player, matches);
     expect(result.id).toBe('m2');
   });
 
@@ -211,7 +195,7 @@ describe('deriveMyUpcoming (mp-wvkh)', () => {
       mkMatch('m1', { id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }, 'scheduled', '10:00'),
       mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'scheduled', '09:00'),
     ];
-    const result = deriveMyUpcoming(player, matches);
+    const result = buildFollowedNextMatch(player, matches);
     expect(result.id).toBe('m2');
   });
 
@@ -220,7 +204,7 @@ describe('deriveMyUpcoming (mp-wvkh)', () => {
       mkMatch('m1', { id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }, 'completed', '08:00'),
       mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'scheduled', '10:00'),
     ];
-    const result = deriveMyUpcoming(player, matches);
+    const result = buildFollowedNextMatch(player, matches);
     expect(result.id).toBe('m2');
   });
 
@@ -229,7 +213,7 @@ describe('deriveMyUpcoming (mp-wvkh)', () => {
     const matches = [
       mkMatch('m1', { id: 'x1', name: 'Alice' }, { id: 'x2', name: 'Bob' }, 'scheduled', '09:00'),
     ];
-    const result = deriveMyUpcoming(nameOnly, matches);
+    const result = buildFollowedNextMatch(nameOnly, matches);
     expect(result).not.toBeNull();
     expect(result.id).toBe('m1');
   });
@@ -238,7 +222,7 @@ describe('deriveMyUpcoming (mp-wvkh)', () => {
     const matches = [
       mkMatch('m1', { id: 'p5', name: 'Eve' }, { id: 'p6', name: 'Frank' }, 'scheduled', '09:00'),
     ];
-    expect(deriveMyUpcoming(player, matches)).toBeNull();
+    expect(buildFollowedNextMatch(player, matches)).toBeNull();
   });
 
   it('skips matches missing a side (hasBothSides guard)', () => {
@@ -246,7 +230,7 @@ describe('deriveMyUpcoming (mp-wvkh)', () => {
       mkMatch('m1', { id: 'p1', name: 'Alice' }, null, 'scheduled', '09:00'),
       mkMatch('m2', { id: 'p1', name: 'Alice' }, { id: 'p3', name: 'Charlie' }, 'scheduled', '10:00'),
     ];
-    const result = deriveMyUpcoming(player, matches);
+    const result = buildFollowedNextMatch(player, matches);
     expect(result.id).toBe('m2');
   });
 });

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -150,7 +150,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
 });
 PlayerLine.displayName = "PlayerLine";
 
-const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder }) => {
+const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder, highlightPlayerId, highlightPlayerName }) => {
   const aWin = match.winner && match.sideA && match.winner.id === match.sideA.id;
   const bWin = match.winner && match.sideB && match.winner.id === match.sideB.id;
   const live = match.status === "running";
@@ -165,12 +165,18 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
   const aTBD = isPlaceholder || (match.sideA && typeof match.sideA.id === "string" && match.sideA.id.startsWith("tbd-"));
   const bTBD = isPlaceholder || (match.sideB && typeof match.sideB.id === "string" && match.sideB.id.startsWith("tbd-"));
 
+  const playerHighlight = (highlightPlayerId || highlightPlayerName) && (
+    (highlightPlayerId && ((match.sideA?.id === highlightPlayerId) || (match.sideB?.id === highlightPlayerId))) ||
+    (highlightPlayerName && ((match.sideA?.name === highlightPlayerName) || (match.sideB?.name === highlightPlayerName) ||
+      (match.sideA?.id === highlightPlayerName) || (match.sideB?.id === highlightPlayerName)))
+  );
+
   return (
     <button
       ref={matchRef}
       type="button"
       data-match-id={match.id}
-      className={`bc-match bc-match--v${variant} ${live ? "bc-match--live" : ""} ${match.status === "completed" ? "bc-match--done" : ""} ${highlighted ? "bc-match--highlight" : ""}`}
+      className={`bc-match bc-match--v${variant} ${live ? "bc-match--live" : ""} ${match.status === "completed" ? "bc-match--done" : ""} ${highlighted ? "bc-match--highlight" : ""} ${playerHighlight ? "bc-match--my-match" : ""}`}
       onClick={onClick}
       aria-label={`Match ${match.id}`}
     >
@@ -249,7 +255,7 @@ function BracketConnectors({ rounds, treeRef, refMap, version }) {
   );
 }
 
-function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef }) {
+function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayerId, highlightPlayerName }) {
   const treeRef = useRef(null);
   const refMap = useRef({});
   const [version, setVersion] = useStateBC(0);
@@ -291,6 +297,8 @@ function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highl
                   highlighted={m.id === highlightedMatchId}
                   matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
                   onClick={() => onMatchClick && onMatchClick(m, ri, mi)}
+                  highlightPlayerId={highlightPlayerId}
+                  highlightPlayerName={highlightPlayerName}
                 />
               </div>
             ))}

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -150,7 +150,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
 });
 PlayerLine.displayName = "PlayerLine";
 
-const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder, highlightPlayerId, highlightPlayerName }) => {
+const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder, highlightPlayer }) => {
   const aWin = match.winner && match.sideA && match.winner.id === match.sideA.id;
   const bWin = match.winner && match.sideB && match.winner.id === match.sideB.id;
   const live = match.status === "running";
@@ -165,11 +165,8 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
   const aTBD = isPlaceholder || (match.sideA && typeof match.sideA.id === "string" && match.sideA.id.startsWith("tbd-"));
   const bTBD = isPlaceholder || (match.sideB && typeof match.sideB.id === "string" && match.sideB.id.startsWith("tbd-"));
 
-  const playerHighlight = (highlightPlayerId || highlightPlayerName) && (
-    (highlightPlayerId && ((match.sideA?.id === highlightPlayerId) || (match.sideB?.id === highlightPlayerId))) ||
-    (highlightPlayerName && ((match.sideA?.name === highlightPlayerName) || (match.sideB?.name === highlightPlayerName) ||
-      (match.sideA?.id === highlightPlayerName) || (match.sideB?.id === highlightPlayerName)))
-  );
+  const _isFollowed = window.isFollowedPlayer || (() => false);
+  const playerHighlight = highlightPlayer && (_isFollowed(match.sideA, highlightPlayer) || _isFollowed(match.sideB, highlightPlayer));
 
   return (
     <button
@@ -255,7 +252,7 @@ function BracketConnectors({ rounds, treeRef, refMap, version }) {
   );
 }
 
-function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayerId, highlightPlayerName }) {
+function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayer }) {
   const treeRef = useRef(null);
   const refMap = useRef({});
   const [version, setVersion] = useStateBC(0);
@@ -297,8 +294,7 @@ function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highl
                   highlighted={m.id === highlightedMatchId}
                   matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
                   onClick={() => onMatchClick && onMatchClick(m, ri, mi)}
-                  highlightPlayerId={highlightPlayerId}
-                  highlightPlayerName={highlightPlayerName}
+                  highlightPlayer={highlightPlayer}
                 />
               </div>
             ))}

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -165,7 +165,7 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
   const aTBD = isPlaceholder || (match.sideA && typeof match.sideA.id === "string" && match.sideA.id.startsWith("tbd-"));
   const bTBD = isPlaceholder || (match.sideB && typeof match.sideB.id === "string" && match.sideB.id.startsWith("tbd-"));
 
-  const _isFollowed = window.isFollowedPlayer || (() => false);
+  const _isFollowed = (typeof window !== "undefined" && window.isFollowedPlayer) || (() => false);
   const playerHighlight = highlightPlayer && (_isFollowed(match.sideA, highlightPlayer) || _isFollowed(match.sideB, highlightPlayer));
 
   return (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1507,7 +1507,6 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
 function ViewerCompetition({ tournament, competition, pools, poolMatches, standings, bracket, onBack, onSelectCompetition, tweaks }) {
   const [tab, setTab] = useState("overview");
   const c = competition;
-  const [followedPlayer] = useFollowedPlayer();
 
   // Phase 2 (mp-rrd) — link a pools/mixed comp to its separate playoffs comp
   // and vice-versa. A mixed tournament is TWO competitions: the pools/mixed

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1721,8 +1721,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightedMatchId={currentMatch?.id}
                     autoScrollMatchId={bracketScrollTarget}
                     scrollContainerRef={bracketScrollRef}
-                    highlightPlayerId={followedPlayer?.id}
-                    highlightPlayerName={followedPlayer?.name}
+                    highlightPlayer={followedPlayer}
                     onMatchClick={(m, ri) => {
                       const label = window.roundLabel(ri, derivedBracket.rounds.length);
                       setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, compKind: c.kind, teamSize: c.teamSize });
@@ -2029,9 +2028,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {liveMatches.filter(m => !currentMatch || m.id !== currentMatch.id).map((m) => (
               <React.Fragment key={m.id}>
-                <div className={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer) ? "vsched-item--me" : ""}>
-                  <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
-                </div>
+                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} highlight={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer)} />
                 {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
@@ -2046,9 +2043,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {upcomingMatches.map((m) => (
               <React.Fragment key={m.id}>
-                <div className={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer) ? "vsched-item--me" : ""}>
-                  <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
-                </div>
+                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} highlight={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer)} />
                 {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
@@ -2067,10 +2062,8 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {recentMatches.map((m) => (
               <React.Fragment key={m.id}>
-                <div className={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer) ? "vsched-item--me" : ""}>
-                  <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
-                </div>
-                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />
+                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} highlight={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer)} />
+                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
           </div>
@@ -2081,7 +2074,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
   );
 }
 
-const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick }) => {
+const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight }) => {
   const aWin = m.winner && m.sideA && m.winner.id === m.sideA.id;
   const bWin = m.winner && m.sideB && m.winner.id === m.sideB.id;
   // Bracket matches carry scoreA/scoreB strings rather than ipponsA/B arrays.
@@ -2104,7 +2097,7 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick }) => {
     ? (window.queueLabel ? window.queueLabel(m) : _localQueueLabel(m))
     : null;
   return (
-    <button className={`vsched-item ${m.status === "running" ? "vsched-item--live" : ""}`} onClick={onClick} style={{ textAlign: "left", width: "100%", border: "none", background: "none", cursor: onClick ? "pointer" : "default" }}>
+    <button className={`vsched-item ${m.status === "running" ? "vsched-item--live" : ""} ${highlight ? "vsched-item--me" : ""}`} onClick={onClick} style={{ textAlign: "left", width: "100%", border: "none", background: "none", cursor: onClick ? "pointer" : "default" }}>
       <div className="vsched-item__head">
         <span className="vsched-item__time">{m.scheduledAt || "—"}</span>
         <span className="vsched-item__court">SHIAIJO {m.court}</span>
@@ -2186,10 +2179,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
 
-  const isHighlighted = (p) => highlightPlayer && (
-    p.id === highlightPlayer.id ||
-    (p.name && highlightPlayer.name && p.name.trim().toLowerCase() === highlightPlayer.name.trim().toLowerCase())
-  );
+  const isHighlighted = (p) => isFollowedPlayer(p, highlightPlayer);
   const matchMap = {};
   matches.forEach(m => {
     const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
@@ -2342,7 +2332,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
               </thead>
               <tbody>
                 {poolStandings && poolStandings.length > 0 ? poolStandings.map((s, i) => (
-                  <tr key={s.player.name} className={highlightPlayer && (s.player.id === highlightPlayer.id || (s.player.name && highlightPlayer.name && s.player.name.trim().toLowerCase() === highlightPlayer.name.trim().toLowerCase())) ? "pool__row--me" : ""}>
+                  <tr key={s.player.name} className={isFollowedPlayer(s.player, highlightPlayer) ? "pool__row--me" : ""}>
                     <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{i + 1}{s.isOverridden ? "*" : ""}</td>
                     <td>
                       <div style={{ fontWeight: 500 }}>
@@ -2362,7 +2352,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                 )) : pool.players.map((p, i) => {
                   const cols = isTeam ? 7 : 5;
                   return (
-                    <tr key={p.name} className={highlightPlayer && (p.id === highlightPlayer.id || (p.name && highlightPlayer.name && p.name.trim().toLowerCase() === highlightPlayer.name.trim().toLowerCase())) ? "pool__row--me" : ""}>
+                    <tr key={p.name} className={isFollowedPlayer(p, highlightPlayer) ? "pool__row--me" : ""}>
                       <td style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{i + 1}</td>
                       <td>
                         <div style={{ fontWeight: 500 }}>
@@ -3376,6 +3366,7 @@ window.AnnouncementCard = AnnouncementCard;
 window.AnnouncementBanner = AnnouncementBanner;
 window.ViewerHome = ViewerHome;
 window.ViewerCompetition = ViewerCompetition;
+window.isFollowedPlayer = isFollowedPlayer;
 window.ViewerSchedule = ViewerSchedule;
 window.ScheduleViewer = ScheduleViewer;
 window.SwissStandingsViewer = SwissStandingsViewer;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1507,6 +1507,7 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
 function ViewerCompetition({ tournament, competition, pools, poolMatches, standings, bracket, onBack, onSelectCompetition, tweaks }) {
   const [tab, setTab] = useState("overview");
   const c = competition;
+  const [followedPlayer] = useFollowedPlayer();
 
   // Phase 2 (mp-rrd) — link a pools/mixed comp to its separate playoffs comp
   // and vice-versa. A mixed tournament is TWO competitions: the pools/mixed
@@ -1706,6 +1707,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
               onSwitchTab={setTab}
               hasActiveFilter={hasActiveFilter}
               filterLabel={filterLabel}
+              highlightPlayer={followedPlayer}
             />
           )}
           {tab === "bracket" && derivedBracket && (
@@ -1719,6 +1721,8 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightedMatchId={currentMatch?.id}
                     autoScrollMatchId={bracketScrollTarget}
                     scrollContainerRef={bracketScrollRef}
+                    highlightPlayerId={followedPlayer?.id}
+                    highlightPlayerName={followedPlayer?.name}
                     onMatchClick={(m, ri) => {
                       const label = window.roundLabel(ri, derivedBracket.rounds.length);
                       setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, compKind: c.kind, teamSize: c.teamSize });
@@ -1729,7 +1733,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             </div>
           )}
           {tab === "pools" && hasPools && (
-            <PoolsViewer pools={pools} standings={standings} poolMatches={poolMatches} tweaks={tweaks} competition={c} onMatchClick={setSelectedMatch} />
+            <PoolsViewer pools={pools} standings={standings} poolMatches={poolMatches} tweaks={tweaks} competition={c} onMatchClick={setSelectedMatch} highlightPlayer={followedPlayer} />
           )}
           {tab === "swiss" && isSwiss && (
             <SwissStandingsViewer competition={c} poolMatches={poolMatches} tweaks={tweaks} />
@@ -1836,7 +1840,7 @@ function MatchDetailCard({ match, onClose }) {
   );
 }
 
-function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks, tournament, compId, standings, pools, poolMatches, onSwitchTab, hasActiveFilter, filterLabel }) {
+function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks, tournament, compId, standings, pools, poolMatches, onSwitchTab, hasActiveFilter, filterLabel, highlightPlayer }) {
   const [expandedMatchId, setExpandedMatchId] = useState(null);
   const [selectedMatch, setSelectedMatch] = useState(null);
   const isSelfRun = tournament && tournament.mode === "self-run";
@@ -2025,7 +2029,9 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {liveMatches.filter(m => !currentMatch || m.id !== currentMatch.id).map((m) => (
               <React.Fragment key={m.id}>
-                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
+                <div className={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer) ? "vsched-item--me" : ""}>
+                  <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
+                </div>
                 {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
@@ -2040,7 +2046,9 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {upcomingMatches.map((m) => (
               <React.Fragment key={m.id}>
-                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
+                <div className={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer) ? "vsched-item--me" : ""}>
+                  <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
+                </div>
                 {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
               </React.Fragment>
             ))}
@@ -2059,8 +2067,10 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           <div className="vsched">
             {recentMatches.map((m) => (
               <React.Fragment key={m.id}>
-                <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
-                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />}
+                <div className={isFollowedPlayer(m.sideA, highlightPlayer) || isFollowedPlayer(m.sideB, highlightPlayer) ? "vsched-item--me" : ""}>
+                  <VSchedItem m={m} tweaks={tweaks} onClick={() => handleMatchClick(m)} />
+                </div>
+                {!isSelfRun && expandedMatchId === m.id && <MatchDetailCard match={m} onClose={() => setExpandedMatchId(null)} />
               </React.Fragment>
             ))}
           </div>
@@ -2172,10 +2182,14 @@ PoolMatchRow.displayName = "PoolMatchRow";
 
 // Round-robin matrix for a single pool. Each off-diagonal cell shows the row
 // player's result (W/L/X) against the column player; diagonal cells are self.
-function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
+function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
 
+  const isHighlighted = (p) => highlightPlayer && (
+    p.id === highlightPlayer.id ||
+    (p.name && highlightPlayer.name && p.name.trim().toLowerCase() === highlightPlayer.name.trim().toLowerCase())
+  );
   const matchMap = {};
   matches.forEach(m => {
     const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
@@ -2207,13 +2221,13 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
           <tr>
             <th className="pool-matrix__corner"></th>
             {players.map((p, i) => (
-              <th key={p.name} className="pool-matrix__col-head" title={p.name}>{i + 1}</th>
+              <th key={p.name} className={`pool-matrix__col-head${isHighlighted(p) ? " pool-matrix__col--me" : ""}`} title={p.name}>{i + 1}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {players.map((rowPlayer, ri) => (
-            <tr key={rowPlayer.name}>
+            <tr key={rowPlayer.name} className={isHighlighted(rowPlayer) ? "pool-matrix__row--me" : ""}>
               <td className="pool-matrix__row-head" title={rowPlayer.name}>
                 <span className="pool-matrix__num">{ri + 1}</span>
                 <span className="pool-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
@@ -2279,7 +2293,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick }) {
   );
 }
 
-function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMatchClick }) {
+function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMatchClick, highlightPlayer }) {
   if (!pools || pools.length === 0) {
     return <div className="empty"><div className="icon">⏳</div><h3>Pools not drawn yet</h3></div>;
   }
@@ -2328,7 +2342,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
               </thead>
               <tbody>
                 {poolStandings && poolStandings.length > 0 ? poolStandings.map((s, i) => (
-                  <tr key={s.player.name}>
+                  <tr key={s.player.name} className={highlightPlayer && (s.player.id === highlightPlayer.id || (s.player.name && highlightPlayer.name && s.player.name.trim().toLowerCase() === highlightPlayer.name.trim().toLowerCase())) ? "pool__row--me" : ""}>
                     <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{i + 1}{s.isOverridden ? "*" : ""}</td>
                     <td>
                       <div style={{ fontWeight: 500 }}>
@@ -2348,7 +2362,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                 )) : pool.players.map((p, i) => {
                   const cols = isTeam ? 7 : 5;
                   return (
-                    <tr key={p.name}>
+                    <tr key={p.name} className={highlightPlayer && (p.id === highlightPlayer.id || (p.name && highlightPlayer.name && p.name.trim().toLowerCase() === highlightPlayer.name.trim().toLowerCase())) ? "pool__row--me" : ""}>
                       <td style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{i + 1}</td>
                       <td>
                         <div style={{ fontWeight: 500 }}>
@@ -2367,7 +2381,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
             {/* Round-robin matrix — always visible */}
             {matches.length > 0 && !isTeam && (
               <div style={{ marginTop: 12 }}>
-                <PoolMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} />
+                <PoolMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayer={highlightPlayer} />
               </div>
             )}
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2222,9 +2222,10 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
                 <span className="pool-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
               </td>
               {players.map((colPlayer, ci) => {
-                if (ri === ci) return <td key={colPlayer.name} className="pool-matrix__cell pool-matrix__cell--self">&mdash;</td>;
+                const colMe = isHighlighted(colPlayer) ? " pool-matrix__col--me" : "";
+                if (ri === ci) return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--self${colMe}`}>&mdash;</td>;
                 const m = matchMap[`${rowPlayer.name}||${colPlayer.name}`];
-                if (!m) return <td key={colPlayer.name} className="pool-matrix__cell pool-matrix__cell--empty"></td>;
+                if (!m) return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--empty${colMe}`}></td>;
 
                 const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
                 const winnerName = typeof m.winner === "object" ? m.winner?.name : m.winner;
@@ -2238,7 +2239,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
                 } : {};
 
                 if (m.status !== "completed") {
-                  return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--pending ${m.status === "running" ? "pool-matrix__cell--live" : ""}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
+                  return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--pending ${m.status === "running" ? "pool-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
                     {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>●</span> : "–"}
                   </td>;
                 }
@@ -2263,7 +2264,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
                 }
 
                 return (
-                  <td key={colPlayer.name} className={`pool-matrix__cell ${rowWon ? "pool-matrix__cell--win" : isDraw ? "pool-matrix__cell--draw" : "pool-matrix__cell--loss"}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
+                  <td key={colPlayer.name} className={`pool-matrix__cell ${rowWon ? "pool-matrix__cell--win" : isDraw ? "pool-matrix__cell--draw" : "pool-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
                     {cellContent}
                   </td>
                 );


### PR DESCRIPTION
## Summary

- Wire \`useFollowedPlayer()\` into \`ViewerCompetition\` so the "Find my matches" selection propagates to all competition detail tabs
- **Overview tab**: shows "Your next match" card (previously hardcoded to null) and highlights the player's matches in live/upcoming/recent lists with an inset left-border accent
- **Pools tab**: highlights the player's row in standings tables and their full row/column in the cross-table matrix
- **Bracket tab**: highlights the player's match cards with an inset left-border

No architecture change — components remount on navigation and re-read localStorage via the existing hook. 4 files changed.

## Test plan

- [x] Select a player on Home → navigate to a competition → verify Overview shows "Your next match" card
- [x] Verify Pools tab highlights their standings row and full cross-table row/column (header + cells)
- [x] Verify Bracket tab highlights their match cards
- [x] Verify Overview match lists show inset left-border accent on the player's matches
- [x] Navigate back to Home → verify selection unchanged
- [x] All Go tests pass (\`go test ./...\`)
- [x] Vitest tests pass (\`buildFollowedNextMatch\` coverage in viewer_mymatch.test.jsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)