### PR TITLE
feat(mp-1w5f): optional per-competition Fighting Spirit awards

### DIFF
--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -1344,4 +1344,83 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		}
 		c.Status(http.StatusNoContent)
 	})
+
+	r.PUT("/competitions/:id/awards", RequireElevatedPassword(elevated), func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+
+		var body struct {
+			FightingSpiritAwards []state.FightingSpiritAward `json:"fightingSpiritAwards"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		awards := body.FightingSpiritAwards
+		if len(awards) > MaxFightingSpiritAwards {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards must not exceed %d entries", MaxFightingSpiritAwards)})
+			return
+		}
+
+		// Validate and trim each award before persisting.
+		trimmed := make([]state.FightingSpiritAward, 0, len(awards))
+		for i, a := range awards {
+			title := strings.TrimSpace(a.Title)
+			recipientName := strings.TrimSpace(a.RecipientName)
+			recipientDojo := strings.TrimSpace(a.RecipientDojo)
+
+			if title == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: title is required", i)})
+				return
+			}
+			if recipientName == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: recipientName is required", i)})
+				return
+			}
+			if err := validateMaxLen("title", title, MaxLenPlayerName); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: %s", i, err.Error())})
+				return
+			}
+			if err := validateMaxLen("recipientName", recipientName, MaxLenPlayerName); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: %s", i, err.Error())})
+				return
+			}
+			if err := validateMaxLen("recipientDojo", recipientDojo, MaxLenPlayerDojo); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: %s", i, err.Error())})
+				return
+			}
+			trimmed = append(trimmed, state.FightingSpiritAward{
+				Title:         title,
+				RecipientName: recipientName,
+				RecipientDojo: recipientDojo,
+			})
+		}
+
+		var compOut *state.Competition
+		var notFoundFlag bool
+		changed, err := store.UpdateCompetitionChanged(id, func(current *state.Competition) (*state.Competition, error) {
+			if current == nil {
+				notFoundFlag = true
+				return nil, nil
+			}
+			current.FightingSpiritAwards = trimmed
+			compOut = current
+			return current, nil
+		})
+		if notFoundFlag {
+			c.JSON(http.StatusNotFound, gin.H{"error": "competition not found"})
+			return
+		}
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if changed {
+			hub.Broadcast(EventTournamentUpdated, nil)
+		}
+		c.JSON(http.StatusOK, compOut)
+	})
 }

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -1351,15 +1351,23 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 
+		// Pointer slice distinguishes "field omitted" (nil) from "explicit
+		// empty array" ([]). The field is documented required (OpenAPI
+		// required: [fightingSpiritAwards]); a body of `{}` must 400 rather
+		// than silently clear the list, while an explicit [] clears it.
 		var body struct {
-			FightingSpiritAwards []state.FightingSpiritAward `json:"fightingSpiritAwards"`
+			FightingSpiritAwards *[]state.FightingSpiritAward `json:"fightingSpiritAwards"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		if body.FightingSpiritAwards == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "fightingSpiritAwards is required (use an empty array to clear all awards)"})
+			return
+		}
 
-		awards := body.FightingSpiritAwards
+		awards := *body.FightingSpiritAwards
 		if len(awards) > MaxFightingSpiritAwards {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards must not exceed %d entries", MaxFightingSpiritAwards)})
 			return
@@ -1373,23 +1381,23 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			recipientDojo := strings.TrimSpace(a.RecipientDojo)
 
 			if title == "" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: title is required", i)})
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards[%d]: title is required", i)})
 				return
 			}
 			if recipientName == "" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: recipientName is required", i)})
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards[%d]: recipientName is required", i)})
 				return
 			}
 			if err := validateMaxLen("title", title, MaxLenPlayerName); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: %s", i, err.Error())})
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards[%d]: %s", i, err.Error())})
 				return
 			}
 			if err := validateMaxLen("recipientName", recipientName, MaxLenPlayerName); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: %s", i, err.Error())})
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards[%d]: %s", i, err.Error())})
 				return
 			}
 			if err := validateMaxLen("recipientDojo", recipientDojo, MaxLenPlayerDojo); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("awards[%d]: %s", i, err.Error())})
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("fightingSpiritAwards[%d]: %s", i, err.Error())})
 				return
 			}
 			trimmed = append(trimmed, state.FightingSpiritAward{

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -8,8 +8,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -1626,6 +1628,232 @@ func TestUpdateCompetitionTeamSizeValidation(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestPUTCompetitionAwards(t *testing.T) {
+	r, store, _, hub, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	cid := "awards-comp"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     cid,
+		Name:   "Awards Comp",
+		Status: state.CompStatusComplete,
+	}))
+
+	t.Run("happy path: awards persisted + 200 + SSE emitted", func(t *testing.T) {
+		ch := hub.Subscribe()
+		defer hub.Unsubscribe(ch)
+
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Fighting Spirit", "recipientName": "Alice Yamada", "recipientDojo": "Shinjuku"},
+				{"title": "Best Technique", "recipientName": "Bob Tanaka"},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+		// Parse response competition and check awards.
+		var resp state.Competition
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Len(t, resp.FightingSpiritAwards, 2)
+		assert.Equal(t, "Fighting Spirit", resp.FightingSpiritAwards[0].Title)
+		assert.Equal(t, "Alice Yamada", resp.FightingSpiritAwards[0].RecipientName)
+		assert.Equal(t, "Shinjuku", resp.FightingSpiritAwards[0].RecipientDojo)
+		assert.Equal(t, "Best Technique", resp.FightingSpiritAwards[1].Title)
+		assert.Equal(t, "Bob Tanaka", resp.FightingSpiritAwards[1].RecipientName)
+		assert.Equal(t, "", resp.FightingSpiritAwards[1].RecipientDojo)
+
+		// Verify persistence.
+		saved, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		require.Len(t, saved.FightingSpiritAwards, 2)
+		assert.Equal(t, "Alice Yamada", saved.FightingSpiritAwards[0].RecipientName)
+
+		// Check SSE tournament_updated was broadcast.
+		sawUpdate := false
+		for range 4 {
+			select {
+			case msg := <-ch:
+				if strings.Contains(msg, `"type":"tournament_updated"`) {
+					sawUpdate = true
+				}
+			default:
+			}
+		}
+		assert.True(t, sawUpdate, "tournament_updated SSE event must be emitted after award save")
+	})
+
+	t.Run("clear awards: empty array persisted", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{"fightingSpiritAwards": []any{}})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+		saved, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		assert.Empty(t, saved.FightingSpiritAwards, "awards must be cleared")
+	})
+
+	t.Run("404 for unknown competition", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Spirit", "recipientName": "Ghost"},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/no-such-comp/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "competition not found")
+	})
+
+	t.Run("400: empty title rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "   ", "recipientName": "Alice"},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "title is required")
+	})
+
+	t.Run("400: empty recipientName rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Spirit", "recipientName": ""},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "recipientName is required")
+	})
+
+	t.Run("400: over-cap count (21 awards) rejected", func(t *testing.T) {
+		awards := make([]map[string]any, 21)
+		for i := range awards {
+			awards[i] = map[string]any{"title": "Spirit", "recipientName": fmt.Sprintf("Person %d", i)}
+		}
+		body, _ := json.Marshal(map[string]any{"fightingSpiritAwards": awards})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "fightingSpiritAwards must not exceed")
+	})
+
+	t.Run("400: title exceeds max length", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": strings.Repeat("x", MaxLenPlayerName+1), "recipientName": "Alice"},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("400: recipientName exceeds max length", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Spirit", "recipientName": strings.Repeat("x", MaxLenPlayerName+1)},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("400: recipientDojo exceeds max length", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Spirit", "recipientName": "Alice", "recipientDojo": strings.Repeat("x", MaxLenPlayerDojo+1)},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("missing elevated password rejected", func(t *testing.T) {
+		// Build a router with an active elevated gate: store has a tournament
+		// with a non-empty AdminPassword. The gate becomes active and any
+		// request without X-Admin-Password must be rejected.
+		tmpDir := t.TempDir()
+		s, err := state.NewStore(tmpDir)
+		require.NoError(t, err)
+		// SaveTournament with AdminPassword set activates the fileElevatedVerifier gate.
+		require.NoError(t, s.SaveTournament(&state.Tournament{
+			Name:          "T",
+			Password:      "mainpw",
+			Courts:        []string{"A"},
+			AdminPassword: "secretadminpw",
+		}))
+		require.NoError(t, s.SaveCompetition(&state.Competition{
+			ID: "awards-elev", Name: "Elev Test",
+		}))
+
+		gin.SetMode(gin.TestMode)
+		elev := NewFileElevatedVerifier(s)
+		hr := gin.New()
+		api := hr.Group("/api")
+		RegisterCompetitionHandlers(api, s, nil, NewHub(), elev)
+
+		body2, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Spirit", "recipientName": "Alice"},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/awards-elev/awards", bytes.NewBuffer(body2))
+		req.Header.Set("Content-Type", "application/json")
+		// Do NOT set X-Admin-Password — should be rejected with 401 (wrong credential).
+		hr.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "missing elevated password must return 401, got %d: %s", w.Code, w.Body.String())
+	})
+
+	t.Run("whitespace trimmed from awards before persisting", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "  Spirit  ", "recipientName": "  Carol  ", "recipientDojo": "  Osaka  "},
+			},
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "response: %s", w.Body.String())
+
+		saved, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		require.Len(t, saved.FightingSpiritAwards, 1)
+		assert.Equal(t, "Spirit", saved.FightingSpiritAwards[0].Title)
+		assert.Equal(t, "Carol", saved.FightingSpiritAwards[0].RecipientName)
+		assert.Equal(t, "Osaka", saved.FightingSpiritAwards[0].RecipientDojo)
 	})
 }
 

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -1856,6 +1856,17 @@ func TestPUTCompetitionAwards(t *testing.T) {
 		assert.Equal(t, "Osaka", saved.FightingSpiritAwards[0].RecipientDojo)
 	})
 
