### PR TITLE
feat(mp-7f2w): render byes as effective-round columns matching the Excel Tree

### DIFF
--- a/internal/engine/bracket.go
+++ b/internal/engine/bracket.go
@@ -239,5 +239,119 @@ func (e *Engine) buildBracketFromLeaves(comp *state.Competition, leaves []string
 	state.ApplyCompetitionDefaults(comp)
 	assignBracketMatchSlots(bracket.Rounds, comp, tournament)
 
+	// Display metadata (mp-7f2w): label each match with its effective round and
+	// real feeders so the viewer renders the same effective-round columns as the
+	// Excel Tree sheet (structural byes skip a column). Computed once here, while
+	// the "Winner of rX-mY" placeholders are still intact — it must NOT be
+	// recomputed after results resolve those placeholders into player names.
+	computeBracketDisplayMetadata(bracket)
+
 	return bracket, nil
+}
+
+// computeBracketDisplayMetadata fills DisplayRound / Hidden / Feeders on every
+// match so the viewer can render effective-round columns identical to the Excel
+// Tree sheet (matches grouped by depth-from-root; structural byes skip a column
+// rather than appearing as empty cards). It is purely additive — the positional
+// ID + "Winner of rX-mY" resolution scheme used by scoring/scheduling/the pool
+// resolver is untouched.
+//
+// A match is REAL iff both sides are non-empty (a structural bye always leaves
+// one side ""). Phantom matches (empty-vs-empty dead matches and one-sided latent
+// byes) are marked Hidden. For each real match, Feeders holds the IDs of the two
+// REAL feeder matches whose winners meet here ([A, B] order); a side fed by a
+// seeded entrant / pool placeholder / bye carries "" (no connector). DisplayRound
+// counts from the final (1 = Final), assigned by walking the real feeder graph
+// outward from the lone real match in the last round.
+//
+// Must run after bye winners have been auto-resolved and propagated (so resolved
+// names already sit in their feeder slots) — i.e. at the end of bracket build.
+func computeBracketDisplayMetadata(bracket *state.Bracket) {
+	rounds := bracket.Rounds
+	numRounds := len(rounds)
+	if numRounds == 0 {
+		return
+	}
+
+	at := func(r, m int) *state.BracketMatch {
+		if r < 0 || r >= numRounds || m < 0 || m >= len(rounds[r]) {
+			return nil
+		}
+		return &rounds[r][m]
+	}
+	isReal := func(m *state.BracketMatch) bool {
+		return m != nil && m.SideA != "" && m.SideB != ""
+	}
+
+	// realFeederID follows a "Winner of rX-mY" side through any phantom (bye)
+	// matches to the underlying REAL feeder match's ID, or "" when the side is a
+	// seeded entrant / resolved name / dead end (no connector line).
+	var realFeederID func(side string) string
+	realFeederID = func(side string) string {
+		if !strings.HasPrefix(side, "Winner of") {
+			return "" // resolved name, pool placeholder, or empty → no feeder
+		}
+		r, m := parseWinnerOf(side, numRounds)
+		f := at(r, m)
+		if f == nil {
+			return ""
+		}
+		if isReal(f) {
+			return f.ID
+		}
+		// Phantom: descend through whichever side carries a competitor.
+		if f.SideA != "" {
+			return realFeederID(f.SideA)
+		}
+		if f.SideB != "" {
+			return realFeederID(f.SideB)
+		}
+		return "" // dead match (both empty)
+	}
+
+	byID := make(map[string]*state.BracketMatch)
+	for r := range rounds {
+		for i := range rounds[r] {
+			mm := &rounds[r][i]
+			byID[mm.ID] = mm
+			if isReal(mm) {
+				mm.Hidden = false
+				mm.DisplayRound = 0 // assigned by the walk below
+				mm.Feeders = []string{realFeederID(mm.SideA), realFeederID(mm.SideB)}
+			} else {
+				mm.Hidden = true
+				mm.DisplayRound = 0
+				mm.Feeders = nil
+			}
+		}
+	}
+
+	// Walk the real feeder graph outward from the final (the lone real match in
+	// the last round). It is a tree, so each match is reached exactly once; the
+	// DisplayRound != 0 guard also bounds against any unexpected cycle.
+	final := at(numRounds-1, 0)
+	if !isReal(final) {
+		return // degenerate bracket (e.g. < 2 competitors)
+	}
+	type qItem struct {
+		m  *state.BracketMatch
+		dr int
+	}
+	queue := []qItem{{final, 1}}
+	for len(queue) > 0 {
+		it := queue[0]
+		queue = queue[1:]
+		if it.m == nil || it.m.DisplayRound != 0 {
+			continue
+		}
+		it.m.DisplayRound = it.dr
+		for _, fid := range it.m.Feeders {
+			if fid == "" {
+				continue
+			}
+			if f := byID[fid]; f != nil && f.DisplayRound == 0 {
+				queue = append(queue, qItem{f, it.dr + 1})
+			}
+		}
+	}
 }

--- a/internal/engine/bracket_identity_test.go
+++ b/internal/engine/bracket_identity_test.go
@@ -220,6 +220,187 @@ func TestBracketIdentity_PurePlayoffs(t *testing.T) {
 	}
 }
 
