### PR TITLE
refactor(mp-i385): drop unused allComps param from resolveCompetitionAwards

### DIFF
--- a/web-mobile/js/__tests__/admin_all_winners.test.jsx
+++ b/web-mobile/js/__tests__/admin_all_winners.test.jsx
@@ -92,7 +92,7 @@ describe('buildAllWinners', () => {
     const comp = { id: 'ko-1', name: 'Knockout', format: 'playoffs', status: 'completed', players: [] };
     const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, config: comp, players: [] });
 
-    const results = await window.buildAllWinners([comp], [comp], {
+    const results = await window.buildAllWinners([comp], {
       fetchCompetitionDetails,
       swissStandings: null,
     });
@@ -110,7 +110,6 @@ describe('buildAllWinners', () => {
 
   it('mixed comp whose OWN knockout final is undecided → state "in-progress", podium []', async () => {
     const mixedComp = { id: 'mixed-2', name: 'Pools+KO', format: 'mixed', status: 'playoffs' };
-    const allComps = [mixedComp];
     // undecided final
     const bracket = {
       rounds: [
@@ -120,7 +119,7 @@ describe('buildAllWinners', () => {
     };
     const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket, standings: null, pools: null, players: [] });
 
-    const results = await window.buildAllWinners([mixedComp], allComps, {
+    const results = await window.buildAllWinners([mixedComp], {
       fetchCompetitionDetails,
       swissStandings: null,
     });
@@ -140,7 +139,7 @@ describe('buildAllWinners', () => {
     const comp = { id: 'league-1', name: 'League', format: 'league', status: 'completed', players: [] };
     const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings, pools: [{ poolName: 'Pool A' }], config: comp, players: [] });
 
-    const results = await window.buildAllWinners([comp], [comp], {
+    const results = await window.buildAllWinners([comp], {
       fetchCompetitionDetails,
       swissStandings: null,
     });
@@ -158,7 +157,7 @@ describe('buildAllWinners', () => {
     const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: comp, players: [] });
 
     // Caller passes only completed comps — if we pass none the result is empty.
-    const results = await window.buildAllWinners([], [comp], {
+    const results = await window.buildAllWinners([], {
       fetchCompetitionDetails,
       swissStandings: null,
     });
@@ -175,7 +174,7 @@ describe('buildAllWinners', () => {
     const fetchCompetitionDetails = vi.fn().mockResolvedValue({ bracket: null, standings: null, pools: null, config: { format: 'swiss' }, players: [] });
     const mockSwissStandings = vi.fn().mockResolvedValue(swissStandingsData);
 
-    const results = await window.buildAllWinners([comp], [comp], {
+    const results = await window.buildAllWinners([comp], {
       fetchCompetitionDetails,
       swissStandings: mockSwissStandings,
     });
@@ -189,7 +188,7 @@ describe('buildAllWinners', () => {
     const comp = { id: 'err-1', name: 'Broken', format: 'playoffs', status: 'completed', players: [] };
     const fetchCompetitionDetails = vi.fn().mockRejectedValue(new Error('Network error'));
 
-    const results = await window.buildAllWinners([comp], [comp], {
+    const results = await window.buildAllWinners([comp], {
       fetchCompetitionDetails,
       swissStandings: null,
     });

--- a/web-mobile/js/__tests__/resolve_awards.test.jsx
+++ b/web-mobile/js/__tests__/resolve_awards.test.jsx
@@ -87,14 +87,13 @@ describe('resolveCompetitionAwards', () => {
   // ── mixed → final (two 3rds), derived from the comp's OWN bracket ─────────
   it('mixed comp with decided OWN-bracket final → state "final", podium has two 3rds', async () => {
     const mixedComp = { id: 'mixed-1', format: 'mixed' };
-    const allComps = [mixedComp]; // no linked playoffs comp in the single-comp model
     const bracket = decidedBracket();
     const fetchers = {
       fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket, players: [] }),
       swissStandings: null,
     };
 
-    const result = await resolveCompetitionAwards(mixedComp, allComps, fetchers);
+    const result = await resolveCompetitionAwards(mixedComp, fetchers);
 
     expect(result.state).toBe('final');
     expect(result.podium).toHaveLength(4);
@@ -109,14 +108,13 @@ describe('resolveCompetitionAwards', () => {
   // ── mixed → in-progress (own knockout not decided) ────────────────────────
   it('mixed comp with undecided OWN-bracket final → state "in-progress", podium []', async () => {
     const mixedComp = { id: 'mixed-2', format: 'mixed' };
-    const allComps = [mixedComp];
     const bracket = undecidedBracket();
     const fetchers = {
       fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket, players: [] }),
       swissStandings: null,
     };
 
-    const result = await resolveCompetitionAwards(mixedComp, allComps, fetchers);
+    const result = await resolveCompetitionAwards(mixedComp, fetchers);
 
     expect(result.state).toBe('in-progress');
     expect(result.podium).toEqual([]);
@@ -126,7 +124,6 @@ describe('resolveCompetitionAwards', () => {
   // ── mixed → in-progress (knockout still has pool placeholders) ────────────
   it('mixed comp whose bracket is still pool placeholders → state "in-progress"', async () => {
     const mixedComp = { id: 'mixed-3', format: 'mixed' };
-    const allComps = [mixedComp];
     // Bracket exists but the final is a forward reference (pools still feeding in).
     const bracket = { rounds: [[{ sideA: 'Pool A-1st', sideB: 'Pool B-1st', winner: null }]] };
     const fetchers = {
@@ -134,7 +131,7 @@ describe('resolveCompetitionAwards', () => {
       swissStandings: null,
     };
 
-    const result = await resolveCompetitionAwards(mixedComp, allComps, fetchers);
+    const result = await resolveCompetitionAwards(mixedComp, fetchers);
 
     expect(result.state).toBe('in-progress');
     expect(result.podium).toEqual([]);
@@ -142,15 +139,14 @@ describe('resolveCompetitionAwards', () => {
 
   // ── standalone playoffs → final ───────────────────────────────────────────
   it('standalone playoffs comp with decided final → state "final", podium has two 3rds', async () => {
-    const comp = { id: 'ko-1', format: 'playoffs' };
-    const allComps = [comp];
+    const comp = { id: 'ko-1', format: 'playoffs' }; // no sourceCompID
     const bracket = decidedBracket();
     const fetchers = {
       fetchCompetitionDetails: vi.fn().mockResolvedValue({ bracket, players: [] }),
       swissStandings: null,
     };
 
-    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+    const result = await resolveCompetitionAwards(comp, fetchers);
 
     expect(result.state).toBe('final');
     expect(result.podium).toHaveLength(4);
@@ -162,7 +158,6 @@ describe('resolveCompetitionAwards', () => {
   // ── league (standings-based) → final ─────────────────────────────────────
   it('league comp → state "final", standings-based podium', async () => {
     const comp = { id: 'league-1', format: 'league' };
-    const allComps = [comp];
     const standings = {
       'Pool A': [
         { player: { name: 'Alice', dojo: 'Aoyama' } },
@@ -176,7 +171,7 @@ describe('resolveCompetitionAwards', () => {
       swissStandings: null,
     };
 
-    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+    const result = await resolveCompetitionAwards(comp, fetchers);
 
     expect(result.state).toBe('final');
     expect(result.podium).toHaveLength(4);
@@ -187,7 +182,6 @@ describe('resolveCompetitionAwards', () => {
   // ── swiss (standings via dedicated endpoint) → final ─────────────────────
   it('swiss comp → calls swissStandings endpoint and returns standings-based podium', async () => {
     const comp = { id: 'swiss-1', format: 'swiss' };
-    const allComps = [comp];
     const swissData = [
       { player: { name: 'Kenji', dojo: 'Club A' } },
       { player: { name: 'Hiro', dojo: 'Club B' } },
@@ -197,7 +191,7 @@ describe('resolveCompetitionAwards', () => {
       swissStandings: vi.fn().mockResolvedValue(swissData),
     };
 
-    const result = await resolveCompetitionAwards(comp, allComps, fetchers);
+    const result = await resolveCompetitionAwards(comp, fetchers);
 
     expect(result.state).toBe('final');
     expect(fetchers.swissStandings).toHaveBeenCalledWith('swiss-1');

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -121,13 +121,13 @@ const PLACE_STYLE_ADMIN = {
 };
 
 // buildAllWinners resolves podium for each completed comp using the shared
-// resolveCompetitionAwards helper (handles mixed→linked-playoffs rule).
+// resolveCompetitionAwards helper.
 // Signature: buildAllWinners(completedComps, fetchers)
 // Returns a Promise resolving to an array of { comp, state, podium } objects
-// (plus an `error` string field when state === "error"), with results whose
-// state === "skip" filtered out (linked playoffs shells).
+// (plus an `error` string field when state === "error").
+// state is one of "final" | "in-progress" | "error".
 async function buildAllWinners(completedComps, fetchers) {
-  const results = await Promise.all(
+  return Promise.all(
     completedComps.map(async (comp) => {
       try {
         const { state, podium } = await window.resolveCompetitionAwards(comp, fetchers);
@@ -137,7 +137,6 @@ async function buildAllWinners(completedComps, fetchers) {
       }
     })
   );
-  return results.filter((r) => r.state !== "skip");
 }
 
 // AllWinnersModal renders a summary of every completed competition with its

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -121,18 +121,23 @@ const PLACE_STYLE_ADMIN = {
 };
 
 // buildAllWinners resolves podium for each completed comp using the shared
-// resolveCompetitionAwards helper.
-async function buildAllWinners(completedComps, allComps, fetchers) {
-  return Promise.all(
+// resolveCompetitionAwards helper (handles mixed→linked-playoffs rule).
+// Signature: buildAllWinners(completedComps, fetchers)
+// Returns a Promise resolving to an array of { comp, state, podium } objects
+// (plus an `error` string field when state === "error"), with results whose
+// state === "skip" filtered out (linked playoffs shells).
+async function buildAllWinners(completedComps, fetchers) {
+  const results = await Promise.all(
     completedComps.map(async (comp) => {
       try {
-        const { state, podium } = await window.resolveCompetitionAwards(comp, allComps, fetchers);
+        const { state, podium } = await window.resolveCompetitionAwards(comp, fetchers);
         return { comp, state, podium };
       } catch (err) {
         return { comp, state: "error", podium: [], error: err?.message || String(err) };
       }
     })
   );
+  return results.filter((r) => r.state !== "skip");
 }
 
 // AllWinnersModal renders a summary of every completed competition with its
@@ -154,7 +159,7 @@ function AllWinnersModal({ comps, onClose }) {
   useEffectA(() => {
     let cancelled = false;
     setState((s) => ({ ...s, loading: true }));
-    buildAllWinners(completed, comps, {
+    buildAllWinners(completed, {
       fetchCompetitionDetails: window.API.fetchCompetitionDetails.bind(window.API),
       swissStandings: window.API.swissStandings ? window.API.swissStandings.bind(window.API) : null,
     }).then((results) => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1768,7 +1768,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             // actual winners; when the final has no winner yet, deriveAwards
             // explicitly falls through to the standings-based path rather
             // than short-circuiting.
-            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} allComps={(tournament && tournament.competitions) || []} />
+            <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} />
           )}
         </div>
       </div>
@@ -2980,9 +2980,7 @@ function bracketHasDecidedFinal(bracket) {
 //   'final'       — podium is the final result
 //   'in-progress' — knockout not yet decided (podium [])
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
-// NOTE: _allComps is vestigial (was used by the removed sourceCompID skip
-// branch) — tracked for removal in bead mp-i385.
-async function resolveCompetitionAwards(comp, _allComps, fetchers) {
+async function resolveCompetitionAwards(comp, fetchers) {
   const fmt = comp && comp.format;
   const ntpFrom = (players) => {
     const m = new Map();
@@ -3015,7 +3013,7 @@ const PLACE_STYLE = {
   3: { icon: "🥉", label: "3rd Place", accent: "var(--bronze, #cd7f32)" },
 };
 
-function AwardsView({ c, bracket, standings, pools, players, allComps }) {
+function AwardsView({ c, bracket, standings, pools, players }) {
   const containerRef = useRefV(null);
   const [isFs, setIsFs] = useState(false);
   const isLeague = c?.format === "league";
@@ -3053,7 +3051,7 @@ function AwardsView({ c, bracket, standings, pools, players, allComps }) {
     }
     let cancelled = false;
     const fetchers = { fetchCompetitionDetails: window.API.fetchCompetitionDetails, swissStandings: null };
-    resolveCompetitionAwards(c, allComps || [], fetchers)
+    resolveCompetitionAwards(c, fetchers)
       .then(({ state, podium }) => {
         if (!cancelled) setKoAwards({ state, awards: podium });
       })
@@ -3061,7 +3059,7 @@ function AwardsView({ c, bracket, standings, pools, players, allComps }) {
         if (!cancelled) setKoAwards({ state: "in-progress", awards: [] });
       });
     return () => { cancelled = true; };
-  }, [c?.id, c?.format, allComps]);
+  }, [c?.id, c?.format]);
 
   const nameToPlayer = useMemo(() => {
     const m = new Map();


### PR DESCRIPTION
## Summary

- Removes the `allComps` parameter from `resolveCompetitionAwards` — it was never read after mp-turx (PR #244) removed the `sourceCompID` skip branch
- Removes `allComps` from `AwardsView` props and its `useEffect` dependency array, eliminating spurious re-renders when the competition list changes
- Updates `buildAllWinners` signature to match (drops the now-unused second arg)
- Updates all call sites and test files

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | Remove `allComps` param from function sig + `AwardsView` props + dep array |
| `web-mobile/js/admin_shell.jsx` | Remove `allComps` param from `buildAllWinners` sig and comment |
| `web-mobile/js/__tests__/resolve_awards.test.jsx` | Drop second arg from all `resolveCompetitionAwards` calls |
| `web-mobile/js/__tests__/admin_all_winners.test.jsx` | Drop second arg from all `buildAllWinners` calls |

## Screenshots

No UI impact — this is a pure dead-code removal with no visible behavior change.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change — 1268 JS tests pass (`npx vitest run`)
- [x] Manual browser verification — not required (no UI behavior change)
- [x] Screenshots added above — N/A (no UI impact)
- [x] No new console errors or warnings

Closes mp-i385