### PR TITLE
feat(mp-scf): UI customization — accent colors and tournament logo

### DIFF
--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -157,9 +157,15 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 
 		// Update state before removing the other extension so GET never
 		// fetches a file that has already been deleted.
+		//
+		// Use a sentinel so the error handler can distinguish "tournament
+		// was never initialized" (file is orphaned, safe to remove) from
+		// other transient failures (new bytes are in place; removing the
+		// file would leave Theme.LogoPath pointing at a missing file).
+		errNotInit := errors.New("tournament not initialized")
 		_, err = store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
 			if current == nil {
-				return errors.New("tournament not initialized")
+				return errNotInit
 			}
 			*desired = *current
 			if desired.Theme == nil {
@@ -169,7 +175,9 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			return nil
 		})
 		if err != nil {
-			_ = os.Remove(fullPath)
+			if errors.Is(err, errNotInit) {
+				_ = os.Remove(fullPath)
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -119,16 +119,16 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			return
 		}
 		fullPath := filepath.Join(brandingDir, fileName)
-		// Write to a temp file then rename atomically so concurrent GET
-		// requests never see a partial write. fileName is always "logo.png"
-		// or "logo.jpg" — server-derived; no user-controlled input reaches
-		// the OS call.
-		tmpPath := fullPath + ".tmp"
-		dst, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) // #nosec G304
+		// Use os.CreateTemp for a unique temp file so concurrent uploads
+		// don't share the same ".tmp" path and corrupt each other's write.
+		// Temp file is in brandingDir so the final Rename stays on the
+		// same filesystem and remains atomic. // #nosec G304
+		dst, err := os.CreateTemp(brandingDir, "logo-*.tmp")
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
+		tmpPath := dst.Name()
 		written, copyErr := io.Copy(dst, io.LimitReader(src, SponsorMaxFileBytes+1))
 		cerr := dst.Close()
 		if copyErr != nil || cerr != nil {

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -27,6 +27,9 @@ var validBrandingContentTypes = map[string]string{
 // serves the tournament logo bytes. Returns 404 when no logo is configured.
 func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 	r.GET("/branding/logo", func(c *gin.Context) {
+		// Prevent browsers/proxies from caching 404s — a newly uploaded logo
+		// would otherwise stay "missing" until a hard refresh.
+		c.Header("Cache-Control", "no-cache")
 		t, err := store.LoadTournament()
 		if err != nil || t == nil || t.Theme == nil || t.Theme.LogoPath == "" {
 			c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"})
@@ -130,10 +133,18 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
 			return
 		}
+		// os.Rename is atomic on POSIX but fails on Windows when the
+		// destination already exists. Remove the destination first and retry
+		// once so repeated logo uploads work on all platforms.
 		if err := os.Rename(tmpPath, fullPath); err != nil {
-			_ = os.Remove(tmpPath)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
+			if removeErr := os.Remove(fullPath); removeErr == nil {
+				err = os.Rename(tmpPath, fullPath)
+			}
+			if err != nil {
+				_ = os.Remove(tmpPath)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
 		}
 
 		// Update state before removing the other extension so GET never
@@ -178,7 +189,9 @@ func handleBrandingLogoDelete(store *state.Store) gin.HandlerFunc {
 			desired.Theme.LogoPath = ""
 			// Nil-out the Theme pointer when all fields are now empty so
 			// tournament.md doesn't persist a bare "theme: {}" block.
-			if desired.Theme.PrimaryColor == "" && desired.Theme.AccentSoftColor == "" {
+			// Include WindowTitle in the check so deleting only the logo
+			// doesn't silently clear a configured window title.
+			if desired.Theme.PrimaryColor == "" && desired.Theme.AccentSoftColor == "" && desired.Theme.WindowTitle == "" {
 				desired.Theme = nil
 			}
 			return nil

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -33,7 +33,11 @@ func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 		// would otherwise stay "missing" until a hard refresh.
 		c.Header("Cache-Control", "no-cache")
 		t, err := store.LoadTournament()
-		if err != nil || t == nil || t.Theme == nil || t.Theme.LogoPath == "" {
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if t == nil || t.Theme == nil || t.Theme.LogoPath == "" {
 			c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"})
 			return
 		}

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -23,10 +23,12 @@ var validBrandingContentTypes = map[string]string{
 	"image/jpeg": "logo.jpg",
 }
 
-// RegisterPublicBrandingHandlers wires the unauthenticated GET route that
-// serves the tournament logo bytes. Returns 404 when no logo is configured.
+// RegisterPublicBrandingHandlers wires the unauthenticated GET and HEAD routes
+// that serve the tournament logo bytes. Returns 404 when no logo is configured.
+// HEAD is registered explicitly because Gin does not auto-route HEAD to GET.
+// The BrandingManager component uses HEAD to probe logo existence on mount.
 func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
-	r.GET("/branding/logo", func(c *gin.Context) {
+	brandingLogoHandler := func(c *gin.Context) {
 		// Prevent browsers/proxies from caching 404s — a newly uploaded logo
 		// would otherwise stay "missing" until a hard refresh.
 		c.Header("Cache-Control", "no-cache")
@@ -59,7 +61,13 @@ func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 		// admin upload flow is infrequent, so this is acceptable.
 		c.Header("Cache-Control", "no-cache")
 		c.File(path)
-	})
+	}
+	r.GET("/branding/logo", brandingLogoHandler)
+	// HEAD is used by BrandingManager to probe logo existence without
+	// fetching the full image payload. Gin does not auto-route HEAD to GET,
+	// so we register it explicitly with the same handler (c.File/ServeContent
+	// strips the body for HEAD requests automatically).
+	r.HEAD("/branding/logo", brandingLogoHandler)
 }
 
 // RegisterBrandingHandlers wires admin-gated mutation endpoints. The caller

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -1,0 +1,180 @@
+package mobileapp
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// brandingDirName is the subdirectory under the store root for uploaded
+// tournament logos. One file at a time: logo.png or logo.jpg.
+const brandingDirName = "branding"
+
+// validBrandingContentTypes maps http.DetectContentType sniff results to
+// the canonical filename extension used on disk.
+var validBrandingContentTypes = map[string]string{
+	"image/png":  "logo.png",
+	"image/jpeg": "logo.jpg",
+}
+
+// RegisterPublicBrandingHandlers wires the unauthenticated GET route that
+// serves the tournament logo bytes. Returns 404 when no logo is configured.
+func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
+	r.GET("/branding/logo", func(c *gin.Context) {
+		t, err := store.LoadTournament()
+		if err != nil || t == nil || t.Theme == nil || t.Theme.LogoPath == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"})
+			return
+		}
+		name := t.Theme.LogoPath
+		// Only allow the two known filenames — never serve arbitrary paths.
+		if name != "logo.png" && name != "logo.jpg" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"})
+			return
+		}
+		path := filepath.Join(store.GetFolder(), brandingDirName, name)
+		info, err := os.Lstat(path)
+		if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "logo file not found"})
+			return
+		}
+		ext := strings.ToLower(filepath.Ext(name))
+		switch ext {
+		case ".png":
+			c.Header("Content-Type", "image/png")
+		case ".jpg":
+			c.Header("Content-Type", "image/jpeg")
+		}
+		// Logo filename changes on each upload (png vs jpg could flip), so
+		// use no-cache to ensure browsers don't serve a stale type. The
+		// admin upload flow is infrequent, so this is acceptable.
+		c.Header("Cache-Control", "no-cache")
+		c.File(path)
+	})
+}
+
+// RegisterBrandingHandlers wires admin-gated mutation endpoints. The caller
+// must use a group whose body cap is at least BrandingMaxBodyBytes (2 MB).
+func RegisterBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
+	r.POST("/branding/logo", handleBrandingLogoUpload(store))
+	r.DELETE("/branding/logo", handleBrandingLogoDelete(store))
+}
+
+func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fh, err := c.FormFile("file")
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
+			return
+		}
+		if fh.Size > SponsorMaxFileBytes {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
+			return
+		}
+
+		src, err := fh.Open()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		defer func() { _ = src.Close() }()
+
+		sniffBuf := make([]byte, 512)
+		nRead, rerr := io.ReadFull(src, sniffBuf)
+		if rerr != nil && !errors.Is(rerr, io.ErrUnexpectedEOF) && !errors.Is(rerr, io.EOF) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": rerr.Error()})
+			return
+		}
+		sniffed := http.DetectContentType(sniffBuf[:nRead])
+		fileName, ok := validBrandingContentTypes[sniffed]
+		if !ok {
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "only PNG or JPEG accepted"})
+			return
+		}
+		if _, err := src.Seek(0, io.SeekStart); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		brandingDir := filepath.Join(store.GetFolder(), brandingDirName)
+		if err := os.MkdirAll(brandingDir, 0o700); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		fullPath := filepath.Join(brandingDir, fileName)
+		// fileName is always "logo.png" or "logo.jpg" — server-derived, no
+		// user-controlled input reaches the OS call.
+		// #nosec G304
+		dst, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		written, copyErr := io.Copy(dst, io.LimitReader(src, SponsorMaxFileBytes+1))
+		cerr := dst.Close()
+		if copyErr != nil || cerr != nil {
+			_ = os.Remove(fullPath)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Join(copyErr, cerr).Error()})
+			return
+		}
+		if written > SponsorMaxFileBytes {
+			_ = os.Remove(fullPath)
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
+			return
+		}
+
+		// Remove the other extension if it exists (switching png→jpg or vice versa).
+		other := "logo.png"
+		if fileName == "logo.png" {
+			other = "logo.jpg"
+		}
+		_ = os.Remove(filepath.Join(brandingDir, other))
+
+		_, err = store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
+			if current == nil {
+				return errors.New("tournament not initialized")
+			}
+			*desired = *current
+			if desired.Theme == nil {
+				desired.Theme = &state.Theme{}
+			}
+			desired.Theme.LogoPath = fileName
+			return nil
+		})
+		if err != nil {
+			_ = os.Remove(fullPath)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"logoPath": fileName})
+	}
+}
+
+func handleBrandingLogoDelete(store *state.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var removed string
+		_, err := store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
+			if current == nil || current.Theme == nil || current.Theme.LogoPath == "" {
+				return errors.New("no logo configured")
+			}
+			*desired = *current
+			removed = current.Theme.LogoPath
+			desired.Theme.LogoPath = ""
+			return nil
+		})
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			return
+		}
+		if removed == "logo.png" || removed == "logo.jpg" {
+			_ = os.Remove(filepath.Join(store.GetFolder(), brandingDirName, removed))
+		}
+		c.JSON(http.StatusOK, gin.H{"removed": removed})
+	}
+}

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -108,10 +108,12 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			return
 		}
 		fullPath := filepath.Join(brandingDir, fileName)
