### PR TITLE
fix(mp-b547): remove debug console.log from buildCompetition

### DIFF
--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -209,7 +209,6 @@ function poolWinners(pools) {
 function buildEmptyCompetition(args) {
   if (!args) { console.error("buildEmptyCompetition: args is undefined!"); return null; }
   const { id, name, kind, gender = "X", format, sampleRoster = "medium", courts, seedCount, status, startTime, date, teamSize, poolMode, poolSize, winnersPerPool, withZekkenName, numberPrefix, checkInEnabled } = args;
-  console.log("buildCompetition: args", args);
   const count = sampleRoster ? ({ small: 8, medium: 16, large: 32 }[sampleRoster] || 16) : 0;
   const players = count > 0 ? makeCompetitors(count, kind, id, seedCount, gender) : [];
   return {
@@ -233,7 +232,6 @@ function buildEmptyCompetition(args) {
 
 function applyFormat(c) {
   if (c.status === "setup") return c;
-  console.log("buildCompetition: c before pools/bracket", c);
   if (c.format === "mixed") {
     c.pools = buildPools(c.players, { poolMode: c.poolSizeMode, poolSize: c.poolSize, winnersPerPool: c.poolWinners, courts: c.courts });
     if (c.status === "pools") {


### PR DESCRIPTION
## Summary

- Remove two leftover `console.log("buildCompetition: ...")` debug statements from `web-mobile/js/data.jsx` that logged full competition objects on every page load.
- The legitimate `console.error` guard in `buildEmptyCompetition` (line 210) is preserved — only debug-level logs are removed.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/data.jsx` | Delete two `console.log` calls (lines 212 and 236) |

## Screenshots

No UI-visible change (removes console output only — no layout, copy, or behavior change). No screenshot required.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change — N/A (pure deletion of debug logging; no new behavior to test)
- [x] Manual browser verification — `grep -rn "console.log" web-mobile/js` returns zero results; `grep -rn "buildCompetition:" web-mobile/dist` returns zero results after rebuild; `console.error` guard confirmed present
- [x] Screenshots added above — N/A (no UI change)
- [x] No new console errors or warnings — this PR *removes* console noise

Closes mp-b547
