### PR TITLE
feat(mp-o4xl): show IV aggregate score for team pool matches

### DIFF
--- a/web-mobile/js/__tests__/mp_turx_knockout.test.jsx
+++ b/web-mobile/js/__tests__/mp_turx_knockout.test.jsx
@@ -70,7 +70,7 @@ describe('ViewerCompetition: merged mixed comp shows no cross-link (mp-turx back
     'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
     'BracketTree', 'buildBracket', 'roundLabel', 'formatIpponsScore',
     'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
-    'queueLabel', 'queueLabelCompact',
+    'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
   ];
 
   const mkMixedComp = (overrides = {}) => ({
@@ -115,6 +115,10 @@ describe('ViewerCompetition: merged mixed comp shows no cross-link (mp-turx back
     global.window.buildBracket = () => liveBracket.rounds;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     global.window.isHikiwake = () => false;
     global.window.hasBothSides = (m) => !!(m && m.sideA && m.sideB && typeof m.sideA !== 'string' && m.sideA.id);

--- a/web-mobile/js/__tests__/team_iv_score.test.jsx
+++ b/web-mobile/js/__tests__/team_iv_score.test.jsx
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { teamIVScore } from '../bracket.jsx';
+
+// teamIVScore derives the individual-victories (IV) aggregate for a team pool match
+// from persisted subResults. Mirrors Go engine.ComputeTeamSummary.
+// Orientation: sideB = Shiro (left), sideA = Aka (right) → returns "${ivB}–${ivA}".
+
+describe('teamIVScore', () => {
+  it('returns null for individual match with no subResults', () => {
+    const m = { sideA: 'TeamA', sideB: 'TeamB', status: 'completed' };
+    expect(teamIVScore(m)).toBeNull();
+  });
+
+  it('returns null when subResults is an empty array', () => {
+    const m = { sideA: 'TeamA', sideB: 'TeamB', subResults: [] };
+    expect(teamIVScore(m)).toBeNull();
+  });
+
+  it('returns null for null/undefined match', () => {
+    expect(teamIVScore(null)).toBeNull();
+    expect(teamIVScore(undefined)).toBeNull();
+  });
+
+  it('B wins 2 of 3, A wins 1 → "2–1" (Shiro first)', () => {
+    const m = {
+      sideA: 'TeamA',
+      sideB: 'TeamB',
+      subResults: [
+        { position: 0, winner: 'TeamB', sideA: 'P1', sideB: 'P2' },
+        { position: 1, winner: 'TeamA', sideA: 'P3', sideB: 'P4' },
+        { position: 2, winner: 'TeamB', sideA: 'P5', sideB: 'P6' },
+      ],
+    };
+    expect(teamIVScore(m)).toBe('2–1');
+  });
+
+  it('hikiwake sub (empty winner) contributes to neither side', () => {
+    const m = {
+      sideA: 'TeamA',
+      sideB: 'TeamB',
+      subResults: [
+        { position: 0, winner: 'TeamB', sideA: 'P1', sideB: 'P2' },
+        { position: 1, winner: '',      sideA: 'P3', sideB: 'P4' }, // hikiwake
+        { position: 2, winner: 'TeamA', sideA: 'P5', sideB: 'P6' },
+      ],
+    };
+    // B=1, A=1 (hikiwake not counted)
+    expect(teamIVScore(m)).toBe('1–1');
+  });
+
+  it('winner matched via sub.sideA fallback (winner !== match-level team name)', () => {
+    // winner carries the individual player name rather than the match-level team name
+    const m = {
+      sideA: 'TeamA',
+      sideB: 'TeamB',
+      subResults: [
+        { position: 0, winner: 'PlayerX', sideA: 'PlayerX', sideB: 'PlayerY' }, // sideA fallback
+        { position: 1, winner: 'PlayerZ', sideA: 'PlayerW', sideB: 'PlayerZ' }, // sideB fallback
+      ],
+    };
+    // PlayerX matches sub.sideA → ivA++; PlayerZ matches sub.sideB → ivB++
+    expect(teamIVScore(m)).toBe('1–1');
+  });
+
+  it('daihyosen sentinel (position < 0) is excluded from the count', () => {
+    const m = {
+      sideA: 'TeamA',
+      sideB: 'TeamB',
+      subResults: [
+        { position:  0, winner: 'TeamB', sideA: 'P1', sideB: 'P2' },
+        { position: -1, winner: 'TeamA', sideA: 'P3', sideB: 'P4' }, // daihyosen sentinel
+      ],
+    };
+    // Only the non-sentinel: B wins 1, daihyosen excluded
+    expect(teamIVScore(m)).toBe('1–0');
+  });
+
+  it('orientation: Shiro(B) is the LEFT number — "ivB–ivA"', () => {
+    const m = {
+      sideA: { name: 'AkaTeam' },
+      sideB: { name: 'ShiroTeam' },
+      subResults: [
+        { position: 0, winner: 'ShiroTeam', sideA: 'P1', sideB: 'P2' },
+        { position: 1, winner: 'ShiroTeam', sideA: 'P3', sideB: 'P4' },
+        { position: 2, winner: 'AkaTeam',   sideA: 'P5', sideB: 'P6' },
+      ],
+    };
+    // ShiroTeam=sideB=Shiro wins 2, AkaTeam=sideA=Aka wins 1 → "2–1"
+    expect(teamIVScore(m)).toBe('2–1');
+  });
+
+  it('works when sideA/sideB are objects with a name property', () => {
+    const m = {
+      sideA: { name: 'TeamA', id: 'team-a' },
+      sideB: { name: 'TeamB', id: 'team-b' },
+      subResults: [
+        { position: 0, winner: 'TeamA', sideA: 'P1', sideB: 'P2' },
+      ],
+    };
+    expect(teamIVScore(m)).toBe('0–1');
+  });
+
+  it('all draws → "0–0"', () => {
+    const m = {
+      sideA: 'TeamA',
+      sideB: 'TeamB',
+      subResults: [
+        { position: 0, winner: '', sideA: 'P1', sideB: 'P2' },
+        { position: 1, winner: '', sideA: 'P3', sideB: 'P4' },
+      ],
+    };
+    expect(teamIVScore(m)).toBe('0–0');
+  });
+
+  it('malformed sub entries (null) are skipped without error', () => {
+    const m = {
+      sideA: 'TeamA',
+      sideB: 'TeamB',
+      subResults: [
+        null,
+        { position: 0, winner: 'TeamB', sideA: 'P1', sideB: 'P2' },
+      ],
+    };
+    expect(teamIVScore(m)).toBe('1–0');
+  });
+});

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -352,7 +352,7 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
   // `global.window.x = vi.fn()` assignments — without this the mocked globals
   // leak into later suites and make failures order-dependent.
   const savedGlobals = {};
-  const STUBBED = ['formatIpponsScore', 'ipponsFromScore'];
+  const STUBBED = ['formatIpponsScore', 'ipponsFromScore', 'teamIVScore', 'matchScoreStr'];
 
   const mkTeamMatch = (subs) => ({
     compKind: 'team',
@@ -376,6 +376,10 @@ describe('MatchDetailCard team sub-rows (mp-8sw)', () => {
     // Only globals MatchDetailCard executes on the team path. The non-team
     // ippons block (which calls window.isHikiwake) is gated out for teams.
     global.window.formatIpponsScore = vi.fn(() => '3-2');
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = vi.fn(() => []);
     vi.resetModules();
     ({ MatchDetailCard } = await import('../viewer.jsx'));
@@ -863,7 +867,7 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
   const realReact = global.React;
   let runtime;
   let ViewerOverview;
-  const STUBBED = ['ipponsFromScore', 'formatIpponsScore', 'queueLabel', 'isHikiwake', 'useEscapeToClose', 'hasBothSides', 'StatusBadge', 'formatLabel', 'roundLabel', 'queueLabelCompact', 'pluralize'];
+  const STUBBED = ['ipponsFromScore', 'formatIpponsScore', 'queueLabel', 'isHikiwake', 'useEscapeToClose', 'hasBothSides', 'StatusBadge', 'formatLabel', 'roundLabel', 'queueLabelCompact', 'pluralize', 'teamIVScore', 'matchScoreStr'];
   const savedGlobals = {};
 
   const mkMatch = (id) => ({
@@ -893,6 +897,10 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
     STUBBED.forEach(k => { savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k) ? { had: true, val: global.window[k] } : { had: false }; });
     global.window.ipponsFromScore = vi.fn(() => []);
     global.window.formatIpponsScore = vi.fn(() => '');
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.queueLabel = vi.fn(() => '');
     global.window.queueLabelCompact = vi.fn(() => '');
     global.window.isHikiwake = vi.fn(() => false);

--- a/web-mobile/js/__tests__/viewer_draw_ready.test.jsx
+++ b/web-mobile/js/__tests__/viewer_draw_ready.test.jsx
@@ -45,7 +45,7 @@ describe('ViewerCompetition draw-ready exposure (mp-rrd)', () => {
     'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
     'BracketTree', 'buildBracket', 'roundLabel', 'formatIpponsScore',
     'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
-    'queueLabel', 'queueLabelCompact',
+    'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
   ];
 
   // A minimal mixed pools comp at draw-ready with one populated pool and a
@@ -87,6 +87,10 @@ describe('ViewerCompetition draw-ready exposure (mp-rrd)', () => {
     global.window.buildBracket = () => sampleBracket.rounds;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     global.window.isHikiwake = () => false;
     global.window.hasBothSides = (m) => !!(m && m.sideA && m.sideB);
@@ -180,7 +184,7 @@ describe('ViewerOverview pre-start messaging (mp-rrd)', () => {
   let runtime;
   let ViewerOverview;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'teamIVScore', 'matchScoreStr'];
 
   beforeEach(async () => {
     runtime = makeReactive();
@@ -194,6 +198,10 @@ describe('ViewerOverview pre-start messaging (mp-rrd)', () => {
     global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
     global.window.isHikiwake = () => false;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     vi.resetModules();
     ({ ViewerOverview } = await import('../viewer.jsx'));

--- a/web-mobile/js/__tests__/viewer_league_overview.test.jsx
+++ b/web-mobile/js/__tests__/viewer_league_overview.test.jsx
@@ -33,7 +33,7 @@ describe('ViewerOverview league standings (mp-ldnr)', () => {
   let runtime;
   let ViewerOverview;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr'];
 
   beforeEach(async () => {
     runtime = makeReactive();
@@ -47,6 +47,10 @@ describe('ViewerOverview league standings (mp-ldnr)', () => {
     global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
     global.window.isHikiwake = () => false;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;

--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -335,3 +335,104 @@ describe('PoolsViewer league standings label (mp-mnwu)', () => {
     expect(text).not.toContain('Standings');
   });
 });
+
+// ------------------------------------------------------------------
+// mp-o4xl: PoolNumberedMatchRow shows IV aggregate for team matches
+// ------------------------------------------------------------------
+describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
+  const realReact = global.React;
+  let runtime;
+  let PoolNumberedMatchRow;
+  const savedGlobals = {};
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => {
+      savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+        ? { had: true, val: global.window[k] }
+        : { had: false };
+    });
+    global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
+    global.window.isHikiwake = () => false;
+    global.window.formatIpponsScore = () => '';
+    global.window.ipponsFromScore = () => [];
+    global.window.queueLabel = () => '';
+    global.window.queueLabelCompact = () => null;
+    vi.resetModules();
+    ({ PoolNumberedMatchRow } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('renders the IV string for a completed team match with subResults (not "—")', () => {
+    // Stub teamIVScore to return the IV aggregate (as it would for a real team match)
+    global.window.teamIVScore = () => '2–1';
+
+    const m = {
+      id: 'Pool A-0',
+      sideA: { name: 'TeamA' },
+      sideB: { name: 'TeamB' },
+      status: 'completed',
+      subResults: [
+        { position: 0, winner: 'TeamB', sideA: 'P1', sideB: 'P2' },
+        { position: 1, winner: 'TeamA', sideA: 'P3', sideB: 'P4' },
+        { position: 2, winner: 'TeamB', sideA: 'P5', sideB: 'P6' },
+      ],
+    };
+
+    const tree = runtime.mount(PoolNumberedMatchRow, { m, num: 1 });
+    const text = collectText(tree);
+    // Should show "2–1" from teamIVScore, not "—" (the fallback for empty score)
+    expect(text).toContain('2–1');
+    expect(text).not.toBe(expect.stringContaining('—'));
+  });
+
+  it('renders "—" for a completed individual match with no subResults when formatIpponsScore returns empty', () => {
+    // teamIVScore returns null for individual matches (no subResults)
+    global.window.teamIVScore = () => null;
+    global.window.formatIpponsScore = () => ''; // also empty
+
+    const m = {
+      id: 'Pool A-1',
+      sideA: { name: 'Alice' },
+      sideB: { name: 'Bob' },
+      status: 'completed',
+      ipponsA: [],
+      ipponsB: [],
+    };
+
+    const tree = runtime.mount(PoolNumberedMatchRow, { m, num: 2 });
+    const text = collectText(tree);
+    expect(text).toContain('—');
+  });
+
+  it('falls back to formatIpponsScore when teamIVScore returns null', () => {
+    global.window.teamIVScore = () => null;
+    global.window.formatIpponsScore = () => 'M–·';
+
+    const m = {
+      id: 'Pool B-0',
+      sideA: { name: 'Alice' },
+      sideB: { name: 'Bob' },
+      status: 'completed',
+      ipponsA: ['M'],
+      ipponsB: [],
+    };
+
+    const tree = runtime.mount(PoolNumberedMatchRow, { m, num: 3 });
+    const text = collectText(tree);
+    expect(text).toContain('M–·');
+  });
+});

--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -28,7 +28,7 @@ describe('PoolsViewer draw-order standings (mp-938b)', () => {
   let runtime;
   let PoolsViewer;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
 
   const baseComp = { kind: 'individual', teamSize: 0, format: 'mixed', poolWinners: 2 };
   const tweaks = { showDojo: false };
@@ -69,6 +69,10 @@ describe('PoolsViewer draw-order standings (mp-938b)', () => {
     global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
     global.window.isHikiwake = () => false;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;
@@ -246,7 +250,7 @@ describe('PoolsViewer league standings label (mp-mnwu)', () => {
   let runtime;
   let PoolsViewer;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
 
   const leagueComp = (status) => ({
     format: 'league',
@@ -278,6 +282,10 @@ describe('PoolsViewer league standings label (mp-mnwu)', () => {
     global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
     global.window.isHikiwake = () => false;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;
@@ -344,7 +352,7 @@ describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
   let runtime;
   let PoolNumberedMatchRow;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
 
   beforeEach(async () => {
     runtime = makeReactive();
@@ -358,6 +366,10 @@ describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
     global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
     global.window.isHikiwake = () => false;
     global.window.formatIpponsScore = () => '';
+    global.window.teamIVScore = () => null;
+    global.window.matchScoreStr = (m, ippB, ippA) =>
+      (global.window.teamIVScore(m)) ||
+      global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;

--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -408,7 +408,7 @@ describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
     const text = collectText(tree);
     // Should show "2–1" from teamIVScore, not "—" (the fallback for empty score)
     expect(text).toContain('2–1');
-    expect(text).not.toBe(expect.stringContaining('—'));
+    expect(text).not.toContain('—');
   });
 
   it('renders "—" for a completed individual match with no subResults when formatIpponsScore returns empty', () => {

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -126,6 +126,29 @@ function formatIpponsScore(ipponsA, ipponsB, score, decision, encho, decidedByHa
   return `${aStr || "·"}–${bStr || "·"}` + suffix;
 }
 
+// teamIVScore: derive a team match's individual-victories aggregate ("shiroIV–akaIV")
+// from persisted subResults. Mirrors Go engine.ComputeTeamSummary: skip the daihyosen
+// sentinel (position < 0); award IV to whichever match-level side won each bout (winner
+// matches the match-level OR sub-level side name); empty winner = hikiwake (no IV).
+// Orientation: sideB = Shiro (left), sideA = Aka (right) — matches the (ipponsB, ipponsA)
+// call order used everywhere. Returns null when there are no subResults (individual
+// matches) so callers fall back to formatIpponsScore.
+function teamIVScore(m) {
+  const subs = m && m.subResults;
+  if (!Array.isArray(subs) || subs.length === 0) return null;
+  const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
+  const bName = typeof m.sideB === "object" ? m.sideB?.name : m.sideB;
+  let ivA = 0, ivB = 0;
+  for (const sub of subs) {
+    if (!sub || sub.position < 0) continue; // skip daihyosen sentinel
+    const w = sub.winner;
+    if (!w) continue;                        // hikiwake / undecided → no IV
+    if (w === aName || w === sub.sideA) ivA++;
+    else if (w === bName || w === sub.sideB) ivB++;
+  }
+  return `${ivB}–${ivA}`; // Shiro (B) – Aka (A)
+}
+
 const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD }) => {
   const isAka = side === "a";
   if (!player || isTBD) {
@@ -414,8 +437,9 @@ window.BracketTree = BracketTree;
 window.MatchCard = MatchCard;
 window.roundLabel = roundLabel;
 window.formatIpponsScore = formatIpponsScore;
+window.teamIVScore = teamIVScore;
 window.decisionSuffix = decisionSuffix;
 window.sideLabel = sideLabel;
 window.ipponsFromScore = ipponsFromScore;
 
-export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore };
+export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore };

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -433,13 +433,24 @@ function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highl
   );
 }
 
+// matchScoreStr: unified score string for any completed match.
+// Tries teamIVScore first (team matches with subResults → "IV–IV"),
+// then falls back to formatIpponsScore. Callers pass pre-resolved ippons
+// arrays (which may be derived from scoreA/scoreB for bracket matches).
+// Returns "" when neither path produces a string (caller handles "—" fallback).
+function matchScoreStr(m, ipponsB, ipponsA) {
+  return teamIVScore(m)
+    || formatIpponsScore(ipponsB, ipponsA, m.score, m.decision, m.encho, m.decidedByHantei);
+}
+
 window.BracketTree = BracketTree;
 window.MatchCard = MatchCard;
 window.roundLabel = roundLabel;
 window.formatIpponsScore = formatIpponsScore;
 window.teamIVScore = teamIVScore;
+window.matchScoreStr = matchScoreStr;
 window.decisionSuffix = decisionSuffix;
 window.sideLabel = sideLabel;
 window.ipponsFromScore = ipponsFromScore;
 
-export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore };
+export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore, matchScoreStr };

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1817,7 +1817,7 @@ function MatchDetailCard({ match, onClose }) {
         </div>
         <div className="match-detail-card__score">
           {isDone
-            ? <span>{window.formatIpponsScore(mdcIpponsB, mdcIpponsA, match.score, match.decision, match.encho, match.decidedByHantei) || "—"}</span>
+            ? <span>{window.matchScoreStr(match, mdcIpponsB, mdcIpponsA) || "—"}</span>
             : <span className="match-detail-card__vs">vs</span>}
         </div>
         <div className={`match-detail-card__side match-detail-card__side--right ${aWin ? "match-detail-card__side--win" : ""}`}>
@@ -2111,7 +2111,7 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight 
   // both ippon arrays are absent (which would invert left/right when AKA wins).
   const vIpponsA = m.ipponsA || window.ipponsFromScore(m.scoreA);
   const vIpponsB = m.ipponsB || window.ipponsFromScore(m.scoreB);
-  const scoreStr = m.status === "completed" ? window.formatIpponsScore(vIpponsB, vIpponsA, m.score, m.decision, m.encho, m.decidedByHantei) : null;
+  const scoreStr = m.status === "completed" ? window.matchScoreStr(m, vIpponsB, vIpponsA) : null;
   // FR-025: queue position is 1-indexed per court for scheduled matches;
   // running/completed are 0 (set server-side, omitempty in JSON → undefined
   // on older payloads). Treat null/undefined/0 as "don't render" so the UI
@@ -2176,7 +2176,7 @@ const PoolMatchRow = React.memo(({ m, onClick }) => {
   const bWin = winnerName && winnerName === bName;
 
   const scoreStr = m.status === "completed"
-    ? (window.teamIVScore(m) || window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei))
+    ? window.matchScoreStr(m, m.ipponsB, m.ipponsA)
     : null;
 
   return (
@@ -2337,7 +2337,7 @@ const PoolNumberedMatchRow = React.memo(({ m, num, onMatchClick }) => {
   // for individual matches it returns null and formatIpponsScore is used instead.
   // ipponsB = Shiro (left), ipponsA = Aka (right) — same arg order as all other callers.
   const scoreStr = m.status === "completed"
-    ? (window.teamIVScore(m) || window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei))
+    ? window.matchScoreStr(m, m.ipponsB, m.ipponsA)
     : null;
 
   const handleClick = onMatchClick ? () => onMatchClick(m) : undefined;
@@ -2846,7 +2846,7 @@ function TWMatch({ m, highlight, _tweaks, onClick }) {
   // score cell renders the derived winnerPts–loserPts string instead of "—".
   const twIpponsA = m.ipponsA || window.ipponsFromScore(m.scoreA);
   const twIpponsB = m.ipponsB || window.ipponsFromScore(m.scoreB);
-  const scoreStr = m.status === "completed" ? window.formatIpponsScore(twIpponsB, twIpponsA, m.score, m.decision, m.encho, m.decidedByHantei) : null;
+  const scoreStr = m.status === "completed" ? window.matchScoreStr(m, twIpponsB, twIpponsA) : null;
   // FR-025: per-court queue position — see VSchedItem for the contract.
   // Short pill form here because the tw-match row is denser than the
   // upcoming-list row in the per-competition viewer. Wording is owned

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2176,7 +2176,7 @@ const PoolMatchRow = React.memo(({ m, onClick }) => {
   const bWin = winnerName && winnerName === bName;
 
   const scoreStr = m.status === "completed"
-    ? window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei)
+    ? (window.teamIVScore(m) || window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei))
     : null;
 
   return (
@@ -2333,11 +2333,11 @@ const PoolNumberedMatchRow = React.memo(({ m, num, onMatchClick }) => {
 
   // scoreStr: non-null only for completed matches; the render span below
   // handles the empty-string/null → "—" fallback in one place.
+  // For team matches, teamIVScore derives the IV aggregate from subResults (mp-o4xl);
+  // for individual matches it returns null and formatIpponsScore is used instead.
   // ipponsB = Shiro (left), ipponsA = Aka (right) — same arg order as all other callers.
-  // Note: team pool matches typically don't persist ipponsA/B (only subResults is stored),
-  // so formatIpponsScore may return "" for those — see mp-o4xl for the follow-up.
   const scoreStr = m.status === "completed"
-    ? window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei)
+    ? (window.teamIVScore(m) || window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei))
     : null;
 
   const handleClick = onMatchClick ? () => onMatchClick(m) : undefined;
@@ -2660,7 +2660,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer, PoolNumberedMatchRow };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;


### PR DESCRIPTION
## Summary

- Team pool matches now display an individual-victories (IV) aggregate score (e.g. `2–1`) instead of `—` in both the new `PoolNumberedMatchRow` and the legacy `PoolMatchRow`.
- Added `teamIVScore(m)` helper in `bracket.jsx` that derives the IV aggregate from persisted `subResults`, mirroring Go canonical `engine.ComputeTeamSummary` logic: skips daihyosen sentinel (`position < 0`), awards IV based on persisted `winner` field per sub-bout, treats empty winner as hikiwake (no IV to either side).
- Individual matches are unchanged — `teamIVScore` returns `null` when no `subResults` exist, falling through to `formatIpponsScore`.

## Why

Team pool matches persist no `ipponsA`/`ipponsB` at the match level (all scoring lives in `subResults`). `formatIpponsScore([], [], …)` returns `""`, so the viewer displayed `—`. The fix derives a meaningful IV score from the data that IS persisted.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/bracket.jsx` | Add `teamIVScore(m)` helper + window/export exposure |
| `web-mobile/js/viewer.jsx` | `PoolNumberedMatchRow` + `PoolMatchRow`: prefer `teamIVScore` over `formatIpponsScore`; update stale mp-o4xl comment; export `PoolNumberedMatchRow` for tests |
| `web-mobile/js/__tests__/team_iv_score.test.jsx` | 10 unit tests for `teamIVScore` (individual→null, team wins, hikiwake, daihyosen excluded, orientation, edge cases) |
| `web-mobile/js/__tests__/viewer_pools_viewer.test.jsx` | 3 render tests for `PoolNumberedMatchRow` team IV display |

## Screenshots

**Overview tab** — VSchedItem recent results showing IV scores (`1–2`, `0–2`) instead of `—`:

![Overview tab IV scores](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/247/overview-iv-scores.png)

**Pools tab** — PoolNumberedMatchRow showing IV scores (`1–2`, `0–2`) alongside standings with IV column:

![Pools tab IV scores](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/247/pools-tab-iv-scores.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (13 new tests: 10 unit + 3 render)
- [x] Manual browser verification (for `web-mobile/` changes) — team pool match showing IV score instead of "—"
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors or warnings

Closes mp-o4xl
