### PR TITLE
feat(mp-4dmr): admin All Winners summary across competitions

### DIFF
--- a/web-mobile/js/__tests__/admin_all_winners.test.jsx
+++ b/web-mobile/js/__tests__/admin_all_winners.test.jsx
@@ -29,6 +29,10 @@ function findAll(node, pred) {
 
 // ── module setup / teardown ───────────────────────────────────────────────────
 
+// Every global this suite stubs lives here so beforeAll can snapshot the prior
+// value and afterAll can restore (or delete) it — otherwise stubs like
+// window.API / window.deriveAwards leak into later suites and cause
+// order-dependent flakes.
 const STUBBED_GLOBALS = {
   pluralize: (n, s, p) => `${n} ${n === 1 ? s : (p || `${s}s`)}`,
   formatLabelShort: (f) => f,
@@ -36,6 +40,15 @@ const STUBBED_GLOBALS = {
   competitionKindLabel: (c) => c.kind === 'team' ? 'Teams' : 'Individual',
   StatusBadge: function StatusBadge() { return null; },
   formatAdminHeaderSub: () => '',
+  useEscapeToClose: vi.fn(),
+  API: {
+    fetchCompetitionDetails: vi.fn(),
+    swissStandings: vi.fn(),
+  },
+  // Real viewer helpers so resolveCompetitionAwards works correctly.
+  deriveAwards,
+  bracketHasDecidedFinal,
+  resolveCompetitionAwards,
 };
 const originalGlobals = {};
 
@@ -48,18 +61,6 @@ beforeAll(async () => {
     originalGlobals[key] = { had: key in window, value: window[key] };
     window[key] = stub;
   }
-
-  // Stub window.API and window.deriveAwards before the module loads.
-  window.API = {
-    fetchCompetitionDetails: vi.fn(),
-    swissStandings: vi.fn(),
-  };
-  window.useEscapeToClose = vi.fn();
-
-  // Expose the real viewer helpers so resolveCompetitionAwards works correctly.
-  window.deriveAwards = deriveAwards;
-  window.bracketHasDecidedFinal = bracketHasDecidedFinal;
-  window.resolveCompetitionAwards = resolveCompetitionAwards;
 
   await import('../admin_shell.jsx');
 });

--- a/web-mobile/js/__tests__/admin_all_winners.test.jsx
+++ b/web-mobile/js/__tests__/admin_all_winners.test.jsx
@@ -1,0 +1,260 @@
+// Tests for the "All winners" admin summary: buildAllWinners helper and
+// AllWinnersModal component (both exported to window by admin_shell.jsx).
+//
+// The component is tested via the static React-stub (non-reactive), which
+// means useState returns the initial value; we therefore test the loading
+// state from the vnode and the async aggregation logic separately via
+// buildAllWinners.
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+// ── tree helpers ─────────────────────────────────────────────────────────────
+
+function collectText(node) {
+  if (node == null || node === false || node === true) return '';
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children !== undefined) return collectText(node.children);
+  return '';
+}
+
+function findAll(node, pred) {
+  if (!node || typeof node !== 'object') return [];
+  const acc = Array.isArray(node) ? [] : (pred(node) ? [node] : []);
+  const kids = Array.isArray(node) ? node : (node.children ?? []);
+  for (const k of kids) acc.push(...findAll(k, pred));
+  return acc;
+}
+
+// ── module setup / teardown ───────────────────────────────────────────────────
+
+const STUBBED_GLOBALS = {
+  pluralize: (n, s, p) => `${n} ${n === 1 ? s : (p || `${s}s`)}`,
+  formatLabelShort: (f) => f,
+  formatDate: (d) => d,
+  competitionKindLabel: (c) => c.kind === 'team' ? 'Teams' : 'Individual',
+  StatusBadge: function StatusBadge() { return null; },
+  formatAdminHeaderSub: () => '',
+};
+const originalGlobals = {};
+
+// buildAllWinners and AllWinnersModal are loaded with admin_shell.jsx import.
+// They are also exposed on window so we can test them without remounting
+// the full AdminDashboard.
+
+beforeAll(async () => {
+  for (const [key, stub] of Object.entries(STUBBED_GLOBALS)) {
+    originalGlobals[key] = { had: key in window, value: window[key] };
+    window[key] = stub;
+  }
+
+  // Stub window.API and window.deriveAwards before the module loads.
+  window.API = {
+    fetchCompetitionDetails: vi.fn(),
+    swissStandings: vi.fn(),
+  };
+  window.useEscapeToClose = vi.fn();
+
+  // Stub deriveAwards — tests for the real function are in viewer_awards.test.jsx.
+  window.deriveAwards = vi.fn((bracket, standings, _pools, _nameToPlayer) => {
+    // Minimal fixture behaviour: return bracket-based podium if bracket has a winner,
+    // otherwise first-4 from standings array.
+    if (bracket && bracket.rounds) {
+      const finalRound = bracket.rounds[bracket.rounds.length - 1];
+      const final = finalRound && finalRound[0];
+      if (final && final.winner) {
+        const sfRound = bracket.rounds[bracket.rounds.length - 2] || [];
+        const thirds = sfRound.map((m) => m.winner === m.sideA ? m.sideB : m.sideA).filter(Boolean);
+        return [
+          { place: 1, name: final.winner, dojo: '' },
+          { place: 2, name: final.winner === final.sideA ? final.sideB : final.sideA, dojo: '' },
+          ...thirds.map((t) => ({ place: 3, name: t, dojo: '' })),
+        ];
+      }
+    }
+    if (Array.isArray(standings) && standings.length > 0) {
+      return standings.slice(0, 4).map((s, i) => ({
+        place: i < 3 ? i + 1 : 3,
+        name: s.player?.name || '',
+        dojo: s.player?.dojo || '',
+      })).filter((e) => e.name);
+    }
+    return [];
+  });
+
+  await import('../admin_shell.jsx');
+});
+
+afterAll(() => {
+  for (const [key, orig] of Object.entries(originalGlobals)) {
+    if (orig.had) window[key] = orig.value;
+    else delete window[key];
+  }
+});
+
+// ── buildAllWinners ───────────────────────────────────────────────────────────
+
+describe('buildAllWinners', () => {
+  it('is exported to window', () => {
+    expect(typeof window.buildAllWinners).toBe('function');
+  });
+
+  it('returns podium for a knockout competition with 4 placings (two 3rds)', async () => {
+    const bracket = {
+      rounds: [
+        [
+          { sideA: 'Alice', sideB: 'Bob', winner: 'Alice' },
+          { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' },
+        ],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+      ],
+    };
+    const comp = { id: 'ko-1', name: 'Knockout', format: 'playoffs-only', status: 'completed', players: [] };
+    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, config: comp, players: [] });
+
+    const results = await window.buildAllWinners([comp], {
+      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].comp.id).toBe('ko-1');
+    // The stub deriveAwards returns the champion + runner-up + two thirds
+    expect(results[0].podium[0].place).toBe(1);
+    expect(results[0].podium[1].place).toBe(2);
+    expect(results[0].podium[2].place).toBe(3);
+    expect(results[0].podium[3].place).toBe(3);
+    expect(results[0].podium).toHaveLength(4);
+  });
+
+  it('returns podium for a pool/standings competition with distinct 3rd and 4th', async () => {
+    const standings = [
+      { player: { name: 'Alice', dojo: 'Aoyama' } },
+      { player: { name: 'Bob', dojo: 'Bunkyo' } },
+      { player: { name: 'Carol', dojo: 'Chiba' } },
+      { player: { name: 'Dan', dojo: 'Denenchofu' } },
+    ];
+    const comp = { id: 'pool-1', name: 'Pools', format: 'pools-and-playoffs', status: 'completed', players: [] };
+    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings, pools: [{ poolName: 'Pool A' }], config: comp, players: [] });
+
+    const results = await window.buildAllWinners([comp], {
+      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    const podium = results[0].podium;
+    // standings-based: places 1,2,3,3 (last two are both 3 per deriveAwards logic)
+    expect(podium[2].place).toBe(3);
+    expect(podium[3].place).toBe(3);
+    // names are distinct
+    expect(podium[2].name).toBe('Carol');
+    expect(podium[3].name).toBe('Dan');
+  });
+
+  it('excludes non-completed competitions (caller is responsible for pre-filtering)', async () => {
+    // buildAllWinners only receives the comps the caller passes — the
+    // filtering (status === "completed") happens in the component; here we
+    // verify buildAllWinners faithfully processes whatever it receives.
+    const comp = { id: 'running-1', name: 'In Progress', format: 'playoffs-only', status: 'pools', players: [] };
+    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: comp, players: [] });
+
+    // Caller passes only completed comps — if we pass none the result is empty.
+    const results = await window.buildAllWinners([], {
+      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+      swissStandings: null,
+    });
+    expect(results).toHaveLength(0);
+    expect(window.API.fetchCompetitionDetails).not.toHaveBeenCalled();
+  });
+
+  it('fetches swissStandings for swiss-format competitions and passes them to deriveAwards', async () => {
+    const swissStandingsData = [
+      { player: { name: 'Kenji', dojo: 'Kendo Club' } },
+      { player: { name: 'Hiro', dojo: 'Musashi Dojo' } },
+    ];
+    const comp = { id: 'swiss-1', name: 'Swiss', format: 'swiss', status: 'completed', players: [] };
+    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: { format: 'swiss' }, players: [] });
+    const mockSwissStandings = vi.fn().mockResolvedValue(swissStandingsData);
+
+    const deriveAwardsSpy = vi.fn().mockReturnValue([{ place: 1, name: 'Kenji', dojo: 'Kendo Club' }]);
+    const origDerive = window.deriveAwards;
+    window.deriveAwards = deriveAwardsSpy;
+
+    try {
+      await window.buildAllWinners([comp], {
+        fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+        swissStandings: mockSwissStandings,
+      });
+      expect(mockSwissStandings).toHaveBeenCalledWith('swiss-1');
+      // deriveAwards should have been called with the swiss standings array
+      expect(deriveAwardsSpy).toHaveBeenCalledWith(
+        null,
+        swissStandingsData,
+        null,
+        expect.any(Map)
+      );
+    } finally {
+      window.deriveAwards = origDerive;
+    }
+  });
+
+  it('returns error field when fetchCompetitionDetails throws, without rejecting the whole Promise', async () => {
+    const comp = { id: 'err-1', name: 'Broken', format: 'playoffs-only', status: 'completed', players: [] };
+    window.API.fetchCompetitionDetails = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const results = await window.buildAllWinners([comp], {
+      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].podium).toEqual([]);
+    expect(results[0].error).toBe('Network error');
+  });
+});
+
+// ── AllWinnersModal component ─────────────────────────────────────────────────
+
+describe('AllWinnersModal', () => {
+  it('is exported to window', () => {
+    expect(typeof window.AllWinnersModal).toBe('function');
+  });
+
+  it('renders without throwing', () => {
+    expect(() => window.AllWinnersModal({
+      comps: [],
+      onClose: vi.fn(),
+    })).not.toThrow();
+  });
+
+  it('renders the modal title', () => {
+    const vnode = window.AllWinnersModal({ comps: [], onClose: vi.fn() });
+    const text = collectText(vnode);
+    expect(text).toContain('All winners');
+  });
+
+  it('shows loading state initially (useState returns initial value in static stub)', () => {
+    const comp = { id: 'c1', name: 'Open', status: 'completed', format: 'playoffs-only', players: [] };
+    const vnode = window.AllWinnersModal({ comps: [comp], onClose: vi.fn() });
+    const text = collectText(vnode);
+    // Initial state is loading:true — should render loading text
+    expect(text).toContain('Loading results');
+  });
+
+  it('renders a Close button', () => {
+    const vnode = window.AllWinnersModal({ comps: [], onClose: vi.fn() });
+    const btns = findAll(vnode, (n) => n.type === 'button');
+    const closeBtn = btns.find((b) => collectText(b).includes('Close'));
+    expect(closeBtn).toBeDefined();
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    const vnode = window.AllWinnersModal({ comps: [], onClose });
+    const btns = findAll(vnode, (n) => n.type === 'button');
+    const closeBtn = btns.find((b) => collectText(b).includes('Close'));
+    closeBtn.props.onClick();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/web-mobile/js/__tests__/admin_all_winners.test.jsx
+++ b/web-mobile/js/__tests__/admin_all_winners.test.jsx
@@ -6,6 +6,7 @@
 // state from the vnode and the async aggregation logic separately via
 // buildAllWinners.
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { bracketHasDecidedFinal, resolveCompetitionAwards, deriveAwards } from '../viewer.jsx';
 
 // ── tree helpers ─────────────────────────────────────────────────────────────
 
@@ -55,32 +56,10 @@ beforeAll(async () => {
   };
   window.useEscapeToClose = vi.fn();
 
-  // Stub deriveAwards — tests for the real function are in viewer_awards.test.jsx.
-  window.deriveAwards = vi.fn((bracket, standings, _pools, _nameToPlayer) => {
-    // Minimal fixture behaviour: return bracket-based podium if bracket has a winner,
-    // otherwise first-4 from standings array.
-    if (bracket && bracket.rounds) {
-      const finalRound = bracket.rounds[bracket.rounds.length - 1];
-      const final = finalRound && finalRound[0];
-      if (final && final.winner) {
-        const sfRound = bracket.rounds[bracket.rounds.length - 2] || [];
-        const thirds = sfRound.map((m) => m.winner === m.sideA ? m.sideB : m.sideA).filter(Boolean);
-        return [
-          { place: 1, name: final.winner, dojo: '' },
-          { place: 2, name: final.winner === final.sideA ? final.sideB : final.sideA, dojo: '' },
-          ...thirds.map((t) => ({ place: 3, name: t, dojo: '' })),
-        ];
-      }
-    }
-    if (Array.isArray(standings) && standings.length > 0) {
-      return standings.slice(0, 4).map((s, i) => ({
-        place: i < 3 ? i + 1 : 3,
-        name: s.player?.name || '',
-        dojo: s.player?.dojo || '',
-      })).filter((e) => e.name);
-    }
-    return [];
-  });
+  // Expose the real viewer helpers so resolveCompetitionAwards works correctly.
+  window.deriveAwards = deriveAwards;
+  window.bracketHasDecidedFinal = bracketHasDecidedFinal;
+  window.resolveCompetitionAwards = resolveCompetitionAwards;
 
   await import('../admin_shell.jsx');
 });
@@ -99,7 +78,7 @@ describe('buildAllWinners', () => {
     expect(typeof window.buildAllWinners).toBe('function');
   });
 
-  it('returns podium for a knockout competition with 4 placings (two 3rds)', async () => {
+  it('returns podium for a standalone knockout competition with 4 placings (two 3rds)', async () => {
     const bracket = {
       rounds: [
         [
@@ -109,17 +88,18 @@ describe('buildAllWinners', () => {
         [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
       ],
     };
-    const comp = { id: 'ko-1', name: 'Knockout', format: 'playoffs-only', status: 'completed', players: [] };
-    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, config: comp, players: [] });
+    const comp = { id: 'ko-1', name: 'Knockout', format: 'playoffs', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, config: comp, players: [] });
 
-    const results = await window.buildAllWinners([comp], {
-      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+    const results = await window.buildAllWinners([comp], [comp], {
+      fetchCompetitionDetails,
       swissStandings: null,
     });
 
     expect(results).toHaveLength(1);
     expect(results[0].comp.id).toBe('ko-1');
-    // The stub deriveAwards returns the champion + runner-up + two thirds
+    expect(results[0].state).toBe('final');
+    // deriveAwards returns champion + runner-up + two thirds
     expect(results[0].podium[0].place).toBe(1);
     expect(results[0].podium[1].place).toBe(2);
     expect(results[0].podium[2].place).toBe(3);
@@ -127,45 +107,91 @@ describe('buildAllWinners', () => {
     expect(results[0].podium).toHaveLength(4);
   });
 
-  it('returns podium for a pool/standings competition with distinct 3rd and 4th', async () => {
+  it('filters out linked playoffs comp (sourceCompID set) — state "skip"', async () => {
+    const mixedComp = { id: 'mixed-1', name: 'Pools+KO', format: 'mixed', status: 'completed' };
+    const playoffComp = { id: 'po-1', name: 'Playoffs', format: 'playoffs', sourceCompID: 'mixed-1', status: 'completed' };
+    const allComps = [mixedComp, playoffComp];
+    const bracket = {
+      rounds: [
+        [{ sideA: 'Alice', sideB: 'Bob', winner: 'Alice' }, { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' }],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+      ],
+    };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, players: [] });
+
+    // Pass both completed comps; the playoffs shell should be filtered (skip)
+    const results = await window.buildAllWinners([mixedComp, playoffComp], allComps, {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    // playoffComp (linked shell) must be filtered out; mixedComp resolved to final
+    expect(results.find(r => r.comp.id === 'po-1')).toBeUndefined();
+    expect(results.find(r => r.comp.id === 'mixed-1')).toBeDefined();
+    const mixedResult = results.find(r => r.comp.id === 'mixed-1');
+    expect(mixedResult.state).toBe('final');
+    expect(mixedResult.podium).toHaveLength(4);
+    expect(mixedResult.podium[2].place).toBe(3);
+    expect(mixedResult.podium[3].place).toBe(3);
+  });
+
+  it('mixed comp whose linked playoffs final is undecided → state "in-progress", podium []', async () => {
+    const mixedComp = { id: 'mixed-2', name: 'Pools+KO', format: 'mixed', status: 'completed' };
+    const playoffComp = { id: 'po-2', name: 'Playoffs', format: 'playoffs', sourceCompID: 'mixed-2', status: 'playoffs' };
+    const allComps = [mixedComp, playoffComp];
+    // undecided final
+    const bracket = {
+      rounds: [
+        [{ sideA: 'Alice', sideB: 'Bob', winner: 'Alice' }, { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' }],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: null }],
+      ],
+    };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, players: [] });
+
+    const results = await window.buildAllWinners([mixedComp], allComps, {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].state).toBe('in-progress');
+    expect(results[0].podium).toEqual([]);
+  });
+
+  it('returns podium for a pool/standings competition (league format)', async () => {
     const standings = [
       { player: { name: 'Alice', dojo: 'Aoyama' } },
       { player: { name: 'Bob', dojo: 'Bunkyo' } },
       { player: { name: 'Carol', dojo: 'Chiba' } },
       { player: { name: 'Dan', dojo: 'Denenchofu' } },
     ];
-    const comp = { id: 'pool-1', name: 'Pools', format: 'pools-and-playoffs', status: 'completed', players: [] };
-    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings, pools: [{ poolName: 'Pool A' }], config: comp, players: [] });
+    const comp = { id: 'league-1', name: 'League', format: 'league', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings, pools: [{ poolName: 'Pool A' }], config: comp, players: [] });
 
-    const results = await window.buildAllWinners([comp], {
-      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+    const results = await window.buildAllWinners([comp], [comp], {
+      fetchCompetitionDetails,
       swissStandings: null,
     });
 
     expect(results).toHaveLength(1);
     const podium = results[0].podium;
-    // standings-based: places 1,2,3,3 (last two are both 3 per deriveAwards logic)
+    expect(podium[0].name).toBe('Alice');
+    expect(podium[1].name).toBe('Bob');
     expect(podium[2].place).toBe(3);
     expect(podium[3].place).toBe(3);
-    // names are distinct
-    expect(podium[2].name).toBe('Carol');
-    expect(podium[3].name).toBe('Dan');
   });
 
   it('excludes non-completed competitions (caller is responsible for pre-filtering)', async () => {
-    // buildAllWinners only receives the comps the caller passes — the
-    // filtering (status === "completed") happens in the component; here we
-    // verify buildAllWinners faithfully processes whatever it receives.
-    const comp = { id: 'running-1', name: 'In Progress', format: 'playoffs-only', status: 'pools', players: [] };
-    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: comp, players: [] });
+    const comp = { id: 'running-1', name: 'In Progress', format: 'playoffs', status: 'pools', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: comp, players: [] });
 
     // Caller passes only completed comps — if we pass none the result is empty.
-    const results = await window.buildAllWinners([], {
-      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+    const results = await window.buildAllWinners([], [comp], {
+      fetchCompetitionDetails,
       swissStandings: null,
     });
     expect(results).toHaveLength(0);
-    expect(window.API.fetchCompetitionDetails).not.toHaveBeenCalled();
+    expect(fetchCompetitionDetails).not.toHaveBeenCalled();
   });
 
   it('fetches swissStandings for swiss-format competitions and passes them to deriveAwards', async () => {
@@ -174,37 +200,25 @@ describe('buildAllWinners', () => {
       { player: { name: 'Hiro', dojo: 'Musashi Dojo' } },
     ];
     const comp = { id: 'swiss-1', name: 'Swiss', format: 'swiss', status: 'completed', players: [] };
-    window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: { format: 'swiss' }, players: [] });
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: { format: 'swiss' }, players: [] });
     const mockSwissStandings = vi.fn().mockResolvedValue(swissStandingsData);
 
-    const deriveAwardsSpy = vi.fn().mockReturnValue([{ place: 1, name: 'Kenji', dojo: 'Kendo Club' }]);
-    const origDerive = window.deriveAwards;
-    window.deriveAwards = deriveAwardsSpy;
-
-    try {
-      await window.buildAllWinners([comp], {
-        fetchCompetitionDetails: window.API.fetchCompetitionDetails,
-        swissStandings: mockSwissStandings,
-      });
-      expect(mockSwissStandings).toHaveBeenCalledWith('swiss-1');
-      // deriveAwards should have been called with the swiss standings array
-      expect(deriveAwardsSpy).toHaveBeenCalledWith(
-        null,
-        swissStandingsData,
-        null,
-        expect.any(Map)
-      );
-    } finally {
-      window.deriveAwards = origDerive;
-    }
+    const results = await window.buildAllWinners([comp], [comp], {
+      fetchCompetitionDetails,
+      swissStandings: mockSwissStandings,
+    });
+    expect(mockSwissStandings).toHaveBeenCalledWith('swiss-1');
+    expect(results[0].state).toBe('final');
+    // standings-based: Kenji is 1st
+    expect(results[0].podium[0].name).toBe('Kenji');
   });
 
   it('returns error field when fetchCompetitionDetails throws, without rejecting the whole Promise', async () => {
-    const comp = { id: 'err-1', name: 'Broken', format: 'playoffs-only', status: 'completed', players: [] };
-    window.API.fetchCompetitionDetails = vi.fn().mockRejectedValue(new Error('Network error'));
+    const comp = { id: 'err-1', name: 'Broken', format: 'playoffs', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const results = await window.buildAllWinners([comp], {
-      fetchCompetitionDetails: window.API.fetchCompetitionDetails,
+    const results = await window.buildAllWinners([comp], [comp], {
+      fetchCompetitionDetails,
       swissStandings: null,
     });
 
@@ -235,7 +249,7 @@ describe('AllWinnersModal', () => {
   });
 
   it('shows loading state initially (useState returns initial value in static stub)', () => {
-    const comp = { id: 'c1', name: 'Open', status: 'completed', format: 'playoffs-only', players: [] };
+    const comp = { id: 'c1', name: 'Open', status: 'completed', format: 'playoffs', players: [] };
     const vnode = window.AllWinnersModal({ comps: [comp], onClose: vi.fn() });
     const text = collectText(vnode);
     // Initial state is loading:true — should render loading text

--- a/web-mobile/js/__tests__/resolve_awards.test.jsx
+++ b/web-mobile/js/__tests__/resolve_awards.test.jsx
@@ -1,0 +1,220 @@
+// Tests for bracketHasDecidedFinal and resolveCompetitionAwards (viewer.jsx).
+// These helpers are the single source of truth for mixed→linked-playoffs
+// podium resolution.
+import { describe, it, expect, vi } from 'vitest';
+import { bracketHasDecidedFinal, resolveCompetitionAwards } from '../viewer.jsx';
+
+// ── bracketHasDecidedFinal ────────────────────────────────────────────────────
+
+describe('bracketHasDecidedFinal', () => {
+  it('returns true when the last round has a decided final', () => {
+    const bracket = {
+      rounds: [
+        [{ sideA: 'A', sideB: 'B', winner: 'A' }],
+        [{ sideA: 'A', sideB: 'C', winner: 'A' }],
+      ],
+    };
+    expect(bracketHasDecidedFinal(bracket)).toBe(true);
+  });
+
+  it('returns false when the final winner is null/empty', () => {
+    const bracket = {
+      rounds: [
+        [{ sideA: 'A', sideB: 'B', winner: 'A' }],
+        [{ sideA: 'A', sideB: 'C', winner: null }],
+      ],
+    };
+    expect(bracketHasDecidedFinal(bracket)).toBe(false);
+  });
+
+  it('returns false when the final winner is empty string', () => {
+    const bracket = {
+      rounds: [[{ sideA: 'A', sideB: 'B', winner: '' }]],
+    };
+    expect(bracketHasDecidedFinal(bracket)).toBe(false);
+  });
+
+  it('returns false for empty rounds array', () => {
+    expect(bracketHasDecidedFinal({ rounds: [] })).toBe(false);
+  });
+
+  it('returns false for null bracket', () => {
+    expect(bracketHasDecidedFinal(null)).toBe(false);
+  });
+
+  it('returns false for undefined bracket', () => {
+    expect(bracketHasDecidedFinal(undefined)).toBe(false);
+  });
+
+  it('returns true with normalized object winner', () => {
+    const bracket = {
+      rounds: [
+        [{ sideA: { id: 'a', name: 'Alice' }, sideB: { id: 'b', name: 'Bob' }, winner: { id: 'a', name: 'Alice' } }],
+      ],
+    };
+    expect(bracketHasDecidedFinal(bracket)).toBe(true);
+  });
+});
+
+// ── resolveCompetitionAwards ──────────────────────────────────────────────────
+
+// Build a minimal decided bracket fixture.
+function decidedBracket() {
+  return {
+    rounds: [
+      [
+        { sideA: 'Alice', sideB: 'Bob', winner: 'Alice' },
+        { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' },
+      ],
+      [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+    ],
+  };
+}
+
+function undecidedBracket() {
+  return {
+    rounds: [
+      [{ sideA: 'Alice', sideB: 'Bob', winner: 'Alice' }, { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' }],
+      [{ sideA: 'Alice', sideB: 'Carol', winner: null }],
+    ],
+  };
+}
+
+describe('resolveCompetitionAwards', () => {
+  // ── mixed → final (two 3rds) ──────────────────────────────────────────────
+  it('mixed comp with decided linked-playoffs final → state "final", podium has two 3rds', async () => {
+    const mixedComp = { id: 'mixed-1', format: 'mixed' };
+    const playoffComp = { id: 'po-1', format: 'playoffs', sourceCompID: 'mixed-1' };
+    const allComps = [mixedComp, playoffComp];
+    const bracket = decidedBracket();
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket, players: [] }),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(mixedComp, allComps, fetchers);
+
+    expect(result.state).toBe('final');
+    expect(result.podium).toHaveLength(4);
+    expect(result.podium[0]).toMatchObject({ place: 1, name: 'Alice' });
+    expect(result.podium[1]).toMatchObject({ place: 2, name: 'Carol' });
+    expect(result.podium[2]).toMatchObject({ place: 3 });
+    expect(result.podium[3]).toMatchObject({ place: 3 });
+    // Verify it fetches the linked PLAYOFF comp, not the mixed comp itself
+    expect(fetchers.fetchCompetitionDetails).toHaveBeenCalledWith('po-1');
+  });
+
+  // ── mixed → in-progress (knockout not decided) ────────────────────────────
+  it('mixed comp with undecided linked-playoffs final → state "in-progress", podium []', async () => {
+    const mixedComp = { id: 'mixed-2', format: 'mixed' };
+    const playoffComp = { id: 'po-2', format: 'playoffs', sourceCompID: 'mixed-2' };
+    const allComps = [mixedComp, playoffComp];
+    const bracket = undecidedBracket();
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket, players: [] }),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(mixedComp, allComps, fetchers);
+
+    expect(result.state).toBe('in-progress');
+    expect(result.podium).toEqual([]);
+  });
+
+  // ── mixed → in-progress (no linked playoff comp yet) ─────────────────────
+  it('mixed comp with no linked playoffs comp → state "in-progress", podium []', async () => {
+    const mixedComp = { id: 'mixed-3', format: 'mixed' };
+    const allComps = [mixedComp]; // no playoffs comp yet
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn(),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(mixedComp, allComps, fetchers);
+
+    expect(result.state).toBe('in-progress');
+    expect(result.podium).toEqual([]);
+    expect(fetchers.fetchCompetitionDetails).not.toHaveBeenCalled();
+  });
+
+  // ── standalone playoffs → final ───────────────────────────────────────────
+  it('standalone playoffs comp with decided final → state "final", podium has two 3rds', async () => {
+    const comp = { id: 'ko-1', format: 'playoffs' }; // no sourceCompID
+    const allComps = [comp];
+    const bracket = decidedBracket();
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket, players: [] }),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+
+    expect(result.state).toBe('final');
+    expect(result.podium).toHaveLength(4);
+    expect(result.podium[0]).toMatchObject({ place: 1, name: 'Alice' });
+    expect(result.podium[2]).toMatchObject({ place: 3 });
+    expect(result.podium[3]).toMatchObject({ place: 3 });
+  });
+
+  // ── linked playoffs shell → skip ──────────────────────────────────────────
+  it('playoffs comp with sourceCompID → state "skip", podium []', async () => {
+    const comp = { id: 'po-99', format: 'playoffs', sourceCompID: 'mixed-99' };
+    const allComps = [comp];
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn(),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+
+    expect(result.state).toBe('skip');
+    expect(result.podium).toEqual([]);
+    expect(fetchers.fetchCompetitionDetails).not.toHaveBeenCalled();
+  });
+
+  // ── league (standings-based) → final ─────────────────────────────────────
+  it('league comp → state "final", standings-based podium', async () => {
+    const comp = { id: 'league-1', format: 'league' };
+    const allComps = [comp];
+    const standings = {
+      'Pool A': [
+        { player: { name: 'Alice', dojo: 'Aoyama' } },
+        { player: { name: 'Bob', dojo: 'Bunkyo' } },
+        { player: { name: 'Carol', dojo: 'Chiba' } },
+        { player: { name: 'Dan', dojo: 'Denenchofu' } },
+      ],
+    };
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket: null, standings, pools: [{ poolName: 'Pool A' }], players: [] }),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+
+    expect(result.state).toBe('final');
+    expect(result.podium).toHaveLength(4);
+    expect(result.podium[0]).toMatchObject({ place: 1, name: 'Alice' });
+    expect(result.podium[3]).toMatchObject({ place: 3, name: 'Dan' });
+  });
+
+  // ── swiss (standings via dedicated endpoint) → final ─────────────────────
+  it('swiss comp → calls swissStandings endpoint and returns standings-based podium', async () => {
+    const comp = { id: 'swiss-1', format: 'swiss' };
+    const allComps = [comp];
+    const swissData = [
+      { player: { name: 'Kenji', dojo: 'Club A' } },
+      { player: { name: 'Hiro', dojo: 'Club B' } },
+    ];
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, players: [] }),
+      swissStandings: vi.fn().mockResolvedValue(swissData),
+    };
+
+    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+
+    expect(result.state).toBe('final');
+    expect(fetchers.swissStandings).toHaveBeenCalledWith('swiss-1');
+    expect(result.podium[0]).toMatchObject({ place: 1, name: 'Kenji' });
+    expect(result.podium[1]).toMatchObject({ place: 2, name: 'Hiro' });
+  });
+});

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -120,48 +120,27 @@ const PLACE_STYLE_ADMIN = {
   3: { icon: "🥉", label: "3rd" },
 };
 
-// buildAllWinners fetches full competition details for each completed comp,
-// calls window.deriveAwards, and returns a Promise resolving to an array of
-// { comp, podium } objects.  Exported as a pure function so it can be unit-
-// tested without mounting a component.
-async function buildAllWinners(completedComps, fetchers) {
-  const { fetchCompetitionDetails, swissStandings } = fetchers;
+// buildAllWinners resolves podium for each completed comp using the shared
+// resolveCompetitionAwards helper (handles mixed→linked-playoffs rule).
+// Signature: buildAllWinners(completedComps, allComps, fetchers)
+// Returns a Promise resolving to an array of { comp, state, podium } objects,
+// with results whose state === "skip" filtered out (linked playoffs shells).
+async function buildAllWinners(completedComps, allComps, fetchers) {
   const results = await Promise.all(
     completedComps.map(async (comp) => {
       try {
-        const detail = await fetchCompetitionDetails(comp.id);
-        const { bracket, standings, pools, config } = detail;
-
-        // For swiss competitions the detail payload does not include standings —
-        // those live behind a separate endpoint.
-        let resolvedStandings = standings;
-        if ((config || comp).format === "swiss" && swissStandings) {
-          try {
-            resolvedStandings = await swissStandings(comp.id);
-          } catch (_) {
-            resolvedStandings = standings;
-          }
-        }
-
-        // Build nameToPlayer from the competition's player list so bracket
-        // entries get dojo enrichment — mirrors AwardsView in viewer.jsx.
-        const nameToPlayer = new Map();
-        (detail.players || comp.players || []).forEach((p) => {
-          if (p && p.name) nameToPlayer.set(p.name, p);
-        });
-
-        const podium = window.deriveAwards(bracket, resolvedStandings, pools, nameToPlayer);
-        return { comp, podium };
+        const { state, podium } = await window.resolveCompetitionAwards(comp, allComps, fetchers);
+        return { comp, state, podium };
       } catch (err) {
-        return { comp, podium: [], error: err.message };
+        return { comp, state: "error", podium: [], error: err.message };
       }
     })
   );
-  return results;
+  return results.filter((r) => r.state !== "skip");
 }
 
 // AllWinnersModal renders a summary of every completed competition with its
-// podium placings, computed via window.deriveAwards.
+// podium placings, computed via window.resolveCompetitionAwards.
 function AllWinnersModal({ comps, onClose }) {
   const completed = (comps || []).filter((c) => c.status === "completed");
   const [state, setState] = useStateA({ loading: true, results: [], error: null });
@@ -170,7 +149,7 @@ function AllWinnersModal({ comps, onClose }) {
 
   useEffectA(() => {
     let cancelled = false;
-    buildAllWinners(completed, {
+    buildAllWinners(completed, comps, {
       fetchCompetitionDetails: window.API.fetchCompetitionDetails.bind(window.API),
       swissStandings: window.API.swissStandings ? window.API.swissStandings.bind(window.API) : null,
     }).then((results) => {
@@ -198,7 +177,7 @@ function AllWinnersModal({ comps, onClose }) {
           {!state.loading && !state.error && state.results.length === 0 && (
             <div style={{ color: "var(--ink-3)", padding: "8px 0" }}>No completed competitions.</div>
           )}
-          {!state.loading && state.results.map(({ comp, podium, error: compErr }) => (
+          {!state.loading && state.results.map(({ comp, state: compState, podium, error: compErr }) => (
             <div key={comp.id} className="card" style={{ padding: "12px 16px" }}>
               <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                 <div style={{ fontWeight: 700, fontSize: 15 }}>{comp.name}</div>
@@ -209,7 +188,10 @@ function AllWinnersModal({ comps, onClose }) {
               {compErr && (
                 <div style={{ fontSize: 13, color: "var(--red)" }}>Could not load results: {compErr}</div>
               )}
-              {!compErr && podium.length === 0 && (
+              {!compErr && compState === "in-progress" && podium.length === 0 && (
+                <div style={{ fontSize: 13, color: "var(--ink-3)" }}>Knockout in progress</div>
+              )}
+              {!compErr && compState !== "in-progress" && podium.length === 0 && (
                 <div style={{ fontSize: 13, color: "var(--ink-3)" }}>No results yet</div>
               )}
               {!compErr && podium.length > 0 && (

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -132,7 +132,7 @@ async function buildAllWinners(completedComps, allComps, fetchers) {
         const { state, podium } = await window.resolveCompetitionAwards(comp, allComps, fetchers);
         return { comp, state, podium };
       } catch (err) {
-        return { comp, state: "error", podium: [], error: err.message };
+        return { comp, state: "error", podium: [], error: err?.message || String(err) };
       }
     })
   );
@@ -164,7 +164,7 @@ function AllWinnersModal({ comps, onClose }) {
     }).then((results) => {
       if (!cancelled) setState({ loading: false, results, error: null });
     }).catch((err) => {
-      if (!cancelled) setState({ loading: false, results: [], error: err.message });
+      if (!cancelled) setState({ loading: false, results: [], error: err?.message || String(err) });
     });
     return () => { cancelled = true; };
   }, [compsSig]);

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -112,10 +112,137 @@ function initialSectionFor(status) {
   return "overview";
 }
 
+// PLACE_STYLE: icons and labels for podium places 1/2/3.
+// Replicated locally from viewer.jsx (PLACE_STYLE is not exported to window).
+const PLACE_STYLE_ADMIN = {
+  1: { icon: "🏆", label: "1st" },
+  2: { icon: "🥈", label: "2nd" },
+  3: { icon: "🥉", label: "3rd" },
+};
+
+// buildAllWinners fetches full competition details for each completed comp,
+// calls window.deriveAwards, and returns a Promise resolving to an array of
+// { comp, podium } objects.  Exported as a pure function so it can be unit-
+// tested without mounting a component.
+async function buildAllWinners(completedComps, fetchers) {
+  const { fetchCompetitionDetails, swissStandings } = fetchers;
+  const results = await Promise.all(
+    completedComps.map(async (comp) => {
+      try {
+        const detail = await fetchCompetitionDetails(comp.id);
+        const { bracket, standings, pools, config } = detail;
+
+        // For swiss competitions the detail payload does not include standings —
+        // those live behind a separate endpoint.
+        let resolvedStandings = standings;
+        if ((config || comp).format === "swiss" && swissStandings) {
+          try {
+            resolvedStandings = await swissStandings(comp.id);
+          } catch (_) {
+            resolvedStandings = standings;
+          }
+        }
+
+        // Build nameToPlayer from the competition's player list so bracket
+        // entries get dojo enrichment — mirrors AwardsView in viewer.jsx.
+        const nameToPlayer = new Map();
+        (detail.players || comp.players || []).forEach((p) => {
+          if (p && p.name) nameToPlayer.set(p.name, p);
+        });
+
+        const podium = window.deriveAwards(bracket, resolvedStandings, pools, nameToPlayer);
+        return { comp, podium };
+      } catch (err) {
+        return { comp, podium: [], error: err.message };
+      }
+    })
+  );
+  return results;
+}
+
+// AllWinnersModal renders a summary of every completed competition with its
+// podium placings, computed via window.deriveAwards.
+function AllWinnersModal({ comps, onClose }) {
+  const completed = (comps || []).filter((c) => c.status === "completed");
+  const [state, setState] = useStateA({ loading: true, results: [], error: null });
+
+  window.useEscapeToClose(onClose);
+
+  useEffectA(() => {
+    let cancelled = false;
+    buildAllWinners(completed, {
+      fetchCompetitionDetails: window.API.fetchCompetitionDetails.bind(window.API),
+      swissStandings: window.API.swissStandings ? window.API.swissStandings.bind(window.API) : null,
+    }).then((results) => {
+      if (!cancelled) setState({ loading: false, results, error: null });
+    }).catch((err) => {
+      if (!cancelled) setState({ loading: false, results: [], error: err.message });
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" style={{ maxWidth: 640, width: "95%" }} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="All winners">
+        <div className="modal__head">
+          <div className="modal__title">🏅 All winners</div>
+          <button className="modal__close" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+        <div className="modal__body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {state.loading && (
+            <div style={{ textAlign: "center", color: "var(--ink-3)", padding: "24px 0" }}>Loading results…</div>
+          )}
+          {!state.loading && state.error && (
+            <div style={{ color: "var(--red)", padding: "8px 0" }}>Failed to load results: {state.error}</div>
+          )}
+          {!state.loading && !state.error && state.results.length === 0 && (
+            <div style={{ color: "var(--ink-3)", padding: "8px 0" }}>No completed competitions.</div>
+          )}
+          {!state.loading && state.results.map(({ comp, podium, error: compErr }) => (
+            <div key={comp.id} className="card" style={{ padding: "12px 16px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                <div style={{ fontWeight: 700, fontSize: 15 }}>{comp.name}</div>
+                <div style={{ fontSize: 12, color: "var(--ink-3)", background: "var(--surface-2, #f0f0f0)", borderRadius: 4, padding: "1px 6px" }}>
+                  {window.competitionKindLabel(comp)}
+                </div>
+              </div>
+              {compErr && (
+                <div style={{ fontSize: 13, color: "var(--red)" }}>Could not load results: {compErr}</div>
+              )}
+              {!compErr && podium.length === 0 && (
+                <div style={{ fontSize: 13, color: "var(--ink-3)" }}>No results yet</div>
+              )}
+              {!compErr && podium.length > 0 && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                  {podium.map((entry, idx) => {
+                    const style = PLACE_STYLE_ADMIN[entry.place] || PLACE_STYLE_ADMIN[3];
+                    return (
+                      <div key={idx} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 14 }}>
+                        <span style={{ fontSize: 16, minWidth: 22 }}>{style.icon}</span>
+                        <span style={{ fontWeight: 600, minWidth: 32, color: "var(--ink-3)", fontSize: 12 }}>{style.label}</span>
+                        <span style={{ fontWeight: 600 }}>{entry.name}</span>
+                        {entry.dojo && <span style={{ color: "var(--ink-3)", fontSize: 13 }}>{entry.dojo}</span>}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="modal__foot">
+          <button className="btn" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompetition, onEditTournament, onAnnounce, onOpenSchedule, onOpenScoreEditor, onOpenImport, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate, showToast }) {
   const t = tournament;
   const comps = t.competitions || [];
   const [exportPdfOpen, setExportPdfOpen] = useStateA(false);
+  const [allWinnersOpen, setAllWinnersOpen] = useStateA(false);
 
   useEffectA(() => {
     // Coalesce bursts of events into a single dashboard refresh. On a busy
@@ -197,6 +324,9 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
           <div className="page-head__actions">
             <button className="btn" onClick={onAnnounce}>📣 Announce</button>
             <button className="btn" onClick={() => setExportPdfOpen(true)}>🖨 Export PDFs</button>
+            {comps.some(c => c.status === "completed") && (
+              <button className="btn" onClick={() => setAllWinnersOpen(true)}>🏅 All winners</button>
+            )}
             <button className="btn" onClick={onEditTournament}>Edit details</button>
             {comps.some(c => c.status === "setup" && (c.players || []).length >= 2) && (
               <button className="btn btn--danger" onClick={onStartAll}>Start all</button>
@@ -253,6 +383,12 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
           password={password}
           showToast={showToast}
           onClose={() => setExportPdfOpen(false)}
+        />
+      )}
+      {allWinnersOpen && (
+        <AllWinnersModal
+          comps={comps}
+          onClose={() => setAllWinnersOpen(false)}
         />
       )}
     </div>
@@ -515,3 +651,5 @@ window.AdminDashboard = AdminDashboard;
 window.CompCard = CompCard;
 window.CourtPicker = CourtPicker;
 window.ExportPdfModal = ExportPdfModal;
+window.AllWinnersModal = AllWinnersModal;
+window.buildAllWinners = buildAllWinners;

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -123,8 +123,9 @@ const PLACE_STYLE_ADMIN = {
 // buildAllWinners resolves podium for each completed comp using the shared
 // resolveCompetitionAwards helper (handles mixed→linked-playoffs rule).
 // Signature: buildAllWinners(completedComps, allComps, fetchers)
-// Returns a Promise resolving to an array of { comp, state, podium } objects,
-// with results whose state === "skip" filtered out (linked playoffs shells).
+// Returns a Promise resolving to an array of { comp, state, podium } objects
+// (plus an `error` string field when state === "error"), with results whose
+// state === "skip" filtered out (linked playoffs shells).
 async function buildAllWinners(completedComps, allComps, fetchers) {
   const results = await Promise.all(
     completedComps.map(async (comp) => {

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -147,8 +147,17 @@ function AllWinnersModal({ comps, onClose }) {
 
   window.useEscapeToClose(onClose);
 
+  // Stable signature of every comp's id:status. A pools+knockout podium can
+  // change without the *completed* set changing — e.g. a mixed comp is already
+  // completed (pools done) while its linked playoffs comp finishes its final.
+  // Keying the effect on all comps' statuses makes the open modal refetch when
+  // any competition completes or its knockout resolves, rather than showing
+  // stale results.
+  const compsSig = (comps || []).map((c) => `${c.id}:${c.status}`).join("|");
+
   useEffectA(() => {
     let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
     buildAllWinners(completed, comps, {
       fetchCompetitionDetails: window.API.fetchCompetitionDetails.bind(window.API),
       swissStandings: window.API.swissStandings ? window.API.swissStandings.bind(window.API) : null,
@@ -158,7 +167,7 @@ function AllWinnersModal({ comps, onClose }) {
       if (!cancelled) setState({ loading: false, results: [], error: err.message });
     });
     return () => { cancelled = true; };
-  }, []);
+  }, [compsSig]);
 
   return (
     <div className="modal-backdrop" onClick={onClose}>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -3202,7 +3202,7 @@ function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp, 
         if (!cancelled) setKoAwards({ state: "in-progress", awards: [] });
       });
     return () => { cancelled = true; };
-  }, [c?.id, c?.format, linkedPlayoffComp?.id]);
+  }, [c?.id, c?.format, linkedPlayoffComp?.id, linkedPlayoffComp?.status]);
 
   const nameToPlayer = useMemo(() => {
     const m = new Map();

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -3081,8 +3081,9 @@ async function resolveCompetitionAwards(comp, allComps, fetchers) {
     return m;
   };
   if (fmt === "mixed") {
-    const playoff = (allComps || []).find((p) => p && p.sourceCompID === comp.id);
-    if (!playoff) return { state: "in-progress", podium: [] };
+    const matchingPlayoffs = (allComps || []).filter((p) => p && p.sourceCompID === comp.id);
+    if (matchingPlayoffs.length !== 1) return { state: "in-progress", podium: [] };
+    const playoff = matchingPlayoffs[0];
     const pd = await fetchers.fetchCompetitionDetails(playoff.id);
     if (bracketHasDecidedFinal(pd.bracket)) {
       return { state: "final", podium: deriveAwards(pd.bracket, null, null, ntpFrom(pd.players)) };
@@ -3097,7 +3098,7 @@ async function resolveCompetitionAwards(comp, allComps, fetchers) {
     if (bracketHasDecidedFinal(d.bracket)) {
       return { state: "final", podium: deriveAwards(d.bracket, null, null, ntpFrom(d.players)) };
     }
-    return { state: "none", podium: [] };
+    return { state: "in-progress", podium: [] };
   }
   // league / swiss (and any standings-based) → standings
   const d = await fetchers.fetchCompetitionDetails(comp.id);
@@ -3141,26 +3142,21 @@ function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp }
     return () => { cancelled = true; };
   }, [c?.id, c?.format, c?.swissCurrentRound]);
 
-  // For mixed (pools+knockout) comps, fetch the linked playoffs bracket to get
-  // the true podium (1/2/3/3 from the knockout final+semis).
+  // For mixed (pools+knockout) comps, delegate to resolveCompetitionAwards so
+  // this view and the All Winners modal share the same resolver (no drift).
   React.useEffect(() => {
     if (!isMixed) return;
     setKoAwards(undefined);
-    if (!linkedPlayoffComp || !window.API?.fetchCompetitionDetails) {
+    if (!window.resolveCompetitionAwards || !window.API?.fetchCompetitionDetails) {
       setKoAwards({ state: "in-progress", awards: [] });
       return;
     }
     let cancelled = false;
-    window.API.fetchCompetitionDetails(linkedPlayoffComp.id)
-      .then((pd) => {
-        if (cancelled) return;
-        if (window.bracketHasDecidedFinal(pd.bracket)) {
-          const ntp = new Map();
-          (pd.players || []).forEach((p) => { if (p && p.name) ntp.set(p.name, p); });
-          setKoAwards({ state: "final", awards: window.deriveAwards(pd.bracket, null, null, ntp) });
-        } else {
-          setKoAwards({ state: "in-progress", awards: [] });
-        }
+    const syntheticAllComps = linkedPlayoffComp ? [linkedPlayoffComp] : [];
+    const fetchers = { fetchCompetitionDetails: window.API.fetchCompetitionDetails, swissStandings: null };
+    window.resolveCompetitionAwards(c, syntheticAllComps, fetchers)
+      .then(({ state, podium }) => {
+        if (!cancelled) setKoAwards({ state, awards: podium });
       })
       .catch(() => {
         if (!cancelled) setKoAwards({ state: "in-progress", awards: [] });

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -3052,6 +3052,7 @@ function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp }
   // the true podium (1/2/3/3 from the knockout final+semis).
   React.useEffect(() => {
     if (!isMixed) return;
+    setKoAwards(undefined);
     if (!linkedPlayoffComp || !window.API?.fetchCompetitionDetails) {
       setKoAwards({ state: "in-progress", awards: [] });
       return;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1860,7 +1860,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             // actual winners; when the final has no winner yet, deriveAwards
             // explicitly falls through to the standings-based path rather
             // than short-circuiting.
-            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} />
+            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} linkedPlayoffComp={linkedComp && linkedComp.role === "playoffs" ? linkedComp.comp : null} />
           )}
         </div>
       </div>
@@ -2657,7 +2657,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -2666,6 +2666,8 @@ if (typeof window !== 'undefined') {
     window.buildPlayerMatchHighlight = buildPlayerMatchHighlight;
     window.buildWatchlistUpcoming = buildWatchlistUpcoming;
     window.deriveAwards = deriveAwards;
+    window.bracketHasDecidedFinal = bracketHasDecidedFinal;
+    window.resolveCompetitionAwards = resolveCompetitionAwards;
     window.addDojoToWatchlist = addDojoToWatchlist;
 }
 
@@ -2961,20 +2963,75 @@ function deriveAwards(bracket, standings, pools, nameToPlayer) {
   return [];
 }
 
+// bracketHasDecidedFinal: true iff the bracket's last round has a decided final.
+function bracketHasDecidedFinal(bracket) {
+  if (!bracket || !bracket.rounds || bracket.rounds.length === 0) return false;
+  const finalRound = bracket.rounds[bracket.rounds.length - 1];
+  const final = finalRound && finalRound[0];
+  return !!(final && final.winner);
+}
+
+// resolveCompetitionAwards: the single source of truth for a competition's
+// podium. Handles the mixed→linked-playoffs rule so pools+knockout always
+// resolves to the KNOCKOUT podium (1/2/3/3), never pool standings.
+// Returns { state, podium } where state is one of:
+//   'final'       — podium is the final result
+//   'in-progress' — pools+knockout whose knockout isn't decided yet (podium [])
+//   'none'        — no results yet (podium [])
+//   'skip'        — a linked playoffs shell; represented by its mixed parent
+// fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
+async function resolveCompetitionAwards(comp, allComps, fetchers) {
+  const fmt = comp && comp.format;
+  const ntpFrom = (players) => {
+    const m = new Map();
+    (players || []).forEach((p) => { if (p && p.name) m.set(p.name, p); });
+    return m;
+  };
+  if (fmt === "mixed") {
+    const playoff = (allComps || []).find((p) => p && p.sourceCompID === comp.id);
+    if (!playoff) return { state: "in-progress", podium: [] };
+    const pd = await fetchers.fetchCompetitionDetails(playoff.id);
+    if (bracketHasDecidedFinal(pd.bracket)) {
+      return { state: "final", podium: deriveAwards(pd.bracket, null, null, ntpFrom(pd.players)) };
+    }
+    return { state: "in-progress", podium: [] };
+  }
+  if (fmt === "playoffs" && comp.sourceCompID) {
+    return { state: "skip", podium: [] };
+  }
+  if (fmt === "playoffs") {
+    const d = await fetchers.fetchCompetitionDetails(comp.id);
+    if (bracketHasDecidedFinal(d.bracket)) {
+      return { state: "final", podium: deriveAwards(d.bracket, null, null, ntpFrom(d.players)) };
+    }
+    return { state: "none", podium: [] };
+  }
+  // league / swiss (and any standings-based) → standings
+  const d = await fetchers.fetchCompetitionDetails(comp.id);
+  let standings = d.standings;
+  if (fmt === "swiss" && fetchers.swissStandings) {
+    try { standings = await fetchers.swissStandings(comp.id); } catch (_) { /* keep detail standings */ }
+  }
+  return { state: "final", podium: deriveAwards(null, standings, d.pools, ntpFrom(d.players)) };
+}
+
 const PLACE_STYLE = {
   1: { icon: "🏆", label: "1st Place", accent: "var(--gold, #d4af37)" },
   2: { icon: "🥈", label: "2nd Place", accent: "var(--silver, #c0c0c0)" },
   3: { icon: "🥉", label: "3rd Place", accent: "var(--bronze, #cd7f32)" },
 };
 
-function AwardsView({ c, bracket, standings, pools, players }) {
+function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp }) {
   const containerRef = useRefV(null);
   const [isFs, setIsFs] = useState(false);
   const isLeague = c?.format === "league";
+  const isMixed = c?.format === "mixed";
   // Swiss standings aren't part of the competition-detail payload — they live
   // behind /swiss/standings. Fetch them here when the format is swiss so the
   // Awards tab works for Swiss competitions too.
   const [swissStandings, setSwissStandings] = useState(null);
+  // koAwards: undefined = not yet loaded, object = { state, awards } for mixed comps.
+  const [koAwards, setKoAwards] = useState(undefined);
 
   React.useEffect(() => {
     const onFsChange = () => setIsFs(!!document.fullscreenElement);
@@ -2991,6 +3048,32 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     return () => { cancelled = true; };
   }, [c?.id, c?.format, c?.swissCurrentRound]);
 
+  // For mixed (pools+knockout) comps, fetch the linked playoffs bracket to get
+  // the true podium (1/2/3/3 from the knockout final+semis).
+  React.useEffect(() => {
+    if (!isMixed) return;
+    if (!linkedPlayoffComp || !window.API?.fetchCompetitionDetails) {
+      setKoAwards({ state: "in-progress", awards: [] });
+      return;
+    }
+    let cancelled = false;
+    window.API.fetchCompetitionDetails(linkedPlayoffComp.id)
+      .then((pd) => {
+        if (cancelled) return;
+        if (window.bracketHasDecidedFinal(pd.bracket)) {
+          const ntp = new Map();
+          (pd.players || []).forEach((p) => { if (p && p.name) ntp.set(p.name, p); });
+          setKoAwards({ state: "final", awards: window.deriveAwards(pd.bracket, null, null, ntp) });
+        } else {
+          setKoAwards({ state: "in-progress", awards: [] });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setKoAwards({ state: "in-progress", awards: [] });
+      });
+    return () => { cancelled = true; };
+  }, [c?.id, c?.format, linkedPlayoffComp?.id]);
+
   const nameToPlayer = useMemo(() => {
     const m = new Map();
     (players || []).forEach((p) => {
@@ -3001,10 +3084,27 @@ function AwardsView({ c, bracket, standings, pools, players }) {
 
   const effectiveStandings = c?.format === "swiss" ? swissStandings : standings;
   const isSwissLoading = c?.format === "swiss" && swissStandings === null;
-  const awards = useMemo(
+  const baseAwards = useMemo(
     () => deriveAwards(bracket, effectiveStandings, pools, nameToPlayer),
     [bracket, effectiveStandings, pools, nameToPlayer]
   );
+
+  // Determine the awards array and state to use for rendering.
+  let awards, resolvedState;
+  if (isMixed) {
+    if (koAwards === undefined) {
+      // Still loading — show loading spinner below.
+      awards = [];
+      resolvedState = "loading";
+    } else {
+      awards = koAwards.awards;
+      resolvedState = koAwards.state;
+    }
+  } else {
+    awards = baseAwards;
+    resolvedState = "final";
+  }
+
   const leagueWinner = isLeague ? (awards.find(a => a.place === 1) || null) : null;
 
   const toggleFs = () => {
@@ -3017,7 +3117,7 @@ function AwardsView({ c, bracket, standings, pools, players }) {
     }
   };
 
-  if (isSwissLoading) {
+  if (isSwissLoading || resolvedState === "loading") {
     return (
       <div className="empty" data-testid="awards-loading">
         <div className="icon">🏆</div>
@@ -3027,6 +3127,14 @@ function AwardsView({ c, bracket, standings, pools, players }) {
   }
 
   if (awards.length === 0) {
+    if (isMixed && resolvedState === "in-progress") {
+      return (
+        <div className="empty" data-testid="awards-in-progress">
+          <div className="icon">🏆</div>
+          <h3>Knockout in progress</h3>
+        </div>
+      );
+    }
     return (
       <div className="empty" data-testid="awards-empty">
         <div className="icon">🏆</div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1901,7 +1901,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             // actual winners; when the final has no winner yet, deriveAwards
             // explicitly falls through to the standings-based path rather
             // than short-circuiting.
-            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} linkedPlayoffComp={linkedComp && linkedComp.role === "playoffs" ? linkedComp.comp : null} />
+            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} linkedPlayoffComp={linkedComp && linkedComp.role === "playoffs" ? linkedComp.comp : null} allComps={(tournament && tournament.competitions) || []} />
           )}
         </div>
       </div>
@@ -3110,8 +3110,7 @@ function bracketHasDecidedFinal(bracket) {
 // resolves to the KNOCKOUT podium (1/2/3/3), never pool standings.
 // Returns { state, podium } where state is one of:
 //   'final'       — podium is the final result
-//   'in-progress' — pools+knockout whose knockout isn't decided yet (podium [])
-//   'none'        — no results yet (podium [])
+//   'in-progress' — knockout not yet decided (podium [])
 //   'skip'        — a linked playoffs shell; represented by its mixed parent
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
 async function resolveCompetitionAwards(comp, allComps, fetchers) {
@@ -3156,7 +3155,7 @@ const PLACE_STYLE = {
   3: { icon: "🥉", label: "3rd Place", accent: "var(--bronze, #cd7f32)" },
 };
 
-function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp }) {
+function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp, allComps }) {
   const containerRef = useRefV(null);
   const [isFs, setIsFs] = useState(false);
   const isLeague = c?.format === "league";
@@ -3193,7 +3192,7 @@ function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp }
       return;
     }
     let cancelled = false;
-    const syntheticAllComps = linkedPlayoffComp ? [linkedPlayoffComp] : [];
+    const syntheticAllComps = allComps && allComps.length > 0 ? allComps : (linkedPlayoffComp ? [linkedPlayoffComp] : []);
     const fetchers = { fetchCompetitionDetails: window.API.fetchCompetitionDetails, swissStandings: null };
     window.resolveCompetitionAwards(c, syntheticAllComps, fetchers)
       .then(({ state, podium }) => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -3187,14 +3187,14 @@ function AwardsView({ c, bracket, standings, pools, players, linkedPlayoffComp, 
   React.useEffect(() => {
     if (!isMixed) return;
     setKoAwards(undefined);
-    if (!window.resolveCompetitionAwards || !window.API?.fetchCompetitionDetails) {
+    if (!window.API?.fetchCompetitionDetails) {
       setKoAwards({ state: "in-progress", awards: [] });
       return;
     }
     let cancelled = false;
     const syntheticAllComps = allComps && allComps.length > 0 ? allComps : (linkedPlayoffComp ? [linkedPlayoffComp] : []);
     const fetchers = { fetchCompetitionDetails: window.API.fetchCompetitionDetails, swissStandings: null };
-    window.resolveCompetitionAwards(c, syntheticAllComps, fetchers)
+    resolveCompetitionAwards(c, syntheticAllComps, fetchers)
       .then(({ state, podium }) => {
         if (!cancelled) setKoAwards({ state, awards: podium });
       })


### PR DESCRIPTION
## Summary

- Adds a **🏅 All winners** button to the admin dashboard that opens a single modal listing every **completed** competition with its podium — no more drilling into each competition's Awards tab one by one.
- **Pools+knockout always shows two 3rd places.** A pools+knockout competition is `format: "mixed"`; its own bracket is a read-only preview and the real knockout lives in a separate `playoffs` competition linked via `sourceCompID`. New shared helpers `bracketHasDecidedFinal()` + `resolveCompetitionAwards()` route a mixed comp to its linked playoffs bracket, yielding the canonical **1st / 2nd / 3rd / 3rd** (two semifinal losers — no bronze match, FIK convention).
- **Shared fix — both views corrected.** The same resolver powers the new All Winners modal *and* the existing per-competition **Awards** tab, which previously showed pool standings (often only one 3rd) for mixed comps. A knockout still in progress shows "Knockout in progress" until its final is decided.
- Works for both **individual and team** competitions. No new backend endpoint, no duplicated ranking logic — `deriveAwards` is reused unchanged.

## Why

After a tournament day the admin needs a consolidated view of who won each competition. Results were scattered across per-competition Awards views with no summary. The deeper bug surfaced in UAT: because a `mixed` comp flips to `completed` when *pools* finish (independently of its knockout), `deriveAwards` saw a preview bracket with no decided final and fell back to pool standings — the wrong podium. The canonical 1/2/3/3 lives in the linked playoffs comp's bracket.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | New exported helpers `bracketHasDecidedFinal()` + `resolveCompetitionAwards()` (the mixed→linked-playoffs resolver, also on `window`); `AwardsView` gains a `linkedPlayoffComp` prop and resolves the knockout podium for mixed comps (with a "Knockout in progress" state); `ViewerCompetition` passes the linked playoffs comp |
| `web-mobile/js/admin_shell.jsx` | `AllWinnersModal` + `buildAllWinners(completedComps, allComps, fetchers)` now delegate to `resolveCompetitionAwards`, drop linked-playoffs shells, and render "Knockout in progress"; `🏅 All winners` button in `AdminDashboard` (shown only when a completed competition exists) |
| `web-mobile/js/__tests__/admin_all_winners.test.jsx` | Updated for the new signature/states: mixed→two 3rds, mixed→in-progress, linked-playoffs skip, league standings, error isolation |
| `web-mobile/js/__tests__/resolve_awards.test.jsx` | New: `bracketHasDecidedFinal` (decided/undecided/empty/null) and `resolveCompetitionAwards` (all five branches) |

## Screenshots

**All winners modal — every completed competition now shows the knockout podium with two 🥉3rds** (e.g. 6D and up: Quinn Walker / Eddard Stark / Thomas Hardy / Cersei Lannister):

![All winners modal — top](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/242/top.png)

![All winners modal — two thirds](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/242/thirds.png)

**Per-competition Awards tab (shared fix) — mixed comp resolves to the knockout podium, "4 places", two 3rds:**

![Per-competition Awards tab](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/242/awardstab.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages green, coverage gate held
- [x] New/updated unit tests cover the change — `resolve_awards.test.jsx` (helpers, 5 resolver branches) + updated `admin_all_winners.test.jsx`; full JS suite 1206 tests pass; existing `viewer_awards.test.jsx` unchanged
- [x] Manual browser verification — seeded 12 real competitions (5 completed mixed comps + linked playoffs with decided finals). Admin **All winners** modal: every comp shows the knockout podium with two 3rds, matching each linked playoffs bracket; non-completed comps excluded; team + individual both render names/dojos. Public viewer **Awards** tab for a mixed comp ("6D and up"): Champion Quinn Walker, 2nd Eddard Stark, 3rd Thomas Hardy, 3rd Cersei Lannister
- [x] Screenshots added above (real browser renders via Playwright/Chromium)
- [x] No new console errors or warnings — checked console (error level): none

Closes mp-4dmr