+// enginePlayoffsBracket runs the real engine path (StartCompetition) and
+// returns the generated bracket so display metadata (mp-7f2w) can be asserted.
+func enginePlayoffsBracket(t *testing.T, players []domain.Player) *state.Bracket {
+	t.Helper()
+	eng, store, _ := setupTestEngine(t)
+
+	compID := fmt.Sprintf("display-%d", len(players))
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:        compID,
+		Format:    state.CompFormatPlayoffs,
+		Kind:      "individual",
+		Courts:    []string{"A"},
+		StartTime: "09:00",
+		Status:    state.CompStatusSetup,
+	}))
+	stripped := make([]domain.Player, len(players))
+	for i, p := range players {
+		stripped[i] = domain.Player{Name: p.Name, Dojo: p.Dojo}
+	}
+	require.NoError(t, store.SaveParticipants(compID, stripped))
+	// Seeds are stored separately (seeds.csv) and merged at load — extract them
+	// from the player Seed field so the seeded test cases actually exercise
+	// seeded generation rather than silently running unseeded.
+	var seeds []domain.SeedAssignment
+	for _, p := range players {
+		if p.Seed > 0 {
+			seeds = append(seeds, domain.SeedAssignment{Name: p.Name, SeedRank: p.Seed})
+		}
+	}
+	if len(seeds) > 0 {
+		require.NoError(t, store.SaveSeeds(compID, seeds))
+	}
+	require.NoError(t, eng.StartCompetition(compID))
+
+	bracket, err := store.LoadBracket(compID)
+	require.NoError(t, err)
+	require.NotNil(t, bracket)
+	return bracket
+}
+
+// excelRoundSizes returns the Excel Tree sheet's elimination-round match counts,
+// ordered earliest → latest (e.g. [QF, SF, Final]), via the same unbalanced-tree
+// depth traversal create-playoffs.go uses.
+func excelRoundSizes(players []domain.Player) []int {
+	seeded := helper.StandardSeeding(players)
+	names := make([]string, len(seeded))
+	for i, p := range seeded {
+		names[i] = p.Name
+	}
+	tree := helper.CreateBalancedTree(names)
+	depth := helper.CalculateDepth(tree)
+	var sizes []int
+	for i := depth; i > 1; i-- {
+		sizes = append(sizes, len(helper.TraverseRounds(tree, 1, i-1)))
+	}
+	return sizes
+}
+
+// TestBracketDisplayMetadata_MatchesExcelRounds verifies that the engine's
+// DisplayRound / Hidden metadata groups real matches into the SAME effective
+// rounds as the Excel Tree sheet (mp-7f2w): structural byes skip a column, no
+// phantom matches are shown, and exactly N-1 real matches exist.
+func TestBracketDisplayMetadata_MatchesExcelRounds(t *testing.T) {
+	cases := []struct {
+		name        string
+		playerCount int
+		numSeeds    int
+	}{
+		{"5 players", 5, 0},
+		{"7 players", 7, 0},
+		{"8 players (pow2)", 8, 0},
+		{"12 players", 12, 0},
+		{"16 players (pow2)", 16, 0},
+		{"24 players", 24, 0},
+		{"24 players 8 seeds", 24, 8},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			players := makeSeededPlayers(tt.playerCount, tt.numSeeds)
+			bracket := enginePlayoffsBracket(t, players)
+
+			// Group real (non-hidden) matches by DisplayRound.
+			byDR := map[int]int{}
+			realTotal := 0
+			maxDR := 0
+			for _, round := range bracket.Rounds {
+				for _, m := range round {
+					if m.Hidden {
+						assert.Zero(t, m.DisplayRound, "hidden match must have DisplayRound 0")
+						// A hidden (bye) match always has an empty side.
+						assert.True(t, m.SideA == "" || m.SideB == "",
+							"hidden match must have a structural-bye empty side")
+						continue
+					}
+					assert.GreaterOrEqual(t, m.DisplayRound, 1,
+						"real match must have DisplayRound >= 1")
+					byDR[m.DisplayRound]++
+					realTotal++
+					if m.DisplayRound > maxDR {
+						maxDR = m.DisplayRound
+					}
+				}
+			}
+
+			// N-1 real matches in a single-elimination bracket.
+			assert.Equal(t, tt.playerCount-1, realTotal,
+				"real-match count must be N-1")
+
+			// engineSizes ordered earliest → latest (highest DisplayRound first).
+			engineSizes := make([]int, maxDR)
+			for dr := 1; dr <= maxDR; dr++ {
+				engineSizes[maxDR-dr] = byDR[dr]
+			}
+			assert.Equal(t, excelRoundSizes(players), engineSizes,
+				"engine effective-round sizes must match the Excel Tree rounds")
+		})
+	}
+}
+
+// TestBracketDisplayMetadata_Feeders verifies the feeder graph is well formed
+// across roster sizes (including deep multi-level bye chains, e.g. 24 players):
+// every feeder ID resolves to a real, non-hidden match one DisplayRound deeper,
+// and every real match except the final is referenced exactly once as a feeder.
+func TestBracketDisplayMetadata_Feeders(t *testing.T) {
+	cases := []struct {
+		name        string
+		playerCount int
+		numSeeds    int
+	}{
+		{"5 players", 5, 0},
+		{"7 players", 7, 0},
+		{"8 players (pow2)", 8, 0},
+		{"12 players", 12, 0},
+		{"16 players (pow2)", 16, 0},
+		{"24 players", 24, 0},
+		{"24 players 8 seeds", 24, 8},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			bracket := enginePlayoffsBracket(t, makeSeededPlayers(tt.playerCount, tt.numSeeds))
+
+			byID := map[string]state.BracketMatch{}
+			var real []state.BracketMatch
+			for _, round := range bracket.Rounds {
+				for _, m := range round {
+					byID[m.ID] = m
+					if !m.Hidden {
+						real = append(real, m)
+					}
+				}
+			}
+
+			refCount := map[string]int{}
+			for _, m := range real {
+				for _, fid := range m.Feeders {
+					if fid == "" {
+						continue
+					}
+					f, ok := byID[fid]
+					require.True(t, ok, "feeder %s must exist", fid)
+					assert.False(t, f.Hidden, "feeder %s must be a real match", fid)
+					assert.Equal(t, m.DisplayRound+1, f.DisplayRound,
+						"feeder must be one DisplayRound deeper than its parent")
+					refCount[fid]++
+				}
+			}
+			// Each real match except the final (DisplayRound 1) is fed into once.
+			for _, m := range real {
+				if m.DisplayRound == 1 {
+					assert.Zero(t, refCount[m.ID], "final must not be a feeder")
+					continue
+				}
+				assert.Equal(t, 1, refCount[m.ID],
+					"real match %s must be referenced as a feeder exactly once", m.ID)
+			}
+		})
+	}
+}
+
 // TestBracketIdentity_MixedComp verifies that the engine's pool-preview path
 // produces leaf arrays identical to the Excel create-pools reference.
 func TestBracketIdentity_MixedComp(t *testing.T) {

--- a/internal/state/bracket.go
+++ b/internal/state/bracket.go
@@ -58,14 +58,17 @@ func (s *Store) copyBracket(b *Bracket) *Bracket {
 	for i, round := range b.Rounds {
 		res.Rounds[i] = make([]BracketMatch, len(round))
 		copy(res.Rounds[i], round)
-		// The shallow copy above aliases the Encho pointer and SubResults
-		// slice (and its nested IpponsA/B/Encho) with the cached bracket, so
-		// a caller mutating a returned match could corrupt cached state
-		// without going through SaveBracket/UpdateBracket. Deep-copy them to
-		// match the pool match copy path (copyMatchResults).
+		// The shallow copy above aliases the Encho pointer, SubResults slice
+		// (and its nested IpponsA/B/Encho), and the Feeders slice with the
+		// cached bracket, so a caller mutating a returned match could corrupt
+		// cached state without going through SaveBracket/UpdateBracket.
+		// Deep-copy them to match the pool match copy path (copyMatchResults).
 		for j := range res.Rounds[i] {
 			res.Rounds[i][j].Encho = round[j].Encho.Clone()
 			res.Rounds[i][j].SubResults = cloneSubResults(round[j].SubResults)
+			if round[j].Feeders != nil {
+				res.Rounds[i][j].Feeders = append([]string(nil), round[j].Feeders...)
+			}
 		}
 	}
 	return res

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -650,6 +650,24 @@ type BracketMatch struct {
 	SubResults []SubMatchResult `json:"subResults,omitempty"`
 	// ResultSource mirrors MatchResult.ResultSource for bracket matches.
 	ResultSource string `json:"resultSource,omitempty"`
+	// Display metadata (mp-7f2w) — additive, computed at generation time so the
+	// viewer can render the bracket with the SAME effective-round columns as the
+	// printed Excel Tree sheet (matches grouped by depth-from-root, structural
+	// byes skipping a column) instead of the balanced pow2 rounds. These fields
+	// are purely for rendering; the resolution/scoring/scheduling logic continues
+	// to use the positional ID + "Winner of rX-mY" scheme unchanged.
+	//
+	// DisplayRound is the effective round counted from the final (1 = Final,
+	// 2 = Semifinal, …). 0 means unset — either a legacy bracket generated before
+	// this field existed (viewer falls back to positional rendering) or a Hidden
+	// phantom match. Hidden marks a structural-bye match (empty-vs-empty dead
+	// match, or a latent bye where one side never had an opponent) that is not a
+	// real bout and must not be drawn as a match card. Feeders holds the IDs of
+	// the two real feeder matches whose winners meet here, in [A, B] order; an
+	// empty string means that side is a seeded entrant / bye (no connector line).
+	DisplayRound int      `json:"displayRound,omitempty"`
+	Hidden       bool     `json:"hidden,omitempty"`
+	Feeders      []string `json:"feeders,omitempty"`
 }
 
 type Bracket struct {

--- a/web-mobile/js/__tests__/bracket_display_model.test.jsx
+++ b/web-mobile/js/__tests__/bracket_display_model.test.jsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { buildDisplayModel, computeMetaTops } from '../bracket.jsx';
+
+// mp-7f2w: the engine tags bracket matches with effective-round metadata
+// (displayRound / hidden / feeders) so the viewer renders the same
+// effective-round columns as the Excel Tree sheet — structural byes skip a
+// column instead of showing empty cards. buildDisplayModel turns the persisted
+// balanced rounds into those columns + a feeder graph, and falls back to the
+// legacy balanced-rounds shape when no metadata is present.
+
+// 5-player bracket as the engine persists it (verified against bracket.json):
+//   QF: Dave/Eve (dr3)  ·  SF: Alice/Bob + Carol (dr2)  ·  Final (dr1)
+//   phantoms: dead match, Carol's bye, latent-bye SF.
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', sideA: 'Alice', sideB: 'Bob', displayRound: 2, feeders: ['', ''] },
+    { id: 'm-r1-1', sideA: '', sideB: '', hidden: true },
+    { id: 'm-r1-2', sideA: 'Carol', sideB: '', hidden: true },
+    { id: 'm-r1-3', sideA: 'Dave', sideB: 'Eve', displayRound: 3, feeders: ['', ''] },
+  ],
+  [
+    { id: 'm-r2-0', sideA: 'Winner of r3-m0', sideB: '', hidden: true },
+    { id: 'm-r2-1', sideA: 'Carol', sideB: 'Winner of r3-m3', displayRound: 2, feeders: ['', 'm-r1-3'] },
+  ],
+  [
+    { id: 'm-r3-0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1', displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'] },
+  ],
+];
+
+describe('buildDisplayModel', () => {
+  it('groups real matches into effective-round columns and drops phantoms', () => {
+    const model = buildDisplayModel(fivePlayerRounds());
+    expect(model.hasMeta).toBe(true);
+    // Columns ordered first round → final: [QF, SF, Final].
+    expect(model.columns.map((c) => c.length)).toEqual([1, 2, 1]);
+    const ids = (col) => col.map((m) => m.id).sort();
+    expect(ids(model.columns[0])).toEqual(['m-r1-3']); // QF: Dave/Eve
+    expect(ids(model.columns[1])).toEqual(['m-r1-0', 'm-r2-1']); // SF: Alice/Bob + Carol
+    expect(ids(model.columns[2])).toEqual(['m-r3-0']); // Final
+    // No hidden/phantom match leaks into any column.
+    const all = model.columns.flat();
+    expect(all.some((m) => m.hidden)).toBe(false);
+    expect(all).toHaveLength(4); // N-1 real matches
+  });
+
+  it('exposes a feeder graph keyed by match id (byes carry no feeder)', () => {
+    const model = buildDisplayModel(fivePlayerRounds());
+    expect(model.feedersById['m-r3-0']).toEqual(['m-r1-0', 'm-r2-1']); // final ← Alice/Bob, Carol SF
+    expect(model.feedersById['m-r2-1']).toEqual(['m-r1-3']); // Carol SF ← Dave/Eve (Carol side is a bye)
+    expect(model.feedersById['m-r1-0']).toEqual([]); // Alice/Bob seeded in
+    expect(model.feedersById['m-r1-3']).toEqual([]); // Dave/Eve seeded in
+  });
+
+  it('falls back to balanced rounds unchanged when no metadata', () => {
+    // 4-player balanced bracket with no displayRound/hidden fields. The legacy
+    // renderer draws connectors positionally inside BracketConnectors (from
+    // `rounds`), so buildDisplayModel produces no feeder graph here.
+    const rounds = [
+      [
+        { id: 'a0', sideA: 'P1', sideB: 'P2' },
+        { id: 'a1', sideA: 'P3', sideB: 'P4' },
+      ],
+      [{ id: 'b0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1' }],
+    ];
+    const model = buildDisplayModel(rounds);
+    expect(model.hasMeta).toBe(false);
+    expect(model.columns).toBe(rounds); // unchanged shape
+    expect(model.feedersById).toEqual({}); // legacy path is positional, no graph
+  });
+
+  it('handles empty / null input', () => {
+    expect(buildDisplayModel(null).hasMeta).toBe(false);
+    expect(buildDisplayModel([]).hasMeta).toBe(false);
+  });
+});
+
+describe('computeMetaTops', () => {
+  it('centres each parent on the mean of its feeders and stacks bye leaves', () => {
+    const model = buildDisplayModel(fivePlayerRounds());
+    const heights = { 'm-r1-0': 100, 'm-r1-3': 100, 'm-r2-1': 100, 'm-r3-0': 100 };
+    const tops = computeMetaTops(model.columns, model.feedersById, heights);
+    const centre = (id) => tops[id] + heights[id] / 2;
+    // Alice/Bob (leaf) is stacked first, Dave/Eve second.
+    expect(centre('m-r1-0')).toBeLessThan(centre('m-r1-3'));
+    // Carol's SF sits on its single feeder (Dave/Eve).
+    expect(centre('m-r2-1')).toBeCloseTo(centre('m-r1-3'), 5);
+    // Final is centred between Alice/Bob and Carol's SF.
+    expect(centre('m-r3-0')).toBeCloseTo((centre('m-r1-0') + centre('m-r2-1')) / 2, 5);
+  });
+});

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -174,7 +174,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
             invisible spacer line so all sides (and thus all bracket cards) keep
             a uniform height (mp-7f2w). When showDojo is off, no line is rendered
             anywhere, so cards stay uniformly short. */}
-        {showDojo ? <span className="bc-dojo">{player.dojo || " "}</span> : null}
+        {showDojo ? <span className="bc-dojo">{player.dojo || <span aria-hidden="true">{"\u00A0"}</span>}</span> : null}
       </div>
       {score != null ? <span className="bc-score">{score}</span> : null}
     </div>

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -169,7 +169,12 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
           {player.number ? <span className="num-prefix">{player.number}</span> : null}
           {player.name}
         </span>
-        {showDojo && player.dojo ? <span className="bc-dojo">{player.dojo}</span> : null}
+        {/* Reserve the dojo line on every side when dojos are shown — a real
+            player without a dojo, or a "Winner of…" placeholder, gets an
+            invisible spacer line so all sides (and thus all bracket cards) keep
+            a uniform height (mp-7f2w). When showDojo is off, no line is rendered
+            anywhere, so cards stay uniformly short. */}
+        {showDojo ? <span className="bc-dojo">{player.dojo || " "}</span> : null}
       </div>
       {score != null ? <span className="bc-score">{score}</span> : null}
     </div>
@@ -296,7 +301,284 @@ function BracketConnectors({ rounds, treeRef, refMap, version }) {
   );
 }
 
