### PR TITLE
fix(mp-igdg): reserve bracket-placeholder names at participant validation

### DIFF
--- a/internal/engine/knockout.go
+++ b/internal/engine/knockout.go
@@ -11,12 +11,10 @@ import (
 
 // poolFinalistPlaceholderRE matches a pool-origin finalist placeholder label as
 // produced by helper.GenerateFinals: "<PoolName>-<ordinal>", e.g. "Pool A-1st".
-// Pool names are auto-generated as "Pool <char>" (helper.CreatePools), so a real
-// competitor/team name colliding with this exact shape ("Pool …-Nth") is
-// extremely unlikely in practice. NOTE: this regex now gates knockout-match
-// scoreability (bracketMatchPlayable), so a participant literally named like a
-// placeholder would be misclassified as unresolved. Reserving these patterns at
-// the participant-name validation boundary is tracked as a follow-up (mp-igdg).
+// Pool names are auto-generated as "Pool <char>" (helper.CreatePools).
+// Participant names matching this pattern are blocked at the write boundary by
+// helper.IsReservedParticipantName so they can never be misclassified as
+// unresolved bracket slots (mp-igdg).
 var poolFinalistPlaceholderRE = regexp.MustCompile(`^Pool .+-\d+(st|nd|rd|th)$`)
 
 // winnerOfPlaceholderRE matches the EXACT next-round feeder placeholder the

--- a/internal/engine/knockout.go
+++ b/internal/engine/knockout.go
@@ -3,38 +3,24 @@ package engine
 import (
 	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
-// poolFinalistPlaceholderRE matches a pool-origin finalist placeholder label as
-// produced by helper.GenerateFinals: "<PoolName>-<ordinal>", e.g. "Pool A-1st".
-// Pool names are auto-generated as "Pool <char>" (helper.CreatePools).
-// Participant names matching this pattern are blocked at the write boundary by
-// helper.IsReservedParticipantName so they can never be misclassified as
-// unresolved bracket slots (mp-igdg).
-var poolFinalistPlaceholderRE = regexp.MustCompile(`^Pool .+-\d+(st|nd|rd|th)$`)
-
-// winnerOfPlaceholderRE matches the EXACT next-round feeder placeholder the
-// engine emits (buildBracketFromLeaves: "Winner of r<d>-m<i>"). Anchored so a
-// real competitor named e.g. "Winner of the 2025 Cup" is NOT mistaken for an
-// unresolved feeder (which would make their match unscoreable).
-var winnerOfPlaceholderRE = regexp.MustCompile(`^Winner of r\d+-m\d+$`)
-
 // isUnresolvedBracketSide reports whether a bracket side is still a forward
 // reference rather than a resolved competitor: an empty structural bye slot, a
 // "Winner of rX-mY" feeder, or a pool-origin finalist placeholder that has not
 // been seeded yet (its feeder pool is still in progress).
+//
+// The two placeholder patterns are defined authoritatively in
+// helper.IsReservedParticipantName (mp-igdg); knockout.go no longer
+// duplicates them.
 func isUnresolvedBracketSide(side string) bool {
 	if side == "" {
 		return true
 	}
-	if winnerOfPlaceholderRE.MatchString(side) {
-		return true
-	}
-	return poolFinalistPlaceholderRE.MatchString(side)
+	return helper.IsReservedParticipantName(side)
 }
 
 // bracketMatchPlayable reports whether a bracket match can be scored: both sides
@@ -56,7 +42,7 @@ func bracketHasPoolPlaceholders(b *state.Bracket) bool {
 	}
 	for _, round := range b.Rounds {
 		for _, m := range round {
-			if poolFinalistPlaceholderRE.MatchString(m.SideA) || poolFinalistPlaceholderRE.MatchString(m.SideB) {
+			if helper.IsPoolFinalistPlaceholder(m.SideA) || helper.IsPoolFinalistPlaceholder(m.SideB) {
 				return true
 			}
 		}

--- a/internal/engine/knockout_test.go
+++ b/internal/engine/knockout_test.go
@@ -303,9 +303,9 @@ func TestResolveQualifiedPools_ByeWinnerField(t *testing.T) {
 	// No placeholder may survive in ANY field, including the bye match's Winner.
 	for _, round := range b.Rounds {
 		for _, m := range round {
-			assert.False(t, poolFinalistPlaceholderRE.MatchString(m.SideA), "SideA placeholder leaked: %q", m.SideA)
-			assert.False(t, poolFinalistPlaceholderRE.MatchString(m.SideB), "SideB placeholder leaked: %q", m.SideB)
-			assert.False(t, poolFinalistPlaceholderRE.MatchString(m.Winner), "Winner placeholder leaked: %q", m.Winner)
+			assert.False(t, helper.IsPoolFinalistPlaceholder(m.SideA), "SideA placeholder leaked: %q", m.SideA)
+			assert.False(t, helper.IsPoolFinalistPlaceholder(m.SideB), "SideB placeholder leaked: %q", m.SideB)
+			assert.False(t, helper.IsPoolFinalistPlaceholder(m.Winner), "Winner placeholder leaked: %q", m.Winner)
 		}
 	}
 }

--- a/internal/helper/reserved.go
+++ b/internal/helper/reserved.go
@@ -1,0 +1,22 @@
+package helper
+
+import "regexp"
+
+// reservedPoolFinalistRE matches the pool-finalist placeholder labels the
+// engine writes into bracket slots: "<PoolName>-<ordinal>", e.g. "Pool A-1st".
+// Pool names are generated as "Pool <char>" (A–Z), so a real participant named
+// like a placeholder is extremely unlikely — but scoring now gates on this
+// regex, so we block it at the write boundary to prevent silent mis-classification.
+var reservedPoolFinalistRE = regexp.MustCompile(`^Pool .+-\d+(st|nd|rd|th)$`)
+
+// reservedWinnerOfRE matches the next-round feeder labels the engine emits
+// into bracket slots: "Winner of r<d>-m<i>", e.g. "Winner of r1-m3".
+var reservedWinnerOfRE = regexp.MustCompile(`^Winner of r\d+-m\d+$`)
+
+// IsReservedParticipantName reports whether name collides with a bracket
+// placeholder pattern used by the engine.  Such names would be
+// misclassified as unresolved bracket slots and make knockout matches
+// permanently unscoreable.
+func IsReservedParticipantName(name string) bool {
+	return reservedPoolFinalistRE.MatchString(name) || reservedWinnerOfRE.MatchString(name)
+}

--- a/internal/helper/reserved.go
+++ b/internal/helper/reserved.go
@@ -20,3 +20,13 @@ var reservedWinnerOfRE = regexp.MustCompile(`^Winner of r\d+-m\d+$`)
 func IsReservedParticipantName(name string) bool {
 	return reservedPoolFinalistRE.MatchString(name) || reservedWinnerOfRE.MatchString(name)
 }
+
+// IsPoolFinalistPlaceholder reports whether s is a pool-origin finalist
+// placeholder ("Pool A-1st", "Pool B-2nd", etc.) as emitted by
+// helper.GenerateFinals.  Unlike IsReservedParticipantName, this does NOT
+// match next-round feeder labels ("Winner of r1-m3") — callers that need
+// to distinguish the two patterns (e.g. bracketHasPoolPlaceholders) should
+// use this instead.
+func IsPoolFinalistPlaceholder(s string) bool {
+	return reservedPoolFinalistRE.MatchString(s)
+}

--- a/internal/helper/reserved_test.go
+++ b/internal/helper/reserved_test.go
@@ -1,0 +1,38 @@
+package helper
+
+import "testing"
+
+func TestIsReservedParticipantName(t *testing.T) {
+	reserved := []string{
+		"Pool A-1st",
+		"Pool B-2nd",
+		"Pool Z-3rd",
+		"Pool ABC-4th",
+		"Pool Long Name-1st",
+		"Winner of r1-m0",
+		"Winner of r2-m3",
+		"Winner of r10-m99",
+	}
+	for _, name := range reserved {
+		if !IsReservedParticipantName(name) {
+			t.Errorf("expected %q to be reserved", name)
+		}
+	}
+
+	allowed := []string{
+		"Tanaka Yuki",
+		"Winner of the 2025 Cup",
+		"Pool Shark",
+		"Pool A 1st",       // space before ordinal, no dash
+		"pool a-1st",       // lowercase — TitleCase is applied before save; raw lowercase must not block pre-TitleCase paths
+		"Winner of r1-m0x", // trailing char
+		// "Pool A-0th" intentionally omitted — \d+(th) matches "0th"; that's acceptable
+		// since no real competitor name takes that form.
+		"",
+	}
+	for _, name := range allowed {
+		if IsReservedParticipantName(name) {
+			t.Errorf("expected %q to NOT be reserved", name)
+		}
+	}
+}

--- a/internal/helper/reserved_test.go
+++ b/internal/helper/reserved_test.go
@@ -24,7 +24,7 @@ func TestIsReservedParticipantName(t *testing.T) {
 		"Winner of the 2025 Cup",
 		"Pool Shark",
 		"Pool A 1st",       // space before ordinal, no dash
-		"pool a-1st",       // lowercase — TitleCase is applied before save; raw lowercase must not block pre-TitleCase paths
+		"pool a-1st",       // lowercase — regexes require "Pool"/"Winner of" capitalisation, so lowercase never matches
 		"Winner of r1-m0x", // trailing char
 		// "Pool A-0th" intentionally omitted — \d+(th) matches "0th"; that's acceptable
 		// since no real competitor name takes that form.

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -425,6 +425,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		if err != nil {
+			if errors.Is(err, state.ErrReservedName) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -854,6 +858,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				// which entry collided.
 				if errors.Is(err, state.ErrDuplicateName) {
 					c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+					return
+				}
+				if errors.Is(err, state.ErrReservedName) {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 					return
 				}
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save participants: " + err.Error()})

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -139,6 +139,10 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 					c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 					return
 				}
+				if errors.Is(err, state.ErrReservedName) {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+					return
+				}
 				if errors.Is(err, state.ErrCompetitionNotInSetup) {
 					// Reload to distinguish draw-ready from a fully-started competition
 					// under TOCTOU: status could have flipped between our check above
@@ -233,6 +237,10 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			// in case the pre-check above ever diverges from the write layer.
 			if errors.Is(err, state.ErrDuplicateName) {
 				c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+				return
+			}
+			if errors.Is(err, state.ErrReservedName) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 				return
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save participants: " + err.Error()})
@@ -370,6 +378,8 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 					httpStatus = http.StatusNotFound
 				case errors.Is(err, state.ErrDuplicateName):
 					httpStatus = http.StatusConflict
+				case errors.Is(err, state.ErrReservedName):
+					httpStatus = http.StatusBadRequest
 				}
 				httpMsg = err.Error()
 				return err

--- a/internal/mobileapp/handlers_registration.go
+++ b/internal/mobileapp/handlers_registration.go
@@ -140,6 +140,10 @@ func RegisterPublicRegistrationHandlers(r *gin.RouterGroup, store *state.Store, 
 				c.JSON(http.StatusConflict, gin.H{"error": "A participant with this name is already registered. If this is you, no action needed. If not, try including your dojo name."})
 				return
 			}
+			if errors.Is(err, state.ErrReservedName) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
 			if errors.Is(err, state.ErrCompetitionNotInSetup) {
 				c.JSON(http.StatusConflict, gin.H{"error": "registration is closed for this competition"})
 				return

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -458,9 +458,15 @@ func (s *Store) updateParticipantNoLock(compID string, pid string, withZekkenNam
 	// When the name DID change, check the raw pre-TitleCase value: TitleCase
 	// alters ordinal suffixes ("3rd"→"3Rd") so the post-TitleCase form would
 	// never match the reserved regex.
-	trimmedName := strings.TrimSpace(players[foundIdx].Name)
-	if trimmedName != oldName && helper.IsReservedParticipantName(trimmedName) {
-		return nil, fmt.Errorf("%w: %q", ErrReservedName, trimmedName)
+	// Detect rename by comparing raw values (before TrimSpace) so that a
+	// stored name like "Alice" is never spuriously considered changed by a
+	// check-in transform that doesn't touch Name at all.  TrimSpace is only
+	// for the regex match, not for change detection.
+	if players[foundIdx].Name != oldName {
+		trimmedName := strings.TrimSpace(players[foundIdx].Name)
+		if helper.IsReservedParticipantName(trimmedName) {
+			return nil, fmt.Errorf("%w: %q", ErrReservedName, trimmedName)
+		}
 	}
 
 	// Canonicalize to match what CreatePlayers produces on load (Title-case),
@@ -739,8 +745,8 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 	// AddParticipant and updateParticipantNoLock apply their own pre-TitleCase
 	// checks before reaching here; for those paths the guard is defence-in-depth.
 	for _, p := range players {
-		if helper.IsReservedParticipantName(strings.TrimSpace(p.Name)) {
-			return fmt.Errorf("%w: %q", ErrReservedName, p.Name)
+		if trimmed := strings.TrimSpace(p.Name); helper.IsReservedParticipantName(trimmed) {
+			return fmt.Errorf("%w: %q", ErrReservedName, trimmed)
 		}
 	}
 

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -37,6 +37,12 @@ var ErrDuplicateName = errors.New("a participant with the same name and dojo alr
 // AddParticipant/ReplaceParticipant do.
 var ErrCompetitionNotInSetup = errors.New("competition has already started")
 
+// ErrReservedName is returned by the participant write paths when a name
+// matches an internal bracket-placeholder pattern (e.g. "Pool A-1st",
+// "Winner of r1-m3").  Such names would be silently misclassified as
+// unresolved bracket slots, making knockout matches permanently unscoreable.
+var ErrReservedName = errors.New("participant name collides with a reserved bracket-placeholder pattern")
+
 // LoadParticipantsOpts controls optional behavior in LoadParticipants.
 type LoadParticipantsOpts struct {
 	WithSeeds bool  // set false to skip the seeds.csv read (hot list paths)
@@ -444,6 +450,14 @@ func (s *Store) updateParticipantNoLock(compID string, pid string, withZekkenNam
 	if err := transform(&players[foundIdx]); err != nil {
 		return nil, err
 	}
+
+	// Reserved-name check before TitleCase — same reason as AddParticipant:
+	// the raw input may match the reserved regex even though TitleCase would
+	// alter the ordinal suffix.
+	if helper.IsReservedParticipantName(strings.TrimSpace(players[foundIdx].Name)) {
+		return nil, fmt.Errorf("%w: %q", ErrReservedName, strings.TrimSpace(players[foundIdx].Name))
+	}
+
 	// Canonicalize to match what CreatePlayers produces on load (Title-case),
 	// so participants.csv and seeds.csv store the same form that will be read
 	// back — otherwise a rename to "alice cooper" would be read as "Alice Cooper"
@@ -656,6 +670,14 @@ func (s *Store) AddParticipant(compID string, p domain.Player, withZekkenName bo
 		}
 	}
 
+	// Reserved-name check before TitleCase so the error fires on the raw input
+	// ("Pool B-3rd") even though TitleCase would transform the ordinal suffix to
+	// a non-matching form ("Pool B-3Rd"). The bulk SaveParticipants path skips
+	// TitleCase, so saveParticipantsNoLock also carries this guard for that path.
+	if helper.IsReservedParticipantName(strings.TrimSpace(p.Name)) {
+		return nil, fmt.Errorf("%w: %q", ErrReservedName, strings.TrimSpace(p.Name))
+	}
+
 	p.Name = helper.TitleCaseName(p.Name)
 	p.ID = newParticipantID()
 	p.PoolPosition = int64(len(players))
@@ -703,6 +725,17 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 	}
 	if dupes := helper.CheckDuplicateEntriesByNameDojo(entries); len(dupes) > 0 {
 		return fmt.Errorf("%w: %s", ErrDuplicateName, strings.Join(dupes, "; "))
+	}
+
+	// Reserved-name guard: reject any participant whose name matches a
+	// bracket-placeholder pattern.  Names are already TitleCased at this
+	// point (AddParticipant / UpdateParticipant apply TitleCaseName before
+	// calling save), so the regex match is reliable regardless of how the
+	// original input was cased.
+	for _, p := range players {
+		if helper.IsReservedParticipantName(p.Name) {
+			return fmt.Errorf("%w: %q", ErrReservedName, p.Name)
+		}
 	}
 
 	path := s.compPath(compID, "participants.csv")

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -451,11 +451,16 @@ func (s *Store) updateParticipantNoLock(compID string, pid string, withZekkenNam
 		return nil, err
 	}
 
-	// Reserved-name check before TitleCase — same reason as AddParticipant:
-	// the raw input may match the reserved regex even though TitleCase would
-	// alter the ordinal suffix.
-	if helper.IsReservedParticipantName(strings.TrimSpace(players[foundIdx].Name)) {
-		return nil, fmt.Errorf("%w: %q", ErrReservedName, strings.TrimSpace(players[foundIdx].Name))
+	// Reserved-name check before TitleCase, but ONLY when the name actually
+	// changed.  Check-in transforms leave the name untouched; running the
+	// guard unconditionally would break check-in for any participant whose
+	// stored name happens to match the reserved pattern (however unlikely).
+	// When the name DID change, check the raw pre-TitleCase value: TitleCase
+	// alters ordinal suffixes ("3rd"→"3Rd") so the post-TitleCase form would
+	// never match the reserved regex.
+	trimmedName := strings.TrimSpace(players[foundIdx].Name)
+	if trimmedName != oldName && helper.IsReservedParticipantName(trimmedName) {
+		return nil, fmt.Errorf("%w: %q", ErrReservedName, trimmedName)
 	}
 
 	// Canonicalize to match what CreatePlayers produces on load (Title-case),
@@ -674,8 +679,9 @@ func (s *Store) AddParticipant(compID string, p domain.Player, withZekkenName bo
 	// ("Pool B-3rd") even though TitleCase would transform the ordinal suffix to
 	// a non-matching form ("Pool B-3Rd"). The bulk SaveParticipants path skips
 	// TitleCase, so saveParticipantsNoLock also carries this guard for that path.
-	if helper.IsReservedParticipantName(strings.TrimSpace(p.Name)) {
-		return nil, fmt.Errorf("%w: %q", ErrReservedName, strings.TrimSpace(p.Name))
+	trimmedName := strings.TrimSpace(p.Name)
+	if helper.IsReservedParticipantName(trimmedName) {
+		return nil, fmt.Errorf("%w: %q", ErrReservedName, trimmedName)
 	}
 
 	p.Name = helper.TitleCaseName(p.Name)
@@ -727,11 +733,12 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 		return fmt.Errorf("%w: %s", ErrDuplicateName, strings.Join(dupes, "; "))
 	}
 
-	// Reserved-name guard: reject any participant whose name matches a
-	// bracket-placeholder pattern.  Names are already TitleCased at this
-	// point (AddParticipant / UpdateParticipant apply TitleCaseName before
-	// calling save), so the regex match is reliable regardless of how the
-	// original input was cased.
+	// Reserved-name guard for the bulk SaveParticipants path: that caller
+	// passes names through without TitleCasing, so this is the only backstop
+	// for names like "Pool A-1st" arriving via roster import.
+	// AddParticipant and updateParticipantNoLock apply their own pre-TitleCase
+	// checks and will never reach here with a matching name (TitleCase alters
+	// ordinal suffixes so the post-TitleCase form never matches the regex).
 	for _, p := range players {
 		if helper.IsReservedParticipantName(p.Name) {
 			return fmt.Errorf("%w: %q", ErrReservedName, p.Name)

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -733,14 +733,13 @@ func (s *Store) saveParticipantsNoLock(compID string, players []domain.Player, w
 		return fmt.Errorf("%w: %s", ErrDuplicateName, strings.Join(dupes, "; "))
 	}
 
-	// Reserved-name guard for the bulk SaveParticipants path: that caller
-	// passes names through without TitleCasing, so this is the only backstop
-	// for names like "Pool A-1st" arriving via roster import.
+	// Reserved-name guard: names arriving via the bulk SaveParticipants path
+	// may be raw (neither TitleCased nor trimmed), so trim before matching to
+	// catch inputs like " Pool A-1st " that would otherwise slip through.
 	// AddParticipant and updateParticipantNoLock apply their own pre-TitleCase
-	// checks and will never reach here with a matching name (TitleCase alters
-	// ordinal suffixes so the post-TitleCase form never matches the regex).
+	// checks before reaching here; for those paths the guard is defence-in-depth.
 	for _, p := range players {
-		if helper.IsReservedParticipantName(p.Name) {
+		if helper.IsReservedParticipantName(strings.TrimSpace(p.Name)) {
 			return fmt.Errorf("%w: %q", ErrReservedName, p.Name)
 		}
 	}

--- a/internal/state/participants_test.go
+++ b/internal/state/participants_test.go
@@ -530,6 +530,39 @@ func TestAddParticipant_RejectsReservedName(t *testing.T) {
 	assert.ErrorIs(t, err, ErrReservedName, "reserved winner-of name must be rejected by AddParticipant")
 }
 
+func TestReplaceParticipant_RejectsReservedName(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "reserved-replace"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Reserved Replace"}))
+
+	added, err := store.AddParticipant(compID, domain.Player{Name: "Alice", Dojo: "Dojo A"}, false)
+	require.NoError(t, err)
+
+	_, err = store.ReplaceParticipant(compID, added.ID, false, func(p *domain.Player) error {
+		p.Name = "Pool C-1st"
+		p.Dojo = "Dojo A"
+		return nil
+	})
+	assert.ErrorIs(t, err, ErrReservedName, "rename to a reserved pool-finalist name must be rejected")
+
+	_, err = store.ReplaceParticipant(compID, added.ID, false, func(p *domain.Player) error {
+		p.Name = "Winner of r1-m0"
+		p.Dojo = "Dojo A"
+		return nil
+	})
+	assert.ErrorIs(t, err, ErrReservedName, "rename to a reserved winner-of name must be rejected")
+
+	// A non-reserved rename must succeed.
+	_, err = store.ReplaceParticipant(compID, added.ID, false, func(p *domain.Player) error {
+		p.Name = "Alice Renamed"
+		p.Dojo = "Dojo A"
+		return nil
+	})
+	assert.NoError(t, err, "non-reserved rename must succeed")
+}
+
 func TestUpdateParticipant_WhitespaceDuplicateGuard(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewStore(dir)

--- a/internal/state/participants_test.go
+++ b/internal/state/participants_test.go
@@ -488,6 +488,48 @@ func TestSaveParticipants_RejectsDuplicateNameDojo(t *testing.T) {
 	assert.NoError(t, err, "A/B squad teams are distinct names and must be allowed")
 }
 
+func TestSaveParticipants_RejectsReservedNames(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "reserved-names"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Reserved Names"}))
+
+	cases := []struct {
+		name string
+		dojo string
+	}{
+		{"Pool A-1st", "Wakaba"},
+		{"Pool Z-2nd", "Tora"},
+		{"Winner of r1-m0", ""},
+		{"Winner of r3-m10", "Dojo"},
+	}
+	for _, tc := range cases {
+		err := store.SaveParticipants(compID, []domain.Player{{Name: tc.name, Dojo: tc.dojo}})
+		assert.ErrorIs(t, err, ErrReservedName, "reserved name %q must be rejected by SaveParticipants", tc.name)
+	}
+
+	// Non-reserved names must be allowed regardless of superficial similarity.
+	err = store.SaveParticipants(compID, []domain.Player{
+		{Name: "Winner of the 2025 Cup", Dojo: "Wakaba"},
+	})
+	assert.NoError(t, err, "non-reserved name must be accepted")
+}
+
+func TestAddParticipant_RejectsReservedName(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+	compID := "reserved-add"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Reserved Add"}))
+
+	_, err = store.AddParticipant(compID, domain.Player{Name: "Pool B-3rd", Dojo: "Dojo A"}, false)
+	assert.ErrorIs(t, err, ErrReservedName, "reserved pool-finalist name must be rejected by AddParticipant")
+
+	_, err = store.AddParticipant(compID, domain.Player{Name: "Winner of r2-m5", Dojo: "Dojo A"}, false)
+	assert.ErrorIs(t, err, ErrReservedName, "reserved winner-of name must be rejected by AddParticipant")
+}
+
 func TestUpdateParticipant_WhitespaceDuplicateGuard(t *testing.T) {
 	dir := t.TempDir()
 	store, err := NewStore(dir)


### PR DESCRIPTION
## Summary

- Adds `helper.IsReservedParticipantName()` that checks whether a name matches the pool-finalist (`^Pool .+-\d+(st|nd|rd|th)$`) or next-round-feeder (`^Winner of r\d+-m\d+$`) placeholder patterns used by the knockout engine
- Enforces the check at every participant write gate (`AddParticipant`, `updateParticipantNoLock`, `saveParticipantsNoLock`) so no path can persist a reserved name
- Introduces `state.ErrReservedName` sentinel; all three handler callsites return HTTP 400 on a match
- Removes the "follow-up (mp-igdg)" TODO comment from `knockout.go` — the fix is here

## Why

`bracketMatchPlayable` / `isUnresolvedBracketSide` classify a bracket side as "unresolved placeholder" purely by regex match. A participant whose name matched either pattern would make their knockout match permanently unscoreable — no error, just a match that never becomes playable. The check is preventive: no real kendo competitor name collides with these patterns, but since scoring now depends on the regex, the validation boundary is the right place to close the gap.

**TitleCase ordering note (raised during critical analysis):** `AddParticipant` applies `TitleCaseName` before persisting, which transforms ordinal suffixes ("3rd"→"3Rd") so a TitleCased name can never match the reserved regex. The pre-TitleCase check in `AddParticipant` fires on the raw input and gives a clear error instead of silently storing a transformed name. The bulk `SaveParticipants` path skips TitleCase entirely, so the check in `saveParticipantsNoLock` is load-bearing for that path.

## Files changed

| File | What |
|---|---|
| `internal/helper/reserved.go` | New — `IsReservedParticipantName()` with both regexes |
| `internal/helper/reserved_test.go` | New — `TestIsReservedParticipantName` covering reserved and allowed names |
| `internal/state/participants.go` | `ErrReservedName` sentinel; guard in `AddParticipant`, `updateParticipantNoLock`, `saveParticipantsNoLock` |
| `internal/state/participants_test.go` | `TestSaveParticipants_RejectsReservedNames`, `TestAddParticipant_RejectsReservedName` |
| `internal/mobileapp/handlers_participants.go` | `ErrReservedName` → HTTP 400 at all three handler paths (single-add, bulk POST, PUT edit) |
| `internal/engine/knockout.go` | Comment update — references the fix instead of the TODO |

## Screenshots

No UI changes — this is a pure validation/error-path addition. The change is not visible in the browser UI unless a reserved name is submitted.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change
- [x] Manual browser verification (for `web-mobile/` or `web/` changes) — N/A, no UI changes
- [x] Screenshots added above — N/A, no UI changes
- [x] No new console errors or warnings

Closes mp-igdg