+	t.Run("400: missing fightingSpiritAwards field (body {}) rejected", func(t *testing.T) {
+		// The field is documented required; a body of `{}` must 400 rather
+		// than silently clear the list. An explicit [] (covered above) clears.
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBufferString("{}"))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "fightingSpiritAwards is required")
+	})
+
 	t.Run("400: malformed JSON body rejected", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBufferString("{not json"))

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -1855,6 +1855,30 @@ func TestPUTCompetitionAwards(t *testing.T) {
 		assert.Equal(t, "Carol", saved.FightingSpiritAwards[0].RecipientName)
 		assert.Equal(t, "Osaka", saved.FightingSpiritAwards[0].RecipientDojo)
 	})
+
+	t.Run("400: malformed JSON body rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid+"/awards", bytes.NewBufferString("{not json"))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("400: invalid competition ID rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"fightingSpiritAwards": []map[string]any{
+				{"title": "Spirit", "recipientName": "Alice"},
+			},
+		})
+		w := httptest.NewRecorder()
+		// An over-length ID (>64 chars) is a single valid path segment that
+		// reaches the handler and is rejected by requireValidCompID before
+		// any store access.
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+strings.Repeat("x", 65)+"/awards", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestDiscardDrawHandler(t *testing.T) {

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -80,6 +80,11 @@ const (
 	// practical ceiling for tournament rosters (no real competition has
 	// exceeded ~200).
 	MaxBulkCheckInIDs = 1000
+
+	// MaxFightingSpiritAwards is the upper bound on the number of fighting
+	// spirit awards a competition may carry. 20 is a generous cap for
+	// the typical ceremony (usually 1–3 honourees).
+	MaxFightingSpiritAwards = 20
 )
 
 // validateMaxLen returns a ValidationError when val exceeds max bytes.

--- a/internal/state/competition_test.go
+++ b/internal/state/competition_test.go
@@ -334,3 +334,84 @@ func TestNaginataJSONAlwaysPresent(t *testing.T) {
 		assert.NotContains(t, string(data), "naginata", "YAML tag keeps omitempty: false must not appear in config.md")
 	})
 }
