### PR TITLE
feat(viewer): league standings on Overview tab

### DIFF
--- a/web-mobile/js/__tests__/viewer_league_overview.test.jsx
+++ b/web-mobile/js/__tests__/viewer_league_overview.test.jsx
@@ -28,18 +28,6 @@ function findInTree(node, predicate) {
   return null;
 }
 
-function findAllInTree(node, predicate, acc = []) {
-  if (!node || typeof node !== 'object') return acc;
-  if (Array.isArray(node)) {
-    node.forEach(k => findAllInTree(k, predicate, acc));
-    return acc;
-  }
-  if (predicate(node)) acc.push(node);
-  const kids = node.children || node.props?.children || [];
-  [].concat(kids).forEach(k => findAllInTree(k, predicate, acc));
-  return acc;
-}
-
 describe('ViewerOverview league standings (mp-ldnr)', () => {
   const realReact = global.React;
   let runtime;

--- a/web-mobile/js/__tests__/viewer_league_overview.test.jsx
+++ b/web-mobile/js/__tests__/viewer_league_overview.test.jsx
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+
+function collectText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children) return collectText(node.children);
+  if (node.props?.children) return collectText(node.props.children);
+  return '';
+}
+
+function findInTree(node, predicate) {
+  if (!node || typeof node !== 'object') return null;
+  if (Array.isArray(node)) {
+    for (const k of node) {
+      const found = findInTree(k, predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (predicate(node)) return node;
+  const kids = node.children || node.props?.children || [];
+  for (const k of [].concat(kids)) {
+    const found = findInTree(k, predicate);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findAllInTree(node, predicate, acc = []) {
+  if (!node || typeof node !== 'object') return acc;
+  if (Array.isArray(node)) {
+    node.forEach(k => findAllInTree(k, predicate, acc));
+    return acc;
+  }
+  if (predicate(node)) acc.push(node);
+  const kids = node.children || node.props?.children || [];
+  [].concat(kids).forEach(k => findAllInTree(k, predicate, acc));
+  return acc;
+}
+
+describe('ViewerOverview league standings (mp-ldnr)', () => {
+  const realReact = global.React;
+  let runtime;
+  let ViewerOverview;
+  const savedGlobals = {};
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => {
+      savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+        ? { had: true, val: global.window[k] }
+        : { had: false };
+    });
+    global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
+    global.window.isHikiwake = () => false;
+    global.window.formatIpponsScore = () => '';
+    global.window.ipponsFromScore = () => [];
+    global.window.queueLabel = () => '';
+    global.window.queueLabelCompact = () => null;
+    vi.resetModules();
+    ({ ViewerOverview } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  const baseProps = {
+    myPlayer: null,
+    myUpcoming: null,
+    currentMatch: null,
+    liveMatches: [],
+    upcomingMatches: [],
+    recentMatches: [],
+    tweaks: {},
+  };
+
+  function makeStandings(count) {
+    const rows = [];
+    for (let i = 0; i < count; i++) {
+      rows.push({
+        player: { id: `p${i}`, name: `Player ${i + 1}`, dojo: `Dojo ${i + 1}` },
+        wins: count - i,
+        losses: i,
+        draws: 0,
+        ipponsGiven: (count - i) * 2,
+        ipponsTaken: i,
+      });
+    }
+    return rows;
+  }
+
+  function makeTeamStandings(count) {
+    const rows = [];
+    for (let i = 0; i < count; i++) {
+      rows.push({
+        player: { id: `t${i}`, name: `Team ${i + 1}`, dojo: '' },
+        wins: count - i,
+        losses: i,
+        draws: 0,
+        individualWins: (count - i) * 3,
+        individualLosses: i * 2,
+        pointsWon: (count - i) * 5,
+        pointsLost: i * 3,
+      });
+    }
+    return rows;
+  }
+
+  const leagueComp = (status = 'pools') => ({
+    format: 'league',
+    status,
+    kind: 'individual',
+    teamSize: 0,
+  });
+
+  const teamLeagueComp = (status = 'pools') => ({
+    format: 'league',
+    status,
+    kind: 'team',
+    teamSize: 5,
+  });
+
+  const pools = [{ poolName: 'League', players: [] }];
+
+  function completedMatches(n) {
+    return Array.from({ length: n }, (_, i) => ({ id: `League-${i}`, status: 'completed' }));
+  }
+
+  function mixedMatches(completed, scheduled) {
+    return [
+      ...Array.from({ length: completed }, (_, i) => ({ id: `League-${i}`, status: 'completed' })),
+      ...Array.from({ length: scheduled }, (_, i) => ({ id: `League-s${i}`, status: 'scheduled' })),
+    ];
+  }
+
+  it('running league shows standings header and top-5 rows', () => {
+    const standings = { League: makeStandings(8) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('pools'),
+      standings,
+      pools,
+      poolMatches: mixedMatches(3, 5),
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Standings');
+    expect(text).toContain('Player 1');
+    expect(text).toContain('Player 5');
+    expect(text).not.toContain('Player 6');
+    expect(text).toContain('Showing top 5 of 8');
+    expect(text).not.toContain('Final standings');
+  });
+
+  it('completed league shows winner badge and final standings', () => {
+    const standings = { League: makeStandings(4) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('completed'),
+      standings,
+      pools,
+      poolMatches: completedMatches(6),
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Final standings');
+    expect(text).toContain('Player 4');
+    expect(text).not.toContain('Showing top 5');
+    const winnerBadge = findInTree(tree, n =>
+      typeof n?.type === 'function' && n.props?.testId === 'league-overview-winner'
+    );
+    expect(winnerBadge).not.toBeNull();
+    expect(winnerBadge.props.name).toBe('Player 1');
+  });
+
+  it('non-league format does NOT show standings section', () => {
+    const standings = { PoolA: makeStandings(4) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: { format: 'mixed', status: 'pools', kind: 'individual', teamSize: 0 },
+      standings,
+      pools: [{ poolName: 'PoolA', players: [] }],
+      poolMatches: mixedMatches(2, 4),
+    });
+    const text = collectText(tree);
+    expect(text).not.toContain('Standings');
+    expect(text).not.toContain('Player 1');
+  });
+
+  it('view-full-standings button calls onSwitchTab("pools")', () => {
+    const onSwitchTab = vi.fn();
+    const standings = { League: makeStandings(3) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('pools'),
+      standings,
+      pools,
+      poolMatches: mixedMatches(1, 2),
+      onSwitchTab,
+    });
+    const btn = findInTree(tree, n =>
+      n?.props?.['data-testid'] === 'league-overview-view-all'
+    );
+    expect(btn).not.toBeNull();
+    btn.props.onClick();
+    expect(onSwitchTab).toHaveBeenCalledWith('pools');
+  });
+
+  it('team league shows correct column headers (W/L/T/IV/IL/PW/PL)', () => {
+    const standings = { League: makeTeamStandings(3) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: teamLeagueComp('pools'),
+      standings,
+      pools,
+      poolMatches: mixedMatches(1, 2),
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Team');
+    expect(text).toContain('IV');
+    expect(text).toContain('IL');
+    expect(text).toContain('Team 1');
+  });
+
+  it('running league with no matches scored shows no standings section', () => {
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('pools'),
+      standings: { League: [] },
+      pools,
+      poolMatches: [],
+    });
+    const text = collectText(tree);
+    expect(text).not.toContain('Standings');
+  });
+
+  it('running league does NOT show winner badge', () => {
+    const standings = { League: makeStandings(4) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('pools'),
+      standings,
+      pools,
+      poolMatches: mixedMatches(3, 3),
+    });
+    const winnerBadge = findInTree(tree, n =>
+      typeof n?.type === 'function' && n.props?.testId === 'league-overview-winner'
+    );
+    expect(winnerBadge).toBeNull();
+  });
+
+  it('completed league shows match progress as N/N', () => {
+    const standings = { League: makeStandings(3) };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('completed'),
+      standings,
+      pools,
+      poolMatches: completedMatches(3),
+    });
+    const text = collectText(tree);
+    expect(text).toContain('3/3 matches');
+  });
+});

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1660,6 +1660,10 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
               upcomingMatches={upcomingMatches}
               recentMatches={recentMatches}
               tweaks={tweaks}
+              standings={standings}
+              pools={pools}
+              poolMatches={poolMatches}
+              onSwitchTab={setTab}
             />
           )}
           {tab === "bracket" && derivedBracket && (
@@ -1790,8 +1794,18 @@ function MatchDetailCard({ match, onClose }) {
   );
 }
 
-function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks }) {
+function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, upcomingMatches, recentMatches, tweaks, standings, pools, poolMatches, onSwitchTab }) {
   const [expandedMatchId, setExpandedMatchId] = useState(null);
+
+  const isLeague = c.format === "league";
+  const isTeam = c.kind === "team" || c.teamSize > 0;
+  const leaguePoolName = isLeague && pools && pools[0] ? pools[0].poolName : null;
+  const leagueStandings = leaguePoolName && standings ? (standings[leaguePoolName] || []) : [];
+  const allMatchesComplete = isLeague && (() => {
+    const all = poolMatches || [];
+    return all.length > 0 && all.every(m => m.status === "completed");
+  })();
+  const leagueWinner = allMatchesComplete && leagueStandings.length > 0 ? leagueStandings[0] : null;
 
   // setup: no draw yet — plain "not started" message.
   if (!c.status || c.status === "setup") {
@@ -1860,6 +1874,66 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
           })()}
         </div>
       ) : null}
