### PR TITLE
refactor(mp-c3pf): remove dead SourceCompID field and legacy split-playoffs code

### DIFF
--- a/internal/engine/estimate_schedule.go
+++ b/internal/engine/estimate_schedule.go
@@ -6,38 +6,9 @@ import (
 )
 
 // EstimateScheduleForCompetition returns a pre-draw ScheduleEstimate for the
-// competition identified by compID. It is a *Engine method (rather than a
-// free function) because it needs the engine's store to load the competition,
-// tournament, and participant roster — matching the pattern of other stateful
-// engine entry points such as GenerateSchedule and StartCompetition.
-// (EstimateForCounts is a free function because it takes pre-derived counts
-// and has no store dependency.)
-//
-// Algorithm:
-//  1. Load the competition; return *NotFoundError if it does not exist.
-//  2. Load the tournament (nil is tolerated — EstimateForCounts and
-//     ApplyTournamentDefaults both handle a nil *Tournament safely).
-//  3. Derive the participant count:
-//     - Normal competitions: len(filterCheckedIn(LoadParticipants(compID)))
-//     when comp.CheckInEnabled (opt-in: full roster when nobody checked in).
-//     - Source-linked playoffs (comp.SourceCompID != "" and comp has an
-//     empty roster): derive from the SOURCE competition's pool count ×
-//     SOURCE competition's PoolWinners (mirrors ResolveQualifiedPools in engine/knockout.go).
-//     If the source has no pools yet (draw not generated), returns a zero
-//     ScheduleEstimate without an error — the estimate is unknown at that stage.
-//  4. Map comp.Format → helper.EstimateMatchCountsInput and call
-//     helper.EstimateMatchCounts to obtain pool and playoff counts.
-//  5. Delegate to EstimateForCounts(poolCount, playoffCount, comp, tournament).
-//
-// Format mapping (state constant → helper format string):
-//
-//	state.CompFormatPlayoffs ("playoffs") → "playoffs"
-//	state.CompFormatMixed    ("mixed")    → "mixed"
-//	state.CompFormatLeague   ("league")   → "league"
-//	state.CompFormatSwiss    ("swiss")    → "swiss"
-//
-// They are the same strings — the constants are defined in state/models.go and
-// the helper uses the same literal values, so no translation is needed.
+// competition identified by compID. It loads the competition and participant
+// roster, derives pool + playoff match counts via helper.EstimateMatchCounts,
+// and delegates to EstimateForCounts.
 func (e *Engine) EstimateScheduleForCompetition(compID string) (ScheduleEstimate, error) {
 	// Step 1: load competition.
 	comp, err := e.store.LoadCompetition(compID)
@@ -90,96 +61,15 @@ func (e *Engine) EstimateScheduleForCompetition(compID string) (ScheduleEstimate
 }
 
 // estimateParticipantCount returns the number of participants for a
-// competition, handling the source-linked playoffs case and the check-in filter.
-//
-// Finding 1 fix: when comp.CheckInEnabled is true, the SAME filterCheckedIn
-// opt-in semantics that runDrawPipeline applies (competition.go:565-567) are
-// applied here. If at least one player is checked in, only checked-in players
-// are counted; if nobody is checked in, the full roster is used (opt-in
-// fallback). filterCheckedIn is called directly (same package) — the logic is
-// NOT duplicated.
-//
-// For source-linked playoffs (comp.SourceCompID != "" and roster is empty),
-// the participant count is derived from the SOURCE competition's pool count ×
-// SOURCE comp.PoolWinners. This mirrors ResolveQualifiedPools in engine/knockout.go,
-// which uses len(pools) × winnersPerPool as the authoritative finalist count (not
-// recomputed from participant count + pool size, because CreatePools may choose
-// a different pool count in "min" vs "max" mode).
-//
-// If the source competition's pools have not been generated yet (len(pools)==0),
-// returns (0, nil) — the caller treats this as "not enough data to estimate"
-// and returns a zero ScheduleEstimate.
+// competition, applying the check-in filter when enabled (mirroring
+// runDrawPipeline's filterCheckedIn opt-in semantics).
 func (e *Engine) estimateParticipantCount(comp *state.Competition) (int, error) {
-	// Source-linked playoffs: roster on disk is empty until StartCompetition.
-	// Detect by checking SourceCompID and a zero-length roster (mirrors the
-	// guard in runDrawPipeline: only auto-resolve when roster is empty).
-	if comp.Format == state.CompFormatPlayoffs && comp.SourceCompID != "" {
-		players, err := e.store.LoadParticipants(comp.ID, comp.WithZekkenName)
-		if err != nil {
-			return 0, err
-		}
-		if len(players) == 0 {
-			// Roster not yet populated — derive from source pools.
-			// Finding 2: estimateFinalistCount loads the source comp to get
-			// the SOURCE's PoolWinners, not comp.PoolWinners.
-			return e.estimateFinalistCount(comp.SourceCompID)
-		}
-		// Roster already populated (competition already started) — use it.
-		// Apply check-in filter (Finding 1) consistently with runDrawPipeline.
-		if comp.CheckInEnabled {
-			players = filterCheckedIn(players)
-		}
-		return len(players), nil
-	}
-
-	// Normal path: load roster from disk.
 	players, err := e.store.LoadParticipants(comp.ID, comp.WithZekkenName)
 	if err != nil {
 		return 0, err
 	}
-	// Finding 1: mirror runDrawPipeline's filterCheckedIn (competition.go:565-567).
-	// Opt-in semantics: if nobody is checked in, full roster is returned unchanged.
 	if comp.CheckInEnabled {
 		players = filterCheckedIn(players)
 	}
 	return len(players), nil
-}
-
-// estimateFinalistCount returns the number of pool winners that will advance
-// from a source competition (identified by srcCompID) to a linked playoffs
-// competition.
-//
-// Finding 2 fix: the winners-per-pool comes from the SOURCE competition's
-// PoolWinners field, not from the playoffs competition's PoolWinners. This
-// mirrors ResolveQualifiedPools in engine/knockout.go which uses srcComp.PoolWinners.
-//
-// It reads:
-//  1. The source competition config to get its PoolWinners (default 2 when ≤0).
-//  2. The SOURCE competition's pools.csv for the authoritative pool count.
-//
-// Returns (0, nil) when the source has no pools yet.
-func (e *Engine) estimateFinalistCount(srcCompID string) (int, error) {
-	// Load the SOURCE competition to get its PoolWinners — not the playoffs
-	// comp's PoolWinners (which is what the old code used via the parameter).
-	srcComp, err := e.store.LoadCompetition(srcCompID)
-	if err != nil {
-		return 0, err
-	}
-	if srcComp == nil {
-		// Source competition referenced by SourceCompID doesn't exist — this
-		// is a misconfiguration (deleted or never created), not a normal
-		// pre-draw state. Surface it as an error so the operator sees it.
-		return 0, notFoundErrorf("playoffs source competition %q not found", srcCompID)
-	}
-
-	pools, err := e.store.LoadPools(srcCompID)
-	if err != nil {
-		return 0, err
-	}
-	if len(pools) == 0 {
-		// Source draw not generated yet — can't estimate.
-		return 0, nil
-	}
-	// Single source of truth for the qualifier-count default (Competition.EffectivePoolWinners).
-	return len(pools) * srcComp.EffectivePoolWinners(), nil
 }

--- a/internal/engine/estimate_schedule_test.go
+++ b/internal/engine/estimate_schedule_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"testing"
 
-	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 	"github.com/stretchr/testify/assert"
@@ -179,101 +178,6 @@ func TestEstimateScheduleForCompetition_ZeroParticipants(t *testing.T) {
 	assert.GreaterOrEqual(t, est.TotalDurationMinutes, 0)
 }
 
-// TestEstimateScheduleForCompetition_SourceLinked_PoolsExist verifies the
-// source-linked playoffs path: the finalist count is derived from the source's
-// pool count × poolWinners when the roster is empty.
-func TestEstimateScheduleForCompetition_SourceLinked_PoolsExist(t *testing.T) {
-	eng, store, _ := setupTestEngine(t)
-
-	srcID := "est-source-comp"
-	playoffsID := "est-linked-playoffs"
-
-	// Set up source competition with pools already generated.
-	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:           srcID,
-		Format:       state.CompFormatMixed,
-		Kind:         "individual",
-		PoolSize:     3,
-		PoolSizeMode: "min",
-		PoolWinners:  2,
-		RoundRobin:   true,
-		Courts:       []string{"A"},
-		StartTime:    "09:00",
-		Status:       state.CompStatusPools,
-	}))
-	saveTestParticipants(t, store, srcID, []string{"A", "B", "C", "D", "E", "F"})
-
-	// Persist 2 pools (mimicking what generatePools produces).
-	fakePools := []helper.Pool{
-		{PoolName: "Pool 1", Players: []domain.Player{{Name: "A"}, {Name: "B"}, {Name: "C"}}},
-		{PoolName: "Pool 2", Players: []domain.Player{{Name: "D"}, {Name: "E"}, {Name: "F"}}},
-	}
-	require.NoError(t, store.SavePools(srcID, fakePools))
-
-	// Set up a source-linked playoffs competition with an empty roster.
-	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:                   playoffsID,
-		Format:               state.CompFormatPlayoffs,
-		Kind:                 "individual",
-		SourceCompID:         srcID,
-		PoolWinners:          2,
-		Courts:               []string{"A"},
-		StartTime:            "09:00",
-		PlayoffMatchDuration: 5,
-		Status:               state.CompStatusSetup,
-	}))
-	// No participants saved (empty roster — the draw hasn't resolved them yet).
-
-	est, err := eng.EstimateScheduleForCompetition(playoffsID)
-	require.NoError(t, err)
-	// 2 pools × 2 winners = 4 finalists → NextPow2(4)=4, bracket=3 matches.
-	assert.Greater(t, est.TotalDurationMinutes, 0,
-		"source-linked playoffs with 4 finalists must produce a non-zero estimate")
-
-	// Cross-check against direct EstimateForCounts with 3 bracket matches.
-	comp, _ := store.LoadCompetition(playoffsID)
-	tourn, _ := store.LoadTournament()
-	direct := EstimateForCounts(0, 3, comp, tourn)
-	assert.Equal(t, direct.TotalDurationMinutes, est.TotalDurationMinutes,
-		"source-linked playoff estimate must agree with direct EstimateForCounts(0,3)")
-}
-
-// TestEstimateScheduleForCompetition_SourceLinked_NoPools verifies the fallback
-// when the source competition's draw has not been generated yet: the playoffs
-// estimate returns a zero ScheduleEstimate without error.
-func TestEstimateScheduleForCompetition_SourceLinked_NoPools(t *testing.T) {
-	eng, store, _ := setupTestEngine(t)
-
-	srcID := "est-source-no-pools"
-	playoffsID := "est-linked-no-pools"
-
-	// Source exists but has no pools.csv yet.
-	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:     srcID,
-		Format: state.CompFormatMixed,
-		Status: state.CompStatusSetup,
-	}))
-
-	// Linked playoffs competition.
-	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:           playoffsID,
-		Format:       state.CompFormatPlayoffs,
-		Kind:         "individual",
-		SourceCompID: srcID,
-		PoolWinners:  2,
-		Courts:       []string{"A"},
-		StartTime:    "09:00",
-		Status:       state.CompStatusSetup,
-	}))
-	// No participants saved.
-
-	est, err := eng.EstimateScheduleForCompetition(playoffsID)
-	require.NoError(t, err, "missing source pools must return (zero, nil), not an error")
-	// Zero matches → TotalDurationMinutes is whatever EstimateForCounts returns
-	// for 0+0 matches (opening block or zero). The critical contract is: no error.
-	assert.GreaterOrEqual(t, est.TotalDurationMinutes, 0)
-}
-
 // ---------------------------------------------------------------------------
 // Finding 1: check-in filter applied in estimateParticipantCount
 // ---------------------------------------------------------------------------
