### PR TITLE
feat(mp-koqh): public results page — all-competition winners summary for spectators

### DIFF
--- a/web-mobile/js/__tests__/viewer_all_winners.test.jsx
+++ b/web-mobile/js/__tests__/viewer_all_winners.test.jsx
@@ -1,0 +1,303 @@
+// Tests for the public "All winners / Results" view:
+//   - buildAllWinnersPublic (aggregation logic, mirroring admin_all_winners.test.jsx)
+//   - AllWinnersView (component rendering states)
+//
+// Both are exported to window by viewer.jsx.
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { bracketHasDecidedFinal, resolveCompetitionAwards, deriveAwards } from '../viewer.jsx';
+
+// ── tree helpers ──────────────────────────────────────────────────────────────
+
+function collectText(node) {
+  if (node == null || node === false || node === true) return '';
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children !== undefined) return collectText(node.children);
+  return '';
+}
+
+function findAll(node, pred) {
+  if (!node || typeof node !== 'object') return [];
+  const acc = Array.isArray(node) ? [] : (pred(node) ? [node] : []);
+  const kids = Array.isArray(node) ? node : (node.children ?? []);
+  for (const k of kids) acc.push(...findAll(k, pred));
+  return acc;
+}
+
+function findByTestId(node, testId) {
+  const all = findAll(node, (n) => n.props && n.props['data-testid'] === testId);
+  return all[0] || null;
+}
+
+// ── module setup / teardown ───────────────────────────────────────────────────
+
+const STUBBED_GLOBALS = {
+  pluralize: (n, s, p) => `${n} ${n === 1 ? s : (p || `${s}s`)}`,
+  formatLabelShort: (f) => f,
+  formatDate: (d) => d,
+  competitionKindLabel: (c) => c.kind === 'team' ? 'Teams' : 'Individual',
+  StatusBadge: function StatusBadge() { return null; },
+  formatViewerHeaderEyebrow: () => '',
+  formatLabel: (f) => f,
+  hasBothSides: () => true,
+  compareDmy: () => 0,
+  useEscapeToClose: vi.fn(),
+  AppRouter: null,
+  API: {
+    fetchCompetitionDetails: vi.fn(),
+    swissStandings: vi.fn(),
+    branding: vi.fn(),
+    bind: vi.fn(),
+  },
+  // Real viewer helpers so resolveCompetitionAwards works correctly.
+  deriveAwards,
+  bracketHasDecidedFinal,
+  resolveCompetitionAwards,
+};
+const originalGlobals = {};
+
+beforeAll(async () => {
+  for (const [key, stub] of Object.entries(STUBBED_GLOBALS)) {
+    originalGlobals[key] = { had: key in window, value: window[key] };
+    window[key] = stub;
+  }
+  // viewer.jsx is already imported (it's the source of the exported functions at
+  // the top of this file). All window.* exports are set by the module load,
+  // including buildAllWinnersPublic and AllWinnersView.
+});
+
+afterAll(() => {
+  for (const [key, orig] of Object.entries(originalGlobals)) {
+    if (orig.had) window[key] = orig.value;
+    else delete window[key];
+  }
+});
+
+// ── buildAllWinnersPublic ─────────────────────────────────────────────────────
+
+describe('buildAllWinnersPublic', () => {
+  it('is exported to window', () => {
+    expect(typeof window.buildAllWinnersPublic).toBe('function');
+  });
+
+  it('returns podium for a standalone knockout competition with 4 placings (two 3rds)', async () => {
+    const bracket = {
+      rounds: [
+        [
+          { sideA: 'Alice', sideB: 'Bob', winner: 'Alice' },
+          { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' },
+        ],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+      ],
+    };
+    const comp = { id: 'ko-1', name: 'Knockout', format: 'playoffs', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, config: comp, players: [] });
+
+    const results = await window.buildAllWinnersPublic([comp], {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].comp.id).toBe('ko-1');
+    expect(results[0].state).toBe('final');
+    expect(results[0].podium[0].place).toBe(1);
+    expect(results[0].podium[1].place).toBe(2);
+    expect(results[0].podium[2].place).toBe(3);
+    expect(results[0].podium[3].place).toBe(3);
+    expect(results[0].podium).toHaveLength(4);
+  });
+
+  it('filters out linked playoffs comp (sourceCompID set) — state "skip"', async () => {
+    const mixedComp = { id: 'mixed-1', name: 'Pools+KO', format: 'mixed', status: 'completed' };
+    const playoffComp = { id: 'po-1', name: 'Playoffs', format: 'playoffs', sourceCompID: 'mixed-1', status: 'completed' };
+    const allComps = [mixedComp, playoffComp];
+    const bracket = {
+      rounds: [
+        [{ sideA: 'Alice', sideB: 'Bob', winner: 'Alice' }, { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' }],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+      ],
+    };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, players: [] });
+
+    // buildAllWinnersPublic takes the full comp list — it filters for completed internally
+    const results = await window.buildAllWinnersPublic(allComps, {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    // playoffComp (linked shell) must be filtered out; mixedComp resolved to final
+    expect(results.find(r => r.comp.id === 'po-1')).toBeUndefined();
+    expect(results.find(r => r.comp.id === 'mixed-1')).toBeDefined();
+    const mixedResult = results.find(r => r.comp.id === 'mixed-1');
+    expect(mixedResult.state).toBe('final');
+    expect(mixedResult.podium).toHaveLength(4);
+    expect(mixedResult.podium[2].place).toBe(3);
+    expect(mixedResult.podium[3].place).toBe(3);
+  });
+
+  it('mixed comp whose OWN knockout final is undecided → state "in-progress", podium []', async () => {
+    const mixedComp = { id: 'mixed-2', name: 'Pools+KO', format: 'mixed', status: 'completed' };
+    const allComps = [mixedComp];
+    // undecided final
+    const bracket = {
+      rounds: [
+        [{ sideA: 'Alice', sideB: 'Bob', winner: 'Alice' }, { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' }],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: null }],
+      ],
+    };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, players: [] });
+
+    const results = await window.buildAllWinnersPublic(allComps, {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].state).toBe('in-progress');
+    expect(results[0].podium).toEqual([]);
+  });
+
+  it('returns podium for a standings-based competition (league format)', async () => {
+    const standings = [
+      { player: { name: 'Alice', dojo: 'Aoyama' } },
+      { player: { name: 'Bob', dojo: 'Bunkyo' } },
+      { player: { name: 'Carol', dojo: 'Chiba' } },
+      { player: { name: 'Dan', dojo: 'Denenchofu' } },
+    ];
+    const comp = { id: 'league-1', name: 'League', format: 'league', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings, pools: [{ poolName: 'Pool A' }], config: comp, players: [] });
+
+    const results = await window.buildAllWinnersPublic([comp], {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    const podium = results[0].podium;
+    expect(podium[0].name).toBe('Alice');
+    expect(podium[1].name).toBe('Bob');
+    expect(podium[2].place).toBe(3);
+    expect(podium[3].place).toBe(3);
+  });
+
+  it('only processes completed competitions (non-completed are skipped)', async () => {
+    const running = { id: 'r-1', name: 'Running', format: 'playoffs', status: 'pools', players: [] };
+    const setup = { id: 's-1', name: 'Setup', format: 'playoffs', status: 'setup', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, players: [] });
+
+    const results = await window.buildAllWinnersPublic([running, setup], {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(0);
+    expect(fetchCompetitionDetails).not.toHaveBeenCalled();
+  });
+
+  it('fetches swissStandings for swiss-format competitions', async () => {
+    const swissData = [
+      { player: { name: 'Kenji', dojo: 'Kendo Club' } },
+      { player: { name: 'Hiro', dojo: 'Musashi Dojo' } },
+    ];
+    const comp = { id: 'swiss-1', name: 'Swiss', format: 'swiss', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: { format: 'swiss' }, players: [] });
+    const mockSwissStandings = vi.fn().mockResolvedValue(swissData);
+
+    const results = await window.buildAllWinnersPublic([comp], {
+      fetchCompetitionDetails,
+      swissStandings: mockSwissStandings,
+    });
+
+    expect(mockSwissStandings).toHaveBeenCalledWith('swiss-1');
+    expect(results[0].state).toBe('final');
+    expect(results[0].podium[0].name).toBe('Kenji');
+  });
+
+  it('returns error field when fetchCompetitionDetails throws, without rejecting the whole Promise', async () => {
+    const comp = { id: 'err-1', name: 'Broken', format: 'playoffs', status: 'completed', players: [] };
+    const fetchCompetitionDetails = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const results = await window.buildAllWinnersPublic([comp], {
+      fetchCompetitionDetails,
+      swissStandings: null,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].podium).toEqual([]);
+    expect(results[0].error).toBe('Network error');
+  });
+});
+
+// ── AllWinnersView component ──────────────────────────────────────────────────
+
+describe('AllWinnersView', () => {
+  it('is exported to window', () => {
+    expect(typeof window.AllWinnersView).toBe('function');
+  });
+
+  it('renders without throwing with empty tournament', () => {
+    expect(() => window.AllWinnersView({
+      tournament: { name: 'Test Tournament', competitions: [] },
+      onBack: vi.fn(),
+    })).not.toThrow();
+  });
+
+  it('shows loading state initially (useState returns initial value in static stub)', () => {
+    const vnode = window.AllWinnersView({
+      tournament: { name: 'Test', competitions: [] },
+      onBack: vi.fn(),
+    });
+    const text = collectText(vnode);
+    // Initial state is loading:true — should render loading text
+    expect(text).toContain('Loading results');
+  });
+
+  it('renders the page title "Results"', () => {
+    const vnode = window.AllWinnersView({
+      tournament: { name: 'Test Tournament', competitions: [] },
+      onBack: vi.fn(),
+    });
+    const text = collectText(vnode);
+    expect(text).toContain('Results');
+  });
+
+  it('renders tournament name in the eyebrow', () => {
+    const vnode = window.AllWinnersView({
+      tournament: { name: 'My Championship', competitions: [] },
+      onBack: vi.fn(),
+    });
+    const text = collectText(vnode);
+    expect(text).toContain('My Championship');
+  });
+
+  it('renders a back button', () => {
+    const vnode = window.AllWinnersView({
+      tournament: { name: 'Test', competitions: [] },
+      onBack: vi.fn(),
+    });
+    const btns = findAll(vnode, (n) => n.type === 'button' && n.props && n.props['aria-label'] === 'Back');
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it('calls onBack when the back button is clicked', () => {
+    const onBack = vi.fn();
+    const vnode = window.AllWinnersView({
+      tournament: { name: 'Test', competitions: [] },
+      onBack,
+    });
+    const btns = findAll(vnode, (n) => n.type === 'button' && n.props && n.props['aria-label'] === 'Back');
+    btns[0].props.onClick();
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('loading state has the expected data-testid', () => {
+    const vnode = window.AllWinnersView({
+      tournament: { name: 'Test', competitions: [] },
+      onBack: vi.fn(),
+    });
+    const loadingNode = findByTestId(vnode, 'all-winners-loading');
+    expect(loadingNode).not.toBeNull();
+  });
+});

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -75,6 +75,9 @@ function parsePath(path) {
     if (path === "/schedule") {
       return { mode: "viewer", viewerScreen: "schedule" };
     }
+    if (path === "/results") {
+      return { mode: "viewer", viewerScreen: "results" };
+    }
     // U1: /glossary — the kendo-term reference page (rendered by
     // GlossaryPage from glossary.jsx). Public, no auth required;
     // linked from viewer home as "Help / Glossary".
@@ -117,6 +120,7 @@ function pathFromState(m, vs, vcid, av) {
     if (vs === "schedule") return "/schedule";
     if (vs === "glossary") return "/glossary";
     if (vs === "reset") return "/reset";
+    if (vs === "results") return "/results";
     return "/";
 }
 
@@ -272,7 +276,7 @@ function App() {
   });
   const [authPrompt, setAuthPrompt] = useS(false);
   const [viewerCompId, setViewerCompId] = useS(initialRoute.viewerCompId || null);
-  const [viewerScreen, setViewerScreen] = useS(initialRoute.viewerScreen || "home"); // home | schedule | glossary | reset
+  const [viewerScreen, setViewerScreen] = useS(initialRoute.viewerScreen || "home"); // home | schedule | glossary | reset | results
   const [adminView, setAdminView] = useS(initialRoute.admin || { kind: "dashboard" });
   const [toast, setToast] = useS(null);
   // T063: SSE connection status, surfaced to display surfaces so the
@@ -849,6 +853,15 @@ function App() {
               }}
             />
           : <div className="loading">Loading…</div>
+      ) : viewerScreen === "results" ? (
+        // mp-koqh: public results summary — all competition placings.
+        window.AllWinnersView
+          ? <window.AllWinnersView
+              tournament={tournament}
+              onBack={() => setViewerScreen("home")}
+              tweaks={THEME}
+            />
+          : <div className="loading">Loading…</div>
       ) : (
         <window.ViewerHome
           tournament={tournament}
@@ -859,6 +872,7 @@ function App() {
             setViewerCompId(compId);
             setViewerScreen("register");
           }}
+          onOpenResults={() => setViewerScreen("results")}
         />
       )}
       {authPrompt && (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -641,7 +641,7 @@ export function TournamentInfo({ tournament }) {
   );
 }
 
-function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister }) {
+function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults }) {
   const t = tournament;
   const comps = t.competitions || [];
   const compsByDate = useMemo(() => {
@@ -825,6 +825,22 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             </div>
             <span className="vlist-item__rowchev">→</span>
           </button>
+
+          {/* mp-koqh: Results summary — only shown when at least one comp has completed. */}
+          {onOpenResults && comps.some((c) => c.status === "completed") && (
+            <button
+              className="vlist-item vlist-item--row"
+              onClick={onOpenResults}
+              data-testid="open-results-btn"
+            >
+              <span className="vlist-item__icon">🏅</span>
+              <div className="vlist-item__rowbody">
+                <div className="vlist-item__rowtitle">Results</div>
+                <div className="vlist-item__rowsub">All competition placings</div>
+              </div>
+              <span className="vlist-item__rowchev">→</span>
+            </button>
+          )}
 
           {dates.length === 0 ? (
             <>
@@ -3684,6 +3700,129 @@ function AnnouncementBanner({ announcements, onDismiss }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// buildAllWinnersPublic — public-viewer equivalent of admin_shell's
+// buildAllWinners. Thin orchestrator: filter completed comps, resolve each
+// through resolveCompetitionAwards, drop linked-playoffs shells (state==="skip").
+// Exported to window so AllWinnersView and tests can reach it.
+// ---------------------------------------------------------------------------
+async function buildAllWinnersPublic(comps, fetchers) {
+  const completed = (comps || []).filter((c) => c.status === "completed");
+  const results = await Promise.all(
+    completed.map(async (comp) => {
+      try {
+        const { state, podium } = await resolveCompetitionAwards(comp, comps, fetchers);
+        return { comp, state, podium };
+      } catch (err) {
+        return { comp, state: "error", podium: [], error: err?.message || String(err) };
+      }
+    })
+  );
+  return results.filter((r) => r.state !== "skip");
+}
+
+// ---------------------------------------------------------------------------
+// AllWinnersView — full-page public results summary.  Mirrors the admin
+// AllWinnersModal rendering but as a full-page view (not a modal), matching
+// the ViewerSchedule / GlossaryPage page pattern. Props: { tournament, onBack, tweaks }.
+// ---------------------------------------------------------------------------
+function AllWinnersView({ tournament, onBack }) {
+  const comps = (tournament && tournament.competitions) || [];
+  const [viewState, setViewState] = useState({ loading: true, results: [], error: null });
+
+  // Stable signature of every comp's id:status — triggers refetch when any
+  // competition completes or its knockout resolves (same pattern as admin modal).
+  const compsSig = comps.map((c) => `${c.id}:${c.status}`).join("|");
+
+  useEffect(() => {
+    let cancelled = false;
+    setViewState((s) => ({ ...s, loading: true }));
+    buildAllWinnersPublic(comps, {
+      fetchCompetitionDetails: window.API.fetchCompetitionDetails.bind(window.API),
+      swissStandings: window.API.swissStandings ? window.API.swissStandings.bind(window.API) : null,
+    }).then((results) => {
+      if (!cancelled) setViewState({ loading: false, results, error: null });
+    }).catch((err) => {
+      if (!cancelled) setViewState({ loading: false, results: [], error: err?.message || String(err) });
+    });
+    return () => { cancelled = true; };
+  }, [compsSig]);
+
+  return (
+    <div className="viewer">
+      <div className="viewer__shell">
+        <div className="viewer__head">
+          <button className="viewer__back" onClick={onBack} aria-label="Back">←</button>
+          <div className="viewer__title-block">
+            <div className="viewer__eyebrow">{tournament && tournament.name}</div>
+            <div className="viewer__title">Results</div>
+            <div className="viewer__sub">All competition placings</div>
+          </div>
+        </div>
+        <div className="viewer__body">
+          {viewState.loading && (
+            <div style={{ textAlign: "center", color: "var(--ink-3)", padding: "24px 0" }} data-testid="all-winners-loading">
+              Loading results…
+            </div>
+          )}
+          {!viewState.loading && viewState.error && (
+            <div style={{ color: "var(--red)", padding: "8px 0" }} data-testid="all-winners-error">
+              Failed to load results: {viewState.error}
+            </div>
+          )}
+          {!viewState.loading && !viewState.error && viewState.results.length === 0 && (
+            <div className="empty" data-testid="all-winners-empty">
+              <div className="icon">🏅</div>
+              <h3>No completed competitions</h3>
+              <div style={{ fontSize: 13 }}>Check back once competitions have finished.</div>
+            </div>
+          )}
+          {!viewState.loading && viewState.results.map(({ comp, state: compState, podium, error: compErr }) => (
+            <div key={comp.id} className="card" style={{ padding: "12px 16px", marginBottom: 12 }} data-testid={`all-winners-card-${comp.id}`}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                <div style={{ fontWeight: 700, fontSize: 15 }}>{comp.name}</div>
+                <div style={{ fontSize: 12, color: "var(--ink-3)", background: "var(--surface-2, #f0f0f0)", borderRadius: 4, padding: "1px 6px" }}>
+                  {competitionKindLabel(comp)}
+                </div>
+              </div>
+              {compErr && (
+                <div style={{ fontSize: 13, color: "var(--red)" }} data-testid={`all-winners-error-${comp.id}`}>
+                  Could not load results: {compErr}
+                </div>
+              )}
+              {!compErr && compState === "in-progress" && (
+                <div style={{ fontSize: 13, color: "var(--ink-3)" }} data-testid={`all-winners-inprogress-${comp.id}`}>
+                  Knockout in progress
+                </div>
+              )}
+              {!compErr && compState === "final" && podium.length === 0 && (
+                <div style={{ fontSize: 13, color: "var(--ink-3)" }}>No results yet</div>
+              )}
+              {!compErr && compState === "final" && podium.map((a, idx) => {
+                const style = PLACE_STYLE[a.place] || PLACE_STYLE[3];
+                return (
+                  <div
+                    key={`${a.place}-${a.name}-${idx}`}
+                    style={{ display: "flex", alignItems: "center", gap: 10, padding: "6px 0", borderBottom: idx < podium.length - 1 ? "1px solid var(--line)" : "none" }}
+                    data-testid={`all-winners-place-${comp.id}-${a.place}-${idx}`}
+                  >
+                    <span style={{ fontSize: 22 }}>{style.icon}</span>
+                    <span style={{ fontSize: 12, color: "var(--ink-3)", minWidth: 60 }}>{style.label}</span>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontWeight: 600, fontSize: 14 }}>{a.name}</div>
+                      {a.dojo && <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{a.dojo}</div>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 window.AnnouncementCard = AnnouncementCard;
 window.AnnouncementBanner = AnnouncementBanner;
 window.ViewerHome = ViewerHome;
@@ -3702,5 +3841,8 @@ window.LS_NOTIFICATIONS_ENABLED = LS_NOTIFICATIONS_ENABLED;
 // (those files don't ES-import viewer.jsx; they pick globals off window).
 window.linkBase = linkBase;
 window.isNonPublicOrigin = isNonPublicOrigin;
+// mp-koqh: public results page.
+window.buildAllWinnersPublic = buildAllWinnersPublic;
+window.AllWinnersView = AllWinnersView;
 export { shouldShowRegister };
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -3726,7 +3726,7 @@ async function buildAllWinnersPublic(comps, fetchers) {
 // AllWinnersModal rendering but as a full-page view (not a modal), matching
 // the ViewerSchedule / GlossaryPage page pattern. Props: { tournament, onBack, tweaks }.
 // ---------------------------------------------------------------------------
-function AllWinnersView({ tournament, onBack }) {
+function AllWinnersView({ tournament, onBack, tweaks }) {
   const comps = (tournament && tournament.competitions) || [];
   const [viewState, setViewState] = useState({ loading: true, results: [], error: null });
 
@@ -3810,7 +3810,7 @@ function AllWinnersView({ tournament, onBack }) {
                     <span style={{ fontSize: 12, color: "var(--ink-3)", minWidth: 60 }}>{style.label}</span>
                     <div style={{ minWidth: 0 }}>
                       <div style={{ fontWeight: 600, fontSize: 14 }}>{a.name}</div>
-                      {a.dojo && <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{a.dojo}</div>}
+                      {tweaks.showDojo && a.dojo && <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{a.dojo}</div>}
                     </div>
                   </div>
                 );


### PR DESCRIPTION
## Summary

- Add a public `/results` page showing all-competition winners for spectators — no admin auth required
- Reuses the shared `resolveCompetitionAwards` logic (from mp-4dmr) so admin and public views stay identical
- Supports all formats: knockout (1/2/3/3), pools+knockout (resolves linked playoffs), league/swiss (standings-based)
- "Results" button appears on the viewer home page only when at least one competition has completed
- SSE-safe: automatically refreshes when competition statuses change

## Why

Spectators currently have to drill into each competition individually to see who won. After a tournament day, a consolidated view of all placings is a common need for closing ceremonies and social media posts.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | Add `buildAllWinnersPublic` orchestrator, `AllWinnersView` full-page component, "Results" button in `ViewerHome` |
| `web-mobile/js/app.jsx` | Add `/results` route (parsePath, pathFromState, render branch, ViewerHome prop) |
| `web-mobile/js/__tests__/viewer_all_winners.test.jsx` | 16 tests: buildAllWinnersPublic (KO, mixed, in-progress, league, swiss, error) + AllWinnersView component |

## Screenshots

### Viewer home — "Results" button (visible when ≥1 competition completed)
![Viewer home with Results button](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/249/viewer-home.png)

### /results page — all-competition podium summary
![Results page](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/249/results-page.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (16 tests in viewer_all_winners.test.jsx)
- [x] Manual browser verification — started app with `make run-mobile`, created tournament with 2 competitions (playoffs + league), completed both, verified `/results` page shows podium for both, verified "Results" button appears on viewer home only after completion
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-koqh
