### PR TITLE
fix(mp-z2ll): map decision "X" to "hikiwake" in seed script

### DIFF
--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -276,9 +276,12 @@ def score_all_matches(comp_id):
                 print(f"  Quick-scored {mid}: {sideA} vs {sideB} -> {res_data['winner_side']}")
             else:
                 res_data = get_predictable_result(False, i + iteration)
-                
+                raw_decision = res_data.get("decision", "")
+                if raw_decision == "X":
+                    raw_decision = "hikiwake"
+
                 # Knockout (bracket) matches can't end in a draw — convert to a win.
-                if not is_pool_match and res_data.get("decision") == "X":
+                if not is_pool_match and raw_decision == "hikiwake":
                     winner = sideA
                     ipponsA = ["M"]
                     ipponsB = []
@@ -289,7 +292,7 @@ def score_all_matches(comp_id):
                     elif res_data["winner_side"] == "B": winner = sideB
                     ipponsA = res_data["ipponsA"]
                     ipponsB = res_data["ipponsB"]
-                    decision = res_data.get("decision", "")
+                    decision = raw_decision
 
                 payload = {
                     "id": mid,


### PR DESCRIPTION
## Summary

- Seed script (`setup_tournament.py`) sent `decision: "X"` (the scoreboard tie-mark) for draw matches, but the score API only accepts canonical wire values. Every individual category aborted scoring at its first draw match with HTTP 400.
- Normalizes `"X"` → `"hikiwake"` in the script before sending, so pool scoring completes successfully.

## Why

`"X"` is the UI tie-mark operators write on a scoreboard — not a domain decision value. The Go score endpoint validates against a strict allowlist (`validation.go:434-445`) and correctly rejects `"X"`. The fix belongs in the caller (the Python script), not in the backend.

## Files changed

| File | What |
|---|---|
| `scripts/setup_tournament.py` | Map `"X"` → `"hikiwake"` before sending decision to score API |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — pre-existing `build_date.txt` embed issue only
- [x] Run `setup_tournament.py` against a live server and verify all individual categories complete pool scoring without 400 errors — all 6 categories scored, 0 errors
- [N/A] New/updated unit tests cover the change — script-only change, no Go code modified
- [N/A] Manual browser verification — no UI changes
- [N/A] Screenshots — no UI changes

Closes mp-z2ll