@@ -387,66 +291,6 @@ func TestEstimateParticipantCount_CheckInFilter(t *testing.T) {
 		assert.Equal(t, direct.TotalDurationMinutes, est.TotalDurationMinutes,
 			"with CheckInEnabled=false, all 8 participants must be used")
 	})
-}
-
-// ---------------------------------------------------------------------------
-// Finding 2: source PoolWinners used for source-linked finalist count
-// ---------------------------------------------------------------------------
-
-// TestEstimateFinalistCount_UsesSourcePoolWinners verifies that the finalist
-// count is derived from the SOURCE competition's PoolWinners, not from the
-// playoffs competition's PoolWinners. Mirrors ResolveQualifiedPools (engine/knockout.go).
-//
-// Finalist counts chosen to be powers-of-2 so bracketMatchCount is stable
-// regardless of Finding 3's fix, keeping this test independent.
-func TestEstimateFinalistCount_UsesSourcePoolWinners(t *testing.T) {
-	eng, store, _ := setupTestEngine(t)
-
-	srcID := "est-src-pw4"
-	playoffsID := "est-playoffs-pw2"
-
-	// Source has PoolWinners=4, 2 pools → 2×4=8 finalists (power-of-2: 7 bouts).
-	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:          srcID,
-		Format:      state.CompFormatMixed,
-		Kind:        "individual",
-		PoolWinners: 4, // SOURCE says 4 winners per pool
-		Status:      state.CompStatusPools,
-	}))
-	fakePools := []helper.Pool{
-		{PoolName: "Pool 1", Players: []domain.Player{{Name: "A"}, {Name: "B"}}},
-		{PoolName: "Pool 2", Players: []domain.Player{{Name: "C"}, {Name: "D"}}},
-	}
-	require.NoError(t, store.SavePools(srcID, fakePools))
-
-	// Playoffs comp has PoolWinners=2 (→ 2×2=4 finalists, 3 bouts) — must NOT be used.
-	require.NoError(t, store.SaveCompetition(&state.Competition{
-		ID:                   playoffsID,
-		Format:               state.CompFormatPlayoffs,
-		Kind:                 "individual",
-		SourceCompID:         srcID,
-		PoolWinners:          2, // PLAYOFF says 2 — must be ignored
-		Courts:               []string{"A"},
-		StartTime:            "09:00",
-		PlayoffMatchDuration: 5,
-		Status:               state.CompStatusSetup,
-	}))
-	// No participants — source-linked path.
-
-	est, err := eng.EstimateScheduleForCompetition(playoffsID)
-	require.NoError(t, err)
-
-	// Expected (fixed): 2 pools × 4 winners (SOURCE) = 8 finalists → 7 bouts.
-	// Buggy code uses 2 pools × 2 winners (PLAYOFF) = 4 finalists → 3 bouts.
-	comp, _ := store.LoadCompetition(playoffsID)
-	tourn, _ := store.LoadTournament()
-	direct8 := EstimateForCounts(0, 7, comp, tourn) // 8 finalists (source PoolWinners=4)
-	direct4 := EstimateForCounts(0, 3, comp, tourn) // 4 finalists (playoff PoolWinners=2 — BUG)
-	assert.Equal(t, direct8.TotalDurationMinutes, est.TotalDurationMinutes,
-		"finalist count must use source comp's PoolWinners=4 (8 finalists, 7 bouts), "+
-			"not playoff comp's PoolWinners=2 (4 finalists, 3 bouts)")
-	assert.NotEqual(t, direct4.TotalDurationMinutes, est.TotalDurationMinutes,
-		"estimate must NOT use the playoff comp's PoolWinners=2 (that would be the bug)")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -270,37 +270,26 @@ func (t *Tournament) Days() []string {
 }
 
 type Competition struct {
-	ID                string            `yaml:"id" json:"id"`
-	Name              string            `yaml:"name" json:"name"`
-	Kind              string            `yaml:"kind" json:"kind"`
-	Format            string            `yaml:"format" json:"format"`
-	PoolFormat        string            `yaml:"pool_format,omitempty" json:"poolFormat,omitempty"` // "full" (default) | "partial"
-	TeamSize          int               `yaml:"team_size" json:"teamSize"`
-	PoolSize          int               `yaml:"pool_size" json:"poolSize"`
-	PoolSizeMode      string            `yaml:"pool_size_mode" json:"poolSizeMode"`
-	PoolWinners       int               `yaml:"pool_winners" json:"poolWinners"`
-	RoundRobin        bool              `yaml:"round_robin" json:"roundRobin"`
-	Courts            []string          `yaml:"courts" json:"courts"`
-	StartTime         string            `yaml:"start_time" json:"startTime"`
-	Date              string            `yaml:"date" json:"date"`
-	Status            CompetitionStatus `yaml:"status" json:"status"`
-	Mirror            bool              `yaml:"mirror" json:"mirror"`
-	WithZekkenName    bool              `yaml:"with_zekken_name" json:"withZekkenName"`
-	NumberPrefix      string            `yaml:"number_prefix,omitempty" json:"numberPrefix,omitempty"`
-	HasParticipantIDs bool              `yaml:"has_participant_ids,omitempty" json:"hasParticipantIDs,omitempty"`
-	// SourceCompID links a playoffs competition back to the mixed
-	// (Pools + Knockout) competition that this competition was seeded from.
-	// NEW competitions never set this field — the split-playoffs flow was
-	// replaced by a single mixed competition whose knockout bracket fills in
-	// incrementally as pools finish (engine.ResolveQualifiedPools, mp-turx).
-	// The field is retained for YAML round-trip compatibility with existing
-	// tournament data files, and engine/estimate_schedule.go still reads it on
-	// the legacy code path that estimates source-linked playoffs that may
-	// already exist on disk. That legacy read is harmless for new comps (the
-	// field is always empty) and is tracked for removal in bead mp-c3pf.
-	SourceCompID         string `yaml:"source_comp_id,omitempty" json:"sourceCompID,omitempty"`
-	PoolMatchDuration    int    `yaml:"pool_match_duration,omitempty" json:"poolMatchDuration,omitempty"`
-	PlayoffMatchDuration int    `yaml:"playoff_match_duration,omitempty" json:"playoffMatchDuration,omitempty"`
+	ID                   string            `yaml:"id" json:"id"`
+	Name                 string            `yaml:"name" json:"name"`
+	Kind                 string            `yaml:"kind" json:"kind"`
+	Format               string            `yaml:"format" json:"format"`
+	PoolFormat           string            `yaml:"pool_format,omitempty" json:"poolFormat,omitempty"` // "full" (default) | "partial"
+	TeamSize             int               `yaml:"team_size" json:"teamSize"`
+	PoolSize             int               `yaml:"pool_size" json:"poolSize"`
+	PoolSizeMode         string            `yaml:"pool_size_mode" json:"poolSizeMode"`
+	PoolWinners          int               `yaml:"pool_winners" json:"poolWinners"`
+	RoundRobin           bool              `yaml:"round_robin" json:"roundRobin"`
+	Courts               []string          `yaml:"courts" json:"courts"`
+	StartTime            string            `yaml:"start_time" json:"startTime"`
+	Date                 string            `yaml:"date" json:"date"`
+	Status               CompetitionStatus `yaml:"status" json:"status"`
+	Mirror               bool              `yaml:"mirror" json:"mirror"`
+	WithZekkenName       bool              `yaml:"with_zekken_name" json:"withZekkenName"`
+	NumberPrefix         string            `yaml:"number_prefix,omitempty" json:"numberPrefix,omitempty"`
+	HasParticipantIDs    bool              `yaml:"has_participant_ids,omitempty" json:"hasParticipantIDs,omitempty"`
+	PoolMatchDuration    int               `yaml:"pool_match_duration,omitempty" json:"poolMatchDuration,omitempty"`
+	PlayoffMatchDuration int               `yaml:"playoff_match_duration,omitempty" json:"playoffMatchDuration,omitempty"`
 	// MaxEnchoPeriods caps how many encho (overtime) periods one match
 	// may run before the operator must call daihyosen. Zero means
 	// unlimited (FIK general default). T104, CHK029.

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2438,16 +2438,6 @@ components:
           type: string
         hasParticipantIDs:
           type: boolean
-        sourceCompID:
-          type: string
-          maxLength: 64
-          description: >
-            DEPRECATED / legacy. Historically linked a separate `playoffs`
-            competition back to a mixed source. New competitions never set it —
-            a mixed (Pools + Knockout) competition now contains its own knockout
-            bracket, which fills in incrementally as each pool finishes (no
-            separate playoffs competition is created). Retained only for YAML
-            round-trip compatibility with pre-existing tournament data.
         teamMatchType:
           type: string
           description: Team-match scoring model — `fixed` (positions) or `kachinuki` (winner-stays).

--- a/web-mobile/js/__tests__/admin_all_winners.test.jsx
+++ b/web-mobile/js/__tests__/admin_all_winners.test.jsx
@@ -108,34 +108,6 @@ describe('buildAllWinners', () => {
     expect(results[0].podium).toHaveLength(4);
   });
 
-  it('filters out linked playoffs comp (sourceCompID set) — state "skip"', async () => {
-    const mixedComp = { id: 'mixed-1', name: 'Pools+KO', format: 'mixed', status: 'completed' };
-    const playoffComp = { id: 'po-1', name: 'Playoffs', format: 'playoffs', sourceCompID: 'mixed-1', status: 'completed' };
-    const allComps = [mixedComp, playoffComp];
-    const bracket = {
-      rounds: [
-        [{ sideA: 'Alice', sideB: 'Bob', winner: 'Alice' }, { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' }],
-        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
-      ],
-    };
-    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, players: [] });
-
-    // Pass both completed comps; the playoffs shell should be filtered (skip)
-    const results = await window.buildAllWinners([mixedComp, playoffComp], allComps, {
-      fetchCompetitionDetails,
-      swissStandings: null,
-    });
-
-    // playoffComp (linked shell) must be filtered out; mixedComp resolved to final
-    expect(results.find(r => r.comp.id === 'po-1')).toBeUndefined();
-    expect(results.find(r => r.comp.id === 'mixed-1')).toBeDefined();
-    const mixedResult = results.find(r => r.comp.id === 'mixed-1');
-    expect(mixedResult.state).toBe('final');
-    expect(mixedResult.podium).toHaveLength(4);
-    expect(mixedResult.podium[2].place).toBe(3);
-    expect(mixedResult.podium[3].place).toBe(3);
-  });
-
   it('mixed comp whose OWN knockout final is undecided → state "in-progress", podium []', async () => {
     const mixedComp = { id: 'mixed-2', name: 'Pools+KO', format: 'mixed', status: 'playoffs' };
     const allComps = [mixedComp];

--- a/web-mobile/js/__tests__/resolve_awards.test.jsx
+++ b/web-mobile/js/__tests__/resolve_awards.test.jsx
@@ -142,7 +142,7 @@ describe('resolveCompetitionAwards', () => {
 
   // ── standalone playoffs → final ───────────────────────────────────────────
   it('standalone playoffs comp with decided final → state "final", podium has two 3rds', async () => {
-    const comp = { id: 'ko-1', format: 'playoffs' }; // no sourceCompID
+    const comp = { id: 'ko-1', format: 'playoffs' };
     const allComps = [comp];
     const bracket = decidedBracket();
     const fetchers = {
@@ -157,22 +157,6 @@ describe('resolveCompetitionAwards', () => {
     expect(result.podium[0]).toMatchObject({ place: 1, name: 'Alice' });
     expect(result.podium[2]).toMatchObject({ place: 3 });
     expect(result.podium[3]).toMatchObject({ place: 3 });
-  });
-
-  // ── linked playoffs shell → skip ──────────────────────────────────────────
-  it('playoffs comp with sourceCompID → state "skip", podium []', async () => {
-    const comp = { id: 'po-99', format: 'playoffs', sourceCompID: 'mixed-99' };
-    const allComps = [comp];
-    const fetchers = {
-      fetchCompetitionDetails: vi.fn(),
-      swissStandings: null,
-    };
-
-    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
-
-    expect(result.state).toBe('skip');
-    expect(result.podium).toEqual([]);
-    expect(fetchers.fetchCompetitionDetails).not.toHaveBeenCalled();
   });
 
   // ── league (standings-based) → final ─────────────────────────────────────

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -121,13 +121,9 @@ const PLACE_STYLE_ADMIN = {
 };
 
 // buildAllWinners resolves podium for each completed comp using the shared
-// resolveCompetitionAwards helper (handles mixed→linked-playoffs rule).
-// Signature: buildAllWinners(completedComps, allComps, fetchers)
-// Returns a Promise resolving to an array of { comp, state, podium } objects
-// (plus an `error` string field when state === "error"), with results whose
-// state === "skip" filtered out (linked playoffs shells).
+// resolveCompetitionAwards helper.
 async function buildAllWinners(completedComps, allComps, fetchers) {
-  const results = await Promise.all(
+  return Promise.all(
     completedComps.map(async (comp) => {
       try {
         const { state, podium } = await window.resolveCompetitionAwards(comp, allComps, fetchers);
@@ -137,7 +133,6 @@ async function buildAllWinners(completedComps, allComps, fetchers) {
       }
     })
   );
-  return results.filter((r) => r.state !== "skip");
 }
 
 // AllWinnersModal renders a summary of every completed competition with its

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2980,9 +2980,9 @@ function bracketHasDecidedFinal(bracket) {
 //   'final'       — podium is the final result
 //   'in-progress' — knockout not yet decided (podium [])
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
-// NOTE: allComps is vestigial (was used by the removed sourceCompID skip
+// NOTE: _allComps is vestigial (was used by the removed sourceCompID skip
 // branch) — tracked for removal in bead mp-i385.
-async function resolveCompetitionAwards(comp, allComps, fetchers) {
+async function resolveCompetitionAwards(comp, _allComps, fetchers) {
   const fmt = comp && comp.format;
   const ntpFrom = (players) => {
     const m = new Map();

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -655,8 +655,6 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   }, [comps, t.date]);
   const dates = Object.keys(compsByDate).sort(compareDmy);
 
-  // Every competition renders as its own standalone entry — the old split model
-  // (sourceCompID pairing) is gone; mixed comps are now a single competition.
   const displayEntriesByDate = useMemo(() => {
     const result = {};
     Object.keys(compsByDate).forEach(d => {
@@ -2981,9 +2979,9 @@ function bracketHasDecidedFinal(bracket) {
 // Returns { state, podium } where state is one of:
 //   'final'       — podium is the final result
 //   'in-progress' — knockout not yet decided (podium [])
-//   'skip'        — a LEGACY linked playoffs shell (sourceCompID set); its podium
-//                   is represented by its mixed parent. New data never hits this.
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
+// NOTE: allComps is vestigial (was used by the removed sourceCompID skip
+// branch) — tracked for removal in bead mp-i385.
 async function resolveCompetitionAwards(comp, allComps, fetchers) {
   const fmt = comp && comp.format;
   const ntpFrom = (players) => {
@@ -2991,12 +2989,6 @@ async function resolveCompetitionAwards(comp, allComps, fetchers) {
     (players || []).forEach((p) => { if (p && p.name) m.set(p.name, p); });
     return m;
   };
-  if (fmt === "playoffs" && comp.sourceCompID) {
-    // Legacy split-model shell (a "- Playoffs" comp seeded from a mixed parent);
-    // represented by its parent, so skip to avoid double-listing. New data never
-    // sets sourceCompID.
-    return { state: "skip", podium: [] };
-  }
   if (fmt === "mixed" || fmt === "playoffs") {
     // Mixed is now a SINGLE competition: its knockout bracket fills in place as
     // pools finish (no separate "- Playoffs" comp). Both mixed and standalone
@@ -3061,8 +3053,6 @@ function AwardsView({ c, bracket, standings, pools, players, allComps }) {
     }
     let cancelled = false;
     const fetchers = { fetchCompetitionDetails: window.API.fetchCompetitionDetails, swissStandings: null };
-    // Mixed awards derive from the comp's OWN bracket (single-competition model);
-    // allComps is only consulted for the legacy sourceCompID skip branch.
     resolveCompetitionAwards(c, allComps || [], fetchers)
       .then(({ state, podium }) => {
         if (!cancelled) setKoAwards({ state, awards: podium });


### PR DESCRIPTION
## Summary

- Remove the dead `SourceCompID` field from `state.Competition` and all code paths that referenced it (Go estimator, JS viewer awards, OpenAPI spec)
- The split-playoffs model (separate "- Playoffs" competition linked via `SourceCompID`) was replaced by in-place knockout in mp-turx; this field and its code paths were vestigial
- The mixed-format schedule estimator already correctly accounts for both pool and playoff phases — no functional fix was needed, only dead-code removal

## Why

mp-turx merged the mixed (Pools + Knockout) flow into a single competition with in-place knockout. The old `SourceCompID` field and the code that read it (estimate_schedule.go's source-linked playoffs branch, viewer.jsx's "skip" state for linked shells) were dead code. Removing them simplifies the codebase and prevents confusion about a model that no longer exists.

## Files changed

| File | What |
|---|---|
| `internal/state/models.go` | Remove `SourceCompID` field from Competition struct |
| `internal/engine/estimate_schedule.go` | Remove `estimateFinalistCount` func and SourceCompID branch in `estimateParticipantCount`; simplify doc comments |
| `internal/engine/estimate_schedule_test.go` | Remove 3 SourceCompID tests (`SourceLinked_PoolsExist`, `SourceLinked_NoPools`, `EstimateFinalistCount_UsesSourcePoolWinners`); remove unused `domain` import |
| `specs/openapi.yaml` | Remove deprecated `sourceCompID` property from Competition schema |
| `web-mobile/js/viewer.jsx` | Remove legacy `sourceCompID` skip branch in `resolveCompetitionAwards`; update doc comment noting `allComps` is vestigial (mp-i385) |
| `web-mobile/js/admin_shell.jsx` | Remove `buildAllWinners` skip-filter and stale doc comments |
| `web-mobile/js/__tests__/resolve_awards.test.jsx` | Remove "playoffs comp with sourceCompID → skip" test case |
| `web-mobile/js/__tests__/admin_all_winners.test.jsx` | Remove "filters out linked playoffs comp (sourceCompID set)" test case |

## Screenshots

No UI changes — this is pure dead-code removal. The awards resolver and schedule estimator produce identical results for all current competition formats. No visual or behavioral change in the browser.

## Test plan

- [x] `make go/test` — lint failure is pre-existing (`build_date.txt` not found in worktree); all Go tests pass
- [x] Go engine tests pass (86.1% coverage): `go test -cover ./internal/engine/...`
- [x] Go state tests pass (84.9% coverage): `go test -cover ./internal/state/...`
- [x] Go mobileapp tests pass (82.6% coverage): `go test -cover ./internal/mobileapp/...`
- [x] JS resolve_awards tests pass (all 14 tests): `npx vitest run js/__tests__/resolve_awards.test.jsx`
- [x] JS admin_all_winners tests pass (all 12 tests): `npx vitest run js/__tests__/admin_all_winners.test.jsx`
- [x] No new/updated unit tests needed — this is dead-code removal; existing tests for mixed-format estimation (`TestEstimateScheduleForCompetition_Mixed`, `TestEstimateMatchCounts_vs_RealMixedDraw`) already verify both pool + playoff phases contribute
- [x] Manual browser verification — not applicable (no UI-affecting change; dead code path never executed in production)

Closes mp-c3pf
