### PR TITLE
fix(mp-mnwu): show 'Standings' instead of 'Final standings' during in-progress league

### DIFF
--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+
+function collectText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children) return collectText(node.children);
+  if (node.props?.children) return collectText(node.props.children);
+  return '';
+}
+
+describe('PoolsViewer league standings label (mp-mnwu)', () => {
+  const realReact = global.React;
+  let runtime;
+  let PoolsViewer;
+  const savedGlobals = {};
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+
+  const leagueComp = (status) => ({
+    format: 'league',
+    kind: 'individual',
+    teamSize: 0,
+    status,
+  });
+
+  const pool = { poolName: 'League', players: [] };
+  const baseStandings = { League: [{ player: { name: 'P1' }, wins: 1, losses: 0, draws: 0, pointsWon: 2, pointsLost: 0 }] };
+  const tweaks = { showDojo: false };
+
+  function makeMatches(completed, scheduled) {
+    return [
+      ...Array.from({ length: completed }, (_, i) => ({ id: `League-c${i}`, status: 'completed' })),
+      ...Array.from({ length: scheduled }, (_, i) => ({ id: `League-s${i}`, status: 'scheduled' })),
+    ];
+  }
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => {
+      savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+        ? { had: true, val: global.window[k] }
+        : { had: false };
+    });
+    global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
+    global.window.isHikiwake = () => false;
+    global.window.formatIpponsScore = () => '';
+    global.window.ipponsFromScore = () => [];
+    global.window.queueLabel = () => '';
+    global.window.queueLabelCompact = () => null;
+    vi.resetModules();
+    ({ PoolsViewer } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('shows "Standings" when league competition is in progress', () => {
+    const tree = runtime.mount(PoolsViewer, {
+      pools: [pool],
+      standings: baseStandings,
+      poolMatches: makeMatches(2, 4),
+      tweaks,
+      competition: leagueComp('pools'),
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Standings');
+    expect(text).not.toContain('Final standings');
+  });
+
+  it('shows "Final standings" when all league matches are complete', () => {
+    const tree = runtime.mount(PoolsViewer, {
+      pools: [pool],
+      standings: baseStandings,
+      poolMatches: makeMatches(6, 0),
+      tweaks,
+      competition: leagueComp('completed'),
+    });
+    const text = collectText(tree);
+    expect(text).toContain('Final standings');
+  });
+
+  it('shows pool name (not "Standings") for non-league competitions', () => {
+    const tree = runtime.mount(PoolsViewer, {
+      pools: [{ poolName: 'PoolA', players: [] }],
+      standings: { PoolA: [] },
+      poolMatches: makeMatches(2, 3),
+      tweaks,
+      competition: { format: 'mixed', kind: 'individual', teamSize: 0, status: 'pools' },
+    });
+    const text = collectText(tree);
+    expect(text).toContain('PoolA');
+    expect(text).not.toContain('Final standings');
+    expect(text).not.toContain('Standings');
+  });
+});

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2315,7 +2315,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
         return (
           <div key={pool.poolName} className="pool" style={{ padding: 14 }}>
             <div className="pool__head">
-              <div className="pool__name">{isLeague ? "Final standings" : pool.poolName}</div>
+              <div className="pool__name">{isLeague ? (allMatchesComplete ? "Final standings" : "Standings") : pool.poolName}</div>
               <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
                 {matches.filter(m => m.status === "completed").length}/{matches.length} matches
               </div>
@@ -2529,7 +2529,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;


### PR DESCRIPTION
## Summary

- `PoolsViewer` was unconditionally showing "Final standings" for all league-format pool tabs, regardless of match completion status — even at 0/10 matches played
- Now shows "Standings" while the competition is in progress, switching to "Final standings" only once all matches are complete
- Matches the existing behaviour already in the `ViewerOverview` league overview section (line 1944)
- Exports `PoolsViewer` for testability and adds three unit tests covering: in-progress, completed, and non-league cases

## Why

Root cause: `PoolsViewer` used `{isLeague ? "Final standings" : pool.poolName}` (unconditional) while `ViewerOverview` (the overview tab) already used `{allMatchesComplete ? "Final standings" : "Standings"}`. The `allMatchesComplete` variable was computed in `PoolsViewer`'s own scope but never applied to the label.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | Fix label ternary in `PoolsViewer`; export `PoolsViewer` for tests |
| `web-mobile/js/__tests__/viewer_pools_viewer.test.jsx` | New: 3 unit tests for the in-progress / completed / non-league label cases |

## Screenshots

_Pools tab — league competition in progress (0/10 matches): label correctly reads "Standings". Captured via headless Chrome driving the live mobile-app preview at `localhost:8096`._

![Pools tab showing Standings label during in-progress league](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/230/pools-standings-in-progress.png)

The completed-state branch (`"Final standings"` when all matches finished) is covered by the unit test `shows "Final standings" when all league matches are complete` in `viewer_pools_viewer.test.jsx`.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (3 new tests in `viewer_pools_viewer.test.jsx`, 1138 total passing)
- [x] Manual browser verification — navigated to Pools tab of an in-progress league competition (0/10 matches); confirmed label shows "Standings" not "Final standings"
- [x] Screenshots added above (in-progress state captured from headless Chrome; completed state covered by unit test)
- [x] No new console errors or warnings

Closes mp-mnwu