### PR TITLE
feat(mp-mjaq): declutter viewer home — collapse display modes, fix glossary

### DIFF
--- a/internal/domain/glossary.go
+++ b/internal/domain/glossary.go
@@ -181,14 +181,8 @@ var Glossary = map[string]Term{
 	"zekken": {
 		ID:      "zekken",
 		Kanji:   "ゼッケン",
-		Short:   "Back name-tag",
-		Tooltip: "The cloth name-tag worn on the competitor's back. The display can show this name (instead of the registered name) so spectators see what's physically visible.",
-	},
-	"dojo": {
-		ID:      "dojo",
-		Kanji:   "道場",
-		Short:   "Club or school",
-		Tooltip: "The training school or club a competitor represents. The pool generator avoids placing two competitors from the same dojo in the same pool when it can.",
+		Short:   "Name tag (nafuda)",
+		Tooltip: "The name tag affixed to the centre of the tare (waist protector). Also called nafuda. The display can show this name (instead of the registered name) so spectators see what's physically visible.",
 	},
 	"dan": {
 		ID:      "dan",

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -189,23 +189,13 @@ function Term({ name, children, nested }) {
 // into the router via app.jsx's parsePath ("/glossary" → viewer mode
 // with viewerScreen='glossary').
 function GlossaryPage({ onBack }) {
-  // Tiering is encoded in the spec but not on the wire — we hand-list
-  // the IDs by tier here. A simpler "alphabetical" list would lose
-  // the volunteer-priority signal in glossary.md. If we add a tier
-  // field to domain.Term later, switch this to a groupBy.
-  const tiers = [
-    {
-      label: 'Tier 1 — Every operator sees these',
-      ids: ['hikiwake', 'encho', 'kiken', 'kiken-voluntary', 'kiken-injury', 'fusenpai', 'fusensho', 'daihyosen', 'hansoku', 'shiro', 'aka', 'shiaijo', 'ippon'],
-    },
-    {
-      label: 'Tier 2 — Team competitions and overtime',
-      ids: ['ippon-shobu', 'kachinuki', 'senpo', 'jiho', 'chuken', 'fukusho', 'taisho'],
-    },
-    {
-      label: 'Tier 3 — Registration and setup',
-      ids: ['zekken', 'dojo', 'dan', 'waza', 'kachinuki-exhaustion'],
-    },
+  // Flat alphabetical list (mp-mjaq).
+  const ids = [
+    'aka', 'chuken', 'daihyosen', 'dan', 'encho',
+    'fukusho', 'fusenpai', 'fusensho', 'hansoku', 'hikiwake',
+    'ippon', 'ippon-shobu', 'jiho', 'kachinuki', 'kachinuki-exhaustion',
+    'kiken', 'kiken-injury', 'kiken-voluntary',
+    'senpo', 'shiaijo', 'shiro', 'taisho', 'waza', 'zekken',
   ];
 
   return (
@@ -224,49 +214,44 @@ function GlossaryPage({ onBack }) {
         </div>
 
         <div className="viewer__body">
-          {tiers.map((tier) => (
-            <section key={tier.label} className="glossary-tier">
-              <div className="section-title" style={{ marginTop: 16 }}>{tier.label}</div>
-              <div className="glossary-list">
-                {tier.ids.map((id) => {
-                  const entry = lookupTerm(id);
-                  if (!entry) return null;
-                  return (
-                    <article key={id} className="glossary-entry" id={`g-${id}`}>
-                      <header className="glossary-entry__head">
-                        <span className="glossary-entry__romaji">{entry.id.split('-').map(capitalise).join('-')}</span>
-                        {entry.kanji && <span className="glossary-entry__kanji"> · {entry.kanji}</span>}
-                        <span className="glossary-entry__short"> — {entry.short}</span>
-                      </header>
-                      <p className="glossary-entry__tooltip">
-                        {renderTooltipBody(entry.tooltip, entry.seeAlso)}
-                      </p>
-                      {entry.seeAlso && entry.seeAlso.length > 0 && (
-                        <div className="glossary-entry__see">
-                          See also:{' '}
-                          {entry.seeAlso.map((refId, i) => (
-                            <React.Fragment key={refId}>
-                              {i > 0 ? ', ' : ''}
-                              <a
-                                href={`#g-${refId}`}
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  const el = document.getElementById(`g-${refId}`);
-                                  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                                }}
-                              >
-                                {capitalise(refId)}
-                              </a>
-                            </React.Fragment>
-                          ))}
-                        </div>
-                      )}
-                    </article>
-                  );
-                })}
-              </div>
-            </section>
-          ))}
+          <div className="glossary-list">
+            {ids.map((id) => {
+              const entry = lookupTerm(id);
+              if (!entry) return null;
+              return (
+                <article key={id} className="glossary-entry" id={`g-${id}`}>
+                  <header className="glossary-entry__head">
+                    <span className="glossary-entry__romaji">{entry.id.split('-').map(capitalise).join('-')}</span>
+                    {entry.kanji && <span className="glossary-entry__kanji"> · {entry.kanji}</span>}
+                    <span className="glossary-entry__short"> — {entry.short}</span>
+                  </header>
+                  <p className="glossary-entry__tooltip">
+                    {renderTooltipBody(entry.tooltip, entry.seeAlso)}
+                  </p>
+                  {entry.seeAlso && entry.seeAlso.length > 0 && (
+                    <div className="glossary-entry__see">
+                      See also:{' '}
+                      {entry.seeAlso.map((refId, i) => (
+                        <React.Fragment key={refId}>
+                          {i > 0 ? ', ' : ''}
+                          <a
+                            href={`#g-${refId}`}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              const el = document.getElementById(`g-${refId}`);
+                              if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                            }}
+                          >
+                            {capitalise(refId)}
+                          </a>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
           {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -189,14 +189,9 @@ function Term({ name, children, nested }) {
 // into the router via app.jsx's parsePath ("/glossary" → viewer mode
 // with viewerScreen='glossary').
 function GlossaryPage({ onBack }) {
-  // Flat alphabetical list (mp-mjaq).
-  const ids = [
-    'aka', 'chuken', 'daihyosen', 'dan', 'encho',
-    'fukusho', 'fusenpai', 'fusensho', 'hansoku', 'hikiwake',
-    'ippon', 'ippon-shobu', 'jiho', 'kachinuki', 'kachinuki-exhaustion',
-    'kiken', 'kiken-injury', 'kiken-voluntary',
-    'senpo', 'shiaijo', 'shiro', 'taisho', 'waza', 'zekken',
-  ];
+  // Derive alphabetical list from the generated GLOSSARY map so new
+  // entries added in glossary.go appear automatically (mp-mjaq).
+  const ids = Object.keys(GLOSSARY).sort();
 
   return (
     <div className="viewer">

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -184,8 +184,8 @@ function Term({ name, children, nested }) {
   );
 }
 
-// GlossaryPage — the /glossary viewer surface. Lists every term
-// grouped by tier so volunteers can browse the full register. Wired
+// GlossaryPage — the /glossary viewer surface. Lists terms in a flat
+// alphabetical layout so volunteers can browse the full register. Wired
 // into the router via app.jsx's parsePath ("/glossary" → viewer mode
 // with viewerScreen='glossary').
 function GlossaryPage({ onBack }) {

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -217,7 +217,7 @@ function GlossaryPage({ onBack }) {
                 <article key={id} className="glossary-entry" id={`g-${id}`}>
                   <header className="glossary-entry__head">
                     <span className="glossary-entry__romaji">{entry.id.split('-').map(capitalise).join('-')}</span>
-                    {entry.kanji && <span className="glossary-entry__kanji"> · {entry.kanji}</span>}
+                    {entry.kanji && <span className="glossary-entry__kanji"><span aria-hidden="true"> · </span>{entry.kanji}</span>}
                     <span className="glossary-entry__short"> — {entry.short}</span>
                   </header>
                   <p className="glossary-entry__tooltip">

--- a/web-mobile/js/glossary_data.js
+++ b/web-mobile/js/glossary_data.js
@@ -10,7 +10,6 @@ export const GLOSSARY = {
   "chuken": {"id":"chuken","kanji":"中堅","short":"Middle player","tooltip":"The team's middle player — fights bout 3 in a 5-person team."},
   "daihyosen": {"id":"daihyosen","kanji":"代表選","short":"Representative bout","tooltip":"Tiebreaker for team knockout matches. When two teams finish equal on both individual wins and points, each picks one player to fight a single-point bout (ippon-shobu) to decide the match.","seeAlso":["ippon-shobu","ippon"]},
   "dan": {"id":"dan","kanji":"段","short":"Rank","tooltip":"A competitor's grade — shodan (1st), nidan (2nd), sandan (3rd), up to 8th. Optional in the entry form."},
-  "dojo": {"id":"dojo","kanji":"道場","short":"Club or school","tooltip":"The training school or club a competitor represents. The pool generator avoids placing two competitors from the same dojo in the same pool when it can."},
   "encho": {"id":"encho","kanji":"延長","short":"Overtime","tooltip":"Overtime — when a knockout match is tied at the end of regulation, an extra period is played until someone scores. Scoring in Encho follows ippon-shobu rules: first to one point wins.","seeAlso":["ippon-shobu","ippon"]},
   "fukusho": {"id":"fukusho","kanji":"副将","short":"Vice-captain","tooltip":"The team's vice-captain — fights bout 4. If a team is short two players, FIK rules require jiho and Fukusho to be the two vacant positions.","seeAlso":["jiho"]},
   "fusenpai": {"id":"fusenpai","kanji":"不戦敗","short":"No-show forfeit","tooltip":"The competitor didn't appear when called to court. The opponent wins 2–0 by default. (Literal meaning: no-fight loss.)"},
@@ -31,7 +30,7 @@ export const GLOSSARY = {
   "sune": {"id":"sune","kanji":"すね","short":"Shin strike","tooltip":"A strike to the shin. Scores a point in Naginata competitions. Not a valid scoring technique in Kendo."},
   "taisho": {"id":"taisho","kanji":"大将","short":"Captain","tooltip":"The team's captain — fights the final bout (bout 5). Like senpo, Taisho must be filled; this position cannot be left vacant.","seeAlso":["senpo"]},
   "waza": {"id":"waza","kanji":"技","short":"Technique","tooltip":"The specific type of strike scored — for example, men, kote, or do. Recorded with each ippon for the match record.","seeAlso":["ippon"]},
-  "zekken": {"id":"zekken","kanji":"ゼッケン","short":"Back name-tag","tooltip":"The cloth name-tag worn on the competitor's back. The display can show this name (instead of the registered name) so spectators see what's physically visible."}
+  "zekken": {"id":"zekken","kanji":"ゼッケン","short":"Name tag (nafuda)","tooltip":"The name tag affixed to the centre of the tare (waist protector). Also called nafuda. The display can show this name (instead of the registered name) so spectators see what's physically visible."}
 };
 
 // Convenience lookup so callers can normalise case at the call site

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -914,16 +914,6 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             </>
           )}
 
-          {/* T069 / FR-016: "Display modes" — link cards into the public
-              /display routes for TV screens, lobby boards, and OBS browser
-              sources. Each link opens in a new tab so the host page
-              (viewer) keeps its tab and stays interactive. Active courts
-              come from tournament.courts (the full configured list); the
-              "all-courts overview" card is always present. Placed below
-              Up Next so a viewer who has already glanced at their next
-              match can drop into the display mode they need. */}
-          <DisplayModes tournament={t} />
-
           {/* mp-c38: sponsor logos. Hidden when none configured. */}
           {window.SponsorStrip && <window.SponsorStrip sponsors={t && t.sponsors} variant="viewer" />}
 
@@ -949,6 +939,14 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
               <span className="vlist-item__rowchev">→</span>
             </a>
           </div>
+
+          {/* T069 / FR-016: "Display modes" — link cards into the public
+              /display routes for TV screens, lobby boards, and OBS browser
+              sources. Each link opens in a new tab so the host page
+              (viewer) keeps its tab and stays interactive. Collapsed by
+              default (mp-mjaq) since most viewers are spectators; only
+              tournament operators need these links. */}
+          <DisplayModes tournament={t} />
           {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>
@@ -1380,43 +1378,6 @@ function DisplayModes({ tournament }) {
     <details style={{ marginTop: 20 }}>
       <summary className="section-title" style={{ cursor: "pointer" }}>Display modes</summary>
       <div className="vlist" data-testid="viewer-home-display-modes">
-        {courts.map((cc) => (
-          <a
-            key={cc}
-            className="vlist-item vlist-item--row"
-            href={`/display?court=${encodeURIComponent(cc)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ textDecoration: "none" }}
-          >
-            <span className="vlist-item__icon">📺</span>
-            <div className="vlist-item__rowbody">
-              <div className="vlist-item__rowtitle"><TermV name="shiaijo">Shiaijo</TermV> {cc} display</div>
-              <div className="vlist-item__rowsub">Fullscreen board for a single court · opens in a new tab</div>
-            </div>
-            <span className="vlist-item__rowchev">→</span>
-          </a>
-        ))}
-        {/* Per-court OBS/vMix overlay entry (previously URL-only). Links to the
-            transparent lower-third streaming overlay so operators can grab the
-            browser-source URL per shiaijo straight from the UI. */}
-        {courts.map((cc) => (
-          <a
-            key={`overlay-${cc}`}
-            className="vlist-item vlist-item--row"
-            href={`/display?court=${encodeURIComponent(cc)}&overlay=1`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ textDecoration: "none" }}
-          >
-            <span className="vlist-item__icon">🎥</span>
-            <div className="vlist-item__rowbody">
-              <div className="vlist-item__rowtitle"><TermV name="shiaijo">Shiaijo</TermV> {cc} streaming overlay</div>
-              <div className="vlist-item__rowsub">Transparent lower-third for OBS / vMix · opens in a new tab</div>
-            </div>
-            <span className="vlist-item__rowchev">→</span>
-          </a>
-        ))}
         <a
           className="vlist-item vlist-item--row"
           href="/display?court=all"
@@ -1431,6 +1392,27 @@ function DisplayModes({ tournament }) {
           </div>
           <span className="vlist-item__rowchev">→</span>
         </a>
+        {/* Per-court links consolidated into compact inline rows. */}
+        {[
+          { icon: "📺", title: "Court displays", suffix: "" },
+          { icon: "🎥", title: "Streaming overlays", suffix: "&overlay=1" },
+        ].map((row) => (
+          <div key={row.title} className="vlist-item vlist-item--row" style={{ textDecoration: "none" }}>
+            <span className="vlist-item__icon">{row.icon}</span>
+            <div className="vlist-item__rowbody">
+              <div className="vlist-item__rowtitle">{row.title}</div>
+              <div className="vlist-item__rowsub" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                {courts.map((cc, i) => (
+                  <span key={cc}>
+                    <a href={`/display?court=${encodeURIComponent(cc)}${row.suffix}`} target="_blank" rel="noopener noreferrer"
+                      style={{ color: "var(--text-link, #2563eb)" }}>Shiaijo {cc}</a>
+                    {i < courts.length - 1 && <span style={{ color: "var(--text-3, #999)", marginLeft: 8 }}>·</span>}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     </details>
   );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1397,7 +1397,7 @@ function DisplayModes({ tournament }) {
           { icon: "📺", title: "Court displays", suffix: "" },
           { icon: "🎥", title: "Streaming overlays", suffix: "&overlay=1" },
         ].map((row) => (
-          <div key={row.title} className="vlist-item vlist-item--row" style={{ textDecoration: "none" }}>
+          <div key={row.title} className="vlist-item vlist-item--row" style={{ cursor: "default" }}>
             <span className="vlist-item__icon">{row.icon}</span>
             <div className="vlist-item__rowbody">
               <div className="vlist-item__rowtitle">{row.title}</div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1408,7 +1408,7 @@ function DisplayModes({ tournament }) {
                   <span key={cc}>
                     <a href={`/display?court=${encodeURIComponent(cc)}${row.suffix}`} target="_blank" rel="noopener noreferrer"
                       style={{ color: "var(--text-link, #2563eb)" }}>Shiaijo {cc}</a>
-                    {i < courts.length - 1 && <span style={{ color: "var(--text-3, #999)", marginLeft: 8 }}>·</span>}
+                    {i < courts.length - 1 && <span aria-hidden="true" style={{ color: "var(--text-3, #999)", marginLeft: 8 }}>·</span>}
                   </span>
                 ))}
               </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1363,10 +1363,12 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
 }
 
 // DisplayModes — viewer-home section linking to the public /display routes.
-// Renders one card per configured court plus an "all-courts overview" card.
-// Each card opens in a new tab so the operator's viewer session stays open.
-// Lives in viewer.jsx (not display.jsx) because it's a viewer-side surface
-// that consumes the display routes rather than rendering them.
+// Collapsed by default inside a <details> element. Contains one "all-courts
+// overview" link plus two compact inline rows (court displays, streaming
+// overlays) each listing per-court links inline rather than one card per
+// court. Each link opens in a new tab so the operator's viewer session stays
+// open. Lives in viewer.jsx (not display.jsx) because it is a viewer-side
+// surface that consumes the display routes rather than rendering them.
 function DisplayModes({ tournament }) {
   const courts = (tournament && tournament.courts) || [];
   // No court list — render nothing rather than a confusing single "all"

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1377,8 +1377,8 @@ function DisplayModes({ tournament }) {
   // data has loaded fully.
   if (courts.length === 0) return null;
   return (
-    <>
-      <div className="section-title" style={{ marginTop: 20 }}>Display modes</div>
+    <details style={{ marginTop: 20 }}>
+      <summary className="section-title" style={{ cursor: "pointer" }}>Display modes</summary>
       <div className="vlist" data-testid="viewer-home-display-modes">
         {courts.map((cc) => (
           <a
@@ -1432,7 +1432,7 @@ function DisplayModes({ tournament }) {
           <span className="vlist-item__rowchev">→</span>
         </a>
       </div>
-    </>
+    </details>
   );
 }
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -940,7 +940,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             </a>
           </div>
 
-          {/* T069 / FR-016: "Display modes" — link cards into the public
+          {/* T069 / FR-016: "Display modes" — links into the public
               /display routes for TV screens, lobby boards, and OBS browser
               sources. Each link opens in a new tab so the host page
               (viewer) keeps its tab and stays interactive. Collapsed by


### PR DESCRIPTION
## Summary

- **Display modes collapsed by default**: Wrapped the Display Modes section in a `<details>/<summary>` element, collapsed by default — most viewers are spectators who don't need TV/overlay links.
- **Reordered viewer home**: Moved glossary link above display modes; moved "All courts overview" to top of the display modes list.
- **Consolidated per-court cards**: Replaced 2N separate cards (N court displays + N streaming overlays) with 2 compact rows containing inline court links. Scales cleanly from 2 to 26 courts without scrolling.
- **Removed `<TermV>` tooltip noise**: Stripped question-mark tooltip wrappers from compact inline links where they added visual clutter.
- **Fixed Zekken glossary entry**: Corrected from "back name-tag" to "name tag (nafuda)" — the zekken/nafuda is affixed to the tare (waist protector), not the back. Updated per FIK terminology in `running_a_kendo_tournament.md`.
- **Removed Dojo from glossary**: "Club" is self-explanatory in context; not a kendo-specific term volunteers need help with.
- **Glossary page cleanup**: Removed tier headings, sorted entries alphabetically, flattened vestigial single-element `tiers` array to a plain `ids` array.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | Collapse DisplayModes in `<details>`, reorder viewer home layout, consolidate per-court cards into data-driven inline-link rows |
| `web-mobile/js/glossary.jsx` | Remove tier headings, flatten tiers→ids array, sort alphabetically |
| `internal/domain/glossary.go` | Fix Zekken definition (nafuda on tare), remove Dojo entry |
| `web-mobile/js/glossary_data.js` | Auto-regenerated from glossary.go (25 entries, was 26) |
| `specs/003-tournament-gap-closure/glossary.md` | Sync spec: remove Dojo, fix Zekken (gitignored, keeps test green) |

## Screenshots

**Viewer home — collapsed (default state)**
Glossary link above Display Modes; display modes collapsed with ▸ triangle.

![viewer-home-collapsed](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/258/viewer-home-collapsed.png)

**Viewer home — expanded display modes**
All courts overview first, then Court displays and Streaming overlays with compact inline Shiaijo A · Shiaijo B links.

![viewer-home-expanded](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/258/viewer-home-expanded.png)

**Glossary page**
Flat alphabetical list (no tier headings), no Dojo entry, Zekken corrected.

![glossary-page](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/258/glossary-page.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all 1304 JS tests, all Go tests green
- [x] New/updated unit tests cover the change — pure UI layout change; existing glossary tests verify spec↔Go sync
- [x] Manual browser verification — verified collapsed/expanded display modes, glossary page layout, inline court links via Playwright + Chrome MCP
- [x] Screenshots added above
- [x] No new console errors or warnings — verified in browser

Closes mp-mjaq