-		// fileName is always "logo.png" or "logo.jpg" — server-derived, no
-		// user-controlled input reaches the OS call.
-		// #nosec G304
-		dst, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+		// Write to a temp file then rename atomically so concurrent GET
+		// requests never see a partial write. fileName is always "logo.png"
+		// or "logo.jpg" — server-derived; no user-controlled input reaches
+		// the OS call.
+		tmpPath := fullPath + ".tmp"
+		dst, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) // #nosec G304
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -119,23 +121,23 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 		written, copyErr := io.Copy(dst, io.LimitReader(src, SponsorMaxFileBytes+1))
 		cerr := dst.Close()
 		if copyErr != nil || cerr != nil {
-			_ = os.Remove(fullPath)
+			_ = os.Remove(tmpPath)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Join(copyErr, cerr).Error()})
 			return
 		}
 		if written > SponsorMaxFileBytes {
-			_ = os.Remove(fullPath)
+			_ = os.Remove(tmpPath)
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
 			return
 		}
-
-		// Remove the other extension if it exists (switching png→jpg or vice versa).
-		other := "logo.png"
-		if fileName == "logo.png" {
-			other = "logo.jpg"
+		if err := os.Rename(tmpPath, fullPath); err != nil {
+			_ = os.Remove(tmpPath)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
 		}
-		_ = os.Remove(filepath.Join(brandingDir, other))
 
+		// Update state before removing the other extension so GET never
+		// fetches a file that has already been deleted.
 		_, err = store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
 			if current == nil {
 				return errors.New("tournament not initialized")
@@ -152,6 +154,14 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
+
+		// Remove the other extension only after state points to the new file.
+		other := "logo.png"
+		if fileName == "logo.png" {
+			other = "logo.jpg"
+		}
+		_ = os.Remove(filepath.Join(brandingDir, other))
+
 		c.JSON(http.StatusOK, gin.H{"logoPath": fileName})
 	}
 }
@@ -166,6 +176,11 @@ func handleBrandingLogoDelete(store *state.Store) gin.HandlerFunc {
 			*desired = *current
 			removed = current.Theme.LogoPath
 			desired.Theme.LogoPath = ""
+			// Nil-out the Theme pointer when all fields are now empty so
+			// tournament.md doesn't persist a bare "theme: {}" block.
+			if desired.Theme.PrimaryColor == "" && desired.Theme.AccentSoftColor == "" {
+				desired.Theme = nil
+			}
 			return nil
 		})
 		if err != nil {

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -84,7 +84,7 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
 			return
 		}
-		if fh.Size > SponsorMaxFileBytes {
+		if fh.Size > BrandingMaxFileBytes {
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
 			return
 		}
@@ -129,14 +129,14 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 			return
 		}
 		tmpPath := dst.Name()
-		written, copyErr := io.Copy(dst, io.LimitReader(src, SponsorMaxFileBytes+1))
+		written, copyErr := io.Copy(dst, io.LimitReader(src, BrandingMaxFileBytes+1))
 		cerr := dst.Close()
 		if copyErr != nil || cerr != nil {
 			_ = os.Remove(tmpPath)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Join(copyErr, cerr).Error()})
 			return
 		}
-		if written > SponsorMaxFileBytes {
+		if written > BrandingMaxFileBytes {
 			_ = os.Remove(tmpPath)
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "logo must be ≤1 MB"})
 			return