+
+// TestFightingSpiritAwardsRoundTrip verifies that FightingSpiritAwards
+// round-trip through YAML correctly: N awards survive, absent field loads
+// as nil, and an empty slice omits the key from YAML output.
+func TestFightingSpiritAwardsRoundTrip(t *testing.T) {
+	t.Run("N awards round-trip through YAML front-matter", func(t *testing.T) {
+		original := Competition{
+			ID:   "fs-comp",
+			Name: "FS Awards",
+			FightingSpiritAwards: []FightingSpiritAward{
+				{Title: "Fighting Spirit", RecipientName: "Alice Yamada", RecipientDojo: "Shinjuku"},
+				{Title: "Best Technique", RecipientName: "Bob Tanaka"},
+			},
+		}
+		data, err := writeFrontMatter(&original)
+		require.NoError(t, err)
+
+		var loaded Competition
+		require.NoError(t, parseFrontMatter(data, &loaded))
+
+		require.Len(t, loaded.FightingSpiritAwards, 2, "both awards must survive the round-trip")
+		assert.Equal(t, "Fighting Spirit", loaded.FightingSpiritAwards[0].Title)
+		assert.Equal(t, "Alice Yamada", loaded.FightingSpiritAwards[0].RecipientName)
+		assert.Equal(t, "Shinjuku", loaded.FightingSpiritAwards[0].RecipientDojo)
+		assert.Equal(t, "Best Technique", loaded.FightingSpiritAwards[1].Title)
+		assert.Equal(t, "Bob Tanaka", loaded.FightingSpiritAwards[1].RecipientName)
+		assert.Equal(t, "", loaded.FightingSpiritAwards[1].RecipientDojo, "absent dojo must be empty string")
+	})
+
+	t.Run("absent field loads as nil (legacy config)", func(t *testing.T) {
+		legacyYAML := []byte("---\nid: legacy\nname: Legacy Comp\n---\n")
+		var c Competition
+		require.NoError(t, parseFrontMatter(legacyYAML, &c))
+		assert.Nil(t, c.FightingSpiritAwards, "absent field must load as nil")
+	})
+
+	t.Run("empty slice omits the key from YAML output", func(t *testing.T) {
+		c := Competition{
+			ID:                   "empty-fs",
+			Name:                 "No Awards",
+			FightingSpiritAwards: []FightingSpiritAward{},
+		}
+		data, err := writeFrontMatter(&c)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "fighting_spirit_awards", "omitempty: empty slice must not appear in YAML")
+	})
+
+	t.Run("dojo optional: omitempty omits it from YAML when empty", func(t *testing.T) {
+		original := Competition{
+			ID:   "no-dojo-comp",
+			Name: "No Dojo",
+			FightingSpiritAwards: []FightingSpiritAward{
+				{Title: "Spirit", RecipientName: "Carol Ito"},
+			},
+		}
+		data, err := writeFrontMatter(&original)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "recipient_dojo", "empty dojo must not appear in YAML")
+	})
+
+	t.Run("round-trips via store SaveCompetition + LoadCompetition", func(t *testing.T) {
+		store, err := NewStore(t.TempDir())
+		require.NoError(t, err)
+
+		comp := &Competition{
+			ID:     "store-fs-comp",
+			Name:   "Store FS Test",
+			Status: CompStatusComplete,
+			FightingSpiritAwards: []FightingSpiritAward{
+				{Title: "Fighting Spirit", RecipientName: "Dan Watanabe", RecipientDojo: "Osaka"},
+			},
+		}
+		require.NoError(t, store.SaveCompetition(comp))
+
+		loaded, err := store.LoadCompetition("store-fs-comp")
+		require.NoError(t, err)
+		require.Len(t, loaded.FightingSpiritAwards, 1)
+		assert.Equal(t, "Dan Watanabe", loaded.FightingSpiritAwards[0].RecipientName)
+		assert.Equal(t, "Osaka", loaded.FightingSpiritAwards[0].RecipientDojo)
+	})
+}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -269,6 +269,16 @@ func (t *Tournament) Days() []string {
 	return days
 }
 
+// FightingSpiritAward is an optional, per-competition individual honour
+// (敢闘賞 / kantōshō) independent of the placement podium. Recipient is a
+// plain name string for parity with the rest of the system (no UUID ref) —
+// it is display-only and matches nothing.
+type FightingSpiritAward struct {
+	Title         string `yaml:"title" json:"title"`
+	RecipientName string `yaml:"recipient_name" json:"recipientName"`
+	RecipientDojo string `yaml:"recipient_dojo,omitempty" json:"recipientDojo,omitempty"`
+}
+
 type Competition struct {
 	ID                   string            `yaml:"id" json:"id"`
 	Name                 string            `yaml:"name" json:"name"`
@@ -328,6 +338,8 @@ type Competition struct {
 	Naginata bool `yaml:"naginata,omitempty" json:"naginata"`
 
 	CheckInEnabled bool `yaml:"check_in_enabled,omitempty" json:"checkInEnabled,omitempty"`
+
+	FightingSpiritAwards []FightingSpiritAward `yaml:"fighting_spirit_awards,omitempty" json:"fightingSpiritAwards,omitempty"`
 
 	Players []domain.Player `yaml:"-" json:"players"`
 }

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1178,6 +1178,50 @@ paths:
           description: Overrides reset.
 
 
+  /api/competitions/{id}/awards:
+    put:
+      tags: [competitions]
+      summary: Set fighting-spirit awards
+      description: |
+        Replaces the full list of fighting-spirit (敢闘賞) awards for the competition.
+        Awards are independent of the auto-derived placement podium and may be set at
+        any competition status. Passing an empty array clears all awards.
+
+        Also requires `X-Admin-Password` when the destructive-ops gate is active
+        (see the AdminPassword security scheme); 503 if locked mode is active
+        without `TOURNAMENT_ADMIN_PASSWORD_HASH`.
+      security:
+        - TournamentPassword: []
+          AdminPassword: []
+      parameters:
+        - $ref: '#/components/parameters/CompetitionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [fightingSpiritAwards]
+              properties:
+                fightingSpiritAwards:
+                  type: array
+                  maxItems: 20
+                  items:
+                    $ref: '#/components/schemas/FightingSpiritAward'
+      responses:
+        '200':
+          description: Awards saved; returns updated competition.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Competition'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/competitions/{id}/schedule:
     put:
       tags: [competitions]
@@ -2445,6 +2489,14 @@ components:
         maxEnchoPeriods:
           type: integer
           description: Maximum number of encho (extended time) periods permitted per match.
+        fightingSpiritAwards:
+          type: array
+          description: >
+            Optional fighting-spirit (敢闘賞) awards for this competition. Independent of the
+            auto-derived placement podium. Absent / empty when no awards have been set.
+          maxItems: 20
+          items:
+            $ref: '#/components/schemas/FightingSpiritAward'
         players:
           type: array
           description: >
@@ -2452,6 +2504,23 @@ components:
             `GET /api/viewer/competitions/{id}`). Always empty in admin competition responses.
           items:
             $ref: '#/components/schemas/Player'
+
+    FightingSpiritAward:
+      type: object
+      required: [title, recipientName]
+      properties:
+        title:
+          type: string
+          maxLength: 100
+          description: Award title, e.g. "Fighting Spirit".
+        recipientName:
+          type: string
+          maxLength: 100
+          description: Plain name of the honouree.
+        recipientDojo:
+          type: string
+          maxLength: 100
+          description: Dojo affiliation of the honouree (optional, for disambiguation).
 
     Player:
       type: object

