### PR TITLE
fix(mp-5ng7): reconcile engine bracket generation with Excel reference

### DIFF
--- a/internal/engine/bracket.go
+++ b/internal/engine/bracket.go
@@ -118,7 +118,10 @@ func (e *Engine) generatePoolPreviewBracket(comp *state.Competition) error {
 func (e *Engine) buildSourceLinkedLeaves(comp *state.Competition) ([]string, error) {
 	srcID := comp.SourceCompID
 	srcComp, err := e.store.LoadCompetition(srcID)
-	if err != nil || srcComp == nil {
+	if err != nil {
+		return nil, fmt.Errorf("loading source competition %q: %w", srcID, err)
+	}
+	if srcComp == nil {
 		return nil, notFoundErrorf("playoffs source competition %q not found", srcID)
 	}
 

--- a/internal/engine/bracket.go
+++ b/internal/engine/bracket.go
@@ -160,13 +160,18 @@ func (e *Engine) buildSourceLinkedLeaves(comp *state.Competition) ([]string, err
 	}
 
 	// Replace placeholders; leave empty slots ("") as-is (they are byes).
+	// Any non-empty leaf that is absent from the resolver means a pool has
+	// fewer standings than poolWinners — fail fast rather than letting a
+	// raw placeholder like "Pool A-2nd" silently appear as a player name.
 	for i, leaf := range leaves {
 		if leaf == "" {
 			continue
 		}
-		if name, ok := resolver[leaf]; ok {
-			leaves[i] = name
+		name, ok := resolver[leaf]
+		if !ok {
+			return nil, validationErrorf("source competition %q: no standings entry for finalist slot %q (pool results may be incomplete)", srcComp.Name, leaf)
 		}
+		leaves[i] = name
 	}
 
 	return leaves, nil

--- a/internal/engine/bracket.go
+++ b/internal/engine/bracket.go
@@ -2,13 +2,21 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
-func (e *Engine) generatePlayoffs(comp *state.Competition, players []domain.Player, seeds []domain.SeedAssignment) error {
+// generatePlayoffs builds and saves an elimination bracket. sourceLinked must
+// be true when players were resolved from a source competition via
+// resolvePoolWinners; false for manually-populated or standalone rosters.
+// When sourceLinked the bracket topology mirrors the pool preview bracket
+// (GenerateFinals ordering + pool adjustments); standalone uses
+// StandardSeeding + CreateBalancedTree, matching the Excel create-playoffs
+// path (mp-5ng7).
+func (e *Engine) generatePlayoffs(comp *state.Competition, players []domain.Player, seeds []domain.SeedAssignment, sourceLinked bool) error {
 	// helper.Player is a type alias for domain.Player (NFR-007); the
 	// Excel-coupled helpers accept domain values directly.
 	if len(seeds) > 0 {
@@ -21,16 +29,24 @@ func (e *Engine) generatePlayoffs(comp *state.Competition, players []domain.Play
 		helper.AssignPlayerNumbers(players, comp.NumberPrefix, 1)
 	}
 
-	// StandardSeedingFull returns a full power-of-two bracket with byes interleaved
-	// at standard positions (empty Name = bye), so the top seeds draw the byes
-	// rather than the draw clustering all byes at the bottom (mp-sess).
-	seededPlayers := helper.StandardSeedingFull(players)
-
-	// Create balanced tree. Leaves are already power-of-two length; empty names
-	// are byes, which buildBracketFromLeaves auto-resolves.
-	leaves := make([]string, len(seededPlayers))
-	for i, p := range seededPlayers {
-		leaves[i] = p.Name
+	var leaves []string
+	if sourceLinked {
+		var err error
+		leaves, err = e.buildSourceLinkedLeaves(comp)
+		if err != nil {
+			return err
+		}
+	} else {
+		// StandardSeeding → CreateBalancedTree → TreeToLeafArray mirrors the
+		// Excel create-playoffs path exactly (mp-5ng7). The unbalanced tree's
+		// structural byes are embedded as "" slots in the pow2 array.
+		seededPlayers := helper.StandardSeeding(players)
+		names := make([]string, len(seededPlayers))
+		for i, p := range seededPlayers {
+			names[i] = p.Name
+		}
+		tree := helper.CreateBalancedTree(names)
+		leaves = helper.TreeToLeafArray(tree)
 	}
 
 	bracket, err := e.buildBracketFromLeaves(comp, leaves)
@@ -76,7 +92,15 @@ func (e *Engine) generatePoolPreviewBracket(comp *state.Competition) error {
 		return nil
 	}
 
-	bracket, err := e.buildBracketFromLeaves(comp, finals)
+	// Mirror the Excel create-pools path: build tree, apply pool adjustments
+	// so 1st-place finishers get byes, then flatten to a pow2 leaf array
+	// (mp-5ng7). This gives the preview bracket the same topology as the
+	// printed Excel bracket.
+	tree := helper.CreateBalancedTree(finals)
+	helper.ApplyPoolAdjustments(tree)
+	previewLeaves := helper.TreeToLeafArray(tree)
+
+	bracket, err := e.buildBracketFromLeaves(comp, previewLeaves)
 	if err != nil {
 		return err
 	}
@@ -85,11 +109,73 @@ func (e *Engine) generatePoolPreviewBracket(comp *state.Competition) error {
 	return e.store.SaveBracket(comp.ID, bracket)
 }
 
+// buildSourceLinkedLeaves builds the ordered leaf array for a playoffs
+// competition that is source-linked to a finished mixed comp (SourceCompID
+// != ""). The topology (bye positions, court grouping) matches the pool
+// preview bracket generated for the source comp, and placeholders are
+// replaced with the actual pool-standings winners so the live bracket
+// names are resolved at draw time (mp-5ng7).
+func (e *Engine) buildSourceLinkedLeaves(comp *state.Competition) ([]string, error) {
+	srcID := comp.SourceCompID
+	srcComp, err := e.store.LoadCompetition(srcID)
+	if err != nil || srcComp == nil {
+		return nil, notFoundErrorf("playoffs source competition %q not found", srcID)
+	}
+
+	pools, err := e.store.LoadPools(srcID)
+	if err != nil {
+		return nil, fmt.Errorf("loading source pools for %q: %w", srcID, err)
+	}
+
+	poolWinners := srcComp.PoolWinners
+	if poolWinners <= 0 {
+		poolWinners = 2
+	}
+
+	// Build placeholder array in the same order the preview bracket uses,
+	// then apply pool adjustments so the topology is identical.
+	finals := helper.GenerateFinals(pools, poolWinners)
+	if len(finals) == 0 {
+		return nil, validationErrorf("source competition %q has no pool finalists", srcComp.Name)
+	}
+	tree := helper.CreateBalancedTree(finals)
+	helper.ApplyPoolAdjustments(tree)
+	leaves := helper.TreeToLeafArray(tree)
+
+	// Build resolver: placeholder key "Pool X-Nth" → actual player name.
+	standings, err := e.CalculatePoolStandings(srcID)
+	if err != nil {
+		return nil, fmt.Errorf("calculating pool standings for %q: %w", srcID, err)
+	}
+	resolver := make(map[string]string, len(finals))
+	for _, pool := range pools {
+		poolStandings := standings[pool.PoolName]
+		for rank := 1; rank <= poolWinners && rank-1 < len(poolStandings); rank++ {
+			key := fmt.Sprintf("%s-%s", pool.PoolName, helper.GetOrdinal(rank))
+			resolver[key] = poolStandings[rank-1].Player.Name
+		}
+	}
+
+	// Replace placeholders; leave empty slots ("") as-is (they are byes).
+	for i, leaf := range leaves {
+		if leaf == "" {
+			continue
+		}
+		if name, ok := resolver[leaf]; ok {
+			leaves[i] = name
+		}
+	}
+
+	return leaves, nil
+}
+
 // buildBracketFromLeaves builds a balanced single-elimination bracket from an
-// ordered slice of leaf labels. Labels may be resolved player names (live
-// playoffs) or pool-origin placeholders (preview bracket) — the tree shape,
-// court assignment, bye resolution, and scheduling are identical either way.
-// The caller persists the result (and sets Preview when appropriate).
+// ordered pow2 leaf array. Callers must provide a pow2-length slice produced
+// by helper.TreeToLeafArray (which mirrors the Excel bracket topology). Labels
+// may be resolved player names (live playoffs) or pool-origin placeholders
+// (preview bracket) — the tree shape, court assignment, bye resolution, and
+// scheduling are identical either way. The caller persists the result (and
+// sets Preview when appropriate).
 func (e *Engine) buildBracketFromLeaves(comp *state.Competition, leaves []string) (*state.Bracket, error) {
 	// NextPow2 ensures we have a balanced tree with enough slots
 	pow2 := helper.NextPow2(len(leaves))
@@ -187,6 +273,28 @@ func (e *Engine) buildBracketFromLeaves(comp *state.Competition, leaves []string
 			m := &bracket.Rounds[rIdx][mIdx]
 			if m.Status == state.MatchStatusCompleted {
 				e.propagateBracketWinner(bracket, rIdx, mIdx)
+			}
+		}
+	}
+
+	// Latent byes: when TreeToLeafArray clusters structural byes
+	// (e.g. 5 players → ["A","B","","","C","","D","E"]), a "" vs ""
+	// dead match propagates "" into a round where the other feeder is
+	// a real "Winner of…" placeholder. That match will auto-resolve at
+	// runtime but at generation time it looks Scheduled. Mark it
+	// Completed so the real-match count stays N-1.
+	for rIdx := range bracket.Rounds {
+		for mIdx := range bracket.Rounds[rIdx] {
+			m := &bracket.Rounds[rIdx][mIdx]
+			if m.Status != state.MatchStatusScheduled {
+				continue
+			}
+			aEmpty := m.SideA == ""
+			bEmpty := m.SideB == ""
+			aPlaceholder := strings.HasPrefix(m.SideA, "Winner of")
+			bPlaceholder := strings.HasPrefix(m.SideB, "Winner of")
+			if (aEmpty && bPlaceholder) || (bEmpty && aPlaceholder) {
+				m.Status = state.MatchStatusCompleted
 			}
 		}
 	}

--- a/internal/engine/bracket_identity_test.go
+++ b/internal/engine/bracket_identity_test.go
@@ -2,10 +2,12 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +16,6 @@ func makePlayers(n int) []domain.Player {
 	players := make([]domain.Player, n)
 	for i := range n {
 		players[i] = domain.Player{
-			ID:   fmt.Sprintf("p%d", i+1),
 			Name: fmt.Sprintf("Player%02d", i+1),
 		}
 	}
@@ -43,16 +44,66 @@ func excelPlayoffsLeaves(players []domain.Player) []string {
 	return helper.TreeToLeafArray(tree)
 }
 
-// enginePlayoffsLeaves mirrors what generatePlayoffs now does for standalone
-// (non-source-linked) playoffs — must produce the same result as the Excel path.
-func enginePlayoffsLeaves(players []domain.Player) []string {
-	seeded := helper.StandardSeeding(players)
-	names := make([]string, len(seeded))
-	for i, p := range seeded {
-		names[i] = p.Name
+// enginePlayoffsLeaves runs the REAL engine path (StartCompetition) and
+// extracts the round-0 leaf ordering from the generated bracket. This exercises
+// generatePlayoffs end-to-end so any drift in the engine path (seeding,
+// tree construction, leaf flattening, bye resolution) is caught.
+func enginePlayoffsLeaves(t *testing.T, players []domain.Player) []string {
+	t.Helper()
+	eng, store, _ := setupTestEngine(t)
+
+	compID := fmt.Sprintf("identity-%d", len(players))
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:        compID,
+		Format:    state.CompFormatPlayoffs,
+		Kind:      "individual",
+		Courts:    []string{"A"},
+		StartTime: "09:00",
+		Status:    state.CompStatusSetup,
+	}))
+	// Strip IDs before saving — players with non-UUID IDs confuse the CSV
+	// hasIDs detector and corrupt names on reload. Let the store mint UUIDs.
+	stripped := make([]domain.Player, len(players))
+	for i, p := range players {
+		stripped[i] = domain.Player{Name: p.Name, Dojo: p.Dojo}
 	}
-	tree := helper.CreateBalancedTree(names)
-	return helper.TreeToLeafArray(tree)
+	require.NoError(t, store.SaveParticipants(compID, stripped))
+	// Seeds are stored separately; extract from the player Seed field.
+	var seeds []domain.SeedAssignment
+	for _, p := range players {
+		if p.Seed > 0 {
+			seeds = append(seeds, domain.SeedAssignment{Name: p.Name, SeedRank: p.Seed})
+		}
+	}
+	if len(seeds) > 0 {
+		require.NoError(t, store.SaveSeeds(compID, seeds))
+	}
+	require.NoError(t, eng.StartCompetition(compID))
+
+	bracket, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	require.NotNil(t, bracket)
+	require.NotEmpty(t, bracket.Rounds)
+
+	// Round 0 is the first round (closest to leaves). Collect the two sides
+	// of every match in order — this reconstructs the pow2 leaf array.
+	pow2 := helper.NextPow2(len(players))
+	leaves := make([]string, pow2)
+	for i, m := range bracket.Rounds[0] {
+		sideA := m.SideA
+		sideB := m.SideB
+		// Strip "Winner of…" placeholders — those are non-leaf slots that arose
+		// from latent byes; treat them as "" (structural bye) for leaf comparison.
+		if strings.HasPrefix(sideA, "Winner of") {
+			sideA = ""
+		}
+		if strings.HasPrefix(sideB, "Winner of") {
+			sideB = ""
+		}
+		leaves[i*2] = sideA
+		leaves[i*2+1] = sideB
+	}
+	return leaves
 }
 
 func excelMixedLeaves(pools []helper.Pool, poolWinners int) []string {
@@ -62,11 +113,59 @@ func excelMixedLeaves(pools []helper.Pool, poolWinners int) []string {
 	return helper.TreeToLeafArray(tree)
 }
 
-func engineMixedLeaves(pools []helper.Pool, poolWinners int) []string {
-	finals := helper.GenerateFinals(pools, poolWinners)
-	tree := helper.CreateBalancedTree(finals)
-	helper.ApplyPoolAdjustments(tree)
-	return helper.TreeToLeafArray(tree)
+// engineMixedLeaves runs the REAL engine path (StartCompetition on a mixed
+// comp) and extracts the preview bracket's round-0 leaf ordering. This
+// exercises generatePoolPreviewBracket end-to-end.
+func engineMixedLeaves(t *testing.T, pools []helper.Pool, poolWinners int) []string {
+	t.Helper()
+	eng, store, _ := setupTestEngine(t)
+
+	compID := fmt.Sprintf("identity-mixed-%d-%d", len(pools), poolWinners)
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:           compID,
+		Format:       state.CompFormatMixed,
+		Kind:         "individual",
+		PoolSize:     2,
+		PoolSizeMode: "min",
+		PoolWinners:  poolWinners,
+		RoundRobin:   true,
+		Courts:       []string{"A"},
+		StartTime:    "09:00",
+		Status:       state.CompStatusSetup,
+	}))
+
+	// Populate one participant per pool slot so pools get created.
+	names := make([]string, len(pools)*2)
+	for i := range names {
+		names[i] = fmt.Sprintf("P%02d", i+1)
+	}
+	players := make([]domain.Player, len(names))
+	for i, n := range names {
+		players[i] = domain.Player{Name: n, Dojo: "D"}
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+	require.NoError(t, eng.StartCompetition(compID))
+
+	bracket, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	require.NotNil(t, bracket)
+	require.NotEmpty(t, bracket.Rounds)
+
+	totalFinalists := len(pools) * poolWinners
+	pow2 := helper.NextPow2(totalFinalists)
+	leaves := make([]string, pow2)
+	for i, m := range bracket.Rounds[0] {
+		sideA, sideB := m.SideA, m.SideB
+		if strings.HasPrefix(sideA, "Winner of") {
+			sideA = ""
+		}
+		if strings.HasPrefix(sideB, "Winner of") {
+			sideB = ""
+		}
+		leaves[i*2] = sideA
+		leaves[i*2+1] = sideB
+	}
+	return leaves
 }
 
 // TestBracketIdentity_PurePlayoffs verifies that the engine's generatePlayoffs
@@ -94,7 +193,7 @@ func TestBracketIdentity_PurePlayoffs(t *testing.T) {
 			players := makeSeededPlayers(tt.playerCount, tt.numSeeds)
 
 			excelLeaves := excelPlayoffsLeaves(players)
-			engineLeaves := enginePlayoffsLeaves(players)
+			engineLeaves := enginePlayoffsLeaves(t, players)
 
 			require.Equal(t, len(excelLeaves), len(engineLeaves),
 				"leaf array lengths must match")
@@ -139,7 +238,7 @@ func TestBracketIdentity_MixedComp(t *testing.T) {
 			}
 
 			excelLeaves := excelMixedLeaves(pools, tt.poolWinners)
-			engineLeaves := engineMixedLeaves(pools, tt.poolWinners)
+			engineLeaves := engineMixedLeaves(t, pools, tt.poolWinners)
 
 			require.Equal(t, len(excelLeaves), len(engineLeaves),
 				"leaf array lengths must match")

--- a/internal/engine/bracket_identity_test.go
+++ b/internal/engine/bracket_identity_test.go
@@ -1,0 +1,163 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makePlayers(n int) []domain.Player {
+	players := make([]domain.Player, n)
+	for i := range n {
+		players[i] = domain.Player{
+			ID:   fmt.Sprintf("p%d", i+1),
+			Name: fmt.Sprintf("Player%02d", i+1),
+		}
+	}
+	return players
+}
+
+func makeSeededPlayers(n, numSeeds int) []domain.Player {
+	players := makePlayers(n)
+	for i := range numSeeds {
+		if i < n {
+			players[i].Seed = i + 1
+		}
+	}
+	return players
+}
+
+// excelPlayoffsLeaves mirrors the Excel create-playoffs.go path:
+// StandardSeeding → extract names → CreateBalancedTree → TreeToLeafArray.
+func excelPlayoffsLeaves(players []domain.Player) []string {
+	seeded := helper.StandardSeeding(players)
+	names := make([]string, len(seeded))
+	for i, p := range seeded {
+		names[i] = p.Name
+	}
+	tree := helper.CreateBalancedTree(names)
+	return helper.TreeToLeafArray(tree)
+}
+
+// enginePlayoffsLeaves mirrors what generatePlayoffs now does for standalone
+// (non-source-linked) playoffs — must produce the same result as the Excel path.
+func enginePlayoffsLeaves(players []domain.Player) []string {
+	seeded := helper.StandardSeeding(players)
+	names := make([]string, len(seeded))
+	for i, p := range seeded {
+		names[i] = p.Name
+	}
+	tree := helper.CreateBalancedTree(names)
+	return helper.TreeToLeafArray(tree)
+}
+
+func excelMixedLeaves(pools []helper.Pool, poolWinners int) []string {
+	finals := helper.GenerateFinals(pools, poolWinners)
+	tree := helper.CreateBalancedTree(finals)
+	helper.ApplyPoolAdjustments(tree)
+	return helper.TreeToLeafArray(tree)
+}
+
+func engineMixedLeaves(pools []helper.Pool, poolWinners int) []string {
+	finals := helper.GenerateFinals(pools, poolWinners)
+	tree := helper.CreateBalancedTree(finals)
+	helper.ApplyPoolAdjustments(tree)
+	return helper.TreeToLeafArray(tree)
+}
+
+// TestBracketIdentity_PurePlayoffs verifies that the engine's generatePlayoffs
+// path produces leaf arrays identical to the Excel create-playoffs reference
+// for various roster sizes.
+func TestBracketIdentity_PurePlayoffs(t *testing.T) {
+	cases := []struct {
+		name        string
+		playerCount int
+		numSeeds    int
+	}{
+		{"5 players unseeded", 5, 0},
+		{"7 players unseeded", 7, 0},
+		{"8 players (pow2)", 8, 0},
+		{"12 players unseeded", 12, 0},
+		{"16 players (pow2)", 16, 0},
+		{"24 players unseeded", 24, 0},
+		{"8 players 4 seeds", 8, 4},
+		{"12 players 4 seeds", 12, 4},
+		{"24 players 8 seeds", 24, 8},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			players := makeSeededPlayers(tt.playerCount, tt.numSeeds)
+
+			excelLeaves := excelPlayoffsLeaves(players)
+			engineLeaves := enginePlayoffsLeaves(players)
+
+			require.Equal(t, len(excelLeaves), len(engineLeaves),
+				"leaf array lengths must match")
+			assert.Equal(t, excelLeaves, engineLeaves,
+				"engine leaves must be identical to Excel leaves")
+
+			assert.Equal(t, helper.NextPow2(tt.playerCount), len(engineLeaves),
+				"leaf array length must be NextPow2(N)")
+
+			realCount := 0
+			for _, v := range engineLeaves {
+				if v != "" {
+					realCount++
+				}
+			}
+			assert.Equal(t, tt.playerCount, realCount,
+				"non-empty slots must equal player count")
+		})
+	}
+}
+
+// TestBracketIdentity_MixedComp verifies that the engine's pool-preview path
+// produces leaf arrays identical to the Excel create-pools reference.
+func TestBracketIdentity_MixedComp(t *testing.T) {
+	cases := []struct {
+		name        string
+		poolNames   []string
+		poolWinners int
+	}{
+		{"2 pools 2 winners", []string{"Pool A", "Pool B"}, 2},
+		{"3 pools 2 winners", []string{"Pool A", "Pool B", "Pool C"}, 2},
+		{"4 pools 2 winners", []string{"Pool A", "Pool B", "Pool C", "Pool D"}, 2},
+		{"4 pools 3 winners", []string{"Pool A", "Pool B", "Pool C", "Pool D"}, 3},
+		{"6 pools 2 winners", []string{"Pool A", "Pool B", "Pool C", "Pool D", "Pool E", "Pool F"}, 2},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			pools := make([]helper.Pool, len(tt.poolNames))
+			for i, name := range tt.poolNames {
+				pools[i] = helper.Pool{PoolName: name}
+			}
+
+			excelLeaves := excelMixedLeaves(pools, tt.poolWinners)
+			engineLeaves := engineMixedLeaves(pools, tt.poolWinners)
+
+			require.Equal(t, len(excelLeaves), len(engineLeaves),
+				"leaf array lengths must match")
+			assert.Equal(t, excelLeaves, engineLeaves,
+				"engine leaves must be identical to Excel leaves")
+
+			totalFinalists := len(tt.poolNames) * tt.poolWinners
+			assert.Equal(t, helper.NextPow2(totalFinalists), len(engineLeaves),
+				"output length must be NextPow2(finalists)")
+
+			realCount := 0
+			for _, v := range engineLeaves {
+				if v != "" {
+					realCount++
+				}
+			}
+			assert.Equal(t, totalFinalists, realCount,
+				"non-empty slots must equal total finalists")
+		})
+	}
+}

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -670,7 +670,15 @@ func (e *Engine) runDrawPipeline(id string) error {
 		comp.SwissCurrentRound = 1
 		comp.Status = state.CompStatusDrawReady
 	default:
-		if err := e.generatePlayoffs(comp, players, seeds, rosterPopulated); err != nil {
+		// sourceLinked governs bracket topology: true → mirror pool-preview
+		// topology via buildSourceLinkedLeaves; false → standalone seeding.
+		// rosterPopulated covers the FIRST draw (roster was empty, just
+		// resolved). comp.RosterSourceResolved covers SUBSEQUENT draws after a
+		// DiscardDraw/GenerateDraw: roster is on disk but was auto-resolved, not
+		// manually set. A comp that has a SourceCompID but a manually-set roster
+		// (ExistingRosterNotClobbered test) has neither flag and uses standalone
+		// seeding — which is the intended behaviour for that case.
+		if err := e.generatePlayoffs(comp, players, seeds, rosterPopulated || comp.RosterSourceResolved); err != nil {
 			return err
 		}
 		comp.Status = state.CompStatusDrawReady
@@ -842,6 +850,16 @@ func (e *Engine) runDrawPipeline(id string) error {
 		// OLD non-UUID format. On next load, the HasIDs-hinted parser
 		// would misparse the file (UUID extraction on non-UUID rows).
 		// Deferral ensures the (flag, file) pair stays consistent.
+		//
+		// RosterSourceResolved marks that this comp's roster was built by
+		// resolving pool winners from SourceCompID, not manually. Set here
+		// (atomically with the Status commit) so a subsequent
+		// DiscardDraw/GenerateDraw replay sees the flag and keeps the
+		// source-linked bracket topology even though rosterPopulated will
+		// be false on re-entry (roster is already on disk).
+		if rosterPopulated {
+			current.RosterSourceResolved = true
+		}
 		return current, nil
 	})
 	if err != nil {

--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -670,7 +670,7 @@ func (e *Engine) runDrawPipeline(id string) error {
 		comp.SwissCurrentRound = 1
 		comp.Status = state.CompStatusDrawReady
 	default:
-		if err := e.generatePlayoffs(comp, players, seeds); err != nil {
+		if err := e.generatePlayoffs(comp, players, seeds, rosterPopulated); err != nil {
 			return err
 		}
 		comp.Status = state.CompStatusDrawReady

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -365,7 +365,12 @@ func TestStartCompetition_PlayoffsFormat_WithByes(t *testing.T) {
 	assert.Len(t, bracket.Rounds[1], 2) // 2 semifinal matches
 	assert.Len(t, bracket.Rounds[2], 1) // 1 final
 
-	// Bye matches (where at least one side is empty) should be auto-completed
+	// Bye matches (where at least one side is empty) should be auto-completed.
+	// Since mp-5ng7 the tree approach (StandardSeeding → CreateBalancedTree →
+	// TreeToLeafArray) mirrors the Excel bracket and clusters structural byes
+	// where the tree is asymmetric. For 5 players the leaf array is
+	// ["A","B","","","C","","D","E"] giving 1 double-bye and 1 single-bye in
+	// round 1. Both are Completed at generation time.
 	byeCount := 0
 	for _, m := range bracket.Rounds[0] {
 		if m.SideA == "" || m.SideB == "" {
@@ -373,19 +378,7 @@ func TestStartCompetition_PlayoffsFormat_WithByes(t *testing.T) {
 			assert.Equal(t, state.MatchStatusCompleted, m.Status)
 		}
 	}
-	// 5 players in 8 slots → 3 byes, distributed to the top 3 seeds (mp-sess), so
-	// exactly three first-round matches are player-vs-bye (one empty side each) and
-	// NONE is an empty-vs-empty double bye. (The old clustered behavior produced a
-	// double bye, so asserting doubleBye==0 — not just byeCount>=2 — is what
-	// actually pins the distribution.)
-	doubleBye := 0
-	for _, m := range bracket.Rounds[0] {
-		if m.SideA == "" && m.SideB == "" {
-			doubleBye++
-		}
-	}
-	assert.Equal(t, 0, doubleBye, "distributed byes must never pair two byes")
-	assert.Equal(t, 3, byeCount, "5 players → 3 single-bye first-round matches")
+	assert.Equal(t, 2, byeCount, "5 players → 2 bye matches (1 double + 1 single)")
 
 	// Matches with one real player and one bye should have a winner
 	for _, m := range bracket.Rounds[0] {

--- a/internal/engine/estimate_schedule_test.go
+++ b/internal/engine/estimate_schedule_test.go
@@ -460,9 +460,10 @@ func TestEstimateFinalistCount_UsesSourcePoolWinners(t *testing.T) {
 // bracketMatchCount returns the count of court-time-consuming bracket matches
 // (those NOT auto-marked Completed at generation time), not NextPow2(players)-1
 // (total slot count). Since mp-5ng7 the draw uses StandardSeeding +
-// CreateBalancedTree + TreeToLeafArray, placing structural byes so every bye
-// auto-resolves a single player-vs-bye match; the real count is the clean
-// single-elimination identity N-1 for every N.
+// CreateBalancedTree + TreeToLeafArray, clustering structural byes where the
+// tree is asymmetric. This produces "" vs "" double-bye slots and later-round
+// "" vs "Winner of…" latent byes — all auto-completed at generation time so
+// they do not consume court time. The real count remains the N-1 identity.
 //
 // The test runs the REAL draw pipeline via eng.StartCompetition, counts the
 // non-auto-resolved matches (Status != Completed at generation time), and

--- a/internal/engine/estimate_schedule_test.go
+++ b/internal/engine/estimate_schedule_test.go
@@ -459,9 +459,10 @@ func TestEstimateFinalistCount_UsesSourcePoolWinners(t *testing.T) {
 //
 // bracketMatchCount returns the count of court-time-consuming bracket matches
 // (those NOT auto-marked Completed at generation time), not NextPow2(players)-1
-// (total slot count). Since mp-sess the draw distributes byes to the top seeds
-// (StandardSeedingFull), so every bye auto-resolves a single player-vs-bye match
-// and the real count is the clean single-elimination identity N-1 for every N.
+// (total slot count). Since mp-5ng7 the draw uses StandardSeeding +
+// CreateBalancedTree + TreeToLeafArray, placing structural byes so every bye
+// auto-resolves a single player-vs-bye match; the real count is the clean
+// single-elimination identity N-1 for every N.
 //
 // The test runs the REAL draw pipeline via eng.StartCompetition, counts the
 // non-auto-resolved matches (Status != Completed at generation time), and

--- a/internal/helper/estimate.go
+++ b/internal/helper/estimate.go
@@ -234,13 +234,13 @@ func poolMatchesPerPool(size int, roundRobin bool, poolFormat string) int {
 // advanced for auto-resolved (Completed) matches, so they must NOT be counted
 // for duration estimation.
 //
-// This is exactly players-1 (for players >= 2). The playoffs draw seeds the
-// bracket with helper.StandardSeedingFull (mp-sess), which distributes the
-// NextPow2(players)-players byes to the top seeds so every bye sits opposite a
-// real player. Each bye therefore auto-resolves a single player-vs-bye leaf
-// match (Completed, court cursor not advanced) and there are NO both-empty
-// matches and no upstream "ghost" propagation. Of the NextPow2(players)-1 total
-// slots, exactly (NextPow2(players)-players) are auto-completed byes, leaving
+// This is exactly players-1 (for players >= 2). The playoffs draw uses
+// StandardSeeding + CreateBalancedTree + TreeToLeafArray (mp-5ng7), which
+// places structural byes in the tree so each bye sits opposite a real player.
+// Each bye therefore auto-resolves a single player-vs-bye leaf match
+// (Completed, court cursor not advanced) and there are NO both-empty matches
+// and no upstream "ghost" propagation. Of the NextPow2(players)-1 total slots,
+// exactly (NextPow2(players)-players) are auto-completed byes, leaving
 // NextPow2(players)-1 - (NextPow2(players)-players) = players-1 real matches —
 // the familiar single-elimination identity (every match eliminates one of N
 // competitors; N-1 eliminations crown a winner).

--- a/internal/helper/estimate.go
+++ b/internal/helper/estimate.go
@@ -236,14 +236,13 @@ func poolMatchesPerPool(size int, roundRobin bool, poolFormat string) int {
 //
 // This is exactly players-1 (for players >= 2). The playoffs draw uses
 // StandardSeeding + CreateBalancedTree + TreeToLeafArray (mp-5ng7), which
-// places structural byes in the tree so each bye sits opposite a real player.
-// Each bye therefore auto-resolves a single player-vs-bye leaf match
-// (Completed, court cursor not advanced) and there are NO both-empty matches
-// and no upstream "ghost" propagation. Of the NextPow2(players)-1 total slots,
-// exactly (NextPow2(players)-players) are auto-completed byes, leaving
-// NextPow2(players)-1 - (NextPow2(players)-players) = players-1 real matches —
-// the familiar single-elimination identity (every match eliminates one of N
-// competitors; N-1 eliminations crown a winner).
+// embeds the tree's structural byes into a pow2 leaf array. Byes are clustered
+// where the tree is asymmetric, so some first-round slots are "" vs "" (double
+// byes) and later rounds can have a "" vs "Winner of…" latent bye. All such
+// slots are auto-completed at generation time (Status=Completed) and do not
+// advance the court cursor, so they do not consume court time. The identity
+// still holds: every real match eliminates one of N competitors, so N-1
+// eliminations crown a winner regardless of where byes cluster.
 //
 // Returns 0 for zero or one player (no real match can be played).
 func bracketMatchCount(players int) int {

--- a/internal/helper/estimate_test.go
+++ b/internal/helper/estimate_test.go
@@ -67,13 +67,12 @@ func TestEstimateMatchCounts_PoolMatchCountPerPoolSize(t *testing.T) {
 // actually CONSUME COURT TIME (i.e., Status != Completed at generation time),
 // not the total slot count NextPow2(players)-1.
 //
-// Since mp-5ng7, generatePlayoffs seeds the draw with StandardSeeding +
-// CreateBalancedTree + TreeToLeafArray, which places structural byes so every
-// bye sits opposite a real player. Each bye therefore auto-resolves a single player-vs-bye leaf
-// match (pre-marked Completed; the court cursor is not advanced for it in
-// assignBracketMatchSlots), and there are NO both-empty matches or upstream
-// "ghost" propagation. The court-time count is thus the clean single-elimination
-// identity: exactly N-1 for N >= 2 (each match eliminates one of N competitors).
+// Since mp-5ng7, generatePlayoffs uses StandardSeeding + CreateBalancedTree +
+// TreeToLeafArray, which clusters structural byes where the tree is asymmetric.
+// This can produce "" vs "" double-bye slots and later-round "" vs "Winner of…"
+// latent byes. All such slots are auto-completed at generation time (Status=
+// Completed) and do not advance the court cursor. The court-time count is
+// therefore the clean single-elimination identity: exactly N-1 for N >= 2.
 func TestEstimateMatchCounts_BracketMatchCount(t *testing.T) {
 	tests := []struct {
 		players int

--- a/internal/helper/estimate_test.go
+++ b/internal/helper/estimate_test.go
@@ -67,9 +67,9 @@ func TestEstimateMatchCounts_PoolMatchCountPerPoolSize(t *testing.T) {
 // actually CONSUME COURT TIME (i.e., Status != Completed at generation time),
 // not the total slot count NextPow2(players)-1.
 //
-// Since mp-sess, generatePlayoffs seeds the draw with StandardSeedingFull, which
-// distributes the NextPow2(N)-N byes to the top seeds so every bye sits opposite
-// a real player. Each bye therefore auto-resolves a single player-vs-bye leaf
+// Since mp-5ng7, generatePlayoffs seeds the draw with StandardSeeding +
+// CreateBalancedTree + TreeToLeafArray, which places structural byes so every
+// bye sits opposite a real player. Each bye therefore auto-resolves a single player-vs-bye leaf
 // match (pre-marked Completed; the court cursor is not advanced for it in
 // assignBracketMatchSlots), and there are NO both-empty matches or upstream
 // "ghost" propagation. The court-time count is thus the clean single-elimination

--- a/internal/helper/excel.go
+++ b/internal/helper/excel.go
@@ -358,7 +358,7 @@ func printSinglePool(f *excelize.File, sheetName string, pool Pool, startCol int
 		// the rank-N IFERROR(INDEX(...MATCH(N,...))) cell directly so the
 		// resolved player name flows into the tree.
 		if rankNum <= numWinners {
-			matchWinners[fmt.Sprintf("%s-%s", pool.PoolName, getOrdinal(rankNum))] = MatchWinner{
+			matchWinners[fmt.Sprintf("%s-%s", pool.PoolName, GetOrdinal(rankNum))] = MatchWinner{
 				cellCoord: cellCoord{sheetName: sheetName, cell: fmt.Sprintf("%s%d", resNameColName, rankRow)},
 			}
 		}

--- a/internal/helper/excel_ranking_test.go
+++ b/internal/helper/excel_ranking_test.go
@@ -240,7 +240,7 @@ func TestPoolWinnerCellsPointToRankingFormulas(t *testing.T) {
 			// that resolves the player name — NOT at a blank cell past the
 			// ranking block.
 			for rank := 1; rank <= numWinners; rank++ {
-				key := fmt.Sprintf("Pool A-%s", getOrdinal(rank))
+				key := fmt.Sprintf("Pool A-%s", GetOrdinal(rank))
 				mw, ok := matchWinners[key]
 				require.True(t, ok, "matchWinners[%q] missing", key)
 

--- a/internal/helper/tree.go
+++ b/internal/helper/tree.go
@@ -156,7 +156,7 @@ func GenerateFinals(pools []Pool, poolWinners int) []string {
 	finalists := make([][]string, len(pools))
 	for i := 0; i < len(pools); i++ {
 		for j := 0; j < poolWinners; j++ {
-			finalists[i] = append(finalists[i], fmt.Sprintf("%s-%s", pools[i].PoolName, getOrdinal(j+1)))
+			finalists[i] = append(finalists[i], fmt.Sprintf("%s-%s", pools[i].PoolName, GetOrdinal(j+1)))
 		}
 	}
 
@@ -251,6 +251,44 @@ func SubdivideTree(node *Node, numSubtrees int) []*Node {
 	return subtrees
 }
 
+// TreeToLeafArray converts a tree built by CreateBalancedTree into a
+// power-of-two leaf array suitable for buildBracketFromLeaves. Internal nodes
+// recurse into left and right subtrees, padding each side to
+// NextPow2(max(len(left), len(right))) with "" (bye slots) before
+// concatenating. The result length is always NextPow2(N) where N is the
+// number of real leaves, and bye positions mirror the tree's structural
+// asymmetry so the same matchups produced by the Excel bracket are reproduced.
+func TreeToLeafArray(node *Node) []string {
+	if node == nil {
+		return nil
+	}
+	if node.LeafNode {
+		return []string{node.LeafVal}
+	}
+	left := TreeToLeafArray(node.Left)
+	right := TreeToLeafArray(node.Right)
+	target := NextPow2(max(len(left), len(right)))
+	for len(left) < target {
+		left = append(left, "")
+	}
+	for len(right) < target {
+		right = append(right, "")
+	}
+	return append(left, right...)
+}
+
+// ApplyPoolAdjustments applies the same pre-order treeAdjustment traversal
+// that PrintLeafNodes performs when pools=true. Use before TreeToLeafArray
+// to reproduce the pool-finalist ordering the Excel bracket applies.
+func ApplyPoolAdjustments(node *Node) {
+	if node == nil || node.LeafNode {
+		return
+	}
+	treeAdjustment(node)
+	ApplyPoolAdjustments(node.Left)
+	ApplyPoolAdjustments(node.Right)
+}
+
 func RoundToPowerOf2(x, y float64) (int, error) {
 	if y == 0 {
 		return 0, fmt.Errorf("divisor cannot be zero")
@@ -303,7 +341,7 @@ func TreePageLayout(numPlayers, numCourts int, singleTree bool) (int, error) {
 	return numPages, nil
 }
 
-func getOrdinal(n int) string {
+func GetOrdinal(n int) string {
 	if n <= 0 {
 		return strconv.Itoa(n)
 	}

--- a/internal/helper/tree_test.go
+++ b/internal/helper/tree_test.go
@@ -1003,7 +1003,7 @@ func TestGenerateFinalsEdgeCases(t *testing.T) {
 					t.Errorf("Expected 5 finalists, got %d", len(finalists))
 				}
 				for i := range 5 {
-					expected := fmt.Sprintf("Pool X-%s", getOrdinal(i+1))
+					expected := fmt.Sprintf("Pool X-%s", GetOrdinal(i+1))
 					if finalists[i] != expected {
 						t.Errorf("Position %d: expected %s, got %s", i, expected, finalists[i])
 					}
@@ -1166,15 +1166,112 @@ func TestPrintLeafNodesEdgeCases(t *testing.T) {
 	}
 }
 
-// applyTreeAdjustments replicates the pre-order traversal that PrintLeafNodes
-// performs when pools=true, calling treeAdjustment at each non-leaf node.
-func applyTreeAdjustments(node *Node) {
-	if node == nil || node.LeafNode {
-		return
+func TestTreeToLeafArray(t *testing.T) {
+	makeLeaves := func(names ...string) []string { return names }
+	makeLabels := func(n int) []string {
+		out := make([]string, n)
+		for i := range n {
+			out[i] = string(rune('A' + i))
+		}
+		return out
 	}
-	treeAdjustment(node)
-	applyTreeAdjustments(node.Left)
-	applyTreeAdjustments(node.Right)
+
+	cases := []struct {
+		name      string
+		input     []string
+		wantLen   int
+		wantSlots []string // nil means "don't check exact slots, just length + non-empty count"
+		wantReal  int      // number of non-empty slots
+	}{
+		{
+			name:      "1 leaf",
+			input:     makeLeaves("A"),
+			wantLen:   1,
+			wantSlots: []string{"A"},
+			wantReal:  1,
+		},
+		{
+			name:      "2 leaves",
+			input:     makeLeaves("A", "B"),
+			wantLen:   2,
+			wantSlots: []string{"A", "B"},
+			wantReal:  2,
+		},
+		{
+			name:  "3 leaves — A gets bye",
+			input: makeLeaves("A", "B", "C"),
+			// CreateBalancedTree splits [A] left, [B,C] right
+			// left → ["A"], right → ["B","C"]
+			// pad left to NextPow2(max(1,2))=2 → ["A",""]
+			// result: ["A","","B","C"]
+			wantLen:   4,
+			wantSlots: []string{"A", "", "B", "C"},
+			wantReal:  3,
+		},
+		{
+			name:     "4 leaves — identity",
+			input:    makeLeaves("A", "B", "C", "D"),
+			wantLen:  4,
+			wantReal: 4,
+		},
+		{
+			name:     "5 leaves",
+			input:    makeLabels(5),
+			wantLen:  8,
+			wantReal: 5,
+		},
+		{
+			name:     "7 leaves",
+			input:    makeLabels(7),
+			wantLen:  8,
+			wantReal: 7,
+		},
+		{
+			name:     "8 leaves — identity",
+			input:    makeLabels(8),
+			wantLen:  8,
+			wantReal: 8,
+		},
+		{
+			name:     "12 leaves",
+			input:    makeLabels(12),
+			wantLen:  16,
+			wantReal: 12,
+		},
+		{
+			name:     "24 leaves",
+			input:    makeLabels(24),
+			wantLen:  32,
+			wantReal: 24,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := CreateBalancedTree(tt.input)
+			got := TreeToLeafArray(tree)
+
+			assert.Len(t, got, tt.wantLen, "output length must be NextPow2(N)")
+
+			realCount := 0
+			for _, v := range got {
+				if v != "" {
+					realCount++
+				}
+			}
+			assert.Equal(t, tt.wantReal, realCount, "non-empty slot count must equal input count")
+
+			if tt.wantSlots != nil {
+				assert.Equal(t, tt.wantSlots, got, "exact slot layout")
+			}
+		})
+	}
+}
+
+// applyTreeAdjustments delegates to the exported ApplyPoolAdjustments so
+// test helpers stay in sync with the production traversal.
+func applyTreeAdjustments(node *Node) {
+	ApplyPoolAdjustments(node)
 }
 
 func leafPool(val string) string {

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -294,9 +294,17 @@ type Competition struct {
 	// starts with an empty roster on disk; StartCompetition resolves the
 	// source's final pool winners into the roster at draw time (see
 	// engine.resolvePoolWinners). Empty for all other competitions.
-	SourceCompID         string `yaml:"source_comp_id,omitempty" json:"sourceCompID,omitempty"`
-	PoolMatchDuration    int    `yaml:"pool_match_duration,omitempty" json:"poolMatchDuration,omitempty"`
-	PlayoffMatchDuration int    `yaml:"playoff_match_duration,omitempty" json:"playoffMatchDuration,omitempty"`
+	SourceCompID string `yaml:"source_comp_id,omitempty" json:"sourceCompID,omitempty"`
+	// RosterSourceResolved is set to true by the draw pipeline the first
+	// time it auto-resolves pool winners into this playoffs competition's
+	// roster (engine.StartCompetition, rosterPopulated branch). On a
+	// DiscardDraw/GenerateDraw retry the roster is already on disk so
+	// rosterPopulated would be false, but the bracket topology must still
+	// mirror the pool preview — this flag is the durable signal that the
+	// roster was source-resolved and not manually set.
+	RosterSourceResolved bool `yaml:"roster_source_resolved,omitempty" json:"rosterSourceResolved,omitempty"`
+	PoolMatchDuration    int  `yaml:"pool_match_duration,omitempty" json:"poolMatchDuration,omitempty"`
+	PlayoffMatchDuration int  `yaml:"playoff_match_duration,omitempty" json:"playoffMatchDuration,omitempty"`
 	// MaxEnchoPeriods caps how many encho (overtime) periods one match
 	// may run before the operator must call daihyosen. Zero means
 	// unlimited (FIK general default). T104, CHK029.


### PR DESCRIPTION
## Summary

- Engine bracket generation now uses the same code path as the Excel reference: `StandardSeeding → CreateBalancedTree → TreeToLeafArray`, so the mobile app and the printed Excel bracket produce byte-identical draws for the same competition.
- New `TreeToLeafArray` helper embeds an unbalanced binary tree into a power-of-two leaf array, preserving matchup topology and bye placement from the tree structure. The existing viewer renders it unchanged.
- Pool-preview brackets and source-linked playoffs sub-competitions also aligned via `ApplyPoolAdjustments` + `TreeToLeafArray`, matching the Excel pool-finals path.

## Why

Three code paths (Excel print, engine preview, engine live) built elimination brackets independently, producing different bye placement and matchup ordering for the same roster. A tournament printed from Excel and run through the mobile app would have different draws — a P1 bug for tournament integrity.

Root cause: `StandardSeedingFull` (engine) interleaved byes into a pow2 array, while the Excel path used an unbalanced tree with structural byes. These are fundamentally different bracket topologies.

## Files changed

| File | What |
|---|---|
| `internal/helper/tree.go` | Add `TreeToLeafArray`, `ApplyPoolAdjustments`; export `GetOrdinal` |
| `internal/helper/tree_test.go` | Unit tests for `TreeToLeafArray` (9 cases); delegate `applyTreeAdjustments` to exported fn |
| `internal/engine/bracket.go` | Rewrite `generatePlayoffs` standalone path; new `buildSourceLinkedLeaves`; pool-preview via tree; latent bye detection |
| `internal/engine/competition.go` | Pass `rosterPopulated` flag to `generatePlayoffs` |
| `internal/engine/bracket_identity_test.go` | New cross-check tests: engine vs Excel leaf arrays for playoffs + mixed comps |
| `internal/engine/engine_test.go` | Update `TestStartCompetition_PlayoffsFormat_WithByes` for tree-based bye clustering |
| `internal/engine/estimate_schedule_test.go` | Update comments to reference new path |
| `internal/helper/estimate.go` | Update `bracketMatchCount` doc comment |
| `internal/helper/estimate_test.go` | Update `StandardSeedingFull` references |
| `internal/helper/excel.go` | `getOrdinal` → `GetOrdinal` |
| `internal/helper/excel_ranking_test.go` | `getOrdinal` → `GetOrdinal` |

## Screenshots

5-player knockout bracket (public viewer → Bracket tab). Quarterfinals: Alice vs Bob (Court A, real), empty vs empty (auto-completed dead match, Court A), Charlie vs bye (auto-completed, Court B), Dave vs Eve (Court B, real). Semifinals: Winner of r3-m0 vs empty (latent bye, auto-completed), Charlie vs Winner of r3-m3 (real). Final: both semifinal winners. Real match count = N-1 = 4.

![5-player knockout bracket](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/241/bracket.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change
  - `TestTreeToLeafArray` — 9 cases (1,2,3,4,5,7,8,12,24 leaves): length = NextPow2(N), non-empty count = N
  - `TestBracketIdentity_PurePlayoffs` — engine == Excel for 5,7,8,12,16,24 players ± seeds
  - `TestBracketIdentity_MixedComp` — engine == Excel for 2–6 pools × 2–3 winners
  - `TestEstimateMatchCounts_vs_RealPlayoffsDraw` — real draw count == N-1 estimate for 4,5,8,12,16 players
  - Updated `TestStartCompetition_PlayoffsFormat_WithByes` for tree-based bye clustering
- [x] Manual browser verification — created 5-player knockout via mobile app, started competition, verified bracket renders with correct structure (screenshot above)
- [x] No new console errors or warnings (only pre-existing "not found" on initial tournament load)
- [x] `make examples` — Excel output unchanged (Excel path untouched)

Closes mp-5ng7

🤖 Generated with [Claude Code](https://claude.com/claude-code)