-function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayer }) {
+// buildDisplayModel decides how to render a bracket. When the engine has tagged
+// matches with effective-round metadata (mp-7f2w: displayRound / hidden /
+// feeders), it groups the REAL matches into effective-round columns identical to
+// the Excel Tree sheet (structural byes skip a column, phantom bye matches are
+// dropped) and exposes a feeder graph for connector drawing. Otherwise it falls
+// back to the legacy balanced-rounds shape with positional (2i, 2i+1) feeders so
+// brackets generated before this field existed render exactly as before.
+// useAutoScrollToMatch smooth-scrolls the bracket so the given match is centred
+// in the scroll container. Shared by both the effective-round (BracketTreeMeta)
+// and legacy (BracketTreeLegacy) renderers so the centring math lives in one place.
+function useAutoScrollToMatch(autoScrollMatchId, refMap, scrollContainerRef, version) {
+  useLayoutEffectBC(() => {
+    if (!autoScrollMatchId) return;
+    const realId = String(autoScrollMatchId).split("::")[0];
+    let frame1 = 0, frame2 = 0;
+    const run = () => {
+      const el = refMap.current[realId];
+      const scrollEl = scrollContainerRef?.current;
+      if (!el || !scrollEl) return;
+      const elRect = el.getBoundingClientRect();
+      const scRect = scrollEl.getBoundingClientRect();
+      const targetLeft = scrollEl.scrollLeft + (elRect.left - scRect.left) - (scRect.width / 2 - elRect.width / 2);
+      const targetTop = scrollEl.scrollTop + (elRect.top - scRect.top) - (scRect.height / 2 - elRect.height / 2);
+      scrollEl.scrollTo({ left: Math.max(0, targetLeft), top: Math.max(0, targetTop), behavior: "smooth" });
+    };
+    frame1 = requestAnimationFrame(() => { frame2 = requestAnimationFrame(run); });
+    return () => { cancelAnimationFrame(frame1); cancelAnimationFrame(frame2); };
+  }, [autoScrollMatchId, version]);
+}
+
+function buildDisplayModel(rounds) {
+  if (!rounds || rounds.length === 0) return { hasMeta: false, columns: rounds || [], feedersById: {} };
+  const hasMeta = rounds.some((r) => r.some((m) => (m.displayRound || 0) > 0 || m.hidden));
+  if (hasMeta) {
+    let maxDR = 0;
+    const real = [];
+    rounds.forEach((r) => r.forEach((m) => {
+      if (!m.hidden && (m.displayRound || 0) > 0) { real.push(m); if (m.displayRound > maxDR) maxDR = m.displayRound; }
+    }));
+    const columns = [];
+    for (let dr = maxDR; dr >= 1; dr--) columns.push(real.filter((m) => m.displayRound === dr));
+    const feedersById = {};
+    real.forEach((m) => { feedersById[m.id] = (m.feeders || []).filter(Boolean); });
+    return { hasMeta: true, columns, feedersById };
+  }
+  // Legacy: columns = rounds. Connectors are positional (BracketConnectors
+  // derives the 2i/2i+1 feeders from `rounds` itself), so no feeder graph is
+  // produced here — feedersById stays empty to match the empty-input shape.
+  return { hasMeta: false, columns: rounds, feedersById: {} };
+}
+
+// computeMetaTops lays out an (uneven) effective-round bracket. It walks the
+// feeder graph from the final: matches with no feeders ("seeded" entrants — real
+// players or bye recipients) are stacked top-to-bottom in depth-first encounter
+// order, and every parent is centred on the mean of its feeders. Returns a map
+// of matchId → absolute top (px). heights is matchId → measured card height.
+function computeMetaTops(columns, feedersById, heights) {
+  const GAP = 16;
+  const DEFAULT_H = 110;
+  const centerOf = {};
+  const inProgress = new Set();
+  let cursor = 0;
+  const visit = (id) => {
+    if (centerOf[id] != null) return centerOf[id];
+    // Cycle guard (mirrors the DisplayRound!=0 guard in the Go BFS): centerOf is
+    // only set post-order for parents, so a cyclic feeders graph would recurse
+    // forever. The engine only emits acyclic trees, but a corrupt/hand-edited
+    // bracket.json must not crash the renderer — break the cycle and return 0.
+    if (inProgress.has(id)) return 0;
+    inProgress.add(id);
+    const fs = (feedersById[id] || []).filter(Boolean);
+    const h = heights[id] || DEFAULT_H;
+    if (fs.length === 0) {
+      const c = cursor + h / 2;
+      cursor += h + GAP;
+      centerOf[id] = c;
+      inProgress.delete(id);
+      return c;
+    }
+    const cs = fs.map(visit);
+    const c = cs.reduce((a, b) => a + b, 0) / cs.length;
+    centerOf[id] = c;
+    inProgress.delete(id);
+    return c;
+  };
+  const rootId = columns[columns.length - 1]?.[0]?.id;
+  if (rootId) visit(rootId);
+  // Defensive: the engine only sets displayRound>0 on matches reachable from the
+  // final, so visit(rootId) already placed every match in `columns`. This loop
+  // is a no-op for engine output and only fires on corrupt/hand-written metadata.
+  columns.forEach((col) => col.forEach((m) => {
+    if (centerOf[m.id] == null) {
+      const h = heights[m.id] || DEFAULT_H;
+      centerOf[m.id] = cursor + h / 2;
+      cursor += h + GAP;
+    }
+  }));
+  const tops = {};
+  columns.forEach((col) => col.forEach((m) => {
+    tops[m.id] = centerOf[m.id] - (heights[m.id] || DEFAULT_H) / 2;
+  }));
+  return tops;
+}
+
+// BracketConnectorsMeta draws feeder→parent elbows for the effective-round
+// layout (mp-7f2w). Unlike the legacy BracketConnectors it pairs by the explicit
+// feeder graph, not binary (2i, 2i+1) positions, so uneven columns connect
+// correctly. A match with a single feeder (the other side is a bye/seeded
+// entrant) gets one elbow; the bye side draws no line.
+function BracketConnectorsMeta({ columns, feedersById, treeRef, refMap, version, showDojo, variant }) {
+  const [paths, setPaths] = useStateBC([]);
+  const [size, setSize] = useStateBC({ w: 0, h: 0 });
+
+  useLayoutEffectBC(() => {
+    const compute = () => {
+      const tree = treeRef.current;
+      if (!tree) return;
+      const treeRect = tree.getBoundingClientRect();
+      const out = [];
+      columns.forEach((col) => col.forEach((m) => {
+        const fs = (feedersById[m.id] || []).filter(Boolean);
+        if (fs.length === 0) return;
+        const mEl = refMap.current[m.id];
+        if (!mEl) return;
+        const mR = mEl.getBoundingClientRect();
+        const mLeft = mR.left - treeRect.left;
+        const mMidY = anchorY(mEl, mR, treeRect.top);
+        fs.forEach((fid) => {
+          const fEl = refMap.current[fid];
+          if (!fEl) return;
+          const fR = fEl.getBoundingClientRect();
+          const fRight = fR.right - treeRect.left;
+          const fMidY = anchorY(fEl, fR, treeRect.top);
+          const midX = (fRight + mLeft) / 2;
+          out.push({ d: `M ${fRight} ${fMidY} L ${midX} ${fMidY} L ${midX} ${mMidY} L ${mLeft} ${mMidY}` });
+        });
+      }));
+      setPaths(out);
+      setSize({ w: tree.scrollWidth, h: tree.scrollHeight });
+    };
+    compute();
+    const ro = new ResizeObserver(compute);
+    if (treeRef.current) ro.observe(treeRef.current);
+    window.addEventListener("resize", compute);
+    return () => { ro.disconnect(); window.removeEventListener("resize", compute); };
+    // showDojo/variant change card heights → feeder anchors move, so recompute.
+  }, [columns, feedersById, version, showDojo, variant]);
+
+  return (
+    <svg className="bc-connectors" width={size.w} height={size.h} style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none" }}>
+      {paths.map((p, i) => (
+        <path key={i} d={p.d} fill="none" stroke="var(--line-strong, #c7cdd9)" strokeWidth="1.5" />
+      ))}
+    </svg>
+  );
+}
+
+// BracketTreeMeta renders the effective-round columns (mp-7f2w). Every card is a
+// real match; structural byes are absent. Cards in column 0 plus every card is
+// absolutely positioned at the feeder-graph-derived top so parents sit centred
+// on their feeders (see computeMetaTops).
+function BracketTreeMeta({ columns, feedersById, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayer }) {
+  const treeRef = useRef(null);
+  const refMap = useRef({});
+  const [version, setVersion] = useStateBC(0);
+  const [cardTops, setCardTops] = useStateBC(null);
+
+  // Reset the measured layout only when the TOPOLOGY changes, not on every new
+  // `columns` reference. Match ids and the feeder graph are frozen at generation
+  // time, so a score update (which only mutates sideA/sideB/status/score) yields
+  // the same signature and the measured tops are preserved — avoiding a reset-to-
+  // null reflow flash on every live-court update. Genuine height changes on
+  // resolution are still caught by the measure effect's ResizeObserver below.
+  const topoSig = React.useMemo(
+    () => columns.map((c) => c.map((m) => m.id).join(",")).join("|"),
+    [columns]
+  );
+  useEffectBC(() => { setCardTops(null); setVersion((v) => v + 1); }, [topoSig]);
+
+  useLayoutEffectBC(() => {
+    const measure = () => {
+      const tree = treeRef.current;
+      if (!tree || !columns || columns.length === 0) return;
+      const heights = {};
+      for (const col of columns) {
+        for (const m of col) {
+          const el = refMap.current[m.id];
+          if (!el) return;
+          heights[m.id] = el.getBoundingClientRect().height;
+        }
+      }
+      const tops = computeMetaTops(columns, feedersById, heights);
+      // Every column is absolutely positioned, so the flow height of each
+      // round-matches container is 0 and the tree would collapse. Derive the
+      // overall content height from the lowest card bottom and pin it on the
+      // containers so the tree (and its scroll area) size correctly.
+      let height = 0;
+      for (const col of columns) {
+        for (const m of col) {
+          const bottom = (tops[m.id] || 0) + (heights[m.id] || 0);
+          if (bottom > height) height = bottom;
+        }
+      }
+      setCardTops((prev) => {
+        if (prev) {
+          const same = Math.abs((prev.height ?? 0) - height) < 0.5 &&
+            Object.keys(tops).length === Object.keys(prev.tops).length &&
+            Object.keys(tops).every((k) => Math.abs((prev.tops[k] ?? 0) - tops[k]) < 0.5);
+          if (same) return prev;
+        }
+        return { tops, height };
+      });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    if (treeRef.current) ro.observe(treeRef.current);
+    window.addEventListener("resize", measure);
+    return () => { ro.disconnect(); window.removeEventListener("resize", measure); };
+    // showDojo/variant affect card heights, so re-measure (and reposition) when
+    // they change — not just on topology/version. The convergence guard keeps a
+    // no-op recompute from causing a render.
+  }, [columns, feedersById, version, showDojo, variant]);
+
+  useAutoScrollToMatch(autoScrollMatchId, refMap, scrollContainerRef, version);
+
+  if (!columns || columns.length === 0) return null;
+  const positioned = !!cardTops;
+  // Every column is absolutely positioned, so override the legacy flex:1 (which
+  // would zero the basis) and pin an explicit height; otherwise the flex row has
+  // no non-abs column to establish its height and the tree collapses.
+  const matchesStyle = positioned ? { flex: "none", height: `${cardTops.height}px`, minHeight: `${cardTops.height}px` } : undefined;
+  return (
+    <div className={`bc-tree bc-tree--v${variant}`} ref={treeRef}>
+      <BracketConnectorsMeta columns={columns} feedersById={feedersById} treeRef={treeRef} refMap={refMap} version={version} showDojo={showDojo} variant={variant} />
+      {columns.map((col, ci) => (
+        <div key={ci} className="bc-round" style={{ "--round": ci }}>
+          <div className="bc-round-label">{roundLabel(ci, columns.length)}</div>
+          <div className={`bc-round-matches${positioned ? " bc-round-matches--abs" : ""}`} style={matchesStyle}>
+            {col.map((m, mi) => {
+              const top = positioned ? cardTops.tops[m.id] : undefined;
+              const wrapStyle = top != null
+                ? { "--mi": mi, position: "absolute", top: `${top}px`, left: 0, right: 0 }
+                : { "--mi": mi };
+              return (
+                <div className="bc-match-wrap" key={m.id} style={wrapStyle}>
+                  <MatchCard
+                    match={m}
+                    variant={variant}
+                    showDojo={showDojo}
+                    highlighted={m.id === highlightedMatchId}
+                    matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
+                    onClick={() => onMatchClick && onMatchClick(m, ci, mi)}
+                    highlightPlayer={highlightPlayer}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// BracketTree switches between the effective-round renderer (when the engine
+// supplied display metadata) and the legacy balanced-rounds renderer.
+function BracketTree(props) {
+  // Memoise on rounds identity: buildDisplayModel returns fresh arrays, and the
+  // meta renderer's effects key on those — recomputing every render would reset
+  // the measured layout in a loop.
+  const model = React.useMemo(() => buildDisplayModel(props.rounds), [props.rounds]);
+  if (model.hasMeta) {
+    return <BracketTreeMeta {...props} columns={model.columns} feedersById={model.feedersById} />;
+  }
+  return <BracketTreeLegacy {...props} />;
+}
+
+function BracketTreeLegacy({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayer }) {
   const treeRef = useRef(null);
   const refMap = useRef({});
   const [version, setVersion] = useStateBC(0);
@@ -373,23 +655,7 @@ function BracketTree({ rounds, variant = 1, showDojo = true, onMatchClick, highl
     return () => { ro.disconnect(); window.removeEventListener("resize", measure); };
   }, [rounds, version]);
 
-  useLayoutEffectBC(() => {
-    if (!autoScrollMatchId) return;
-    const realId = String(autoScrollMatchId).split("::")[0];
-    let frame1 = 0, frame2 = 0;
-    const run = () => {
-      const el = refMap.current[realId];
-      const scrollEl = scrollContainerRef?.current;
-      if (!el || !scrollEl) return;
-      const elRect = el.getBoundingClientRect();
-      const scRect = scrollEl.getBoundingClientRect();
-      const targetLeft = scrollEl.scrollLeft + (elRect.left - scRect.left) - (scRect.width / 2 - elRect.width / 2);
-      const targetTop = scrollEl.scrollTop + (elRect.top - scRect.top) - (scRect.height / 2 - elRect.height / 2);
-      scrollEl.scrollTo({ left: Math.max(0, targetLeft), top: Math.max(0, targetTop), behavior: "smooth" });
-    };
-    frame1 = requestAnimationFrame(() => { frame2 = requestAnimationFrame(run); });
-    return () => { cancelAnimationFrame(frame1); cancelAnimationFrame(frame2); };
-  }, [autoScrollMatchId, version]);
+  useAutoScrollToMatch(autoScrollMatchId, refMap, scrollContainerRef, version);
 
   if (!rounds) return null;
   // Round 0 flows naturally; rounds ≥ 1 are absolutely positioned at the measured
@@ -453,4 +719,4 @@ window.decisionSuffix = decisionSuffix;
 window.sideLabel = sideLabel;
 window.ipponsFromScore = ipponsFromScore;
 
-export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore, matchScoreStr };
+export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore, matchScoreStr, buildDisplayModel, computeMetaTops };

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2995,6 +2995,7 @@ function bracketHasDecidedFinal(bracket) {
 // Returns { state, podium } where state is one of:
 //   'final'       — podium is the final result
 //   'in-progress' — knockout not yet decided (podium [])
+//   'skip'        — legacy linked-playoffs shell (sourceCompID); caller should ignore
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
 async function resolveCompetitionAwards(comp, fetchers) {
   // A linked-playoffs shell (legacy split-comp layout carrying sourceCompID)

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2997,6 +2997,14 @@ function bracketHasDecidedFinal(bracket) {
 //   'in-progress' — knockout not yet decided (podium [])
 // fetchers = { fetchCompetitionDetails(id), swissStandings(id)|null }
 async function resolveCompetitionAwards(comp, fetchers) {
+  // A linked-playoffs shell (legacy split-comp layout carrying sourceCompID)
+  // derives its podium from its source comp, never standalone — drop it so it
+  // doesn't appear twice in the results summary. buildAllWinnersPublic filters
+  // state==="skip". (The current data model no longer emits sourceCompID, so
+  // this is defensive parity with the documented behaviour.)
+  if (comp && comp.sourceCompID) {
+    return { state: "skip", podium: [] };
+  }
   const fmt = comp && comp.format;
   const ntpFrom = (players) => {
     const m = new Map();
@@ -3699,7 +3707,7 @@ async function buildAllWinnersPublic(comps, fetchers) {
   const results = await Promise.all(
     completed.map(async (comp) => {
       try {
-        const { state, podium } = await resolveCompetitionAwards(comp, comps, fetchers);
+        const { state, podium } = await resolveCompetitionAwards(comp, fetchers);
         return { comp, state, podium };
       } catch (err) {
         return { comp, state: "error", podium: [], error: err?.message || String(err) };


### PR DESCRIPTION
## Summary

- **Bracket byes no longer render as confusing empty cards.** Elimination brackets in the mobile viewer showed structural byes as empty match cards — empty-vs-empty "dead" matches and one-sided "latent bye" slots with `AKA`/`SHIRO` badges but no names. The printed Excel Tree sheet never does this.
- The viewer now places each match in the column of its **effective round** (depth from the final), so a bye recipient simply **skips a column** — matching the Excel exactly. For 5 players: QF = Dave/Eve only; SF = Alice/Bob (whose winner byes the dead semifinal) + Carol (round-1 bye); Final.
- All bracket cards are now a **uniform height** (the dojo line is reserved on every side when dojos are shown).

## Why

`internal/engine/bracket.go:buildBracketFromLeaves` builds a *balanced* pow2 tree from the `TreeToLeafArray` output, producing balanced halving rounds with phantom bye matches. mp-5ng7 made the matchups/bye-recipients byte-identical to the Excel, but **not** the round/column structure — so the viewer showed Alice/Bob in the QF column with a phantom dead match and a phantom latent-bye SF. Verified against the real Excel Tree sheet (`create-playoffs` on 5 players): the Excel renders one QF (Dave/Eve), two SFs (Alice/Bob + Carol), one Final — exactly the effective-round layout this PR adopts.

## Approach (additive metadata — no migration, scoring untouched)

The persisted `state.Bracket` keeps its existing **balanced** rounds and the positional `Winner of rX-mY` feeder scheme; resolution/scoring/scheduling/pool-resolver logic is **unchanged**. Three optional fields are added to `state.BracketMatch`:

- `DisplayRound` — effective round (1 = Final; 0 = unset/legacy/phantom)
- `Hidden` — a structural-bye "match" that is not a real bout
- `Feeders` — the two real feeder match IDs (`""` = a seeded entrant / bye side, no connector)

`engine.computeBracketDisplayMetadata` runs **once** at generation (while placeholders are intact), marks phantoms `Hidden`, and assigns `DisplayRound` by walking the real feeder graph out from the final. The viewer's `buildDisplayModel` groups real matches into effective-round columns when metadata is present, else **falls back to the legacy balanced rendering unchanged** (brackets generated before this field regenerate on restart — no migration).

## Files changed

| File | What |
|---|---|
| `internal/state/models.go` | Add optional `DisplayRound` / `Hidden` / `Feeders` to `BracketMatch` |
| `internal/engine/bracket.go` | `computeBracketDisplayMetadata`: mark phantom byes Hidden, assign effective round + real feeders from the feeder graph (with a cycle guard) |
| `internal/engine/bracket_identity_test.go` | `TestBracketDisplayMetadata_MatchesExcelRounds` (5/7/8/12/16/24 ±seeds) asserts engine effective-round sizes == Excel `eliminationMatchRounds`; `TestBracketDisplayMetadata_Feeders` verifies feeder-edge integrity over the same sizes |
| `web-mobile/js/bracket.jsx` | `buildDisplayModel` (effective-round columns or legacy fallback); new `BracketTreeMeta` + `BracketConnectorsMeta` (feeder-graph layout, parents centred on feeders, explicit-height containers, in-progress cycle guard); shared `useAutoScrollToMatch` hook; `PlayerLine` reserves the dojo line for uniform card height |
| `web-mobile/js/__tests__/bracket_display_model.test.jsx` | New unit tests for `buildDisplayModel` (grouping + legacy fallback) and `computeMetaTops` (feeder-centred layout) |

## Screenshots

**Before** — structural byes shown as empty match cards (the bug):

![before](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/255/before.png)

**After** — effective-round columns matching the Excel; Alice/Bob sits in the Semifinals column, Dave/Eve is the lone quarterfinal, no empty cards, uniform card heights:

![after](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/255/after.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests; `internal/engine` 86.1%)
- [x] New/updated unit tests cover the change (Go: effective-round sizes vs Excel + feeder-edge integrity across 5/7/8/12/16/24 ±seeds; JS: `buildDisplayModel` + `computeMetaTops`; 1273 JS tests pass)
- [x] Manual browser verification — exercised the live mobile app: 5-player playoffs (QF=Dave/Eve, SF=Alice/Bob+Carol, Final; no empty cards, uniform 118px cards, 3 aligned connectors), 8-player pow2 (standard 4/2/1, no regression), and mixed-comp preview (pool top seeds bye into the SF)
- [x] Screenshots added above (before = legacy fallback render; after = effective-round render)
- [x] No new console errors or warnings

Reviewed at depth via tri-review (3 parallel lenses + adversarial verification): 6 low-severity findings, all addressed (DRY hook extraction, dead-code removal, cycle guard, table-driven feeder test, live-court re-measure flash fix, defensive comments).

Closes mp-7f2w
