### PR TITLE
feat(mp-s1gl): centralized publicURL config for all share/QR links

### DIFF
--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -417,6 +417,68 @@ func TestTournamentHandlers(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "contacts[0].label")
 	})
+
+	// mp-s1gl: publicURL validation + trailing-slash normalization.
+	t.Run("PUT accepts empty publicURL (field is optional)", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}, PublicURL: ""}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("PUT accepts valid https publicURL and strips trailing slash", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}, PublicURL: "https://my-tournament.example.com/"}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		stored, err := store.LoadTournament()
+		require.NoError(t, err)
+		assert.Equal(t, "https://my-tournament.example.com", stored.PublicURL, "trailing slash must be stripped")
+	})
+
+	t.Run("PUT rejects non-http publicURL", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}, PublicURL: "javascript:alert(1)"}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "publicURL")
+	})
+
+	t.Run("PUT rejects over-500-char publicURL", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}}))
+		longURL := "https://example.com/" + strings.Repeat("x", MaxLenPublicURL)
+		tour := state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}, PublicURL: longURL}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "publicURL")
+	})
+
+	t.Run("PUT accepts http publicURL (non-https passes validation)", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}, PublicURL: "http://staging.example.com"}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
 }
 
 // TestTournamentHandlers_LockedMode_PUTRejectsPasswordChange pins the

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -479,6 +479,17 @@ func TestTournamentHandlers(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+	t.Run("PUT rejects scheme-only publicURL (no host)", func(t *testing.T) {
+		require.NoError(t, store.SaveTournament(&state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}}))
+		tour := state.Tournament{Name: "PU Test", Password: "secret", Courts: []string{"A"}, PublicURL: "https://"}
+		body, _ := json.Marshal(tour)
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/tournament", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "publicURL")
+	})
 }
 
 // TestTournamentHandlers_LockedMode_PUTRejectsPasswordChange pins the

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -160,6 +160,7 @@ var errSelfRunRequiresAdminPassword = errors.New("self-run tournaments require a
 // /tournament handlers. Count validation (>MaxTournamentContacts) is enforced
 // by validateTournamentLengths as a 400 error rather than silently truncating.
 func trimPublicInfoFields(t *state.Tournament) {
+	t.PublicURL = strings.TrimSpace(t.PublicURL)
 	t.VenueAddress = strings.TrimSpace(t.VenueAddress)
 	t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
 	t.OpeningTime = strings.TrimSpace(t.OpeningTime)
@@ -207,6 +208,17 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("closingBlock", t.ClosingBlock, MaxLenCeremonyBlock); err != nil {
 		return err
 	}
+	// mp-s1gl: publicURL — externally-shareable base URL for QR codes / share links.
+	if err := validateMaxLen("publicURL", t.PublicURL, MaxLenPublicURL); err != nil {
+		return err
+	}
+	if err := validateHTTPURL("publicURL", t.PublicURL); err != nil {
+		return err
+	}
+	// Normalize trailing slash so callers can always append "/path" without
+	// worrying about double slashes. Done post-validation to keep the error
+	// message on the pre-trim value.
+	t.PublicURL = strings.TrimRight(t.PublicURL, "/")
 	// mp-ef3: public tournament info fields.
 	if err := validateMaxLen("venueAddress", t.VenueAddress, MaxLenVenueAddress); err != nil {
 		return err

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -215,6 +215,9 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateHTTPURL("publicURL", t.PublicURL); err != nil {
 		return err
 	}
+	if err := validateURLHasHost("publicURL", t.PublicURL); err != nil {
+		return err
+	}
 	// Normalize trailing slash so callers can always append "/path" without
 	// worrying about double slashes. Done post-validation to keep the error
 	// message on the pre-trim value.

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -38,6 +38,7 @@ const (
 	MaxLenCeremonyBlock      = 16  // "1h30m" etc.
 
 	// mp-ef3: public tournament info field caps.
+	MaxLenPublicURL       = 500 // mp-s1gl: externally-shareable base URL
 	MaxLenVenueAddress    = 300
 	MaxLenVenueMapURL     = 500
 	MaxLenDisplayTime     = 8 // "HH:MM" or "HH:MM:SS"

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -19,6 +19,7 @@ package mobileapp
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -111,6 +112,24 @@ func validateHTTPURL(field, val string) error {
 		return &ValidationError{
 			Field:   field,
 			Message: "must start with http:// or https://",
+		}
+	}
+	return nil
+}
+
+// validateURLHasHost rejects scheme-only values like "https://" that pass the
+// prefix check in validateHTTPURL but have no host, which would produce a
+// broken base URL after trailing-slash normalization (e.g. "https:").
+// Empty strings pass (the field is optional).
+func validateURLHasHost(field, val string) error {
+	if val == "" {
+		return nil
+	}
+	u, err := url.Parse(val)
+	if err != nil || u.Host == "" {
+		return &ValidationError{
+			Field:   field,
+			Message: "must include a host (e.g. https://my-tournament.example.com)",
 		}
 	}
 	return nil

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -79,6 +79,9 @@ type Tournament struct {
 
 	// Public tournament info fields (mp-ef3). All optional (omitempty).
 	// Rendered read-only on the viewer home page; editable in the admin setup form.
+	// PublicURL is the externally-shareable base URL for this tournament (mp-s1gl).
+	// When set it overrides window.location.origin for QR codes and share links.
+	PublicURL    string              `yaml:"public_url,omitempty" json:"publicURL,omitempty"`
 	VenueAddress string              `yaml:"venue_address,omitempty" json:"venueAddress,omitempty"`
 	VenueMapURL  string              `yaml:"venue_map_url,omitempty" json:"venueMapURL,omitempty"`
 	OpeningTime  string              `yaml:"opening_time,omitempty" json:"openingTime,omitempty"`

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL } from '../viewer.jsx';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, linkBase, isNonPublicOrigin } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 
@@ -1014,6 +1014,107 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
     const modal = findInTree(runtime.currentTree(), n => n?.type?.name === 'MatchViewerModal');
     expect(modal).toBeTruthy();
     expect(modal.props.match.id).toBe('curr2');
+  });
+});
+
+// mp-s1gl: linkBase and isNonPublicOrigin unit tests.
+describe('linkBase', () => {
+  it('returns configured publicURL when set', () => {
+    expect(linkBase({ publicURL: 'https://my-tournament.example.com' })).toBe('https://my-tournament.example.com');
+  });
+
+  it('falls back to window.location.origin when publicURL is empty string', () => {
+    expect(linkBase({ publicURL: '' })).toBe(window.location.origin);
+  });
+
+  it('falls back to window.location.origin when publicURL is absent', () => {
+    expect(linkBase({})).toBe(window.location.origin);
+  });
+
+  it('falls back to window.location.origin when tournament is null', () => {
+    expect(linkBase(null)).toBe(window.location.origin);
+  });
+
+  it('falls back to window.location.origin when tournament is undefined', () => {
+    expect(linkBase(undefined)).toBe(window.location.origin);
+  });
+});
+
+describe('isNonPublicOrigin', () => {
+  it('returns true for empty string', () => {
+    expect(isNonPublicOrigin('')).toBe(true);
+  });
+
+  it('returns true for null', () => {
+    expect(isNonPublicOrigin(null)).toBe(true);
+  });
+
+  it('returns true for undefined', () => {
+    expect(isNonPublicOrigin(undefined)).toBe(true);
+  });
+
+  it('returns true for the string "null" (opaque sandboxed-iframe origin)', () => {
+    expect(isNonPublicOrigin('null')).toBe(true);
+  });
+
+  it('returns true for localhost', () => {
+    expect(isNonPublicOrigin('http://localhost')).toBe(true);
+  });
+
+  it('returns true for localhost with port', () => {
+    expect(isNonPublicOrigin('http://localhost:8080')).toBe(true);
+  });
+
+  it('returns true for 0.0.0.0', () => {
+    expect(isNonPublicOrigin('http://0.0.0.0')).toBe(true);
+  });
+
+  it('returns true for 127.x.x.x loopback', () => {
+    expect(isNonPublicOrigin('http://127.0.0.1')).toBe(true);
+  });
+
+  it('returns true for 127.x.x.x loopback variant', () => {
+    expect(isNonPublicOrigin('http://127.1.2.3')).toBe(true);
+  });
+
+  it('returns true for 192.168.x.x LAN', () => {
+    expect(isNonPublicOrigin('http://192.168.1.100')).toBe(true);
+  });
+
+  it('returns true for 10.x.x.x private range', () => {
+    expect(isNonPublicOrigin('http://10.0.0.1')).toBe(true);
+  });
+
+  it('returns true for 172.16.x.x private range', () => {
+    expect(isNonPublicOrigin('http://172.16.0.1')).toBe(true);
+  });
+
+  it('returns true for 172.31.x.x private range', () => {
+    expect(isNonPublicOrigin('http://172.31.255.254')).toBe(true);
+  });
+
+  it('returns false for 172.15.x.x (not in private range)', () => {
+    expect(isNonPublicOrigin('http://172.15.0.1')).toBe(false);
+  });
+
+  it('returns false for 172.32.x.x (not in private range)', () => {
+    expect(isNonPublicOrigin('http://172.32.0.1')).toBe(false);
+  });
+
+  it('returns true for *.local mDNS names', () => {
+    expect(isNonPublicOrigin('http://myserver.local')).toBe(true);
+  });
+
+  it('returns true for a public hostname with a non-standard port', () => {
+    expect(isNonPublicOrigin('http://my-tournament.example.com:8080')).toBe(true);
+  });
+
+  it('returns false for a public https URL', () => {
+    expect(isNonPublicOrigin('https://my-tournament.example.com')).toBe(false);
+  });
+
+  it('returns false for a public http URL (non-localhost)', () => {
+    expect(isNonPublicOrigin('http://staging.example.com')).toBe(false);
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1038,6 +1038,19 @@ describe('linkBase', () => {
   it('falls back to window.location.origin when tournament is undefined', () => {
     expect(linkBase(undefined)).toBe(window.location.origin);
   });
+
+  it('returns empty string when publicURL is absent and origin is opaque ("null")', () => {
+    const orig = window.location.origin;
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, origin: 'null' },
+      writable: true, configurable: true,
+    });
+    expect(linkBase({})).toBe('');
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, origin: orig },
+      writable: true, configurable: true,
+    });
+  });
 });
 
 describe('isNonPublicOrigin', () => {
@@ -1115,6 +1128,10 @@ describe('isNonPublicOrigin', () => {
 
   it('returns false for a public http URL (non-localhost)', () => {
     expect(isNonPublicOrigin('http://staging.example.com')).toBe(false);
+  });
+
+  it('returns true for IPv6 loopback ::1', () => {
+    expect(isNonPublicOrigin('http://[::1]')).toBe(true);
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1040,16 +1040,18 @@ describe('linkBase', () => {
   });
 
   it('returns empty string when publicURL is absent and origin is opaque ("null")', () => {
-    const orig = window.location.origin;
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, origin: 'null' },
-      writable: true, configurable: true,
-    });
-    expect(linkBase({})).toBe('');
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, origin: orig },
-      writable: true, configurable: true,
-    });
+    const origDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
+    try {
+      Object.defineProperty(window, 'location', {
+        value: { origin: 'null' },
+        writable: true, configurable: true,
+      });
+      expect(linkBase({})).toBe('');
+    } finally {
+      if (origDescriptor) {
+        Object.defineProperty(window, 'location', origDescriptor);
+      }
+    }
   });
 });
 

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -1287,7 +1287,7 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, pa
 }
 
 function AdminExport({ c, t, password }) {
-  const url = `${window.location.origin}/viewer.html?id=${t.id}#comp-${c.id}`;
+  const url = `${(window.linkBase || (() => window.location.origin))(t)}/viewer.html?id=${t.id}#comp-${c.id}`;
 
   const downloadXlsx = async () => {
     try {

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -306,7 +306,11 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               <div className="field__hint">The address participants reach this tournament at — used for QR codes and share links. Leave blank to use the current browser address.</div>
               {publicURL.trim() === "" && isNonPublicOrigin(window.location.origin) && (
                 <div className="field__hint" style={{ color: "var(--red)", marginTop: 4 }}>
-                  {`Links will use this device's address (${window.location.origin}), which may not be reachable by remote attendees. Set a Public URL to fix this.`}
+                  {(() => {
+                    const o = window.location.origin;
+                    const label = (!o || o === "null") ? "an unknown local address" : o;
+                    return `Links will use this device's address (${label}), which may not be reachable by remote attendees. Set a Public URL to fix this.`;
+                  })()}
                 </div>
               )}
             </div>

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -306,7 +306,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               <div className="field__hint">The address participants reach this tournament at — used for QR codes and share links. Leave blank to use the current browser address.</div>
               {publicURL.trim() === "" && isNonPublicOrigin(window.location.origin) && (
                 <div className="field__hint" style={{ color: "var(--red)", marginTop: 4 }}>
-                  {`Links will use this device's address (${window.location.origin}), which won't work for remote attendees. Set a Public URL to fix this.`}
+                  {`Links will use this device's address (${window.location.origin}), which may not be reachable by remote attendees. Set a Public URL to fix this.`}
                 </div>
               )}
             </div>

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -18,6 +18,8 @@ const MAX_COURTS = window.MAX_COURTS;
 const pluralize = window.pluralize;
 const AdminTopbar = window.AdminTopbar;
 const Breadcrumbs = window.Breadcrumbs;
+// mp-s1gl: link-base helpers from viewer.jsx (exposed on window at load time).
+const isNonPublicOrigin = window.isNonPublicOrigin || (() => false);
 
 // Returns the final competition name, trimming the raw user input before
 // the empty-check so a whitespace-only string ("   ") falls through to the
@@ -111,6 +113,8 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [lunchBlock, setLunchBlock] = useStateA(tournament.lunchBlock || "");
   const [closingBlock, setClosingBlock] = useStateA(tournament.closingBlock || "");
   // mp-ef3: public tournament info fields.
+  // mp-s1gl: externally-shareable base URL for QR codes / share links.
+  const [publicURL, setPublicURL] = useStateA(tournament.publicURL || "");
   const [venueAddress, setVenueAddress] = useStateA(tournament.venueAddress || "");
   const [venueMapURL, setVenueMapURL] = useStateA(tournament.venueMapURL || "");
   const [openingTime, setOpeningTime] = useStateA(tournament.openingTime || "");
@@ -179,6 +183,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       openingBlock: openingBlock.trim() || undefined,
       lunchBlock: lunchBlock.trim() || undefined,
       closingBlock: closingBlock.trim() || undefined,
+      publicURL: publicURL.trim() || undefined,
       venueAddress: venueAddress.trim() || undefined,
       venueMapURL: venueMapURL.trim() || undefined,
       openingTime: openingTime.trim() || undefined,
@@ -289,6 +294,22 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           {/* mp-ef3: Tournament Information (Public) */}
           <div style={{ borderTop: "1px solid var(--line)", marginTop: 20, paddingTop: 20 }}>
             <div style={{ fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--ink-3)", marginBottom: 12 }}>Tournament Information (Public)</div>
+            {/* mp-s1gl: Public URL — single source of truth for externally-shareable links */}
+            <div className="field">
+              <label className="field__label">Public URL</label>
+              <input
+                className="input"
+                value={publicURL}
+                onChange={(e) => setPublicURL(e.target.value)}
+                placeholder="https://my-tournament.example.com"
+              />
+              <div className="field__hint">The address participants reach this tournament at — used for QR codes and share links. Leave blank to use the current browser address.</div>
+              {publicURL.trim() === "" && isNonPublicOrigin(window.location.origin) && (
+                <div className="field__hint" style={{ color: "var(--red)", marginTop: 4 }}>
+                  {`Links will use this device's address (${window.location.origin}), which won't work for remote attendees. Set a Public URL to fix this.`}
+                </div>
+              )}
+            </div>
             <div className="field">
               <label className="field__label">Venue address</label>
               <input className="input" value={venueAddress} onChange={(e) => setVenueAddress(e.target.value)} placeholder="123 Sport Centre Dr, City" />

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -469,7 +469,7 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
       </div>
       {shareOpen && (
         <ShareRegistrationModal
-          url={`${window.location.origin}/register/${c.id}`}
+          url={`${(window.linkBase || (() => window.location.origin))(tournament)}/register/${c.id}`}
           onClose={() => setShareOpen(false)}
           showToast={showToast}
         />

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -540,6 +540,38 @@ function MyMatchAlertBanner({ match, onView, onDismiss }) {
 // testing (mp-ef3 Copilot round 2).
 export const isHttpURL = (u) => /^https?:\/\//i.test(u);
 
+// linkBase returns the configured publicURL (mp-s1gl) for the given tournament,
+// falling back to the current frame's origin when publicURL is not set. This is
+// the single source of truth for building externally-shareable links (QR codes,
+// viewer share links) so operators can set one canonical URL regardless of what
+// address the admin browser is using.
+export const linkBase = (t) => (t && t.publicURL) || window.location.origin;
+
+// isNonPublicOrigin returns true when the given origin looks like a device-local
+// or LAN address that won't be reachable by remote attendees. Used to warn the
+// operator when publicURL is unset and the fallback origin would produce
+// unworkable QR codes / share links (mp-s1gl).
+//
+// Treats falsy / "null" (opaque-origin sandboxed iframe) as non-public so the
+// warning degrades gracefully and never renders "null/register/..." links.
+export const isNonPublicOrigin = (origin) => {
+  if (!origin || origin === "null") return true;
+  let host, hasPort = false;
+  try {
+    const u = new URL(origin);
+    host = u.hostname;
+    hasPort = u.port !== "";
+  } catch { return true; }
+  if (host === "localhost" || host === "0.0.0.0") return true;
+  if (host.endsWith(".local")) return true;
+  if (/^127\./.test(host)) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  if (hasPort) return true;
+  return false;
+};
+
 // TournamentInfo renders optional public tournament info (mp-ef3) as a
 // read-only card on the viewer home page. Returns null when no info fields
 // are set so the card is invisible for tournaments that haven't filled them in.
@@ -3591,5 +3623,9 @@ window.tournamentMatches = tournamentMatches;
 window.currentMatchOf = currentMatchOf;
 window.NotificationSettings = NotificationSettings;
 window.LS_NOTIFICATIONS_ENABLED = LS_NOTIFICATIONS_ENABLED;
+// mp-s1gl: expose link-base helpers for admin_shell.jsx / admin_schedule.jsx
+// (those files don't ES-import viewer.jsx; they pick globals off window).
+window.linkBase = linkBase;
+window.isNonPublicOrigin = isNonPublicOrigin;
 export { shouldShowRegister };
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -545,7 +545,15 @@ export const isHttpURL = (u) => /^https?:\/\//i.test(u);
 // the single source of truth for building externally-shareable links (QR codes,
 // viewer share links) so operators can set one canonical URL regardless of what
 // address the admin browser is using.
-export const linkBase = (t) => (t && t.publicURL) || window.location.origin;
+// Guard against opaque-origin contexts (sandboxed iframes) where
+// window.location.origin is the literal string "null". Falling back to
+// window.location.origin in that case would produce "null/register/..." links,
+// so return an empty string instead so callers get a relative path.
+export const linkBase = (t) => {
+  if (t && t.publicURL) return t.publicURL;
+  const origin = window.location.origin;
+  return (!origin || origin === "null") ? "" : origin;
+};
 
 // isNonPublicOrigin returns true when the given origin looks like a device-local
 // or LAN address that won't be reachable by remote attendees. Used to warn the
@@ -563,6 +571,7 @@ export const isNonPublicOrigin = (origin) => {
     hasPort = u.port !== "";
   } catch { return true; }
   if (host === "localhost" || host === "0.0.0.0") return true;
+  if (host === "::1" || host === "[::1]") return true;  // IPv6 loopback
   if (host.endsWith(".local")) return true;
   if (/^127\./.test(host)) return true;
   if (/^10\./.test(host)) return true;


### PR DESCRIPTION
## Summary

- Add a `publicURL` field to tournament config (`tournament.md` front-matter) as the single source of truth for externally-shareable links (registration QR, viewer share link, future printed-tag QR from mp-yin4).
- Refactor the two browser link sites (`admin_shell.jsx`, `admin_schedule.jsx`) to prefer `publicURL` over `window.location.origin`, with graceful fallback when unset.
- Add a **non-public origin warning** in admin settings: when the field is empty and the current origin looks like localhost/LAN/private-IP, a red warning names the detected address and nudges the operator to configure a proper URL. Includes an opaque-origin guard for sandboxed iframe edge cases.

## Why

The two existing share-link sites infer the host from `window.location.origin`, which encodes whatever the admin happened to click from — typically `localhost` or a LAN IP during tournament setup. These produce un-shareable QR codes and links. Additionally, the server-side printed-tag QR feature (mp-yin4) needs a base URL that isn't available in a browser context. A single configured field solves both.

## Files changed

| File | What |
|---|---|
| `internal/state/models.go` | Add `PublicURL` field to `Tournament` struct |
| `internal/mobileapp/validation.go` | Add `MaxLenPublicURL = 500` constant |
| `internal/mobileapp/handlers_tournament.go` | TrimSpace + validateMaxLen + validateHTTPURL + trailing-slash normalization |
| `internal/mobileapp/handlers_test.go` | 5 table-driven sub-tests for publicURL validation |
| `web-mobile/js/viewer.jsx` | Add `linkBase()` and `isNonPublicOrigin()` helpers, expose on `window.*` |
| `web-mobile/js/admin_shell.jsx` | Use `linkBase(tournament)` for registration share link |
| `web-mobile/js/admin_schedule.jsx` | Use `linkBase(t)` for viewer share link |
| `web-mobile/js/admin_setup.jsx` | Public URL input + non-public origin warning in admin settings form |
| `web-mobile/js/__tests__/viewer.test.jsx` | 24 new tests for `linkBase` and `isNonPublicOrigin` |

## Screenshots

**With URL configured** — field shows saved value (`https://kendo-cup.example.com`), no warning:

![Public URL set](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-s1gl/url-set.png)

**Field empty on localhost** — red warning detects non-public origin and names it:

![Public URL empty with warning](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-s1gl/url-empty-warning.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — 1202 JS tests, all Go packages green
- [x] New/updated unit tests cover the change — 5 Go sub-tests (empty/valid+strip/non-http/over-length/plain-http), 24 JS tests (linkBase fallback, isNonPublicOrigin for localhost/LAN/private-IP/opaque-origin/public)
- [x] Manual browser verification — created tournament, navigated to Edit details, confirmed: field renders with correct placeholder/hint; warning appears on localhost with detected address; warning disappears when URL entered; save persists (PUT 200); trailing slash stripped in YAML; value survives reload; `linkBase(tournament)` returns configured value; `linkBase({})` falls back to origin
- [x] Screenshots added above
- [x] No new console errors or warnings (pre-existing viewer 404 only)

Closes mp-s1gl