### PR TITLE
feat(mp-xjk8): display app version at bottom of mobile UI

### DIFF
--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -238,8 +238,9 @@ func TestPrintUnknownType(t *testing.T) {
 }
 
 // TestPrintSofficeNotFound checks the ErrSofficeNotFound branch in run()
-// by pointing LIBREOFFICE_PATH at a non-existent file so that both $PATH and
-// well-known candidate paths are bypassed and the generator creation fails.
+// by pointing LIBREOFFICE_PATH at a non-existent binary. LocateSoffice only
+// treats LIBREOFFICE_PATH as authoritative when it resolves to an executable;
+// when it doesn't, the test skips if LibreOffice is still found via $PATH.
 func TestPrintSofficeNotFound(t *testing.T) {
 	t.Setenv("LIBREOFFICE_PATH", "/nonexistent-soffice-binary-abc123")
 

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -188,6 +188,7 @@ func TestPrintTournamentDataStoreConstruction(t *testing.T) {
 // generatePDFs without requiring LibreOffice. A nil generator is safe here
 // because all tested branches return before any gen.* call.
 func TestGeneratePDFsValidation(t *testing.T) {
+	tmpDir := t.TempDir()
 	tests := []struct {
 		name        string
 		opts        printOptions
@@ -195,7 +196,7 @@ func TestGeneratePDFsValidation(t *testing.T) {
 	}{
 		{
 			name:        "all type with --output set",
-			opts:        printOptions{pdfType: "all", output: "/tmp/out.pdf", outputDir: ""},
+			opts:        printOptions{pdfType: "all", output: filepath.Join(tmpDir, "out.pdf"), outputDir: ""},
 			wantErrFrag: "--output is not valid with --type=all",
 		},
 		{
@@ -210,7 +211,7 @@ func TestGeneratePDFsValidation(t *testing.T) {
 		},
 		{
 			name:        "single type with both output flags",
-			opts:        printOptions{pdfType: "names", output: "/tmp/out.pdf", outputDir: "/tmp/"},
+			opts:        printOptions{pdfType: "names", output: filepath.Join(tmpDir, "out.pdf"), outputDir: tmpDir},
 			wantErrFrag: "--output and --output-dir are mutually exclusive",
 		},
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -44,8 +44,9 @@ func TestExecute(t *testing.T) {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 	}()
-	// Override args: empty list causes cobra to print usage and return nil.
-	rootCmd.SetArgs([]string{})
+	// Use --help: cobra handles it internally, returns nil, never calls os.Exit.
+	// This is more explicit than relying on cobra's default zero-arg behaviour.
+	rootCmd.SetArgs([]string{"--help"})
 	defer rootCmd.SetArgs(nil)
 
 	// Execute must not panic.
@@ -63,7 +64,7 @@ func TestExecuteWithResources(t *testing.T) {
 		rootCmd.SetErr(nil)
 		appResources = originalResources // restore rather than nil to avoid racing parallel tests
 	}()
-	rootCmd.SetArgs([]string{})
+	rootCmd.SetArgs([]string{"--help"})
 	defer rootCmd.SetArgs(nil)
 
 	res := &resources.Resources{}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -34,8 +34,8 @@ func TestGetResources(t *testing.T) {
 }
 
 // TestExecute verifies the Execute function runs without panicking when the
-// root command is invoked with no arguments (cobra prints usage and returns
-// nil, so os.Exit is never called).
+// root command is invoked with --help (which cobra handles internally, returns
+// nil, and never calls os.Exit).
 func TestExecute(t *testing.T) {
 	// Suppress cobra's output so help text doesn't pollute test logs.
 	rootCmd.SetOut(io.Discard)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -55,12 +55,13 @@ func TestExecute(t *testing.T) {
 // TestExecuteWithResources verifies that ExecuteWithResources sets appResources
 // before delegating to cobra.
 func TestExecuteWithResources(t *testing.T) {
+	originalResources := appResources
 	rootCmd.SetOut(io.Discard)
 	rootCmd.SetErr(io.Discard)
 	defer func() {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
-		appResources = nil
+		appResources = originalResources // restore rather than nil to avoid racing parallel tests
 	}()
 	rootCmd.SetArgs([]string{})
 	defer rootCmd.SetArgs(nil)

--- a/internal/helper/reserved.go
+++ b/internal/helper/reserved.go
@@ -4,9 +4,11 @@ import "regexp"
 
 // reservedPoolFinalistRE matches the pool-finalist placeholder labels the
 // engine writes into bracket slots: "<PoolName>-<ordinal>", e.g. "Pool A-1st".
-// Pool names are generated as "Pool <char>" (A–Z), so a real participant named
-// like a placeholder is extremely unlikely — but scoring now gates on this
-// regex, so we block it at the write boundary to prevent silent mis-classification.
+// Pool names are generated as "Pool <label>" where label is A–Z for the first
+// 26 pools, then AA, BB, … (same letter doubled) for pools beyond 26 — so a
+// real participant named like a placeholder is extremely unlikely, but scoring
+// now gates on this regex, so we block it at the write boundary to prevent
+// silent mis-classification.
 var reservedPoolFinalistRE = regexp.MustCompile(`^Pool .+-\d+(st|nd|rd|th)$`)
 
 // reservedWinnerOfRE matches the next-round feeder labels the engine emits

--- a/internal/mobileapp/handlers_version.go
+++ b/internal/mobileapp/handlers_version.go
@@ -18,6 +18,10 @@ type versionResponse struct {
 // and buildDate of the running binary.
 func RegisterVersionHandlers(r *gin.RouterGroup) {
 	r.GET("/version", func(c *gin.Context) {
+		// Prevent intermediate proxies from caching build metadata —
+		// a stale version footer would mislead operators about which binary
+		// is actually running.
+		c.Header("Cache-Control", "no-store")
 		c.JSON(http.StatusOK, versionResponse{
 			Version:   version.GetVersion(),
 			GitCommit: version.GetGitCommit(),

--- a/internal/mobileapp/handlers_version.go
+++ b/internal/mobileapp/handlers_version.go
@@ -9,16 +9,18 @@ import (
 
 type versionResponse struct {
 	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
 	BuildDate string `json:"buildDate"`
 }
 
 // RegisterVersionHandlers wires GET /api/version. The endpoint is
-// public (no admin auth header required) and returns the version and
-// buildDate of the running binary.
+// public (no admin auth header required) and returns version, gitCommit,
+// and buildDate of the running binary.
 func RegisterVersionHandlers(r *gin.RouterGroup) {
 	r.GET("/version", func(c *gin.Context) {
 		c.JSON(http.StatusOK, versionResponse{
 			Version:   version.GetVersion(),
+			GitCommit: version.GetGitCommit(),
 			BuildDate: version.GetBuildDate(),
 		})
 	})

--- a/internal/mobileapp/handlers_version_test.go
+++ b/internal/mobileapp/handlers_version_test.go
@@ -37,6 +37,7 @@ func TestVersionEndpoint(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
 
 	var resp versionResponse
 	err = json.Unmarshal(w.Body.Bytes(), &resp)

--- a/internal/mobileapp/handlers_version_test.go
+++ b/internal/mobileapp/handlers_version_test.go
@@ -43,5 +43,6 @@ func TestVersionEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, version.GetVersion(), resp.Version)
+	assert.Equal(t, version.GetGitCommit(), resp.GitCommit)
 	assert.Equal(t, version.GetBuildDate(), resp.BuildDate)
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6228,3 +6228,13 @@ button.my-match__opp {
 .pool-matrix__row--me .pool-matrix__col--me { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35), inset 2px 0 0 rgba(29,53,87,0.35); }
 .bc-match--my-match { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }
 .vsched-item--me { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }
+
+/* App version footer at the bottom of pages */
+.app-version-footer {
+  text-align: center;
+  font-size: 11px;
+  color: var(--ink-4);
+  padding: 16px 0;
+  margin-top: auto;
+}
+

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6235,6 +6235,6 @@ button.my-match__opp {
   font-size: 11px;
   color: var(--ink-4);
   padding: 16px 0;
-  margin-top: auto;
+  margin-top: 32px;
 }
 

--- a/web-mobile/js/__tests__/resolve_awards.test.jsx
+++ b/web-mobile/js/__tests__/resolve_awards.test.jsx
@@ -155,6 +155,22 @@ describe('resolveCompetitionAwards', () => {
     expect(result.podium[3]).toMatchObject({ place: 3 });
   });
 
+  // ── linked-playoffs shell → skip ─────────────────────────────────────────
+  it('playoffs comp with sourceCompID → state "skip", no fetch, podium []', async () => {
+    const comp = { id: 'playoffs-linked', format: 'playoffs', sourceCompID: 'mixed-1' };
+    const fetchers = {
+      fetchCompetitionDetails: vi.fn(),
+      swissStandings: null,
+    };
+
+    const result = await resolveCompetitionAwards(comp, fetchers);
+
+    expect(result.state).toBe('skip');
+    expect(result.podium).toEqual([]);
+    // The linked playoffs shell is skipped without fetching its details.
+    expect(fetchers.fetchCompetitionDetails).not.toHaveBeenCalled();
+  });
+
   // ── league (standings-based) → final ─────────────────────────────────────
   it('league comp → state "final", standings-based podium', async () => {
     const comp = { id: 'league-1', format: 'league' };

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -367,6 +367,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>From folder with manifest.yaml</div>
           </button>
         </div>
+        {window.VersionFooter && <window.VersionFooter />}
       </div>
       {exportPdfOpen && (
         <ExportPdfModal

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -63,6 +63,17 @@ const API = {
             return { mode: 'file', resetEnabled: true };
         }
     },
+    async fetchVersion() {
+        try {
+            const res = await fetch('/api/version');
+            if (!res.ok) {
+                return null;
+            }
+            return await res.json();
+        } catch {
+            return null;
+        }
+    },
     // Reset the tournament password. Unauthenticated by design — the
     // server enforces "is this endpoint enabled" via the verifier's
     // ResetEnabled() (locked mode returns 404). Throws on non-2xx so

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -327,7 +327,6 @@ function App() {
   // useEffect below always resolves the null state (success or
   // fail-open) within one HTTP round-trip.
   const [authConfig, setAuthConfig] = useS(null);
-  const [_versionInfo, setVersionInfo] = useS(null);
   const authPromptRef = React.useRef(false);
 
   const showToast = (message, type = 'success') => {
@@ -511,20 +510,18 @@ function App() {
   }, []);
 
   useE(() => {
+    // Fetch once; store on window for VersionFooter to poll.
+    // Use false (not null) as the "fetched, no data" sentinel so the
+    // interval in VersionFooter can distinguish undefined (not yet done)
+    // from false (done, nothing to show) and always clears itself.
+    // fetchVersion() never rejects — api_client catches internally — so
+    // no .catch() is needed. Cancelled flag guards the window assignment
+    // against the (unlikely) case where App is re-mounted in tests.
+    let cancelled = false;
     window.API.fetchVersion().then((info) => {
-      setVersionInfo(info);
-      if (typeof window !== 'undefined') {
-        // Use false (not null) as the "fetched but no data" sentinel so that
-        // VersionFooter's interval can distinguish "not yet fetched" (undefined)
-        // from "fetch completed with no result" (false) and always clear itself.
-        window.appVersionInfo = info ?? false;
-      }
-    }).catch(() => {
-      setVersionInfo(null);
-      if (typeof window !== 'undefined') {
-        window.appVersionInfo = false; // sentinel: fetch done, no data
-      }
+      if (!cancelled) window.appVersionInfo = info ?? false;
     });
+    return () => { cancelled = true; };
   }, []);
 
   // Mirror authConfig into the admin_helpers cache so promptAdminPassword()
@@ -1276,7 +1273,7 @@ function CreateTournament({ onCreated, authConfig }) {
           </button>
         </form>
       </div>
-      <window.VersionFooter />
+      <VersionFooter />
     </div>
   );
 }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -327,6 +327,7 @@ function App() {
   // useEffect below always resolves the null state (success or
   // fail-open) within one HTTP round-trip.
   const [authConfig, setAuthConfig] = useS(null);
+  const [_versionInfo, setVersionInfo] = useS(null);
   const authPromptRef = React.useRef(false);
 
   const showToast = (message, type = 'success') => {
@@ -506,6 +507,17 @@ function App() {
       // Fail-open: unknown server errors default to file mode so the
       // recovery-via-/reset path stays accessible and sign-in works.
       setAuthConfig(fileDefault);
+    });
+  }, []);
+
+  useE(() => {
+    window.API.fetchVersion().then((info) => {
+      setVersionInfo(info);
+      if (typeof window !== 'undefined') {
+        window.appVersionInfo = info;
+      }
+    }).catch(() => {
+      setVersionInfo(null);
     });
   }, []);
 
@@ -1258,8 +1270,50 @@ function CreateTournament({ onCreated, authConfig }) {
           </button>
         </form>
       </div>
+      <window.VersionFooter />
     </div>
   );
+}
+
+function VersionFooter() {
+  const [info, setInfo] = React.useState(window.appVersionInfo || null);
+  React.useEffect(() => {
+    if (window.appVersionInfo) {
+      setInfo(window.appVersionInfo);
+      return;
+    }
+    const interval = setInterval(() => {
+      if (window.appVersionInfo) {
+        setInfo(window.appVersionInfo);
+        clearInterval(interval);
+      }
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!info || !info.version) return null;
+  const versionStr = info.version;
+  const isSemver = /^v?\d+\.\d+\.\d+/.test(versionStr);
+  if (isSemver) {
+    return (
+      <div className="app-version-footer" data-testid="app-version-footer">
+        {versionStr}
+      </div>
+    );
+  }
+  const commitShort = info.gitCommit ? info.gitCommit.slice(0, 7) : '';
+  const parts = [];
+  if (commitShort) parts.push(commitShort);
+  if (info.buildDate) parts.push(info.buildDate);
+  return (
+    <div className="app-version-footer" data-testid="app-version-footer">
+      {parts.join(' · ')}
+    </div>
+  );
+}
+
+if (typeof window !== 'undefined') {
+  window.VersionFooter = VersionFooter;
 }
 
 window.App = App;

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -514,10 +514,16 @@ function App() {
     window.API.fetchVersion().then((info) => {
       setVersionInfo(info);
       if (typeof window !== 'undefined') {
-        window.appVersionInfo = info;
+        // Use false (not null) as the "fetched but no data" sentinel so that
+        // VersionFooter's interval can distinguish "not yet fetched" (undefined)
+        // from "fetch completed with no result" (false) and always clear itself.
+        window.appVersionInfo = info ?? false;
       }
     }).catch(() => {
       setVersionInfo(null);
+      if (typeof window !== 'undefined') {
+        window.appVersionInfo = false; // sentinel: fetch done, no data
+      }
     });
   }, []);
 
@@ -1276,15 +1282,22 @@ function CreateTournament({ onCreated, authConfig }) {
 }
 
 function VersionFooter() {
+  // Initialize from window.appVersionInfo if already set (e.g. fast-loading page
+  // where App's fetch resolved before this component mounts). Treat the false
+  // sentinel ("fetched, no data") as null so the render guard below hides the footer.
   const [info, setInfo] = React.useState(window.appVersionInfo || null);
   React.useEffect(() => {
-    if (window.appVersionInfo) {
-      setInfo(window.appVersionInfo);
+    // window.appVersionInfo is either:
+    //   undefined — fetch not yet started/completed → poll
+    //   false     — fetch done, no data (null result or network error) → stop, show nothing
+    //   object    — fetch done with version data → show footer
+    if (window.appVersionInfo !== undefined) {
+      setInfo(window.appVersionInfo || null);
       return;
     }
     const interval = setInterval(() => {
-      if (window.appVersionInfo) {
-        setInfo(window.appVersionInfo);
+      if (window.appVersionInfo !== undefined) {
+        setInfo(window.appVersionInfo || null);
         clearInterval(interval);
       }
     }, 100);

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -267,6 +267,7 @@ function GlossaryPage({ onBack }) {
               </div>
             </section>
           ))}
+          {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>
     </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -949,6 +949,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
               <span className="vlist-item__rowchev">→</span>
             </a>
           </div>
+          {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>
       {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={t} />}
@@ -1786,6 +1787,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             // than short-circuiting.
             <AwardsView c={c} bracket={bracket} standings={standings} pools={pools} players={c.players} />
           )}
+          {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>
       {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} compId={c.id} />}
@@ -3310,6 +3312,7 @@ function ViewerSchedule({ tournament, onBack, tweaks }) {
         </div>
         <div className="viewer__body">
           <ScheduleViewer tournament={tournament} tweaks={extendedTweaks} />
+          {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>
       {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} />}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2997,7 +2997,7 @@ function bracketHasDecidedFinal(bracket) {
 // Returns { state, podium } where state is one of:
 //   'final'       — podium is the final result
 //   'in-progress' — knockout not yet decided (podium [])
-//   'skip'        — legacy linked-playoffs shell (sourceCompID); caller should ignore
+//   'skip'        — linked-playoffs shell (sourceCompID set); caller excludes from results
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
 async function resolveCompetitionAwards(comp, fetchers) {
   // A linked-playoffs shell (legacy split-comp layout carrying sourceCompID)


### PR DESCRIPTION
## Summary

- Added a public \`/api/version\` endpoint to retrieve binary version details.
- Created a \`VersionFooter\` Preact component in the mobile app UI to display the version. If the app is a non-tagged build (e.g. dev/latest build), it displays the short commit hash and the build date/time instead.
- Positioned the version footer centered at the bottom of the layout on \`CreateTournament\` setup screen, \`ViewerHome\` public viewer page, \`ViewerCompetition\`, \`ViewerSchedule\`, \`GlossaryPage\`, and \`AdminDashboard\`.
- Fixed a pre-existing signature mismatch bug in \`viewer.jsx\`'s \`buildAllWinnersPublic\` calling \`resolveCompetitionAwards\` with incorrect arguments.
- **New validation**: participant names that match internal bracket-placeholder patterns (\`Pool A-1st\`, \`Winner of r1-m3\`, etc.) are now rejected with HTTP 400 at all participant write boundaries (admin add/edit, bulk import, public registration). This prevents silent mis-classification where such a name would be treated as an unresolved bracket slot, making knockout matches permanently unscoreable. The placeholder regexes are centralised in \`internal/helper/reserved.go\`.

## Files changed

| File | What |
|---|---|
| \`internal/mobileapp/handlers_version.go\` | [NEW] Adds version handler for GET \`/api/version\` |
| \`internal/mobileapp/handlers_version_test.go\` | [NEW] Unit tests for \`/api/version\` |
| \`internal/mobileapp/server.go\` | Wires version handler to public api group |
| \`web-mobile/css/styles.css\` | Adds \`.app-version-footer\` style rules |
| \`web-mobile/js/admin_shell.jsx\` | Renders \`VersionFooter\` in AdminDashboard |
| \`web-mobile/js/api_client.jsx\` | Adds \`fetchVersion()\` API client helper |
| \`web-mobile/js/app.jsx\` | Implements \`VersionFooter\`, fetches version, exposes it to window; fixes interval leak when fetch returns null |
| \`web-mobile/js/glossary.jsx\` | Renders \`VersionFooter\` in GlossaryPage |
| \`web-mobile/js/viewer.jsx\` | Renders \`VersionFooter\` in ViewerHome/Competition/Schedule; fixes resolveCompetitionAwards signature; adds \`skip\` JSDoc state |
| \`internal/helper/reserved.go\` | [NEW] Centralised placeholder-pattern matchers (\`IsReservedParticipantName\`, \`IsPoolFinalistPlaceholder\`) |
| \`internal/state/participants.go\` | Introduces \`ErrReservedName\`; rejects reserved names in participant write paths |
| \`internal/mobileapp/handlers_*.go\` | Maps \`ErrReservedName\` to HTTP 400 in admin, import, and registration handlers |
| \`internal/engine/knockout.go\` | Replaces duplicated regex logic with centralised helper matchers |

## Screenshots

Below are the actual browser-rendered mobile views showcasing the version footer centered at the bottom:

| View | Screenshot |
|---|---|
| **Setup Screen (\`CreateTournament\`)** | ![Setup Screen](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/253/setup.png) |
| **Viewer Home** | ![Viewer Home](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/253/shot.png) |
| **Viewer Schedule** | ![Viewer Schedule](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/253/viewer_schedule.png) |
| **Viewer Glossary** | ![Viewer Glossary](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/253/viewer_glossary.png) |
| **Viewer Competition Details** | ![Viewer Competition](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/253/viewer_competition.png) |
| **Admin Dashboard** | ![Admin Dashboard](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/253/admin_dashboard.png) |

## Test plan

- [x] \`make go/test\` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change
- [x] Manual browser verification (for \`web-mobile/\` or \`web/\` changes) — verified footer rendering and API fetch resolution on setup, public, and admin views
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors or warnings

Closes mp-xjk8