### PR TITLE
fix(mp-wihb): show format-aware labels for League competitions

### DIFF
--- a/web-mobile/js/__tests__/ui.test.jsx
+++ b/web-mobile/js/__tests__/ui.test.jsx
@@ -14,6 +14,16 @@ describe('UI Components', () => {
       const dot = badge.children.find(c => c && c.props && c.props.className === 'dot dot--live');
       expect(dot).toBeDefined();
     });
+
+    it('should show "League" label for pools status when format is league', () => {
+      const badge = StatusBadge({ status: 'pools', format: 'league' });
+      expect(badge.children).toContain('League');
+    });
+
+    it('should still show "Pools" label for pools status when format is mixed', () => {
+      const badge = StatusBadge({ status: 'pools', format: 'mixed' });
+      expect(badge.children).toContain('Pools');
+    });
   });
 
   describe('formatDate', () => {

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -1425,7 +1425,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         // Show pools/bracket in nav when draw is ready (preview) or running.
         // Use .length checks: the state store returns [] / {rounds:[]} (never null)
         // when files are absent, so plain truthiness would always show the items.
-        (pools?.length || (isDrawReady && c.format !== "playoffs" && c.format !== "swiss")) ? { id: "pools", label: isDrawReady ? "Pools — preview" : "Pools — live" } : null,
+        (pools?.length || (isDrawReady && c.format !== "playoffs" && c.format !== "swiss")) ? { id: "pools", label: (c.format === "league" ? "League" : "Pools") + " — " + (isDrawReady ? "preview" : "live") } : null,
         // T191 (FR-050d): Swiss competitions surface a dedicated round
         // management panel for the "Generate next round" workflow.
         c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds — manage" } : null,
@@ -1456,7 +1456,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             <div className="page-head__eyebrow">{t.name} ›</div>
             <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
               <h1 className="page-head__title">{c.name}</h1>
-              <StatusBadge status={localStatus ?? c.status} />
+              <StatusBadge status={localStatus ?? c.status} format={c.format} />
             </div>
             <div className="page-head__sub">
               {window.competitionKindLabel(c)} · {c.players.length} {c.kind === "team" ? "teams" : "players"} ·

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -339,7 +339,7 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
               {courts.length > 0 && `${(c.date || c.startTime) ? " · " : ""}${courts.join(", ")}`}
             </div>
           </div>
-          <StatusBadge status={c.status} />
+          <StatusBadge status={c.status} format={c.format} />
         </div>
         <div className="tcard__stats">
           <div className="tcard__stat"><div className="v">{playerCount}</div><div className="l">{pluralize(playerCount, c.kind === "team" ? "Team" : "Player")}</div></div>

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -1,6 +1,6 @@
 // Shared UI primitives used by both admin and viewer modules.
 
-function StatusBadge({ status, showLiveDot }) {
+function StatusBadge({ status, showLiveDot, format }) {
   const map = {
     setup: ["badge--setup", "Pending"],
     "draw-ready": ["badge--draw-ready", "Draw ready"],
@@ -8,7 +8,8 @@ function StatusBadge({ status, showLiveDot }) {
     playoffs: ["badge--playoffs", "Playoffs"],
     completed: ["badge--completed", "Completed"],
   };
-  const [cls, label] = map[status || "setup"] || ["badge--setup", status];
+  const [cls, rawLabel] = map[status || "setup"] || ["badge--setup", status];
+  const label = (status === "pools" && format === "league") ? "League" : rawLabel;
   const showLive = showLiveDot && (status === "pools" || status === "playoffs");
   return (
     <span className={`badge ${cls}`}>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1872,7 +1872,6 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
   // logic in ViewerCompetition), so the pointer text must match.
   if (c.status === "draw-ready") {
     const isSwiss = c.format === "swiss";
-    const isLeague = c.format === "league";
     return (
       <div className="empty" style={{ padding: 32 }}>
         <div className="icon">📋</div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -805,7 +805,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                               {c.players.length} {c.kind === "team" ? "teams" : "players"} · {formatLabel(c.format)} · Starts {c.startTime}
                             </div>
                           </div>
-                          <StatusBadge status={c.status} showLiveDot />
+                          <StatusBadge status={c.status} showLiveDot format={c.format} />
                         </div>
                         {c.status && c.status !== "setup" && c.status !== "draw-ready" && total > 0 && (
                           <div className="vlist-item__progress">
@@ -1622,10 +1622,11 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
   // data via /swiss/standings (it's not part of the competition-detail
   // payload — see api_client.jsx).
   const isSwiss = c.format === "swiss";
+  const isLeague = c.format === "league";
   const tabs = [
     { id: "overview", label: "Overview" },
     isSwiss ? { id: "swiss", label: "Standings" } : null,
-    hasPools && !isSwiss ? { id: "pools", label: "Pools" } : null,
+    hasPools && !isSwiss ? { id: "pools", label: isLeague ? "League" : "Pools" } : null,
     hasBracket && !isSwiss ? { id: "bracket", label: "Bracket" } : null,
     c.status === "completed" ? { id: "results", label: "Awards" } : null,
   ].filter(Boolean);
@@ -1659,7 +1660,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             <div className="viewer__title">{c.name}</div>
             <div className="viewer__sub">{competitionKindLabel(c)}</div>
           </div>
-          <StatusBadge status={c.status} showLiveDot />
+          <StatusBadge status={c.status} showLiveDot format={c.format} />
         </div>
         <div className="viewer__tabs">
           {tabs.map((tb) => (
@@ -1871,6 +1872,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
   // logic in ViewerCompetition), so the pointer text must match.
   if (c.status === "draw-ready") {
     const isSwiss = c.format === "swiss";
+    const isLeague = c.format === "league";
     return (
       <div className="empty" style={{ padding: 32 }}>
         <div className="icon">📋</div>
@@ -1878,6 +1880,8 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
         <div style={{ fontSize: 13 }}>
           Starts at {c.startTime}. {isSwiss
             ? "Check the Standings tab to follow the rounds."
+            : isLeague
+            ? "Browse the League tab to see the draw."
             : "Browse the Pools and Bracket tabs to see the draw."}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- League competitions showed "Pools" in the status badge, the viewer tab, the admin sidebar tab, and the draw-ready guidance text — regardless of format
- Root cause: all four sites hardcoded the string "Pools"; the `format` field was never consulted
- Fix: `StatusBadge` gains an optional `format` prop; when `status=pools && format=league` the label is "League". The viewer and admin nav tabs derive their label from `c.format`. The draw-ready prose adds a league-specific branch. Swiss and mixed/playoffs are unaffected (Swiss already had its own tab; mixed correctly shows Pools)

## Files changed

| File | What |
|---|---|
| `web-mobile/js/ui.jsx` | `StatusBadge`: add optional `format` prop; override label to "League" when `status=pools && format=league` |
| `web-mobile/js/viewer.jsx` | Viewer tab label: "League" for league format; draw-ready prose: "Browse the League tab"; thread `format` into `StatusBadge` at both call sites |
| `web-mobile/js/admin_competition.jsx` | Admin sidebar tab: "League — preview/live" for league format; thread `format` into `StatusBadge` |
| `web-mobile/js/admin_shell.jsx` | Thread `format` into `StatusBadge` on the competition card |
| `web-mobile/js/__tests__/ui.test.jsx` | Two new `StatusBadge` tests: league format shows "League"; mixed format still shows "Pools" |

## Screenshots

Viewer for a League competition with status=pools — badge says "League", tab says "League":

![mp-wihb league viewer — badge and tab both say League](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/230/mp-wihb-league-viewer.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — pre-existing `build_date.txt` gosec false-positive unrelated to this change; Go tests and lint all pass
- [x] New/updated unit tests cover the change — 2 new `StatusBadge` tests in `ui.test.jsx`, all 15 tests in that file pass
- [x] Manual browser verification — started a League competition, confirmed status badge shows "League" (not "Pools"), viewer tab shows "League" (not "Pools"), draw-ready state shows "Browse the League tab to see the draw."
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-wihb