### PR TITLE
docs(mp-c3pf): remove stale source-linked playoffs comment references (follow-up to #245)

### DIFF
--- a/internal/engine/competition.go
+++ b/internal/engine/competition.go
@@ -559,8 +559,8 @@ func dropSeedAssignments(seeds []domain.SeedAssignment, excluded map[string]bool
 //     OUTSIDE the comp-config lock. Two concurrent GenerateDraw calls
 //     could overwrite each other's pools.csv before the atomic Status
 //     commit serializes them. Left as a follow-up.
-//   - SaveParticipants (source-linked playoffs roster path) also has its own
-//     lock acquisition. A failure mid-pipeline leaves partial state on disk.
+//   - SaveParticipants also has its own lock acquisition. A failure
+//     mid-pipeline leaves partial state on disk.
 func (e *Engine) runDrawPipeline(id string) error {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {

--- a/internal/helper/estimate.go
+++ b/internal/helper/estimate.go
@@ -23,9 +23,7 @@ type EstimateMatchCountsInput struct {
 	Format string
 
 	// PlayerCount is the number of participants that will take part in
-	// this competition. For competitions with an empty pre-draw roster
-	// (source-linked playoffs) the caller must derive the count from the
-	// source competition's pool count × PoolWinners.
+	// this competition.
 	PlayerCount int
 
 	// Pool-phase fields — relevant for "mixed" and "league" formats.


### PR DESCRIPTION
## Summary

- Two comment-only fixes removing stale references to the source-linked playoffs code path that [#245](https://github.com/gitrgoliveira/bracket-creator/pull/245) deleted
- Surfaced by a tri-lens review (simplify + correctness + security) + adversarial verification run over #245 *after* it merged

## Why

#245 removed the `SourceCompID` field and `estimateFinalistCount`, but two docstrings/comments in files it didn't touch still named that now-deleted code path. They would mislead a future reader into thinking the source-linked playoffs derivation still exists.

## Files changed

| File | What |
|---|---|
| `internal/helper/estimate.go` | `EstimateMatchCountsInput.PlayerCount` docstring no longer describes deriving the count from a source competition's pools (`estimateFinalistCount` is gone) |
| `internal/engine/competition.go` | `runDrawPipeline` limitations comment drops the `(source-linked playoffs roster path)` attribution on the still-valid `SaveParticipants` lock note |

## Screenshots

No UI changes — comment-only.

## Test plan

- [x] `make go/test` passes (full gate: lint + security + tests, all packages green incl. `internal/state` which flaked in #245's CI)
- [x] No behavior change — both edits are comments only
- [ ] Manual browser verification — not applicable (no UI/runtime change)

Relates to mp-c3pf (follow-up cleanup after #245 merged)
