### PR TITLE
fix(mp-kqfu): make demo Teams competition a real team event

### DIFF
--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -148,15 +148,18 @@ def run_competition_setup(cat):
     seeds_path = os.path.join(DATA_DIR, cat.get('seeds', "")) if cat.get('seeds') else None
 
     print(f"Creating competition: {title} (ID: {comp_id})")
-    team_size = cat.get('team_size', 1)
+    # teamSize follows the API contract: 0 = individual, >0 = team (engine
+    # checks comp.TeamSize > 0; OpenAPI Competition.teamSize: "0 for
+    # individual"). Categories without an explicit team_size are individual,
+    # so default to 0 — never 1, which would make them look like 1-person
+    # team comps internally. kind is derived the same way so kind and
+    # teamSize can never disagree. Each team CSV row is one team
+    # (TeamName, Dojo); team_size sets the sub-bouts per encounter.
+    team_size = cat.get('team_size', 0)
     payload = {
         "id": comp_id,
         "name": title,
-        # A competition with >1 player per team must be created with
-        # kind="team" so the viewer/admin label it as a team event and
-        # count entries as TEAMS (not players). Each CSV row is one team
-        # (TeamName, Dojo); team_size only sets the sub-bouts per encounter.
-        "kind": "team" if team_size > 1 else "individual",
+        "kind": "team" if team_size > 0 else "individual",
         "format": "mixed",
         "poolSize": 3,
         "poolWinners": 2,

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -148,9 +148,15 @@ def run_competition_setup(cat):
     seeds_path = os.path.join(DATA_DIR, cat.get('seeds', "")) if cat.get('seeds') else None
 
     print(f"Creating competition: {title} (ID: {comp_id})")
+    team_size = cat.get('team_size', 1)
     payload = {
         "id": comp_id,
         "name": title,
+        # A competition with >1 player per team must be created with
+        # kind="team" so the viewer/admin label it as a team event and
+        # count entries as TEAMS (not players). Each CSV row is one team
+        # (TeamName, Dojo); team_size only sets the sub-bouts per encounter.
+        "kind": "team" if team_size > 1 else "individual",
         "format": "mixed",
         "poolSize": 3,
         "poolWinners": 2,
@@ -158,7 +164,7 @@ def run_competition_setup(cat):
         "courts": ["A", "B"],
         "withZekkenName": cat.get('zekken', True),
         "numberPrefix": cat.get('number_prefix', ""),
-        "teamSize": cat.get('team_size', 1),
+        "teamSize": team_size,
         "startTime": cat.get('startTime', ""),
         "date": cat.get('date', ""),
         "status": "setup"

--- a/test-data/team_registrations_2026.csv
+++ b/test-data/team_registrations_2026.csv
@@ -1,36 +1,36 @@
-Frodo Baggins,BAGGINS
-Gandalf the Grey,GANDALF
-Hermione Granger,GRANGER
-Inigo Montoya,MONTOYA
-Jon Snow,SNOW
-Katniss Everdeen,EVERDEEN
-Legolas Greenleaf,GREENLEAF
-Moby Dick,DICK
-Neville Longbottom,LONGBOTTOM
-Othello,OTHELLO
-Petyr Baelish,BAELISH
-Quirinus Quirrell,QUIRRELL
-Ron Weasley,WEASLEY
-Quentin Blake,BLAKE
-Philip K Dick,DICK
-Samwise Gamgee,GAMGEE
-Tyrion Lannister,LANNISTER
-Ulysses,ULYSSES
-Voldemort,VOLDEMORT
-Willy Wonka,WONKA
-Xaro Xhoan Daxos,DAXOS
-Ygritte,YGRITTE
-Kevin Clark,CLARK
-Luke Rodriguez,RODRIGUEZ
-Michael Lewis,LEWIS
-Nathan Lee,LEE
-Oliver Walker,WALKER
-Paul Hall,HALL
-Quentin Allen,ALLEN
-Robert Young,YOUNG
-Steven Hernandez,HERNANDEZ
-Thomas King,KING
-Uriel Wright,WRIGHT
-Victor Lopez,LOPEZ
-William Hill,HILL
-Xavier Scott,SCOTT
+Kenshikan Crimson,London Kenshikan
+Kenshikan Azure,London Kenshikan
+Renbukan Storm,Edinburgh Renbukan
+Renbukan Frost,Edinburgh Renbukan
+Bushido Thunder,Manchester Bushido
+Bushido Shadow,Manchester Bushido
+Kenyukai Blaze,Bristol Kenyukai
+Kenyukai Tide,Bristol Kenyukai
+Seishinkan Ember,Oxford Seishinkan
+Seishinkan Onyx,Oxford Seishinkan
+Mushin Steel,Cambridge Mushin
+Mushin Jade,Cambridge Mushin
+Kensei Scarlet,Cardiff Kensei
+Kensei Cobalt,Cardiff Kensei
+Shidokan Amber,Birmingham Shidokan
+Shidokan Violet,Birmingham Shidokan
+Eikoku Bronze,Leeds Eikokukan
+Eikoku Pearl,Leeds Eikokukan
+Renshin Coral,Glasgow Renshinkan
+Renshin Slate,Glasgow Renshinkan
+Kendokai Copper,Liverpool Kendokai
+Kendokai Mist,Liverpool Kendokai
+Tora Dawn,Sheffield Toraryu
+Tora Granite,Sheffield Toraryu
+Hokushin Cinder,Newcastle Hokushin
+Hokushin Twilight,Newcastle Hokushin
+Zanshin Aurora,Nottingham Zanshin
+Zanshin Ivory,Nottingham Zanshin
+Brighton Falcons,Brighton Kenshikai
+York Cranes,York Yushinkan
+Bath Ravens,Bath Meishinkan
+Durham Vipers,Durham Kobukan
+Norwich Hawks,Norwich Seibukan
+Exeter Lions,Exeter Chidokan
+Reading Bears,Reading Shobukan
+Coventry Wolves,Coventry Tenshinkan

--- a/test-data/team_registrations_2026_seeds.csv
+++ b/test-data/team_registrations_2026_seeds.csv
@@ -1,3 +1,3 @@
 Rank,Name
-1,Philip K Dick
-2,Quentin Blake
+1,Kenshikan Crimson
+2,Renbukan Storm


### PR DESCRIPTION
## Summary

- The demo **Teams** competition is now a real team event. Previously `test-data/team_registrations_2026.csv` held person-name + surname rows (e.g. `Frodo Baggins,BAGGINS`) that parse as `Name,Dojo` — so the comp loaded ~36 individuals misread as 36 one-person "teams" with surnames as dojos.
- Each CSV row is now **one team** (`TeamName, Dojo`). A team is just a name — no member roster required — exactly like the Excel/CLI generator treats team competitions (`--team-matches` only sets sub-bouts per encounter).
- The viewer/admin now correctly label the comp **"TEAMS · 5-PERSON"** and count **"36 teams"** (was "INDIVIDUAL" / "36 players").

## Why

Root cause: the team registration fixture used individual-shaped rows, and `setup_tournament.py` created the competition with `teamSize: 5` but **without** `kind: "team"`. The viewer's `competitionKindLabel()` keys the "Teams" label off `c.kind === "team"`, so the demo rendered as an individual event with surnames-as-dojos. This blocked team-side viewer validation (team standings, team count, dojo-conflict avoidance).

Per maintainer guidance: team member rosters/lineups are **not** required for a valid team comp — a team is a name with a dojo.

## Files changed

| File | What |
|---|---|
| `test-data/team_registrations_2026.csv` | Rewritten as 36 fictitious `TeamName, Dojo` rows across 22 dojos, with up to 2 teams per dojo to exercise dojo-conflict avoidance |
| `test-data/team_registrations_2026_seeds.csv` | Seeds now reference real team names (`Kenshikan Crimson` #1, `Renbukan Storm` #2) |
| `scripts/setup_tournament.py` | Set `kind: "team"` for team categories (derived from `team_size > 1`) so the comp is labeled/counted as a team event |

## Screenshots

No `web-mobile/`/`web/` **code** was changed (this is test-data + a setup script), so a code-diff screenshot is N/A. The change does alter what the seeded demo renders; verified live in a real browser against `mobile-app`:

- Competition card eyebrow: **"TEAMS · 5-PERSON"**, title "Teams", subline **"36 teams · Pools + Knockout · Starts 09:30"** (previously "INDIVIDUAL · 5-PERSON" / "36 players").
- "Up Next" match cards render **team-vs-team** with dojos, e.g. `Eikoku Bronze (Leeds Eikokukan)` vs `Kenshikan Crimson (London Kenshikan)`.

## Test plan

- [x] `make go/test` passes — Go lint + govulncheck + JS lint + all package tests green. (One failure, `TestAtomicWriteFile_UniqueSuffixAvoidsCollision` in `internal/state`, is a known-flaky `/tmp` concurrency artifact under the parallel full-suite run; passes 3/3 in isolation. No Go code changed in this PR.)
- [x] New/updated unit tests cover the change — N/A: change is demo fixture data + a setup script (no Go code paths added). Behavior verified end-to-end via live mobile-app probe (below).
- [x] Manual browser verification — seeded the Teams comp via `setup_tournament.py` flow against `mobile-app`; confirmed in-browser: 36 teams (not individuals), correct "TEAMS · 5-PERSON" label, team-vs-team cards with dojos, 12 pools with **0 dojo-conflicts** (same-dojo teams separated), seed #1 at top of its pool, team `quick-score` (3-1-1 → winner) works.
- [x] Screenshots added above (textual attestation — no UI code change)
- [x] No new console errors or warnings

Closes mp-kqfu