--- a/internal/mobileapp/handlers_branding_test.go
+++ b/internal/mobileapp/handlers_branding_test.go
@@ -134,7 +134,7 @@ func TestPostBrandingLogo_AdminGated(t *testing.T) {
 }
 
 func TestGetBrandingLogo_ServesPNG(t *testing.T) {
-	h, dir, cleanup := brandingTestSetup(t)
+	h, _, cleanup := brandingTestSetup(t)
 	defer cleanup()
 
 	// Upload a PNG first.
@@ -145,7 +145,6 @@ func TestGetBrandingLogo_ServesPNG(t *testing.T) {
 	w := httptest.NewRecorder()
 	(*h).ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
-	_ = dir
 
 	// Now GET it.
 	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)

--- a/internal/mobileapp/handlers_branding_test.go
+++ b/internal/mobileapp/handlers_branding_test.go
@@ -1,0 +1,261 @@
+package mobileapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/engine"
+	"github.com/gitrgoliveira/bracket-creator/internal/resources"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func brandingTestSetup(t *testing.T) (*http.Handler, string, func()) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "branding-test-*")
+	require.NoError(t, err)
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "Branding Test Cup", Password: "secret",
+	}))
+	eng := engine.New(store)
+	mockFS := fstest.MapFS{"web-mobile/index.html": {Data: []byte("<html/>")}}
+	res := resources.NewResources(nil, mockFS)
+	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
+	h := http.Handler(router)
+	return &h, tempDir, func() { _ = os.RemoveAll(tempDir) }
+}
+
+func buildBrandingUpload(t *testing.T, filename string, content []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	mw := multipart.NewWriter(body)
+	if filename != "" {
+		fw, err := mw.CreateFormFile("file", filename)
+		require.NoError(t, err)
+		_, err = fw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, mw.Close())
+	return body, mw.FormDataContentType()
+}
+
+func TestGetBrandingLogo_NotFound(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	req := httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPostBrandingLogo_HappyPath_PNG(t *testing.T) {
+	h, dir, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
+}
+
+func TestPostBrandingLogo_HappyPath_JPEG(t *testing.T) {
+	h, dir, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	body, ct := buildBrandingUpload(t, "logo.jpg", tinyJPEG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.jpg"))
+}
+
+func TestPostBrandingLogo_ReplacesOtherExt(t *testing.T) {
+	// Upload PNG then JPEG — PNG must be removed.
+	h, dir, cleanup := brandingTestSetup(t)
+	defer cleanup()
+
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body, ct = buildBrandingUpload(t, "logo.jpg", tinyJPEG)
+	req = httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.jpg"))
+	assert.NoFileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
+}
+
+func TestPostBrandingLogo_RejectsBadType(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	// Send plain text — sniff will report text/plain.
+	body, ct := buildBrandingUpload(t, "evil.txt", []byte("not an image"))
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+}
+
+func TestPostBrandingLogo_AdminGated(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	// No password.
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetBrandingLogo_ServesPNG(t *testing.T) {
+	h, dir, cleanup := brandingTestSetup(t)
+	defer cleanup()
+
+	// Upload a PNG first.
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	_ = dir
+
+	// Now GET it.
+	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+}
+
+func TestDeleteBrandingLogo_RemovesFile(t *testing.T) {
+	h, dir, cleanup := brandingTestSetup(t)
+	defer cleanup()
+
+	// Upload first.
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Delete.
+	req = httptest.NewRequest(http.MethodDelete, "/api/branding/logo", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoFileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
+
+	// GET should now return 404.
+	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDeleteBrandingLogo_NoLogoReturns404(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	req := httptest.NewRequest(http.MethodDelete, "/api/branding/logo", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestPutTournament_ThemeColorsAccepted verifies that valid hex theme colors
+// round-trip through PUT /api/tournament (mp-scf).
+func TestPutTournament_ThemeColorsAccepted(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	body := `{"name":"Test Cup","password":"secret","courts":["A"],"theme":{"primaryColor":"#ff0000","accentSoftColor":"#ffe0e0"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/tournament", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	theme, _ := resp["theme"].(map[string]interface{})
+	require.NotNil(t, theme)
+	assert.Equal(t, "#ff0000", theme["primaryColor"])
+}
+
+// TestPutTournament_ThemeBadColorRejected verifies that an invalid hex color
+// is rejected with 400 (mp-scf).
+func TestPutTournament_ThemeBadColorRejected(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	body := `{"name":"Test Cup","password":"secret","courts":["A"],"theme":{"primaryColor":"red"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/tournament", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestPutTournament_LogoPathPreserved verifies that PUT /api/tournament does
+// not clear an existing logo (mp-scf).
+func TestPutTournament_LogoPathPreserved(t *testing.T) {
+	h, dir, cleanup := brandingTestSetup(t)
+	defer cleanup()
+
+	// Upload a logo.
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req := httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// PUT tournament without a theme field.
+	req = httptest.NewRequest(http.MethodPut, "/api/tournament",
+		bytes.NewBufferString(`{"name":"Branding Test Cup","password":"secret","courts":["A"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Logo file should still exist.
+	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
+
+	// GET /api/branding/logo should still return 200.
+	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/mobileapp/handlers_branding_test.go
+++ b/internal/mobileapp/handlers_branding_test.go
@@ -303,3 +303,31 @@ func TestPutTournament_LogoPathPreserved(t *testing.T) {
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+// TestHeadBrandingLogo covers the HEAD probe used by BrandingManager on mount
+// to detect whether a logo exists without fetching the full image payload.
+func TestHeadBrandingLogo(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+
+	// HEAD before any upload → 404 (logo not configured).
+	req := httptest.NewRequest(http.MethodHead, "/api/branding/logo", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// Upload a PNG.
+	body, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req = httptest.NewRequest(http.MethodPost, "/api/branding/logo", body)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// HEAD after upload → 200 (logo present).
+	req = httptest.NewRequest(http.MethodHead, "/api/branding/logo", nil)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/mobileapp/handlers_branding_test.go
+++ b/internal/mobileapp/handlers_branding_test.go
@@ -182,6 +182,51 @@ func TestDeleteBrandingLogo_RemovesFile(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+// TestDeleteBrandingLogo_PreservesWindowTitle verifies that deleting the logo
+// does not nil-out the Theme when a windowTitle is configured, so operators
+// don't silently lose their window title setting.
+func TestDeleteBrandingLogo_PreservesWindowTitle(t *testing.T) {
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+
+	// Set a windowTitle via PUT /tournament.
+	body := `{"name":"Test Cup","password":"secret","courts":["A"],"theme":{"windowTitle":"My Cup 2026"}}`
+	req := httptest.NewRequest(http.MethodPut, "/api/tournament", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tournament-Password", "secret")
+	w := httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Upload a logo.
+	logoBody, ct := buildBrandingUpload(t, "logo.png", tinyPNG)
+	req = httptest.NewRequest(http.MethodPost, "/api/branding/logo", logoBody)
+	req.Header.Set("Content-Type", ct)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Delete the logo.
+	req = httptest.NewRequest(http.MethodDelete, "/api/branding/logo", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Theme must survive with the windowTitle intact.
+	req = httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
+	req.Header.Set("X-Tournament-Password", "secret")
+	w = httptest.NewRecorder()
+	(*h).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	theme, _ := got["theme"].(map[string]any)
+	require.NotNil(t, theme, "theme must not be nil after logo delete when windowTitle is set")
+	assert.Equal(t, "My Cup 2026", theme["windowTitle"], "windowTitle must be preserved after logo delete")
+}
+
 func TestDeleteBrandingLogo_NoLogoReturns404(t *testing.T) {
 	h, _, cleanup := brandingTestSetup(t)
 	defer cleanup()
@@ -204,9 +249,9 @@ func TestPutTournament_ThemeColorsAccepted(t *testing.T) {
 	w := httptest.NewRecorder()
 	(*h).ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp map[string]interface{}
+	var resp map[string]any
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	theme, _ := resp["theme"].(map[string]interface{})
+	theme, _ := resp["theme"].(map[string]any)
 	require.NotNil(t, theme)
 	assert.Equal(t, "#ff0000", theme["primaryColor"])
 }

--- a/internal/mobileapp/handlers_branding_test.go
+++ b/internal/mobileapp/handlers_branding_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/engine"
 	"github.com/gitrgoliveira/bracket-creator/internal/resources"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -18,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func brandingTestSetup(t *testing.T) (*http.Handler, string, func()) {
+func brandingTestSetup(t *testing.T) (*gin.Engine, string, func()) {
 	t.Helper()
 	tempDir, err := os.MkdirTemp("", "branding-test-*")
 	require.NoError(t, err)
@@ -31,8 +32,7 @@ func brandingTestSetup(t *testing.T) (*http.Handler, string, func()) {
 	mockFS := fstest.MapFS{"web-mobile/index.html": {Data: []byte("<html/>")}}
 	res := resources.NewResources(nil, mockFS)
 	router, _ := NewRouter(store, eng, res, NewFileVerifier(store))
-	h := http.Handler(router)
-	return &h, tempDir, func() { _ = os.RemoveAll(tempDir) }
+	return router, tempDir, func() { _ = os.RemoveAll(tempDir) }
 }
 
 func buildBrandingUpload(t *testing.T, filename string, content []byte) (*bytes.Buffer, string) {
@@ -54,7 +54,7 @@ func TestGetBrandingLogo_NotFound(t *testing.T) {
 	defer cleanup()
 	req := httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
@@ -66,7 +66,7 @@ func TestPostBrandingLogo_HappyPath_PNG(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
 }
@@ -79,7 +79,7 @@ func TestPostBrandingLogo_HappyPath_JPEG(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.jpg"))
 }
@@ -94,7 +94,7 @@ func TestPostBrandingLogo_ReplacesOtherExt(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	body, ct = buildBrandingUpload(t, "logo.jpg", tinyJPEG)
@@ -102,7 +102,7 @@ func TestPostBrandingLogo_ReplacesOtherExt(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.FileExists(t, filepath.Join(dir, brandingDirName, "logo.jpg"))
 	assert.NoFileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
@@ -117,7 +117,7 @@ func TestPostBrandingLogo_RejectsBadType(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
 }
 
@@ -129,7 +129,7 @@ func TestPostBrandingLogo_AdminGated(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	// No password.
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
@@ -143,13 +143,13 @@ func TestGetBrandingLogo_ServesPNG(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Now GET it.
 	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
 }
@@ -164,21 +164,21 @@ func TestDeleteBrandingLogo_RemovesFile(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Delete.
 	req = httptest.NewRequest(http.MethodDelete, "/api/branding/logo", nil)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.NoFileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
 
 	// GET should now return 404.
 	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
@@ -195,7 +195,7 @@ func TestDeleteBrandingLogo_PreservesWindowTitle(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Upload a logo.
@@ -204,21 +204,21 @@ func TestDeleteBrandingLogo_PreservesWindowTitle(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Delete the logo.
 	req = httptest.NewRequest(http.MethodDelete, "/api/branding/logo", nil)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// Theme must survive with the windowTitle intact.
 	req = httptest.NewRequest(http.MethodGet, "/api/tournament", nil)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
@@ -233,7 +233,7 @@ func TestDeleteBrandingLogo_NoLogoReturns404(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/api/branding/logo", nil)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
@@ -247,7 +247,7 @@ func TestPutTournament_ThemeColorsAccepted(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]any
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
@@ -266,7 +266,7 @@ func TestPutTournament_ThemeBadColorRejected(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
@@ -282,7 +282,7 @@ func TestPutTournament_LogoPathPreserved(t *testing.T) {
 	req.Header.Set("Content-Type", ct)
 	req.Header.Set("X-Tournament-Password", "secret")
 	w := httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	// PUT tournament without a theme field.
@@ -291,7 +291,7 @@ func TestPutTournament_LogoPathPreserved(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Tournament-Password", "secret")
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	// Logo file should still exist.
@@ -300,6 +300,6 @@ func TestPutTournament_LogoPathPreserved(t *testing.T) {
 	// GET /api/branding/logo should still return 200.
 	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
 	w = httptest.NewRecorder()
-	(*h).ServeHTTP(w, req)
+	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -634,6 +634,11 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			t.Mode = state.TournamentModeOfficiated
 		}
 
+		if err := state.ValidateTheme(t.Theme); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
 		// Reject empty Password on POST (initial setup) in file mode.
 		// AuthMiddleware allows POST /api/tournament unauthenticated
 		// when the tournament is uninitialized — this is the bootstrap

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -327,6 +327,12 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			return
 		}
 
+		// Validate hex color fields on the optional theme block (mp-scf).
+		if err := state.ValidateTheme(t.Theme); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
 		if err := validateTournamentDurationDays(t.DurationDays); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -400,6 +406,20 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			// via PUT /api/auth/admin-password, never here.
 			if current != nil {
 				desired.AdminPassword = current.AdminPassword
+			}
+
+			// Preserve Theme.LogoPath (mp-scf): LogoPath has json:"-" so the
+			// bound body never carries it. The logo is managed via
+			// POST/DELETE /api/branding/logo; this PUT must not clear it.
+			// Also preserve the entire Theme when the client omits it (nil)
+			// so a routine name/venue save doesn't wipe configured colors.
+			if current != nil && current.Theme != nil {
+				if desired.Theme == nil {
+					desired.Theme = &state.Theme{}
+					*desired.Theme = *current.Theme
+				} else {
+					desired.Theme.LogoPath = current.Theme.LogoPath
+				}
 			}
 
 			// Immutability of Mode (mp-7h7): Mode is chosen once at creation

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -329,8 +329,15 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 
 		// Trim windowTitle so whitespace-only input doesn't persist as an
 		// effectively-blank browser title instead of falling back to the default.
+		// Also nil-out a fully-empty Theme (no colors, no title set by the
+		// client) so tournament.md stays clean and the UI doesn't treat an
+		// unintentional "theme: {}" as "branding is configured".
+		// LogoPath is excluded: it has json:"-" and is never set via this path.
 		if t.Theme != nil {
 			t.Theme.WindowTitle = strings.TrimSpace(t.Theme.WindowTitle)
+			if t.Theme.PrimaryColor == "" && t.Theme.AccentSoftColor == "" && t.Theme.WindowTitle == "" {
+				t.Theme = nil
+			}
 		}
 
 		// Validate hex color fields on the optional theme block (mp-scf).
@@ -642,8 +649,12 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 
 		// Trim windowTitle so whitespace-only input doesn't persist as an
 		// effectively-blank browser title instead of falling back to the default.
+		// Also nil-out a fully-empty Theme so tournament.md stays clean.
 		if t.Theme != nil {
 			t.Theme.WindowTitle = strings.TrimSpace(t.Theme.WindowTitle)
+			if t.Theme.PrimaryColor == "" && t.Theme.AccentSoftColor == "" && t.Theme.WindowTitle == "" {
+				t.Theme = nil
+			}
 		}
 
 		if err := state.ValidateTheme(t.Theme); err != nil {

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -327,6 +327,12 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 			return
 		}
 
+		// Trim windowTitle so whitespace-only input doesn't persist as an
+		// effectively-blank browser title instead of falling back to the default.
+		if t.Theme != nil {
+			t.Theme.WindowTitle = strings.TrimSpace(t.Theme.WindowTitle)
+		}
+
 		// Validate hex color fields on the optional theme block (mp-scf).
 		if err := state.ValidateTheme(t.Theme); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -632,6 +638,12 @@ func RegisterTournamentHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub
 		}
 		if t.Mode == "" {
 			t.Mode = state.TournamentModeOfficiated
+		}
+
+		// Trim windowTitle so whitespace-only input doesn't persist as an
+		// effectively-blank browser title instead of falling back to the default.
+		if t.Theme != nil {
+			t.Theme.WindowTitle = strings.TrimSpace(t.Theme.WindowTitle)
 		}
 
 		if err := state.ValidateTheme(t.Theme); err != nil {

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -58,10 +58,15 @@ const (
 	BrandingMaxBodyBytes int64 = 2 << 20 // 2 MB
 )
 
-// SponsorMaxFileBytes is the in-handler cap on the logo file itself
+// SponsorMaxFileBytes is the in-handler cap on the sponsor logo file itself
 // (the multipart `file` field), distinct from the envelope cap above.
 // See mp-c38 plan.
 const SponsorMaxFileBytes int64 = 1 << 20 // 1 MB
+
+// BrandingMaxFileBytes is the in-handler cap on the tournament branding
+// logo file itself. Kept separate from SponsorMaxFileBytes so the two
+// limits can evolve independently.
+const BrandingMaxFileBytes int64 = 1 << 20 // 1 MB
 
 // MaxBodyBytes returns a Gin middleware that rejects requests whose
 // body exceeds n bytes. Two checks, in order of cost:

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -52,6 +52,10 @@ const (
 	// boundary, form-field overhead, and the optional link/name fields
 	// without letting a client stream gigabytes through the parser.
 	SponsorMaxBodyBytes int64 = 2 << 20 // 2 MB
+
+	// BrandingMaxBodyBytes caps POST /api/branding/logo (tournament logo
+	// upload, mp-scf). Same rationale and size as SponsorMaxBodyBytes.
+	BrandingMaxBodyBytes int64 = 2 << 20 // 2 MB
 )
 
 // SponsorMaxFileBytes is the in-handler cap on the logo file itself

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -116,6 +116,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	RegisterPublicAnnouncementHandlers(api, store)
 	RegisterPublicRegistrationHandlers(api, store, hub)
 	RegisterPublicSponsorHandlers(api, store)
+	RegisterPublicBrandingHandlers(api, store)
 
 	// Public password-reset + auth-config endpoints. Both must live
 	// outside the admin group: /reset is the recovery path for a
@@ -162,6 +163,10 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	// on the same group (DELETE skips the cap by method anyway).
 	adminSponsorBody := adminGroup(r, SponsorMaxBodyBytes, verifier, store)
 	RegisterSponsorHandlers(adminSponsorBody, store)
+
+	// Tournament branding logo (mp-scf) — same 2 MB envelope as sponsors.
+	adminBrandingBody := adminGroup(r, BrandingMaxBodyBytes, verifier, store)
+	RegisterBrandingHandlers(adminBrandingBody, store)
 
 	// Static files & SPA Fallback
 	mobileFS := res.GetMobileWebFS()

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -191,7 +191,7 @@ func ValidateTheme(theme *Theme) error {
 	if theme.AccentSoftColor != "" && !hexColorRE.MatchString(theme.AccentSoftColor) {
 		return errors.New("accentSoftColor must be a 6-digit hex color (e.g. #e7eaf3)")
 	}
-	if len(theme.WindowTitle) > maxWindowTitleLen {
+	if len([]rune(theme.WindowTitle)) > maxWindowTitleLen {
 		return fmt.Errorf("windowTitle must be %d characters or fewer", maxWindowTitleLen)
 	}
 	return nil

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -161,20 +161,26 @@ func ValidateSponsor(s Sponsor) error {
 }
 
 // Theme holds per-tournament branding overrides (mp-scf). PrimaryColor and
-// AccentSoftColor are CSS hex values (#rrggbb). LogoPath stores the uploaded
-// logo filename under tournament-data/branding/; it is NOT exposed in JSON
-// responses (the logo is served via GET /api/branding/logo instead).
+// AccentSoftColor are CSS hex values (#rrggbb). WindowTitle overrides the
+// browser tab/window title; it defaults to "Bracket Creator Mobile" when
+// empty. LogoPath stores the uploaded logo filename under
+// tournament-data/branding/; it is NOT exposed in JSON responses (the logo
+// is served via GET /api/branding/logo instead).
 // All fields are optional; omit the whole block for the default styling.
 type Theme struct {
 	PrimaryColor    string `yaml:"primary_color,omitempty"    json:"primaryColor,omitempty"`
 	AccentSoftColor string `yaml:"accent_soft_color,omitempty" json:"accentSoftColor,omitempty"`
+	WindowTitle     string `yaml:"window_title,omitempty"      json:"windowTitle,omitempty"`
 	LogoPath        string `yaml:"logo_path,omitempty"         json:"-"` // disk filename; served via /api/branding/logo
 }
+
+const maxWindowTitleLen = 100
 
 var hexColorRE = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
 
 // ValidateTheme returns an error when any non-empty color field is not a
-// valid 6-digit CSS hex value. An entirely nil/empty Theme is always valid.
+// valid 6-digit CSS hex value, or when WindowTitle exceeds 100 characters.
+// An entirely nil/empty Theme is always valid.
 func ValidateTheme(theme *Theme) error {
 	if theme == nil {
 		return nil
@@ -184,6 +190,9 @@ func ValidateTheme(theme *Theme) error {
 	}
 	if theme.AccentSoftColor != "" && !hexColorRE.MatchString(theme.AccentSoftColor) {
 		return errors.New("accentSoftColor must be a 6-digit hex color (e.g. #e7eaf3)")
+	}
+	if len(theme.WindowTitle) > maxWindowTitleLen {
+		return fmt.Errorf("windowTitle must be %d characters or fewer", maxWindowTitleLen)
 	}
 	return nil
 }

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -92,6 +93,11 @@ type Tournament struct {
 	// Stored as omitempty so legacy tournament.md files without sponsors
 	// round-trip cleanly (no `sponsors: []` key emitted).
 	Sponsors []Sponsor `yaml:"sponsors,omitempty" json:"sponsors,omitempty"`
+
+	// Theme holds optional branding overrides: custom accent colors and a
+	// tournament logo (mp-scf). All fields are omitempty so existing
+	// tournament.md files without a theme block round-trip cleanly.
+	Theme *Theme `yaml:"theme,omitempty" json:"theme,omitempty"`
 }
 
 // TournamentContact is a single contact entry for attendees (mp-ef3).
@@ -150,6 +156,34 @@ func ValidateSponsor(s Sponsor) error {
 	u, err := url.Parse(s.Link)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.User != nil {
 		return ErrSponsorLinkInvalid
+	}
+	return nil
+}
+
+// Theme holds per-tournament branding overrides (mp-scf). PrimaryColor and
+// AccentSoftColor are CSS hex values (#rrggbb). LogoPath stores the uploaded
+// logo filename under tournament-data/branding/; it is NOT exposed in JSON
+// responses (the logo is served via GET /api/branding/logo instead).
+// All fields are optional; omit the whole block for the default styling.
+type Theme struct {
+	PrimaryColor    string `yaml:"primary_color,omitempty"    json:"primaryColor,omitempty"`
+	AccentSoftColor string `yaml:"accent_soft_color,omitempty" json:"accentSoftColor,omitempty"`
+	LogoPath        string `yaml:"logo_path,omitempty"         json:"-"` // disk filename; served via /api/branding/logo
+}
+
+var hexColorRE = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+
+// ValidateTheme returns an error when any non-empty color field is not a
+// valid 6-digit CSS hex value. An entirely nil/empty Theme is always valid.
+func ValidateTheme(theme *Theme) error {
+	if theme == nil {
+		return nil
+	}
+	if theme.PrimaryColor != "" && !hexColorRE.MatchString(theme.PrimaryColor) {
+		return errors.New("primaryColor must be a 6-digit hex color (e.g. #1d3557)")
+	}
+	if theme.AccentSoftColor != "" && !hexColorRE.MatchString(theme.AccentSoftColor) {
+		return errors.New("accentSoftColor must be a 6-digit hex color (e.g. #e7eaf3)")
 	}
 	return nil
 }

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -98,6 +98,80 @@ func TestSubMatchResult_HanteiRoundTrip(t *testing.T) {
 	})
 }
 
+// TestTournamentTheme_RoundTrip verifies that Theme survives a YAML marshal/
+// unmarshal cycle and that LogoPath is not exposed via JSON (mp-scf).
+func TestTournamentTheme_RoundTrip(t *testing.T) {
+	t.Run("full theme survives YAML round-trip", func(t *testing.T) {
+		tour := &Tournament{
+			Name: "Test",
+			Theme: &Theme{
+				PrimaryColor:    "#ff0000",
+				AccentSoftColor: "#ffe0e0",
+				LogoPath:        "logo.png",
+			},
+		}
+		b, err := yaml.Marshal(tour)
+		require.NoError(t, err)
+		var got Tournament
+		require.NoError(t, yaml.Unmarshal(b, &got))
+		require.NotNil(t, got.Theme)
+		assert.Equal(t, "#ff0000", got.Theme.PrimaryColor)
+		assert.Equal(t, "#ffe0e0", got.Theme.AccentSoftColor)
+		assert.Equal(t, "logo.png", got.Theme.LogoPath)
+	})
+	t.Run("logo_path is omitted from JSON", func(t *testing.T) {
+		tour := &Tournament{
+			Name:  "Test",
+			Theme: &Theme{PrimaryColor: "#1d3557", LogoPath: "logo.png"},
+		}
+		b, err := json.Marshal(tour)
+		require.NoError(t, err)
+		s := string(b)
+		assert.Contains(t, s, `"primaryColor":"#1d3557"`)
+		assert.NotContains(t, s, "logoPath")
+		assert.NotContains(t, s, "logo_path")
+		assert.NotContains(t, s, "logo.png")
+	})
+	t.Run("legacy tournament without theme key parses cleanly", func(t *testing.T) {
+		raw := `name: Old Tournament
+password: secret
+courts: [A]
+`
+		var got Tournament
+		require.NoError(t, yaml.Unmarshal([]byte(raw), &got))
+		assert.Nil(t, got.Theme)
+	})
+}
+
+// TestValidateTheme covers the hex-color acceptance criteria (mp-scf).
+func TestValidateTheme(t *testing.T) {
+	cases := []struct {
+		name    string
+		theme   *Theme
+		wantErr bool
+	}{
+		{"nil is valid", nil, false},
+		{"empty struct is valid", &Theme{}, false},
+		{"valid colors", &Theme{PrimaryColor: "#1d3557", AccentSoftColor: "#e7eaf3"}, false},
+		{"uppercase hex valid", &Theme{PrimaryColor: "#1D3557"}, false},
+		{"bad primary", &Theme{PrimaryColor: "red"}, true},
+		{"bad primary short", &Theme{PrimaryColor: "#fff"}, true},
+		{"bad accent", &Theme{AccentSoftColor: "notacolor"}, true},
+		{"empty primary ok", &Theme{AccentSoftColor: "#e7eaf3"}, false},
+		{"empty accent ok", &Theme{PrimaryColor: "#1d3557"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTheme(tc.theme)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // --- Tournament.Days() ---
 
 func TestTournament_Days(t *testing.T) {

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -107,6 +107,7 @@ func TestTournamentTheme_RoundTrip(t *testing.T) {
 			Theme: &Theme{
 				PrimaryColor:    "#ff0000",
 				AccentSoftColor: "#ffe0e0",
+				WindowTitle:     "My Cup 2026",
 				LogoPath:        "logo.png",
 			},
 		}
@@ -117,6 +118,7 @@ func TestTournamentTheme_RoundTrip(t *testing.T) {
 		require.NotNil(t, got.Theme)
 		assert.Equal(t, "#ff0000", got.Theme.PrimaryColor)
 		assert.Equal(t, "#ffe0e0", got.Theme.AccentSoftColor)
+		assert.Equal(t, "My Cup 2026", got.Theme.WindowTitle)
 		assert.Equal(t, "logo.png", got.Theme.LogoPath)
 	})
 	t.Run("logo_path is omitted from JSON", func(t *testing.T) {
@@ -159,6 +161,9 @@ func TestValidateTheme(t *testing.T) {
 		{"bad accent", &Theme{AccentSoftColor: "notacolor"}, true},
 		{"empty primary ok", &Theme{AccentSoftColor: "#e7eaf3"}, false},
 		{"empty accent ok", &Theme{PrimaryColor: "#1d3557"}, false},
+		{"window title ok", &Theme{WindowTitle: "My Tournament 2026"}, false},
+		{"window title at max length ok", &Theme{WindowTitle: string(make([]byte, 100))}, false},
+		{"window title too long", &Theme{WindowTitle: string(make([]byte, 101))}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -162,8 +162,8 @@ func TestValidateTheme(t *testing.T) {
 		{"empty primary ok", &Theme{AccentSoftColor: "#e7eaf3"}, false},
 		{"empty accent ok", &Theme{PrimaryColor: "#1d3557"}, false},
 		{"window title ok", &Theme{WindowTitle: "My Tournament 2026"}, false},
-		{"window title at max length ok", &Theme{WindowTitle: string(make([]byte, 100))}, false},
-		{"window title too long", &Theme{WindowTitle: string(make([]byte, 101))}, true},
+		{"window title at max length ok", &Theme{WindowTitle: strings.Repeat("a", 100)}, false},
+		{"window title too long", &Theme{WindowTitle: strings.Repeat("a", 101)}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/web-mobile/index.html
+++ b/web-mobile/index.html
@@ -74,6 +74,9 @@
     <!-- admin_sponsors.js exports SponsorsManager. Loaded before admin_setup.js
          (which embeds it inside the Edit Tournament page) — mp-c38. -->
     <script type="module" src="/dist/admin_sponsors.js?v=5"></script>
+    <!-- admin_branding.js exports BrandingManager. Loaded before admin_setup.js
+         (which embeds it inside the Edit Tournament page) — mp-scf. -->
+    <script type="module" src="/dist/admin_branding.js?v=5"></script>
     <script type="module" src="/dist/admin_setup.js?v=5"></script>
     <script type="module" src="/dist/admin.js?v=5"></script>
     <script type="module" src="/dist/app.js?v=5"></script>

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -27,18 +27,18 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   }, [logoKey]);
 
   // Sync incoming theme changes (e.g. after a tournament SSE reload).
-  // Always update — falsy values reset the pickers/inputs to their defaults.
-  // Also propagate to the parent so the PUT payload stays consistent
-  // if Save is clicked after an SSE-driven refresh.
+  // Always update pickers/inputs, but only propagate to the parent when
+  // tournament.theme is explicitly set — passing null when absent keeps
+  // the parent PUT payload clean (theme block omitted unless configured).
   useEffectBr(() => {
-    const t = (tournament && tournament.theme) || {};
-    const pc = t.primaryColor || "#1d3557";
-    const asc = t.accentSoftColor || "#e7eaf3";
-    const wt = t.windowTitle || "";
+    const rawTheme = tournament && tournament.theme;
+    const pc = (rawTheme && rawTheme.primaryColor) || "#1d3557";
+    const asc = (rawTheme && rawTheme.accentSoftColor) || "#e7eaf3";
+    const wt = (rawTheme && rawTheme.windowTitle) || "";
     setPrimaryColor(pc);
     setAccentSoftColor(asc);
     setWindowTitle(wt);
-    if (onThemeChange) onThemeChange({ primaryColor: pc, accentSoftColor: asc, windowTitle: wt });
+    if (onThemeChange) onThemeChange(rawTheme ? { primaryColor: pc, accentSoftColor: asc, windowTitle: wt } : null);
   }, [tournament]);
 
   const handleColorChange = (field, value) => {

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -28,11 +28,17 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
 
   // Sync incoming theme changes (e.g. after a tournament SSE reload).
   // Always update — falsy values reset the pickers/inputs to their defaults.
+  // Also propagate to the parent so the PUT payload stays consistent
+  // if Save is clicked after an SSE-driven refresh.
   useEffectBr(() => {
     const t = (tournament && tournament.theme) || {};
-    setPrimaryColor(t.primaryColor || "#1d3557");
-    setAccentSoftColor(t.accentSoftColor || "#e7eaf3");
-    setWindowTitle(t.windowTitle || "");
+    const pc = t.primaryColor || "#1d3557";
+    const asc = t.accentSoftColor || "#e7eaf3";
+    const wt = t.windowTitle || "";
+    setPrimaryColor(pc);
+    setAccentSoftColor(asc);
+    setWindowTitle(wt);
+    if (onThemeChange) onThemeChange({ primaryColor: pc, accentSoftColor: asc, windowTitle: wt });
   }, [tournament]);
 
   const handleColorChange = (field, value) => {

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -58,7 +58,12 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   const handleWindowTitleChange = (value) => {
     setWindowTitle(value);
     if (onThemeChange) onThemeChange({ primaryColor, accentSoftColor, windowTitle: value });
-    document.title = value || "Bracket Creator Mobile";
+    // Route through the shared helper so the default string stays in one place.
+    if (typeof window.applyTheme === "function") {
+      window.applyTheme({ primaryColor, accentSoftColor, windowTitle: value });
+    } else {
+      document.title = value || "Bracket Creator Mobile";
+    }
   };
 
   const handleLogoUpload = async (e) => {

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -13,6 +13,7 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
 
   const [primaryColor, setPrimaryColor] = useStateBr(theme.primaryColor || "#1d3557");
   const [accentSoftColor, setAccentSoftColor] = useStateBr(theme.accentSoftColor || "#e7eaf3");
+  const [windowTitle, setWindowTitle] = useStateBr(theme.windowTitle || "");
   const [hasLogo, setHasLogo] = useStateBr(false);
   const [logoKey, setLogoKey] = useStateBr(0); // bump to force img reload
   const [busy, setBusy] = useStateBr(false);
@@ -26,29 +27,38 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   }, [logoKey]);
 
   // Sync incoming theme changes (e.g. after a tournament SSE reload).
-  // Always update — falsy values reset the pickers to their defaults.
+  // Always update — falsy values reset the pickers/inputs to their defaults.
   useEffectBr(() => {
     const t = (tournament && tournament.theme) || {};
     setPrimaryColor(t.primaryColor || "#1d3557");
     setAccentSoftColor(t.accentSoftColor || "#e7eaf3");
+    setWindowTitle(t.windowTitle || "");
   }, [tournament]);
 
   const handleColorChange = (field, value) => {
+    const next = {
+      primaryColor: field === "primaryColor" ? value : primaryColor,
+      accentSoftColor: field === "accentSoftColor" ? value : accentSoftColor,
+      windowTitle,
+    };
     if (field === "primaryColor") setPrimaryColor(value);
     else setAccentSoftColor(value);
-    // Propagate to parent so the PUT /tournament body includes updated colors.
-    if (onThemeChange) onThemeChange({ primaryColor: field === "primaryColor" ? value : primaryColor, accentSoftColor: field === "accentSoftColor" ? value : accentSoftColor });
+    // Propagate to parent so the PUT /tournament body includes all branding.
+    if (onThemeChange) onThemeChange(next);
     // Live-preview the color change in CSS without waiting for save.
     if (typeof window.applyTheme === "function") {
-      window.applyTheme({
-        primaryColor: field === "primaryColor" ? value : primaryColor,
-        accentSoftColor: field === "accentSoftColor" ? value : accentSoftColor,
-      });
+      window.applyTheme(next);
     } else {
       const root = document.documentElement;
       if (field === "primaryColor") root.style.setProperty("--accent", value);
       else root.style.setProperty("--accent-soft", value);
     }
+  };
+
+  const handleWindowTitleChange = (value) => {
+    setWindowTitle(value);
+    if (onThemeChange) onThemeChange({ primaryColor, accentSoftColor, windowTitle: value });
+    document.title = value || "Bracket Creator Mobile";
   };
 
   const handleLogoUpload = async (e) => {
@@ -91,9 +101,25 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
     <div className="card card--pad-lg" style={{ marginTop: 16 }}>
       <div className="card__title">Branding</div>
       <div className="field__hint" style={{ marginBottom: 16 }}>
-        Customize accent colors and the tournament logo shown on the viewer,
-        lobby, and admin screens. Changes refresh on next page load;
-        colors preview instantly below.
+        Customize the browser tab title, accent colors, and the tournament logo
+        shown on the viewer, lobby, and admin screens. Colors and title preview
+        instantly; the logo takes effect on next page load.
+      </div>
+
+      <div className="field" style={{ marginBottom: 16 }}>
+        <label className="field__label">Browser tab / window title</label>
+        <input
+          type="text"
+          value={windowTitle}
+          maxLength={100}
+          placeholder="Bracket Creator Mobile"
+          onChange={(e) => handleWindowTitleChange(e.target.value)}
+          style={{ width: "100%", boxSizing: "border-box" }}
+        />
+        <div className="field__hint">
+          Shown in the browser tab and title bar on all pages. Defaults to
+          "Bracket Creator Mobile" when blank.
+        </div>
       </div>
 
       <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 16 }}>

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -32,13 +32,19 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   // the parent PUT payload clean (theme block omitted unless configured).
   useEffectBr(() => {
     const rawTheme = tournament && tournament.theme;
+    // Treat a theme object that carries no meaningful fields as "absent":
+    // when only a logo is configured, the server returns theme:{} because
+    // LogoPath has json:"-". Propagating defaults in that case would persist
+    // unwanted color values on the next Save.
+    const hasThemeConfig = rawTheme &&
+      (rawTheme.primaryColor || rawTheme.accentSoftColor || rawTheme.windowTitle);
     const pc = (rawTheme && rawTheme.primaryColor) || "#1d3557";
     const asc = (rawTheme && rawTheme.accentSoftColor) || "#e7eaf3";
     const wt = (rawTheme && rawTheme.windowTitle) || "";
     setPrimaryColor(pc);
     setAccentSoftColor(asc);
     setWindowTitle(wt);
-    if (onThemeChange) onThemeChange(rawTheme ? { primaryColor: pc, accentSoftColor: asc, windowTitle: wt } : null);
+    if (onThemeChange) onThemeChange(hasThemeConfig ? { primaryColor: pc, accentSoftColor: asc, windowTitle: wt } : null);
   }, [tournament]);
 
   const handleColorChange = (field, value) => {

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -1,0 +1,172 @@
+// Branding admin section — embedded in the Edit Tournament page (mp-scf).
+// Lets operators configure accent colors and upload a tournament logo.
+//
+// Endpoints (via window.API.uploadBrandingLogo / window.API.deleteBrandingLogo):
+//   POST   /api/branding/logo   multipart {file}
+//   DELETE /api/branding/logo
+// Theme colors are saved via the parent's tournament PUT call, not here.
+
+const { useState: useStateBr, useRef: useRefBr, useEffect: useEffectBr } = React;
+
+function BrandingManager({ tournament, password, showToast, onThemeChange }) {
+  const theme = (tournament && tournament.theme) || {};
+
+  const [primaryColor, setPrimaryColor] = useStateBr(theme.primaryColor || "#1d3557");
+  const [accentSoftColor, setAccentSoftColor] = useStateBr(theme.accentSoftColor || "#e7eaf3");
+  const [hasLogo, setHasLogo] = useStateBr(false);
+  const [logoKey, setLogoKey] = useStateBr(0); // bump to force img reload
+  const [busy, setBusy] = useStateBr(false);
+  const fileRef = useRefBr(null);
+
+  // Probe whether a logo exists on mount.
+  useEffectBr(() => {
+    fetch('/api/branding/logo', { method: 'HEAD' })
+      .then(r => setHasLogo(r.ok))
+      .catch(() => setHasLogo(false));
+  }, [logoKey]);
+
+  // Sync incoming theme changes (e.g. after a tournament SSE reload).
+  useEffectBr(() => {
+    const t = (tournament && tournament.theme) || {};
+    if (t.primaryColor) setPrimaryColor(t.primaryColor);
+    if (t.accentSoftColor) setAccentSoftColor(t.accentSoftColor);
+  }, [tournament]);
+
+  const handleColorChange = (field, value) => {
+    if (field === "primaryColor") setPrimaryColor(value);
+    else setAccentSoftColor(value);
+    // Propagate to parent so the PUT /tournament body includes updated colors.
+    if (onThemeChange) onThemeChange({ primaryColor: field === "primaryColor" ? value : primaryColor, accentSoftColor: field === "accentSoftColor" ? value : accentSoftColor });
+    // Live-preview the color change in CSS without waiting for save.
+    if (typeof window.applyTheme === "function") {
+      window.applyTheme({
+        primaryColor: field === "primaryColor" ? value : primaryColor,
+        accentSoftColor: field === "accentSoftColor" ? value : accentSoftColor,
+      });
+    } else {
+      const root = document.documentElement;
+      if (field === "primaryColor") root.style.setProperty("--accent", value);
+      else root.style.setProperty("--accent-soft", value);
+    }
+  };
+
+  const handleLogoUpload = async (e) => {
+    e.preventDefault();
+    const file = fileRef.current && fileRef.current.files && fileRef.current.files[0];
+    if (!file) {
+      if (showToast) showToast("Choose a PNG or JPEG file", "error");
+      return;
+    }
+    setBusy(true);
+    try {
+      await window.API.uploadBrandingLogo({ file, password });
+      setHasLogo(true);
+      setLogoKey(k => k + 1);
+      if (fileRef.current) fileRef.current.value = "";
+      if (showToast) showToast("Logo updated", "success");
+    } catch (err) {
+      if (showToast) showToast(err && err.message ? err.message : "Upload failed", "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleLogoDelete = async () => {
+    if (!window.confirm("Remove the tournament logo?")) return;
+    setBusy(true);
+    try {
+      await window.API.deleteBrandingLogo(password);
+      setHasLogo(false);
+      setLogoKey(k => k + 1);
+      if (showToast) showToast("Logo removed", "success");
+    } catch (err) {
+      if (showToast) showToast(err && err.message ? err.message : "Delete failed", "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="card card--pad-lg" style={{ marginTop: 16 }}>
+      <div className="card__title">Branding</div>
+      <div className="field__hint" style={{ marginBottom: 16 }}>
+        Customize accent colors and the tournament logo shown on the viewer,
+        lobby, and admin screens. Changes refresh on next page load;
+        colors preview instantly below.
+      </div>
+
+      <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 16 }}>
+        <div className="field" style={{ flex: 1, minWidth: 160 }}>
+          <label className="field__label">Primary accent color</label>
+          <input
+            type="color"
+            value={primaryColor}
+            onChange={(e) => handleColorChange("primaryColor", e.target.value)}
+            style={{ width: "100%", height: 36, cursor: "pointer", border: "1px solid var(--line)", borderRadius: 6 }}
+          />
+          <div className="field__hint">
+            Used for buttons, headers, and highlights. Default: #1d3557.
+          </div>
+        </div>
+        <div className="field" style={{ flex: 1, minWidth: 160 }}>
+          <label className="field__label">Soft accent (background tint)</label>
+          <input
+            type="color"
+            value={accentSoftColor}
+            onChange={(e) => handleColorChange("accentSoftColor", e.target.value)}
+            style={{ width: "100%", height: 36, cursor: "pointer", border: "1px solid var(--line)", borderRadius: 6 }}
+          />
+          <div className="field__hint">
+            Used for row highlights and badges. Default: #e7eaf3.
+          </div>
+        </div>
+      </div>
+
+      <div className="field__hint" style={{ marginBottom: 16, fontSize: 12, color: "var(--ink-3)" }}>
+        Save the tournament form below to persist color changes.
+      </div>
+
+      <div style={{ borderTop: "1px solid var(--line)", paddingTop: 16, marginTop: 4 }}>
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>Tournament logo</div>
+        <div className="field__hint" style={{ marginBottom: 12 }}>
+          PNG or JPEG, up to 1 MB. Replaces the default kendo logo on all screens.
+          Falls back to the default logo if removed.
+        </div>
+
+        {hasLogo && (
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12, padding: "8px 12px", border: "1px solid var(--line)", borderRadius: 8 }}>
+            <img
+              key={logoKey}
+              src={`/api/branding/logo?v=${logoKey}`}
+              alt="Tournament logo"
+              style={{ height: 48, width: "auto", maxWidth: 120, objectFit: "contain" }}
+            />
+            <div style={{ flex: 1 }}>Current logo</div>
+            <button
+              className="btn btn--danger"
+              disabled={busy}
+              onClick={handleLogoDelete}
+            >
+              Remove
+            </button>
+          </div>
+        )}
+
+        <form onSubmit={handleLogoUpload} style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <div className="field">
+            <label className="field__label">{hasLogo ? "Replace logo" : "Upload logo"} (PNG or JPEG, ≤1 MB)</label>
+            <input ref={fileRef} type="file" accept="image/png,image/jpeg" />
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <button type="submit" className="btn btn--primary" disabled={busy}>
+              {busy ? "Uploading…" : hasLogo ? "Replace logo" : "Upload logo"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+window.BrandingManager = BrandingManager;
+export { BrandingManager };

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -26,10 +26,11 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   }, [logoKey]);
 
   // Sync incoming theme changes (e.g. after a tournament SSE reload).
+  // Always update — falsy values reset the pickers to their defaults.
   useEffectBr(() => {
     const t = (tournament && tournament.theme) || {};
-    if (t.primaryColor) setPrimaryColor(t.primaryColor);
-    if (t.accentSoftColor) setAccentSoftColor(t.accentSoftColor);
+    setPrimaryColor(t.primaryColor || "#1d3557");
+    setAccentSoftColor(t.accentSoftColor || "#e7eaf3");
   }, [tournament]);
 
   const handleColorChange = (field, value) => {

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -122,6 +122,8 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const nextKeyRef = useRefA((tournament.contacts || []).length);
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
+  // mp-scf: theme colors (updated live by BrandingManager via onThemeChange).
+  const [theme, setTheme] = useStateA(tournament.theme || null);
 
   // Elevated (destructive-ops) password — spec 004 / mp-e21. File mode only;
   // in locked mode it's the TOURNAMENT_ADMIN_PASSWORD_HASH env var (read-only
@@ -185,6 +187,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       awardsNote: awardsNote.trim() || undefined,
       infoNotes: infoNotes.trim() || undefined,
       contacts: contacts.filter(c => (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
+      theme: theme || undefined,
     });
   };
 
@@ -389,6 +392,17 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
             tournament={tournament}
             password={password}
             showToast={showToast}
+          />
+        )}
+        {/* mp-scf: branding (colors + logo). onThemeChange propagates color
+            changes back to this component's theme state so they are included
+            in the tournament PUT payload when Save is clicked. */}
+        {window.BrandingManager && (
+          <window.BrandingManager
+            tournament={tournament}
+            password={password}
+            showToast={showToast}
+            onThemeChange={setTheme}
           />
         )}
       </div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -66,7 +66,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
     <div className="topbar-stack">
       <div className="topbar">
         <div className="topbar__brand">
-          <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Kendo Tournament Logo" className="topbar__logo" decoding="async" />
+          <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Tournament logo" className="topbar__logo" decoding="async" />
           <div>
             <div className="topbar__title">{tournament?.name || "Bracket Creator"}</div>
             <div className="topbar__sub">Admin console</div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -64,7 +64,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
     <div className="topbar-stack">
       <div className="topbar">
         <div className="topbar__brand">
-          <img src="/logo.jpeg" alt="Kendo Tournament Logo" className="topbar__logo" decoding="async" />
+          <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Kendo Tournament Logo" className="topbar__logo" decoding="async" />
           <div>
             <div className="topbar__title">{tournament?.name || "Bracket Creator"}</div>
             <div className="topbar__sub">Admin console</div>

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -787,6 +787,31 @@ const API = {
             const err = await res.json().catch(() => ({}));
             throw new Error(err.error || `Failed to delete sponsor (Status ${res.status})`);
         }
+    },
+    // mp-scf: tournament branding — logo upload/delete and theme color update.
+    async uploadBrandingLogo({ file, password }) {
+        const fd = new FormData();
+        fd.append('file', file);
+        const res = await fetch('/api/branding/logo', {
+            method: 'POST',
+            headers: { 'X-Tournament-Password': password },
+            body: fd,
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to upload logo (Status ${res.status})`);
+        }
+        return res.json();
+    },
+    async deleteBrandingLogo(password) {
+        const res = await fetch('/api/branding/logo', {
+            method: 'DELETE',
+            headers: { 'X-Tournament-Password': password },
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to delete logo (Status ${res.status})`);
+        }
     }
 };
 

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -788,7 +788,7 @@ const API = {
             throw new Error(err.error || `Failed to delete sponsor (Status ${res.status})`);
         }
     },
-    // mp-scf: tournament branding — logo upload/delete and theme color update.
+    // mp-scf: tournament branding — logo upload/delete.
     async uploadBrandingLogo({ file, password }) {
         const fd = new FormData();
         fd.append('file', file);

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -20,6 +20,23 @@ const THEME = {
   "cardVariant": 1
 };
 
+// mp-scf: apply tournament-configured CSS custom properties. Called once
+// after tournament load and again on tournament_updated. Removes overrides
+// when the theme field is absent so the CSS defaults take over.
+function applyTheme(theme) {
+  const root = document.documentElement;
+  if (theme && theme.primaryColor) {
+    root.style.setProperty("--accent", theme.primaryColor);
+  } else {
+    root.style.removeProperty("--accent");
+  }
+  if (theme && theme.accentSoftColor) {
+    root.style.setProperty("--accent-soft", theme.accentSoftColor);
+  } else {
+    root.style.removeProperty("--accent-soft");
+  }
+}
+
 // Pure helper: parse the current pathname into the App's view state.
 // Extracted so it remains unit-testable; previously inlined as a
 // closure in App() which prevented both reuse and isolated testing.
@@ -399,6 +416,7 @@ function App() {
         const comps = await window.API.fetchCompetitions();
         t.competitions = comps;
         setTournament(t);
+        applyTheme(t.theme); // mp-scf: apply custom colors
       }
     } catch (e) {
       console.error("Failed to load tournament", e);
@@ -930,7 +948,7 @@ function AuthModal({ onClose, onSuccess, onForgotPassword, resetEnabled }) {
     // dialog could be obscured by chrome or by announcement cards.
     <div className="modal-backdrop" onClick={onClose} style={{ zIndex: 1000 }}>
       <div className="modal auth" onClick={(e) => e.stopPropagation()}>
-        <img src="/logo.jpeg" alt="Kendo Tournament Logo" className="auth__logo" decoding="async" />
+        <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Kendo Tournament Logo" className="auth__logo" decoding="async" />
         <div className="auth__title">Admin sign in</div>
         <div className="auth__sub">Enter the tournament password to manage brackets, schedules and live results.</div>
         <form onSubmit={submit}>

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -35,6 +35,7 @@ function applyTheme(theme) {
   } else {
     root.style.removeProperty("--accent-soft");
   }
+  document.title = (theme && theme.windowTitle) || "Bracket Creator Mobile";
 }
 
 // Pure helper: parse the current pathname into the App's view state.

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -952,7 +952,7 @@ function AuthModal({ onClose, onSuccess, onForgotPassword, resetEnabled }) {
     // dialog could be obscured by chrome or by announcement cards.
     <div className="modal-backdrop" onClick={onClose} style={{ zIndex: 1000 }}>
       <div className="modal auth" onClick={(e) => e.stopPropagation()}>
-        <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Kendo Tournament Logo" className="auth__logo" decoding="async" />
+        <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Tournament logo" className="auth__logo" decoding="async" />
         <div className="auth__title">Admin sign in</div>
         <div className="auth__sub">Enter the tournament password to manage brackets, schedules and live results.</div>
         <form onSubmit={submit}>

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -37,6 +37,9 @@ function applyTheme(theme) {
   }
   document.title = (theme && theme.windowTitle) || "Bracket Creator Mobile";
 }
+// Expose globally so BrandingManager (loaded as a separate module) can call
+// window.applyTheme() for live previews without duplicating the logic.
+window.applyTheme = applyTheme;
 
 // Pure helper: parse the current pathname into the App's view state.
 // Extracted so it remains unit-testable; previously inlined as a

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -695,7 +695,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
     <div className="viewer">
       <div className="viewer__shell">
         <div className="viewer__head viewer__head--hero">
-          <img src="/logo.jpeg" alt="Kendo Tournament Logo" className="topbar__logo viewer__logo" decoding="async" />
+          <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Kendo Tournament Logo" className="topbar__logo viewer__logo" decoding="async" />
           <div className="viewer__title-block">
             <div className="viewer__eyebrow">{formatDate(t.date)} · {t.venue}</div>
             <div className="viewer__title viewer__title--lg">{t.name}</div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -695,7 +695,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
     <div className="viewer">
       <div className="viewer__shell">
         <div className="viewer__head viewer__head--hero">
-          <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Kendo Tournament Logo" className="topbar__logo viewer__logo" decoding="async" />
+          <img src="/api/branding/logo" onError={(e) => { e.target.onerror = null; e.target.src = "/logo.jpeg"; }} alt="Tournament logo" className="topbar__logo viewer__logo" decoding="async" />
           <div className="viewer__title-block">
             <div className="viewer__eyebrow">{formatDate(t.date)} · {t.venue}</div>
             <div className="viewer__title viewer__title--lg">{t.name}</div>


### PR DESCRIPTION
## Summary

- Adds \`Theme\` struct to \`Tournament\` with configurable \`primaryColor\`, \`accentSoftColor\`, \`windowTitle\` (hex colors + browser tab title), and \`logoPath\` (disk-only, not in JSON responses)
- New \`GET/POST/DELETE /api/branding/logo\` endpoints: public GET serves the logo from \`tournament-data/branding/\`; admin POST/DELETE manage upload and removal
- \`BrandingManager\` component on the Edit Tournament admin page: window title input, two color pickers with live preview, and logo upload/remove UI
- All logo \`<img>\` sites (admin topbar, viewer hero, auth screen) now use \`/api/branding/logo\` with \`onError\` fallback to \`/logo.jpeg\`
- \`applyTheme()\` applies \`--accent\`/\`--accent-soft\` CSS vars and sets \`document.title\` on tournament load and on every \`tournament_updated\` SSE event

## Files changed

| File | What |
|---|---|
| \`internal/state/models.go\` | \`Theme\` struct (\`primaryColor\`, \`accentSoftColor\`, \`windowTitle\`, \`logoPath\`), \`ValidateTheme\`, \`Tournament.Theme\` field |
| \`internal/state/models_test.go\` | YAML round-trip, JSON logo-path omit, \`ValidateTheme\` cases incl. windowTitle length |
| \`internal/mobileapp/handlers_branding.go\` | New: public logo GET, admin logo POST/DELETE; atomic temp+rename write; state update before removing other extension |
| \`internal/mobileapp/handlers_branding_test.go\` | New: 12 handler tests covering happy paths, bad type, auth, logo-path preservation |
| \`internal/mobileapp/handlers_tournament.go\` | Hex color validation + windowTitle validation on PUT and POST; preserve \`Theme.LogoPath\` across PUT |
| \`internal/mobileapp/middleware.go\` | \`BrandingMaxBodyBytes\` constant (2 MB) |
| \`internal/mobileapp/server.go\` | Register public and admin branding routes |
| \`web-mobile/js/admin_branding.jsx\` | New: \`BrandingManager\` component with windowTitle input, color pickers, logo upload |
| \`web-mobile/js/admin_setup.jsx\` | Mount \`BrandingManager\`; add \`theme\` state to \`handleSave\` payload |
| \`web-mobile/js/admin_shell.jsx\` | Admin topbar logo → \`/api/branding/logo\` with fallback |
| \`web-mobile/js/viewer.jsx\` | Viewer hero logo → \`/api/branding/logo\` with fallback |
| \`web-mobile/js/app.jsx\` | Auth screen logo + \`applyTheme()\` (CSS vars + \`document.title\`) after tournament load |
| \`web-mobile/js/api_client.jsx\` | \`uploadBrandingLogo\`, \`deleteBrandingLogo\` API helpers |
| \`web-mobile/index.html\` | Load \`admin_branding.js\` before \`admin_setup.js\` |

## Screenshots

**Viewer page** — tournament name ("Kendo World Cup 2026") appears as the window/tab title (top-left topbar) and is set via \`windowTitle\` in the theme:

![Viewer page showing custom window title](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/228/viewer.png)

**Branding card on Edit Tournament page** — window title input, primary + soft accent color pickers, and tournament logo upload section:

![Branding card on Edit Tournament page](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/228/branding.png)

## Test plan

- [x] \`make go/test\` passes (lint + security scan + tests) — Go lint/sec/tests all green; JS lint blocked on missing \`node_modules\` in worktree (works in main repo)
- [x] New/updated unit tests cover the change — 12 new branding handler tests + 5 Theme model tests (incl. windowTitle round-trip and max-length validation)
- [x] Manual browser verification — Branding card renders with window title input and 2 color pickers; windowTitle set to "Kendo World Cup 2026" appears in topbar and tab; \`GET /api/branding/logo\` returns 404 without upload; fallback logo loads; live CSS var + title preview confirmed
- [x] Screenshots added above — real browser screenshots via Playwright headless
- [x] No new console errors or warnings — only pre-existing "tournament not found" on fresh data dir before POST /tournament

Closes mp-scf