--- a/web-mobile/js/__tests__/admin_elevated.test.jsx
+++ b/web-mobile/js/__tests__/admin_elevated.test.jsx
@@ -16,6 +16,7 @@ describe('API elevated-password header (X-Admin-Password)', () => {
     ['resetOverrides', () => API.resetOverrides('c1', 'main', 'adminpw'), 'DELETE', '/api/competitions/c1/overrides'],
     ['addParticipant', () => API.addParticipant('c1', { name: 'X', dojo: 'D' }, 'main', 'adminpw'), 'POST', '/api/competitions/c1/participants'],
     ['replaceParticipant', () => API.replaceParticipant('c1', 'p1', { name: 'X', dojo: 'D' }, 'main', 'adminpw'), 'PUT', '/api/competitions/c1/participants/p1'],
+    ['updateCompetitionAwards', () => API.updateCompetitionAwards('c1', [], 'main', 'adminpw'), 'PUT', '/api/competitions/c1/awards'],
   ];
 
   gated.forEach(([label, call, method, url]) => {

--- a/web-mobile/js/__tests__/fighting_spirit.test.jsx
+++ b/web-mobile/js/__tests__/fighting_spirit.test.jsx
@@ -1,0 +1,248 @@
+// Tests for Fighting Spirit awards: AwardsView rendering + API method.
+// Covers:
+//   - FightingSpiritSection renders awards separate from the podium
+//   - FightingSpiritSection renders nothing when the list is empty/absent
+//   - API.updateCompetitionAwards sends correct URL, method, headers, body
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FightingSpiritSection, AwardsView } from '../viewer.jsx';
+import { API } from '../api_client.jsx';
+
+// --- Tree helpers (mirrors viewer.test.jsx) ---
+
+function collectText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children) return collectText(node.children);
+  if (node.props?.children) return collectText(node.props.children);
+  return '';
+}
+
+function findByTestId(node, testId) {
+  if (!node || typeof node !== 'object') return null;
+  if (Array.isArray(node)) {
+    for (const k of node) {
+      const found = findByTestId(k, testId);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (node.props?.['data-testid'] === testId) return node;
+  const childResults = [
+    ...(Array.isArray(node.children) ? node.children : node.children ? [node.children] : []),
+    ...(Array.isArray(node.props?.children) ? node.props.children : node.props?.children ? [node.props.children] : []),
+  ];
+  for (const child of childResults) {
+    const found = findByTestId(child, testId);
+    if (found) return found;
+  }
+  return null;
+}
+
+// --- FightingSpiritSection ---
+
+describe('FightingSpiritSection', () => {
+  it('renders nothing when fsAwards is undefined', () => {
+    const result = FightingSpiritSection({ fsAwards: undefined, isFs: false });
+    expect(result).toBeNull();
+  });
+
+  it('renders nothing when fsAwards is null', () => {
+    const result = FightingSpiritSection({ fsAwards: null, isFs: false });
+    expect(result).toBeNull();
+  });
+
+  it('renders nothing when fsAwards is an empty array', () => {
+    const result = FightingSpiritSection({ fsAwards: [], isFs: false });
+    expect(result).toBeNull();
+  });
+
+  it('renders a section with the correct testId when awards are present', () => {
+    const awards = [
+      { title: 'Fighting Spirit', recipientName: 'Alice Yamada', recipientDojo: 'Shinjuku' },
+    ];
+    const result = FightingSpiritSection({ fsAwards: awards, isFs: false });
+    const section = findByTestId(result, 'fighting-spirit-section');
+    expect(section).not.toBeNull();
+  });
+
+  it('renders each award row with the correct testId', () => {
+    const awards = [
+      { title: 'Fighting Spirit', recipientName: 'Alice', recipientDojo: 'Shinjuku' },
+      { title: 'Best Technique', recipientName: 'Bob' },
+    ];
+    const result = FightingSpiritSection({ fsAwards: awards, isFs: false });
+    expect(findByTestId(result, 'fighting-spirit-award-0')).not.toBeNull();
+    expect(findByTestId(result, 'fighting-spirit-award-1')).not.toBeNull();
+  });
+
+  it('includes recipient name in rendered text', () => {
+    const awards = [{ title: 'Spirit', recipientName: 'Carol Ito', recipientDojo: 'Osaka' }];
+    const result = FightingSpiritSection({ fsAwards: awards, isFs: false });
+    const text = collectText(result);
+    expect(text).toContain('Carol Ito');
+  });
+
+  it('includes dojo in rendered text when present', () => {
+    const awards = [{ title: 'Spirit', recipientName: 'Dan', recipientDojo: 'Kyoto' }];
+    const result = FightingSpiritSection({ fsAwards: awards, isFs: false });
+    const text = collectText(result);
+    expect(text).toContain('Kyoto');
+  });
+
+  it('does not render dojo element when absent', () => {
+    const awards = [{ title: 'Spirit', recipientName: 'Eve' }];
+    const result = FightingSpiritSection({ fsAwards: awards, isFs: false });
+    const text = collectText(result);
+    expect(text).not.toContain('undefined');
+  });
+
+  it('renders title text in the award row', () => {
+    const awards = [{ title: 'Kantōshō', recipientName: 'Fumi' }];
+    const result = FightingSpiritSection({ fsAwards: awards, isFs: false });
+    const text = collectText(result);
+    expect(text).toContain('Kantōshō');
+  });
+});
+
+// --- AwardsView — Fighting Spirit section is independent of the podium ---
+//
+// NOTE: With the static React stub, child component vnodes are NOT executed —
+// they appear as {type: FightingSpiritSection, props: {...}} in the tree.
+// We assert via the vnode type (component reference), which is reliable
+// and doesn't require a reactive runtime.
+
+function findFightingSpiritVnode(node) {
+  if (!node || typeof node !== 'object') return null;
+  if (Array.isArray(node)) {
+    for (const k of node) {
+      const found = findFightingSpiritVnode(k);
+      if (found) return found;
+    }
+    return null;
+  }
+  // The vnode emitted by JSX for <FightingSpiritSection ...> has type === FightingSpiritSection.
+  if (node.type === FightingSpiritSection) return node;
+  const kids = node.children || node.props?.children;
+  if (kids) {
+    return findFightingSpiritVnode(kids);
+  }
+  return null;
+}
+
+describe('AwardsView + Fighting Spirit awards', () => {
+  const fsAwards = [
+    { title: 'Fighting Spirit', recipientName: 'Grace Hayashi', recipientDojo: 'Sapporo' },
+  ];
+
+  it('includes a FightingSpiritSection vnode when bracket has no final winner (no-podium branch)', () => {
+    // A bracket with no winner → awards array empty → early-return branch.
+    // The FS section vnode must still be in the tree.
+    const comp = { id: 'c1', name: 'Test Comp', format: 'playoffs', fightingSpiritAwards: fsAwards };
+    const result = AwardsView({ c: comp, bracket: null, standings: null, pools: null, players: [] });
+    const fsVnode = findFightingSpiritVnode(result);
+    expect(fsVnode).not.toBeNull();
+    // Props must carry the awards.
+    expect(fsVnode.props.fsAwards).toEqual(fsAwards);
+  });
+
+  it('does NOT include a FightingSpiritSection vnode when comp has no awards (empty-bracket branch)', () => {
+    const comp = { id: 'c2', name: 'Test Comp', format: 'playoffs', fightingSpiritAwards: [] };
+    const result = AwardsView({ c: comp, bracket: null, standings: null, pools: null, players: [] });
+    const fsVnode = findFightingSpiritVnode(result);
+    expect(fsVnode).toBeNull();
+  });
+
+  it('includes a FightingSpiritSection vnode alongside a completed podium', () => {
+    const bracket = {
+      rounds: [
+        [],
+        [
+          { sideA: 'Alice', sideB: 'Bob', winner: 'Alice' },
+          { sideA: 'Carol', sideB: 'Dan', winner: 'Carol' },
+        ],
+        [{ sideA: 'Alice', sideB: 'Carol', winner: 'Alice' }],
+      ],
+    };
+    const comp = { id: 'c3', name: 'Comp', format: 'playoffs', fightingSpiritAwards: fsAwards };
+    const result = AwardsView({ c: comp, bracket, standings: null, pools: null, players: [] });
+    // The main tree text must include the champion name.
+    expect(collectText(result)).toContain('Alice');
+    // The FS vnode must also be in the tree, separate from podium.
+    const fsVnode = findFightingSpiritVnode(result);
+    expect(fsVnode).not.toBeNull();
+    expect(fsVnode.props.fsAwards).toEqual(fsAwards);
+  });
+
+  it('the FightingSpiritSection vnode is NOT nested inside a podium-place element', () => {
+    const bracket = {
+      rounds: [
+        [],
+        [{ sideA: 'X', sideB: 'Y', winner: 'X' }],
+        [{ sideA: 'X', sideB: 'Z', winner: 'X' }],
+      ],
+    };
+    const comp = { id: 'c4', name: 'Comp', format: 'playoffs', fightingSpiritAwards: fsAwards };
+    const result = AwardsView({ c: comp, bracket, standings: null, pools: null, players: [] });
+    // The FS vnode must exist.
+    const fsVnode = findFightingSpiritVnode(result);
+    expect(fsVnode).not.toBeNull();
+    // awards-place-1-0 must NOT contain a FightingSpiritSection vnode inside it.
+    const place1 = findByTestId(result, 'awards-place-1-0');
+    if (place1) {
+      expect(findFightingSpiritVnode(place1)).toBeNull();
+    }
+  });
+});
+
+// --- API.updateCompetitionAwards ---
+
+describe('API.updateCompetitionAwards', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('calls PUT /api/competitions/:id/awards with correct headers and body', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'c1', fightingSpiritAwards: [] }),
+    });
+    const awards = [{ title: 'Fighting Spirit', recipientName: 'Alice', recipientDojo: 'Tokyo' }];
+    await API.updateCompetitionAwards('c1', awards, 'mainpw', 'adminpw');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/competitions/c1/awards',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Tournament-Password': 'mainpw',
+          'X-Admin-Password': 'adminpw',
+        }),
+      })
+    );
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(body).toEqual({ fightingSpiritAwards: awards });
+  });
+
+  it('omits X-Admin-Password when adminPassword is empty', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    await API.updateCompetitionAwards('c1', [], 'mainpw', '');
+    const headers = global.fetch.mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty('X-Admin-Password');
+  });
+
+  it('throws on non-2xx response with server error message', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'title is required' }),
+    });
+    await expect(API.updateCompetitionAwards('c1', [{}], 'pw', 'adm')).rejects.toThrow('title is required');
+  });
+
+  it('returns parsed competition JSON on success', async () => {
+    const comp = { id: 'c1', fightingSpiritAwards: [{ title: 'Spirit', recipientName: 'Bob' }] };
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => comp });
+    const result = await API.updateCompetitionAwards('c1', comp.fightingSpiritAwards, 'pw', 'adm');
+    expect(result.fightingSpiritAwards[0].recipientName).toBe('Bob');
+  });
+});

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -326,17 +326,30 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
   const withKey = (a) => ({ ...a, _key: keyCounter.current++ });
   const [awards, setAwards] = useStateA(() => (c.fightingSpiritAwards || []).map(withKey));
   const [saving, setSaving] = useStateA(false);