+
+      {/* League standings summary (mp-ldnr) */}
+      {isLeague && leagueStandings.length > 0 && (c.status === "pools" || c.status === "playoffs" || c.status === "completed") && (
+        <div className="pool" style={{ padding: 14, marginBottom: 12 }} data-testid="league-overview-standings">
+          {leagueWinner && <WinnerBadge name={leagueWinner.player?.name || ""} testId="league-overview-winner" marginBottom={12} />}
+          <div className="pool__head">
+            <div className="pool__name">{allMatchesComplete ? "Final standings" : "Standings"}</div>
+            {poolMatches && (
+              <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
+                {poolMatches.filter(m => m.status === "completed").length}/{poolMatches.length} matches
+              </div>
+            )}
+          </div>
+          <table className="pool__table">
+            <thead>
+              {isTeam ? (
+                <tr><th>#</th><th>Team</th><th className="num">W</th><th className="num">L</th><th className="num">T</th><th className="num">IV</th><th className="num">IL</th><th className="num">PW</th><th className="num">PL</th></tr>
+              ) : (
+                <tr><th>#</th><th>Player</th><th className="num">W</th><th className="num">L</th><th className="num">D</th><th className="num">PW</th><th className="num">PL</th></tr>
+              )}
+            </thead>
+            <tbody>
+              {leagueStandings.slice(0, 5).map((s, i) => (
+                <tr key={s.player?.id || s.player?.name || i}>
+                  <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{i + 1}{s.isOverridden ? "*" : ""}</td>
+                  <td>
+                    <div style={{ fontWeight: 500 }}>
+                      {s.player?.number ? <span className="num-prefix">{s.player.number}</span> : null}
+                      {s.player?.name || ""}
+                    </div>
+                    {tweaks?.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</div> : null}
+                  </td>
+                  <td className="num">{s.wins || 0}</td>
+                  <td className="num">{s.losses || 0}</td>
+                  <td className="num">{s.draws || 0}</td>
+                  {isTeam && <td className="num">{s.individualWins || 0}</td>}
+                  {isTeam && <td className="num">{s.individualLosses || 0}</td>}
+                  <td className="num">{isTeam ? (s.pointsWon || 0) : (s.ipponsGiven || 0)}</td>
+                  <td className="num">{isTeam ? (s.pointsLost || 0) : (s.ipponsTaken || 0)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {leagueStandings.length > 5 && (
+            <div style={{ marginTop: 8, fontSize: 11, color: "var(--ink-3)" }}>
+              Showing top 5 of {leagueStandings.length}
+            </div>
+          )}
+          {onSwitchTab && (
+            <button
+              className="btn btn--link"
+              style={{ marginTop: 8, fontSize: 13, padding: 0 }}
+              onClick={() => onSwitchTab("pools")}
+              data-testid="league-overview-view-all"
+            >
+              View full standings →
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Current match — shown inline, before Up Next */}
       {currentMatch && currentMatch.status === "running" && (


### PR DESCRIPTION
## Summary
- **League competitions** now show a condensed standings table (top 5) on the Overview tab, so viewers see who's winning without switching to the Pools tab
- Shows **winner badge** when all matches are completed, with "Final standings" header
- Includes **match progress counter** (e.g. "3/15 matches") and a **"View full standings →"** link that switches to the Pools tab
- Supports both individual (W/L/D/PW/PL) and team (W/L/T/IV/IL/PW/PL) league column layouts

Closes mp-ldnr

## Test plan
- [x] Unit tests: 8 new tests covering running/completed league, non-league exclusion, winner badge, tab switching, team columns, empty standings
- [x] All 1094 JS tests pass (42 files)
- [x] Go lint passes
- [x] Manual browser verification: standings table renders correctly on Overview tab for an in-progress league competition with scored matches
- [x] "View full standings →" link switches to Pools tab
- [x] Verify completed league shows winner badge + "Final standings" header
- [x] Verify non-league competitions (mixed, playoffs) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)