### PR TITLE
feat(mp-9lx2): add Edit shortcut on viewer competition page

### DIFF
--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -298,6 +298,10 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
           <div className="card__title" style={{ marginBottom: 6 }}>Live results →</div>
           <div className="card__sub">Visual bracket / pool standings</div>
         </button>
+        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection("settings")}>
+          <div className="card__title" style={{ marginBottom: 6 }}>Edit Competition →</div>
+          <div className="card__sub">Change format, courts, and settings</div>
+        </button>
       </div>
     </div>
   );

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -298,10 +298,6 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
           <div className="card__title" style={{ marginBottom: 6 }}>Live results →</div>
           <div className="card__sub">Visual bracket / pool standings</div>
         </button>
-        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection("settings")}>
-          <div className="card__title" style={{ marginBottom: 6 }}>Edit Competition →</div>
-          <div className="card__sub">Change format, courts, and settings</div>
-        </button>
       </div>
     </div>
   );

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -787,6 +787,8 @@ function App() {
           onBack={() => setViewerCompId(null)}
           onSelectCompetition={setViewerCompId}
           onAdminClick={requestAdmin}
+          authed={authed}
+          onEditCompetition={(id) => { setMode("admin"); setAdminView({ kind: "competition", id, section: "settings" }); }}
           tweaks={THEME}
         />
       ) : viewerScreen === "schedule" ? (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1504,7 +1504,7 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
   );
 }
 
-function ViewerCompetition({ tournament, competition, pools, poolMatches, standings, bracket, onBack, onSelectCompetition, tweaks }) {
+function ViewerCompetition({ tournament, competition, pools, poolMatches, standings, bracket, onBack, onSelectCompetition, authed, onEditCompetition, tweaks }) {
   const [tab, setTab] = useState("overview");
   const c = competition;
 
@@ -1661,6 +1661,9 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             <div className="viewer__sub">{competitionKindLabel(c)}</div>
           </div>
           <StatusBadge status={c.status} showLiveDot format={c.format} />
+          {authed && onEditCompetition && (
+            <button className="viewer__admin-pill" onClick={() => onEditCompetition(c.id)}>✎ Edit</button>
+          )}
         </div>
         <div className="viewer__tabs">
           {tabs.map((tb) => (


### PR DESCRIPTION
## Summary

- Add a "✎ Edit" pill to the **viewer** competition header that appears only when the user is already authenticated as admin.
- Clicking it navigates directly to admin competition settings — no need to go back to the dashboard first.

## Why

When an admin is watching a competition from the public viewer and spots something to fix, they had to: go back → admin dashboard → find the competition → click Settings. This shortcut collapses that to one tap.

The pill is invisible to unauthenticated viewers — no security exposure.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/app.jsx` | Pass `authed` state and `onEditCompetition` callback to `ViewerCompetition` |
| `web-mobile/js/viewer.jsx` | Add `authed` + `onEditCompetition` props; render pill in `viewer__head` when authed |

## Screenshots

**Viewer competition page — "✎ Edit" pill visible when authenticated as admin:**

![Viewer with Edit pill](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/233/viewer-with-edit-pill.png)

**After clicking — jumps directly to admin Competition Settings:**

![Admin settings after clicking Edit](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/233/admin-settings-via-edit.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + all tests)
- [x] New/updated unit tests — N/A (UI wiring only, no new logic)
- [x] Manual browser verification — logged in as admin, navigated to viewer competition page, "✎ Edit" pill visible; click navigates to admin competition settings; pill absent in unauthenticated viewer session
- [x] Screenshots added above — browser-captured via headless Chromium
- [x] No new console errors or warnings

Closes mp-9lx2