+  // `dirty` guards the prop-sync effect: the parent refetches the competition
+  // on unrelated SSE events (match updates, status changes), which would
+  // otherwise clobber the operator's typed-but-unsaved edits. We only re-sync
+  // from props when there are no pending edits — except on a competition
+  // SWITCH, where we always reset to the new comp's list.
+  const [dirty, setDirty] = useStateA(false);
+  const lastCompId = useRefA(c.id);
   const mountedRef = useRefA(true);
   useEffectA(() => () => { mountedRef.current = false; }, []);
 
-  // Sync from parent when the competition prop refreshes (e.g. SSE update).
+  // Sync from parent. Reset unconditionally when switching competitions;
+  // otherwise skip while the user has unsaved edits (see `dirty` above).
   useEffectA(() => {
-    setAwards((c.fightingSpiritAwards || []).map(withKey));
-  }, [c.fightingSpiritAwards]);
+    const switched = lastCompId.current !== c.id;
+    lastCompId.current = c.id;
+    if (switched || !dirty) {
+      setAwards((c.fightingSpiritAwards || []).map(withKey));
+      if (switched) setDirty(false);
+    }
+  }, [c.id, c.fightingSpiritAwards, dirty]);
 
-  const addRow = () => setAwards(prev => [...prev, withKey({ title: "Fighting Spirit", recipientName: "", recipientDojo: "" })]);
-  const removeRow = (idx) => setAwards(prev => prev.filter((_, i) => i !== idx));
-  const updateField = (idx, field, val) => setAwards(prev => prev.map((a, i) => i === idx ? { ...a, [field]: val } : a));
+  const addRow = () => { setDirty(true); setAwards(prev => [...prev, withKey({ title: "Fighting Spirit", recipientName: "", recipientDojo: "" })]); };
+  const removeRow = (idx) => { setDirty(true); setAwards(prev => prev.filter((_, i) => i !== idx)); };
+  const updateField = (idx, field, val) => { setDirty(true); setAwards(prev => prev.map((a, i) => i === idx ? { ...a, [field]: val } : a)); };
 
   const save = async () => {
     const admin = window.promptAdminPassword ? window.promptAdminPassword() : null;
@@ -346,7 +359,9 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
       // Strip the client-only `_key` before sending to the API.
       const payload = awards.map(({ _key, ...rest }) => rest);
       await window.API.updateCompetitionAwards(c.id, payload, password, admin);
-      if (mountedRef.current) showToast("Fighting Spirit awards saved.", "success");
+      // Edits are now persisted; clear dirty so the next prop refresh
+      // (the save triggers an SSE refetch) re-syncs to the saved state.
+      if (mountedRef.current) { setDirty(false); showToast("Fighting Spirit awards saved.", "success"); }
     } catch (e) {
       if (mountedRef.current) showToast(e.message || "Failed to save awards", "error");
     } finally {

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -313,6 +313,92 @@ export function formatCompMinutes(m) {
   return `${h}h ${String(min).padStart(2, "0")}m`;
 }
 
+// FightingSpiritAwardsEditor: free-text form for adding/removing/saving
+// optional fighting-spirit (敢闘賞) awards for a competition. Each award has
+// a title, recipient name, and optional dojo. Save calls
+// API.updateCompetitionAwards (elevated-gated PUT /api/competitions/:id/awards).
+// v1 = free-text only; no competitor picker (deferred).
+function FightingSpiritAwardsEditor({ c, password, showToast }) {
+  const [awards, setAwards] = useStateA(() => (c.fightingSpiritAwards || []).map(a => ({ ...a })));
+  const [saving, setSaving] = useStateA(false);
+  const mountedRef = useRefA(true);
+  useEffectA(() => () => { mountedRef.current = false; }, []);
+
+  // Sync from parent when the competition prop refreshes (e.g. SSE update).
+  useEffectA(() => {
+    setAwards((c.fightingSpiritAwards || []).map(a => ({ ...a })));
+  }, [c.fightingSpiritAwards]);
+
+  const addRow = () => setAwards(prev => [...prev, { title: "Fighting Spirit", recipientName: "", recipientDojo: "" }]);
+  const removeRow = (idx) => setAwards(prev => prev.filter((_, i) => i !== idx));
+  const updateField = (idx, field, val) => setAwards(prev => prev.map((a, i) => i === idx ? { ...a, [field]: val } : a));
+
+  const save = async () => {
+    const admin = window.promptAdminPassword ? window.promptAdminPassword() : null;
+    if (admin === null) return;
+    setSaving(true);
+    try {
+      await window.API.updateCompetitionAwards(c.id, awards, password, admin);
+      if (mountedRef.current) showToast("Fighting Spirit awards saved.", "success");
+    } catch (e) {
+      if (mountedRef.current) showToast(e.message || "Failed to save awards", "error");
+    } finally {
+      if (mountedRef.current) setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 24, padding: 16, borderTop: "1px solid var(--line)", display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ fontWeight: 600, fontSize: 14 }}>🔥 Fighting Spirit Awards <span style={{ fontWeight: 400, fontSize: 12, color: "var(--ink-3)" }}>(optional)</span></div>
+      <div className="field__hint" style={{ marginTop: -4 }}>Record individual honourees independent of the placement podium. Shown to viewers on the Awards tab.</div>
+      {awards.length === 0 && (
+        <div style={{ fontSize: 12, color: "var(--ink-3)", fontStyle: "italic" }}>No awards yet.</div>
+      )}
+      {awards.map((a, idx) => (
+        <div key={idx} style={{ display: "flex", gap: 6, alignItems: "flex-start", flexWrap: "wrap" }}>
+          <input
+            className="input"
+            placeholder="Title (e.g. Fighting Spirit)"
+            value={a.title || ""}
+            onChange={e => updateField(idx, "title", e.target.value)}
+            style={{ flex: "1 1 140px", minWidth: 100 }}
+            data-testid={`fs-award-title-${idx}`}
+          />
+          <input
+            className="input"
+            placeholder="Recipient name"
+            value={a.recipientName || ""}
+            onChange={e => updateField(idx, "recipientName", e.target.value)}
+            style={{ flex: "2 1 180px", minWidth: 120 }}
+            data-testid={`fs-award-name-${idx}`}
+          />
+          <input
+            className="input"
+            placeholder="Dojo (optional)"
+            value={a.recipientDojo || ""}
+            onChange={e => updateField(idx, "recipientDojo", e.target.value)}
+            style={{ flex: "1 1 120px", minWidth: 90 }}
+            data-testid={`fs-award-dojo-${idx}`}
+          />
+          <button
+            className="btn btn--sm btn--ghost"
+            onClick={() => removeRow(idx)}
+            aria-label="Remove award"
+            data-testid={`fs-award-remove-${idx}`}
+          >✕</button>
+        </div>
+      ))}
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button className="btn btn--sm btn--ghost" onClick={addRow} data-testid="fs-award-add">+ Add award</button>
+        <button className="btn btn--sm btn--primary" onClick={save} disabled={saving} data-testid="fs-award-save">
+          {saving && <span className="spinner" />}
+          {saving ? "Saving…" : "Save awards"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, onStatusChange }) {
   const [lastSaved, setLastSaved] = useStateA(null);
   const [saveErr, setSaveErr] = useStateA(null);
@@ -903,6 +989,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>Show check-in column and counter. Disable for competitions that don't need attendance tracking.</div>
         </div>
       </div>
+      <FightingSpiritAwardsEditor c={c} password={password} showToast={showToast} />
       <div style={{ marginTop: 24, padding: 16, borderTop: "1px solid var(--line)", display: "flex", flexDirection: "column", gap: 12 }}>
         {(local.status === "pools" || local.status === "playoffs") && (
           <div>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -348,9 +348,10 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
   };
 
   return (
-    <div style={{ marginTop: 24, padding: 16, borderTop: "1px solid var(--line)", display: "flex", flexDirection: "column", gap: 10 }}>
-      <div style={{ fontWeight: 600, fontSize: 14 }}>🔥 Fighting Spirit Awards <span style={{ fontWeight: 400, fontSize: 12, color: "var(--ink-3)" }}>(optional)</span></div>
-      <div className="field__hint" style={{ marginTop: -4 }}>Record individual honourees independent of the placement podium. Shown to viewers on the Awards tab.</div>
+    <div className="row">
+      <div className="card" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <div className="card__title">🔥 Fighting Spirit Awards <span style={{ fontWeight: 400, fontSize: 12, color: "var(--ink-3)" }}>(optional)</span></div>
+        <div className="card__sub" style={{ marginTop: -4 }}>Record individual honourees independent of the placement podium. Shown to viewers on the Awards tab.</div>
       {awards.length === 0 && (
         <div style={{ fontSize: 12, color: "var(--ink-3)", fontStyle: "italic" }}>No awards yet.</div>
       )}
@@ -394,6 +395,7 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
           {saving && <span className="spinner" />}
           {saving ? "Saving…" : "Save awards"}
         </button>
+      </div>
       </div>
     </div>
   );
@@ -989,7 +991,6 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>Show check-in column and counter. Disable for competitions that don't need attendance tracking.</div>
         </div>
       </div>
-      <FightingSpiritAwardsEditor c={c} password={password} showToast={showToast} />
       <div style={{ marginTop: 24, padding: 16, borderTop: "1px solid var(--line)", display: "flex", flexDirection: "column", gap: 12 }}>
         {(local.status === "pools" || local.status === "playoffs") && (
           <div>
@@ -1510,6 +1511,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         // individual competitions so the sidebar stays uncluttered.
         c.kind === "team" ? { id: "lineups", label: "Lineups" } : null,
         { id: "settings", label: "Settings" },
+        { id: "awards", label: "Fighting Spirit" },
       ].filter(Boolean)
     },
     {
@@ -1627,6 +1629,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {section === "participants" && <AdminParticipants c={c} tournament={t} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} />}
             {section === "lineups" && window.AdminTeamLineupsList && <window.AdminTeamLineupsList comp={c} password={password} showToast={showToast} />}
             {section === "settings" && <AdminSettings c={c} tournament={t} onUpdate={onUpdate} onBack={onBack} password={password} showToast={showToast} onStatusChange={setLocalStatus} />}
+            {section === "awards" && <FightingSpiritAwardsEditor c={c} password={password} showToast={showToast} />}
             {/* T191/T193 (FR-050d/e): Swiss-round management. */}
             {/* onViewStandings is wired to the public viewer URL so the */}
             {/* operator can navigate into the viewer-mode standings */}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -319,17 +319,22 @@ export function formatCompMinutes(m) {
 // API.updateCompetitionAwards (elevated-gated PUT /api/competitions/:id/awards).
 // v1 = free-text only; no competitor picker (deferred).
 function FightingSpiritAwardsEditor({ c, password, showToast }) {
-  const [awards, setAwards] = useStateA(() => (c.fightingSpiritAwards || []).map(a => ({ ...a })));
+  // Each row carries a stable client-only `_key` so React keys survive
+  // mid-list removals (index keys cause inputs to "jump" / reuse the wrong
+  // DOM node when a middle row is deleted). `_key` is stripped before save.
+  const keyCounter = useRefA(0);
+  const withKey = (a) => ({ ...a, _key: keyCounter.current++ });
+  const [awards, setAwards] = useStateA(() => (c.fightingSpiritAwards || []).map(withKey));
   const [saving, setSaving] = useStateA(false);
   const mountedRef = useRefA(true);
   useEffectA(() => () => { mountedRef.current = false; }, []);
 
   // Sync from parent when the competition prop refreshes (e.g. SSE update).
   useEffectA(() => {
-    setAwards((c.fightingSpiritAwards || []).map(a => ({ ...a })));
+    setAwards((c.fightingSpiritAwards || []).map(withKey));
   }, [c.fightingSpiritAwards]);
 
-  const addRow = () => setAwards(prev => [...prev, { title: "Fighting Spirit", recipientName: "", recipientDojo: "" }]);
+  const addRow = () => setAwards(prev => [...prev, withKey({ title: "Fighting Spirit", recipientName: "", recipientDojo: "" })]);
   const removeRow = (idx) => setAwards(prev => prev.filter((_, i) => i !== idx));
   const updateField = (idx, field, val) => setAwards(prev => prev.map((a, i) => i === idx ? { ...a, [field]: val } : a));
 
@@ -338,7 +343,9 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
     if (admin === null) return;
     setSaving(true);
     try {
-      await window.API.updateCompetitionAwards(c.id, awards, password, admin);
+      // Strip the client-only `_key` before sending to the API.
+      const payload = awards.map(({ _key, ...rest }) => rest);
+      await window.API.updateCompetitionAwards(c.id, payload, password, admin);
       if (mountedRef.current) showToast("Fighting Spirit awards saved.", "success");
     } catch (e) {
       if (mountedRef.current) showToast(e.message || "Failed to save awards", "error");
@@ -356,7 +363,7 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
         <div style={{ fontSize: 12, color: "var(--ink-3)", fontStyle: "italic" }}>No awards yet.</div>
       )}
       {awards.map((a, idx) => (
-        <div key={idx} style={{ display: "flex", gap: 6, alignItems: "flex-start", flexWrap: "wrap" }}>
+        <div key={a._key} style={{ display: "flex", gap: 6, alignItems: "flex-start", flexWrap: "wrap" }}>
           <input
             className="input"
             placeholder="Title (e.g. Fighting Spirit)"

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -552,7 +552,9 @@ const API = {
     },
     // Replace the full fighting-spirit awards list for a competition.
     // awards: array of { title, recipientName, recipientDojo? }.
-    // Requires the elevated (admin) password.
+    // Requires X-Admin-Password only when the elevated gate is active
+    // (locked mode); in file mode the gate is optional. adminPassword is
+    // sent when provided and ignored server-side when the gate is off.
     async updateCompetitionAwards(id, awards, password, adminPassword) {
         const res = await fetch(`/api/competitions/${id}/awards`, {
             method: 'PUT',

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -550,6 +550,25 @@ const API = {
         }
         return res.json();
     },
+    // Replace the full fighting-spirit awards list for a competition.
+    // awards: array of { title, recipientName, recipientDojo? }.
+    // Requires the elevated (admin) password.
+    async updateCompetitionAwards(id, awards, password, adminPassword) {
+        const res = await fetch(`/api/competitions/${id}/awards`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Tournament-Password': password,
+                ...adminHdr(adminPassword)
+            },
+            body: JSON.stringify({ fightingSpiritAwards: awards })
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || "Failed to update competition awards");
+        }
+        return res.json();
+    },
     // T129/T130: per-round team lineups (FR-040). GET returns the persisted
     // TeamLineup for (compId, teamId, round) — 404 when no lineup has been
     // submitted yet, which the form treats as "blank, editable". PUT replaces

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -3875,6 +3875,10 @@ function AllWinnersView({ tournament, onBack, tweaks }) {
                   </div>
                 );
               })}
+              {/* Fighting Spirit awards: an independent annotation (not the
+                  placement podium), shown for any competition that has them
+                  regardless of podium state. Self-guards when empty. */}
+              <FightingSpiritSection fsAwards={comp.fightingSpiritAwards} isFs={false} />
             </div>
           ))}
         </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2674,7 +2674,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer, PoolNumberedMatchRow };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -3139,18 +3139,26 @@ function AwardsView({ c, bracket, standings, pools, players }) {
   }
 
   if (awards.length === 0) {
+    const fsAwards = c?.fightingSpiritAwards;
+    const hasFsAwards = fsAwards && fsAwards.length > 0;
     if (isMixed && resolvedState === "in-progress") {
       return (
-        <div className="empty" data-testid="awards-in-progress">
-          <div className="icon">🏆</div>
-          <h3>Knockout in progress</h3>
+        <div>
+          <div className="empty" data-testid="awards-in-progress">
+            <div className="icon">🏆</div>
+            <h3>Knockout in progress</h3>
+          </div>
+          {hasFsAwards && <FightingSpiritSection fsAwards={fsAwards} isFs={isFs} />}
         </div>
       );
     }
     return (
-      <div className="empty" data-testid="awards-empty">
-        <div className="icon">🏆</div>
-        <h3>Final standings not yet available</h3>
+      <div>
+        <div className="empty" data-testid="awards-empty">
+          <div className="icon">🏆</div>
+          <h3>Final standings not yet available</h3>
+        </div>
+        {hasFsAwards && <FightingSpiritSection fsAwards={fsAwards} isFs={isFs} />}
       </div>
     );
   }
@@ -3213,6 +3221,8 @@ function AwardsView({ c, bracket, standings, pools, players }) {
             );
           })}
         </div>
+        {/* Fighting Spirit awards — distinct section, independent of the podium */}
+        <FightingSpiritSection fsAwards={c?.fightingSpiritAwards} isFs={isFs} />
       </div>
     );
   }
@@ -3289,6 +3299,58 @@ function AwardsView({ c, bracket, standings, pools, players }) {
           ))}
         </div>
       )}
+
+      {/* Fighting Spirit awards — distinct section, independent of the podium */}
+      <FightingSpiritSection fsAwards={c?.fightingSpiritAwards} isFs={isFs} />
+    </div>
+  );
+}
+
+// FightingSpiritSection renders the 🔥 Fighting Spirit subsection inside
+// AwardsView. Distinct from the placement podium — never merged into
+// deriveAwards/podium logic. Renders nothing when the list is empty/absent.
+function FightingSpiritSection({ fsAwards, isFs }) {
+  if (!fsAwards || fsAwards.length === 0) return null;
+  return (
+    <div
+      style={{ marginTop: 24, borderTop: "1px solid var(--line)", paddingTop: 16 }}
+      data-testid="fighting-spirit-section"
+    >
+      <div
+        className="section-title"
+        style={{ margin: "0 0 12px", fontSize: isFs ? 22 : 15 }}
+      >
+        🔥 Fighting Spirit
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {fsAwards.map((a, idx) => (
+          <div
+            key={idx}
+            style={{
+              padding: isFs ? "14px 20px" : "10px 14px",
+              borderRadius: 8,
+              background: "var(--accent-soft, #fff7ed)",
+              border: "1px solid var(--accent-warm, #fb923c)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+            data-testid={`fighting-spirit-award-${idx}`}
+          >
+            <div style={{ fontSize: isFs ? 13 : 11, fontWeight: 600, color: "var(--ink-3)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              {a.title}
+            </div>
+            <div style={{ fontSize: isFs ? 22 : 16, fontWeight: 700, color: "var(--ink-1)" }}>
+              {a.recipientName}
+            </div>
+            {a.recipientDojo && (
+              <div style={{ fontSize: isFs ? 14 : 12, color: "var(--ink-3)" }}>
+                {a.recipientDojo}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds optional, per-competition **Fighting Spirit** (敢闘賞) awards — individual honourees independent of the auto-derived placement podium. A competition may have zero, one, or many.
- New dedicated admin nav entry **"Fighting Spirit"** (its own page, not buried in Settings) with a free-text editor: title + recipient name + optional dojo, add/remove/save.
- New endpoint `PUT /api/competitions/:id/awards` (elevated-gated), with validation, trimming, and an SSE `tournament_updated` broadcast.
- Awards render in **two** viewer surfaces, each in a visually distinct "🔥 Fighting Spirit" section separate from the 1st/2nd/3rd podium: the per-competition **Awards tab** and the all-winners **Results** summary page.

## Why

Kendo tournaments routinely give special individual awards (Fighting Spirit, etc.) that are independent of placement. There was no persisted per-competition award model — only a tournament-level free-text note and a display-only derived podium.

A **dedicated endpoint** is used rather than the existing settings `PUT /competitions/:id` because that handler's transform is a deliberate field whitelist that would silently drop a new field, and awards are a post-completion annotation that shouldn't run the setup-validation gauntlet. On-disk persistence is free: `writeFrontMatter` marshals the whole `Competition`, so the `omitempty` field round-trips with no migration.

## Files changed

| File | What |
|---|---|
| `internal/state/models.go` | `FightingSpiritAward{Title,RecipientName,RecipientDojo}` type + `FightingSpiritAwards []…` `omitempty` field on `Competition` |
| `internal/mobileapp/handlers_competition.go` | `PUT /competitions/:id/awards` handler (validate → `UpdateCompetitionChanged` → SSE broadcast) |
| `internal/mobileapp/validation.go` | `MaxFightingSpiritAwards = 20` cap |
| `internal/mobileapp/handlers_competition_test.go` | handler tests: happy/clear/404/empty/over-cap/length/elevated/trim/malformed-JSON/invalid-ID |
| `internal/state/competition_test.go` | YAML round-trip tests (present / absent / empty) |
| `specs/openapi.yaml` | route + `FightingSpiritAward` schema + `Competition` field |
| `web-mobile/js/admin_competition.jsx` | `FightingSpiritAwardsEditor` as its own "Fighting Spirit" nav page (moved out of Settings) |
| `web-mobile/js/api_client.jsx` | `API.updateCompetitionAwards(id, awards, password, admin)` |
| `web-mobile/js/viewer.jsx` | `FightingSpiritSection` in `AwardsView` (per-comp Awards tab) **and** in `AllWinnersView` (Results page) |
| `web-mobile/js/__tests__/fighting_spirit.test.jsx` | `FightingSpiritSection` + `AwardsView` integration tests |
| `web-mobile/js/__tests__/admin_elevated.test.jsx` | `updateCompetitionAwards` API client test |

## Screenshots

**Admin — dedicated "Fighting Spirit" nav entry (its own page, not in Settings):**

![Admin Fighting Spirit nav page](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/256/fs-admin-nav.png)

**Public viewer — per-competition Awards tab (🔥 Fighting Spirit section distinct from the podium):**

![Awards tab with Fighting Spirit section](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/256/fs-awards-tab.png?v=2)

**Public viewer — all-winners Results summary page (Fighting Spirit per competition):**

![Results page with Fighting Spirit section](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/256/fs-results-page.png?v=3)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all Go packages green, gosec/golangci clean
- [x] New/updated unit tests cover the change — Go handler + state round-trip; JS `FightingSpiritSection`/`AwardsView`; full JS suite 1321/1321
- [x] Manual browser verification — admin: added/removed/saved awards on the new "Fighting Spirit" nav page (PUT → 200, persisted to `config.md`, survived rebuild); public viewer: drove a 2-player comp to completion and confirmed the 🔥 Fighting Spirit section renders distinct from the podium on both the per-competition Awards tab and the all-winners Results page
- [x] Screenshots added above
- [x] No new console errors or warnings

> Note: `internal/mobileapp` package coverage is 84.9% (just under the 85% gate). This is **pre-existing** debt tracked in `mp-3abe` — the new awards handler itself is at full statement coverage; the gap is in unrelated pre-existing code.

Closes mp-1w5f


