### PR TITLE
feat(mp-jvzy): show player names in league matrix headers

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -51,6 +51,73 @@ func saveTestParticipants(t *testing.T, store *state.Store, compID string, names
 	require.NoError(t, store.SaveParticipants(compID, players))
 }
 
+// TestStartCompetition_LeagueMatchesCarrySideIDs pins that generated
+// league/pool matches stamp each side's participant UUID (SideAID/SideBID)
+// from the roster. The league matrix relies on these to cross-reference a
+// cell to the right row/column player when two participants share a name.
+func TestStartCompetition_LeagueMatchesCarrySideIDs(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "league-ids"
+
+	createTestCompetition(t, store, compID, "league", 4)
+	// Real UUID-v4-shaped ids: the participant loader sniffs the first CSV
+	// field and only treats a row as id-bearing when it matches the UUID
+	// shape (else it parses as the legacy name-first format).
+	const (
+		idA = "11111111-1111-4111-8111-111111111111"
+		idB = "22222222-2222-4222-8222-222222222222"
+		idC = "33333333-3333-4333-8333-333333333333"
+		idD = "44444444-4444-4444-8444-444444444444"
+	)
+	players := []domain.Player{
+		{ID: idA, Name: "Tanaka Kenji", Dojo: "Tokyo"},
+		{ID: idB, Name: "Tanaka Kenji", Dojo: "Osaka"}, // same name, different dojo
+		{ID: idC, Name: "Suzuki Hiro", Dojo: "Nagoya"},
+		{ID: idD, Name: "Watanabe Ryo", Dojo: "Kyoto"},
+	}
+	require.NoError(t, store.SaveParticipants(compID, players))
+
+	require.NoError(t, eng.StartCompetition(compID))
+
+	matches, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	require.NotEmpty(t, matches)
+
+	validIDs := map[string]bool{idA: true, idB: true, idC: true, idD: true}
+	for _, m := range matches {
+		assert.NotEmpty(t, m.SideAID, "match %s SideAID should be stamped from the roster", m.ID)
+		assert.NotEmpty(t, m.SideBID, "match %s SideBID should be stamped from the roster", m.ID)
+		assert.True(t, validIDs[m.SideAID], "match %s SideAID %q is not a roster id", m.ID, m.SideAID)
+		assert.True(t, validIDs[m.SideBID], "match %s SideBID %q is not a roster id", m.ID, m.SideBID)
+		assert.NotEqual(t, m.SideAID, m.SideBID, "a match must be between two distinct participants")
+	}
+
+	// Scoring a match sends names only (no ids). Verify the backfill in
+	// writeMatchResult preserves the generation-time SideAID/SideBID rather
+	// than wiping them via the whole-struct `*r = *result` overwrite, and
+	// resolves WinnerID from the WinnerSide hint — the only way to tell apart
+	// the winner when both sides share a name (this is exactly the A-0
+	// Tanaka-vs-Tanaka match).
+	first := matches[0]
+	wantA, wantB := first.SideAID, first.SideBID
+	require.NoError(t, eng.RecordMatchResult(compID, first.ID, &state.MatchResult{
+		ID: first.ID, SideA: first.SideA, SideB: first.SideB,
+		Winner: first.SideA, WinnerSide: "A", Status: state.MatchStatusCompleted,
+	}))
+	reloaded, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	var got *state.MatchResult
+	for i := range reloaded {
+		if reloaded[i].ID == first.ID {
+			got = &reloaded[i]
+		}
+	}
+	require.NotNil(t, got)
+	assert.Equal(t, wantA, got.SideAID, "scoring must preserve SideAID")
+	assert.Equal(t, wantB, got.SideBID, "scoring must preserve SideBID")
+	assert.Equal(t, wantA, got.WinnerID, "WinnerSide=A must resolve WinnerID to SideAID even when both sides share a name")
+}
+
 // --- Pool Generation Tests ---
 
 func TestStartCompetition_MixedFormat_BasicGeneration(t *testing.T) {

--- a/internal/engine/pools.go
+++ b/internal/engine/pools.go
@@ -115,12 +115,14 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 				round = -1
 			}
 			results = append(results, state.MatchResult{
-				ID:     p.PoolName + "-" + strconv.Itoa(i),
-				SideA:  m.SideA.Name,
-				SideB:  m.SideB.Name,
-				Status: state.MatchStatusScheduled,
-				Court:  poolCourts[i%len(poolCourts)],
-				Round:  round,
+				ID:      p.PoolName + "-" + strconv.Itoa(i),
+				SideA:   m.SideA.Name,
+				SideB:   m.SideB.Name,
+				SideAID: m.SideA.ID,
+				SideBID: m.SideB.ID,
+				Status:  state.MatchStatusScheduled,
+				Court:   poolCourts[i%len(poolCourts)],
+				Round:   round,
 				// ScheduledAt is populated below by
 				// assignPoolMatchSlots — uniform start times were
 				// retired in T150.

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -137,6 +137,38 @@ func deriveDaihyosenWinner(result *state.MatchResult) {
 	}
 }
 
+// backfillMatchIdentity preserves the participant ids stamped on a pool/league
+// match at generation, and resolves the winner id. It runs inside every
+// score-write closure right before the whole-struct `*r = *result` overwrite:
+// score requests carry side NAMES only (no ids), so without this the overwrite
+// would wipe SideAID/SideBID on the first score and break league-matrix cell
+// mapping. WinnerID is resolved from an explicit WinnerSide hint when present
+// (the only way to tell apart two participants who share a name), else from a
+// name match (unambiguous unless both sides share a name). `stored` is the
+// on-disk record (with the generation-time ids); `result` is the incoming
+// score. Purely additive — never touches name-based scoring/standings logic.
+func backfillMatchIdentity(result, stored *state.MatchResult) {
+	if result.SideAID == "" {
+		result.SideAID = stored.SideAID
+	}
+	if result.SideBID == "" {
+		result.SideBID = stored.SideBID
+	}
+	if result.WinnerID != "" {
+		return
+	}
+	switch {
+	case result.WinnerSide == "A":
+		result.WinnerID = result.SideAID
+	case result.WinnerSide == "B":
+		result.WinnerID = result.SideBID
+	case result.Winner != "" && result.Winner == result.SideA && result.Winner != result.SideB:
+		result.WinnerID = result.SideAID
+	case result.Winner != "" && result.Winner == result.SideB && result.Winner != result.SideA:
+		result.WinnerID = result.SideBID
+	}
+}
+
 func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.MatchResult) error {
 	result.ID = matchId // normalize ID-less payloads before overwriting
 	applyHansokuIppons(result)
@@ -154,33 +186,7 @@ func (e *Engine) writeMatchResult(compId string, matchId string, result *state.M
 		if result.SideB == "" {
 			result.SideB = r.SideB
 		}
-		// Preserve the participant ids stamped at generation: score
-		// requests carry names only, so without this backfill the
-		// whole-struct `*r = *result` below would wipe SideAID/SideBID
-		// on the first score, breaking league-matrix cell mapping.
-		if result.SideAID == "" {
-			result.SideAID = r.SideAID
-		}
-		if result.SideBID == "" {
-			result.SideBID = r.SideBID
-		}
-		// Resolve WinnerID from the side ids now that they are present.
-		// Prefer an explicit WinnerSide hint (set by handlers that know
-		// the winning side by score, not name — the only way to tell apart
-		// two participants who share a name); otherwise fall back to a
-		// name match, which is unambiguous unless both sides share a name.
-		if result.WinnerID == "" {
-			switch {
-			case result.WinnerSide == "A":
-				result.WinnerID = result.SideAID
-			case result.WinnerSide == "B":
-				result.WinnerID = result.SideBID
-			case result.Winner != "" && result.Winner == result.SideA && result.Winner != result.SideB:
-				result.WinnerID = result.SideAID
-			case result.Winner != "" && result.Winner == result.SideB && result.Winner != result.SideA:
-				result.WinnerID = result.SideBID
-			}
-		}
+		backfillMatchIdentity(result, r)
 		if result.Court == "" {
 			result.Court = r.Court
 		}
@@ -235,33 +241,7 @@ func (e *Engine) RecordMatchResultWithIneligibility(compId string, matchId strin
 		if result.SideB == "" {
 			result.SideB = r.SideB
 		}
-		// Preserve the participant ids stamped at generation: score
-		// requests carry names only, so without this backfill the
-		// whole-struct `*r = *result` below would wipe SideAID/SideBID
-		// on the first score, breaking league-matrix cell mapping.
-		if result.SideAID == "" {
-			result.SideAID = r.SideAID
-		}
-		if result.SideBID == "" {
-			result.SideBID = r.SideBID
-		}
-		// Resolve WinnerID from the side ids now that they are present.
-		// Prefer an explicit WinnerSide hint (set by handlers that know
-		// the winning side by score, not name — the only way to tell apart
-		// two participants who share a name); otherwise fall back to a
-		// name match, which is unambiguous unless both sides share a name.
-		if result.WinnerID == "" {
-			switch {
-			case result.WinnerSide == "A":
-				result.WinnerID = result.SideAID
-			case result.WinnerSide == "B":
-				result.WinnerID = result.SideBID
-			case result.Winner != "" && result.Winner == result.SideA && result.Winner != result.SideB:
-				result.WinnerID = result.SideAID
-			case result.Winner != "" && result.Winner == result.SideB && result.Winner != result.SideA:
-				result.WinnerID = result.SideBID
-			}
-		}
+		backfillMatchIdentity(result, r)
 		if result.Court == "" {
 			result.Court = r.Court
 		}

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -144,9 +144,11 @@ func deriveDaihyosenWinner(result *state.MatchResult) {
 // would wipe SideAID/SideBID on the first score and break league-matrix cell
 // mapping. WinnerID is resolved from an explicit WinnerSide hint when present
 // (the only way to tell apart two participants who share a name), else from a
-// name match (unambiguous unless both sides share a name). `stored` is the
-// on-disk record (with the generation-time ids); `result` is the incoming
-// score. Purely additive — never touches name-based scoring/standings logic.
+// name match (unambiguous unless both sides share a name), and as a last
+// resort — for a same-name head-to-head with no side hint — from the scoreline
+// (the side with more ippons is the winner). `stored` is the on-disk record
+// (with the generation-time ids); `result` is the incoming score. Purely
+// additive — never touches name-based scoring/standings logic.
 func backfillMatchIdentity(result, stored *state.MatchResult) {
 	if result.SideAID == "" {
 		result.SideAID = stored.SideAID
@@ -166,7 +168,31 @@ func backfillMatchIdentity(result, stored *state.MatchResult) {
 		result.WinnerID = result.SideAID
 	case result.Winner != "" && result.Winner == result.SideB && result.Winner != result.SideA:
 		result.WinnerID = result.SideBID
+	case result.Winner != "":
+		// Same-name head-to-head (Winner matches both sides) with no
+		// WinnerSide hint — e.g. the admin score editor, which picks a
+		// winner by name. The winning side usually has more ippons, so
+		// infer from the scoreline. Equal counts (hantei/undecidable) or a
+		// draw (empty Winner) leave WinnerID empty → name fallback.
+		switch a, b := countScoringIppons(result.IpponsA), countScoringIppons(result.IpponsB); {
+		case a > b:
+			result.WinnerID = result.SideAID
+		case b > a:
+			result.WinnerID = result.SideBID
+		}
 	}
+}
+
+// countScoringIppons counts real ippon marks, ignoring empty entries and the
+// "•" placeholder the UI uses for an unfilled slot.
+func countScoringIppons(ippons []string) int {
+	n := 0
+	for _, v := range ippons {
+		if v != "" && v != "•" {
+			n++
+		}
+	}
+	return n
 }
 
 func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.MatchResult) error {

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -154,6 +154,33 @@ func (e *Engine) writeMatchResult(compId string, matchId string, result *state.M
 		if result.SideB == "" {
 			result.SideB = r.SideB
 		}
+		// Preserve the participant ids stamped at generation: score
+		// requests carry names only, so without this backfill the
+		// whole-struct `*r = *result` below would wipe SideAID/SideBID
+		// on the first score, breaking league-matrix cell mapping.
+		if result.SideAID == "" {
+			result.SideAID = r.SideAID
+		}
+		if result.SideBID == "" {
+			result.SideBID = r.SideBID
+		}
+		// Resolve WinnerID from the side ids now that they are present.
+		// Prefer an explicit WinnerSide hint (set by handlers that know
+		// the winning side by score, not name — the only way to tell apart
+		// two participants who share a name); otherwise fall back to a
+		// name match, which is unambiguous unless both sides share a name.
+		if result.WinnerID == "" {
+			switch {
+			case result.WinnerSide == "A":
+				result.WinnerID = result.SideAID
+			case result.WinnerSide == "B":
+				result.WinnerID = result.SideBID
+			case result.Winner != "" && result.Winner == result.SideA && result.Winner != result.SideB:
+				result.WinnerID = result.SideAID
+			case result.Winner != "" && result.Winner == result.SideB && result.Winner != result.SideA:
+				result.WinnerID = result.SideBID
+			}
+		}
 		if result.Court == "" {
 			result.Court = r.Court
 		}
@@ -207,6 +234,33 @@ func (e *Engine) RecordMatchResultWithIneligibility(compId string, matchId strin
 		}
 		if result.SideB == "" {
 			result.SideB = r.SideB
+		}
+		// Preserve the participant ids stamped at generation: score
+		// requests carry names only, so without this backfill the
+		// whole-struct `*r = *result` below would wipe SideAID/SideBID
+		// on the first score, breaking league-matrix cell mapping.
+		if result.SideAID == "" {
+			result.SideAID = r.SideAID
+		}
+		if result.SideBID == "" {
+			result.SideBID = r.SideBID
+		}
+		// Resolve WinnerID from the side ids now that they are present.
+		// Prefer an explicit WinnerSide hint (set by handlers that know
+		// the winning side by score, not name — the only way to tell apart
+		// two participants who share a name); otherwise fall back to a
+		// name match, which is unambiguous unless both sides share a name.
+		if result.WinnerID == "" {
+			switch {
+			case result.WinnerSide == "A":
+				result.WinnerID = result.SideAID
+			case result.WinnerSide == "B":
+				result.WinnerID = result.SideBID
+			case result.Winner != "" && result.Winner == result.SideA && result.Winner != result.SideB:
+				result.WinnerID = result.SideAID
+			case result.Winner != "" && result.Winner == result.SideB && result.Winner != result.SideA:
+				result.WinnerID = result.SideBID
+			}
 		}
 		if result.Court == "" {
 			result.Court = r.Court

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -1201,3 +1201,89 @@ func TestUnresolvedKnockoutMatch_ScoringGated(t *testing.T) {
 	assert.Equal(t, "B", loaded.Rounds[0][0].Court, "court reschedule must have landed")
 	assert.Equal(t, "10:00", loaded.Rounds[0][0].ScheduledAt, "time reschedule must have landed")
 }
+
+// TestBackfillMatchIdentity directly exercises backfillMatchIdentity, in
+// particular the same-name-head-to-head scoreline-inference branch that the
+// admin score editor relies on (it picks a winner by NAME, sending no
+// WinnerSide hint). The two pre-existing PreservesSideIDs tests both set
+// WinnerSide:"A", so this branch — and the equal-count "leave WinnerID empty"
+// tie — were previously uncovered (mp-jvzy tri-review finding).
+func TestBackfillMatchIdentity(t *testing.T) {
+	const (
+		idA = "11111111-1111-4111-8111-111111111111"
+		idB = "22222222-2222-4222-8222-222222222222"
+	)
+
+	tests := []struct {
+		name       string
+		result     state.MatchResult
+		wantWinner string
+	}{
+		{
+			name:       "WinnerSide A hint wins over everything",
+			result:     state.MatchResult{Winner: "Tanaka Kenji", WinnerSide: "A"},
+			wantWinner: idA,
+		},
+		{
+			name:       "WinnerSide B hint",
+			result:     state.MatchResult{Winner: "Tanaka Kenji", WinnerSide: "B"},
+			wantWinner: idB,
+		},
+		{
+			name:       "unambiguous name match resolves to SideA",
+			result:     state.MatchResult{SideA: "Alice", SideB: "Bob", Winner: "Alice"},
+			wantWinner: idA,
+		},
+		{
+			name:       "unambiguous name match resolves to SideB",
+			result:     state.MatchResult{SideA: "Alice", SideB: "Bob", Winner: "Bob"},
+			wantWinner: idB,
+		},
+		{
+			name:       "same-name head-to-head: SideA has more ippons",
+			result:     state.MatchResult{SideA: "Tanaka Kenji", SideB: "Tanaka Kenji", Winner: "Tanaka Kenji", IpponsA: []string{"M", "K"}, IpponsB: []string{"D"}},
+			wantWinner: idA,
+		},
+		{
+			name:       "same-name head-to-head: SideB has more ippons (symmetry)",
+			result:     state.MatchResult{SideA: "Tanaka Kenji", SideB: "Tanaka Kenji", Winner: "Tanaka Kenji", IpponsA: []string{"D"}, IpponsB: []string{"M", "K"}},
+			wantWinner: idB,
+		},
+		{
+			name:       "same-name head-to-head: equal ippons is undecidable, WinnerID empty",
+			result:     state.MatchResult{SideA: "Tanaka Kenji", SideB: "Tanaka Kenji", Winner: "Tanaka Kenji", IpponsA: []string{"M"}, IpponsB: []string{"D"}},
+			wantWinner: "",
+		},
+		{
+			name:       "scoreline count ignores the • placeholder",
+			result:     state.MatchResult{SideA: "Tanaka Kenji", SideB: "Tanaka Kenji", Winner: "Tanaka Kenji", IpponsA: []string{"M", "•"}, IpponsB: []string{"•"}},
+			wantWinner: idA,
+		},
+		{
+			name:       "explicit WinnerID preserved (early return, no inference)",
+			result:     state.MatchResult{Winner: "Tanaka Kenji", WinnerID: "explicit-id", IpponsA: []string{"M", "K"}},
+			wantWinner: "explicit-id",
+		},
+		{
+			name:       "draw (empty Winner) leaves WinnerID empty",
+			result:     state.MatchResult{SideA: "Tanaka Kenji", SideB: "Tanaka Kenji", Winner: "", IpponsA: []string{"M"}, IpponsB: []string{"M"}},
+			wantWinner: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.result
+			// `stored` carries the generation-time ids; `result` (the incoming
+			// score) starts without them — mirrors the real write path.
+			stored := &state.MatchResult{SideAID: idA, SideBID: idB}
+			backfillMatchIdentity(&result, stored)
+
+			assert.Equal(t, tc.wantWinner, result.WinnerID, "WinnerID")
+			// Side ids are always backfilled from `stored` (runs before the
+			// WinnerID early-return), even in the explicit-WinnerID case.
+			assert.Equal(t, idA, result.SideAID, "SideAID backfilled")
+			assert.Equal(t, idB, result.SideBID, "SideBID backfilled")
+		})
+	}
+}

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -291,6 +291,10 @@ func (e *Engine) RecordMatchResultWithIneligibilityTx(tx state.StoreTx, compID, 
 		if result.SideB == "" {
 			result.SideB = r.SideB
 		}
+		// Preserve generation-time participant ids + resolve winner id across
+		// the whole-struct overwrite below (the /score endpoint scores through
+		// this Tx path). See backfillMatchIdentity.
+		backfillMatchIdentity(result, r)
 		if result.Court == "" {
 			result.Court = r.Court
 		}
@@ -417,6 +421,10 @@ func (e *Engine) recordMatchResultTx(tx state.StoreTx, compID, matchID string, r
 		if result.SideB == "" {
 			result.SideB = r.SideB
 		}
+		// Preserve generation-time participant ids + resolve winner id across
+		// the whole-struct overwrite below (the /score endpoint scores through
+		// this Tx path). See backfillMatchIdentity.
+		backfillMatchIdentity(result, r)
 		if result.Court == "" {
 			result.Court = r.Court
 		}

--- a/internal/engine/scoring_tx_test.go
+++ b/internal/engine/scoring_tx_test.go
@@ -287,6 +287,50 @@ func TestRecordMatchResultWithIneligibilityTx_Basic(t *testing.T) {
 	assert.Equal(t, state.MatchStatusCompleted, matches[0].Status)
 }
 
+// TestRecordMatchResultWithIneligibilityTx_PreservesSideIDs guards the
+// regression where scoring through the /score (transaction) path wiped the
+// SideAID/SideBID stamped at generation: the whole-struct overwrite in the Tx
+// write closure dropped them because score requests carry names only. It also
+// checks WinnerID resolves from the WinnerSide hint, the only way to tell apart
+// a winner when both sides share a name.
+func TestRecordMatchResultWithIneligibilityTx_PreservesSideIDs(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "tx-ids"
+	createTestCompetition(t, store, compID, "league", 2)
+
+	aID := helper.NewUUID4()
+	bID := helper.NewUUID4()
+	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+		{ID: aID, Name: "Tanaka Kenji", Dojo: "Tokyo"},
+		{ID: bID, Name: "Tanaka Kenji", Dojo: "Osaka"}, // same name, different id
+	}))
+	// Match with ids stamped at generation (sides stored by name).
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "Pool A-0", SideA: "Tanaka Kenji", SideB: "Tanaka Kenji",
+			SideAID: aID, SideBID: bID, Status: state.MatchStatusScheduled},
+	}))
+
+	// Score via the Tx path with NAMES only (no ids) — exactly what /score sends.
+	result := &state.MatchResult{
+		ID: "Pool A-0", SideA: "Tanaka Kenji", SideB: "Tanaka Kenji",
+		Winner: "Tanaka Kenji", WinnerSide: "A", IpponsA: []string{"M"},
+		Status: state.MatchStatusCompleted,
+	}
+	var engErr error
+	_ = store.WithTransaction(compID, func(tx state.StoreTx) error {
+		_, engErr = eng.RecordMatchResultWithIneligibilityTx(tx, compID, "Pool A-0", result)
+		return nil
+	})
+	require.NoError(t, engErr)
+
+	matches, err := store.LoadPoolMatches(compID)
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, aID, matches[0].SideAID, "Tx score must preserve SideAID")
+	assert.Equal(t, bID, matches[0].SideBID, "Tx score must preserve SideBID")
+	assert.Equal(t, aID, matches[0].WinnerID, "WinnerSide=A must resolve WinnerID even when both sides share a name")
+}
+
 // TestStartMatchTx_BlocksIneligibleParticipant verifies the FR-035
 // pre-flight gate. After Alice is recorded as kiken'd on Pool A-0
 // (her status: ineligible, matchID=Pool A-0), StartMatchTx for

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -337,12 +337,18 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 		}
 
 		// Determine team winner per kendo rules: most individual wins wins.
+		// winnerSide records the WINNING SIDE (not just the name) so the
+		// engine can stamp WinnerID even when both sides share a name —
+		// the name alone can't tell two same-name participants apart.
 		winner := ""
+		winnerSide := ""
 		switch {
 		case req.TeamAWins > req.TeamBWins:
 			winner = req.SideA
+			winnerSide = "A"
 		case req.TeamBWins > req.TeamAWins:
 			winner = req.SideB
+			winnerSide = "B"
 		}
 
 		// Synthesise SubResults so standings IV/IL/IT counts are correct.
@@ -368,6 +374,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			SideA:      req.SideA,
 			SideB:      req.SideB,
 			Winner:     winner,
+			WinnerSide: winnerSide,
 			Status:     state.MatchStatusCompleted,
 			SubResults: subResults,
 		}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -498,10 +498,10 @@ type SubMatchResult struct {
 }
 
 type MatchResult struct {
-	ID             string           `json:"id"`
-	SideA          string           `json:"sideA"` // Player/Team Name
-	SideB          string           `json:"sideB"`
-	Winner         string           `json:"winner"`
+	ID     string `json:"id"`
+	SideA  string `json:"sideA"` // Player/Team Name
+	SideB  string `json:"sideB"`
+	Winner string `json:"winner"`
 	// SideAID/SideBID/WinnerID carry the participant UUID for each side and
 	// the winner when available. Sides are stored by name everywhere else,
 	// but a name is not unique within a competition — two participants from
@@ -513,9 +513,9 @@ type MatchResult struct {
 	// name, and these stay empty for legacy data, so behavior is unchanged
 	// when ids are absent. omitempty + append-only CSV columns keep old
 	// files/readers fully compatible.
-	SideAID        string           `json:"sideAId,omitempty"`
-	SideBID        string           `json:"sideBId,omitempty"`
-	WinnerID       string           `json:"winnerId,omitempty"`
+	SideAID  string `json:"sideAId,omitempty"`
+	SideBID  string `json:"sideBId,omitempty"`
+	WinnerID string `json:"winnerId,omitempty"`
 	// WinnerSide is a transient hint ("A"/"B") set by scoring handlers that
 	// know the winning SIDE unambiguously (e.g. quick-score, where the
 	// winner is decided by ippon counts, not a name). writeMatchResult uses

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -502,6 +502,27 @@ type MatchResult struct {
 	SideA          string           `json:"sideA"` // Player/Team Name
 	SideB          string           `json:"sideB"`
 	Winner         string           `json:"winner"`
+	// SideAID/SideBID/WinnerID carry the participant UUID for each side and
+	// the winner when available. Sides are stored by name everywhere else,
+	// but a name is not unique within a competition — two participants from
+	// different dojos may share a name (CheckDuplicateEntriesByNameDojo only
+	// rejects same-name AND same-dojo). These ids let consumers (e.g. the
+	// league matrix) cross-reference a match cell to the right row/column
+	// player AND tell apart the winner when two identical-name players meet.
+	// Purely additive metadata: all Go scoring/standings logic still keys on
+	// name, and these stay empty for legacy data, so behavior is unchanged
+	// when ids are absent. omitempty + append-only CSV columns keep old
+	// files/readers fully compatible.
+	SideAID        string           `json:"sideAId,omitempty"`
+	SideBID        string           `json:"sideBId,omitempty"`
+	WinnerID       string           `json:"winnerId,omitempty"`
+	// WinnerSide is a transient hint ("A"/"B") set by scoring handlers that
+	// know the winning SIDE unambiguously (e.g. quick-score, where the
+	// winner is decided by ippon counts, not a name). writeMatchResult uses
+	// it to resolve WinnerID from the stored side ids even when both sides
+	// share a name. Never persisted (json/CSV omit) — it only carries the
+	// side decision from the handler to the id-resolution step.
+	WinnerSide     string           `json:"-" yaml:"-"`
 	IpponsA        []string         `json:"ipponsA"` // M, K, D, T, H
 	IpponsB        []string         `json:"ipponsB"`
 	HansokuA       int              `json:"hansokuA"`

--- a/internal/state/pools.go
+++ b/internal/state/pools.go
@@ -90,6 +90,12 @@ func parsePoolsFile(path string) (any, error) {
 		if len(rec) > 6 {
 			player.Number = rec[6]
 		}
+		// Participant UUID (appended after the legacy 7-column layout).
+		// Absent in pre-change files → empty id; the league matrix then
+		// falls back to name-based cell matching.
+		if len(rec) > 7 {
+			player.ID = rec[7]
+		}
 		pools[idx].Players = append(pools[idx].Players, player)
 	}
 
@@ -195,7 +201,7 @@ func (s *Store) savePoolsLocked(compID string, pools []helper.Pool) error {
 			if player.Seed > 0 {
 				seedStr = strconv.Itoa(player.Seed)
 			}
-			if err := writer.Write([]string{p.PoolName, player.Name, strconv.Itoa(i), player.DisplayName, player.Dojo, seedStr, player.Number}); err != nil {
+			if err := writer.Write([]string{p.PoolName, player.Name, strconv.Itoa(i), player.DisplayName, player.Dojo, seedStr, player.Number, player.ID}); err != nil {
 				return err
 			}
 		}
@@ -344,6 +350,18 @@ func parsePoolMatchesRecords(records [][]string) []MatchResult {
 		} else {
 			m.Round = -1
 		}
+		// Participant-id columns (appended after Round, after the legacy
+		// 15-column layout). Absent in files written before this was added
+		// → ids stay empty and consumers fall back to name matching.
+		if len(rec) > 16 {
+			m.SideAID = rec[16]
+		}
+		if len(rec) > 17 {
+			m.SideBID = rec[17]
+		}
+		if len(rec) > 18 {
+			m.WinnerID = rec[18]
+		}
 
 		results = append(results, m)
 	}
@@ -380,7 +398,7 @@ func (s *Store) savePoolMatchesLocked(compID string, results []MatchResult, writ
 	// the previous os.Create + streaming pattern lacked.
 	var buf bytes.Buffer
 	writer := csv.NewWriter(&buf)
-	if err := writer.Write([]string{"PoolName", "MatchIdx", "SideA", "SideB", "Winner", "IpponsA", "IpponsB", "HansokuA", "HansokuB", "Decision", "Status", "Court", "SubResults", "ScheduledAt", "ResultSource", "Round"}); err != nil {
+	if err := writer.Write([]string{"PoolName", "MatchIdx", "SideA", "SideB", "Winner", "IpponsA", "IpponsB", "HansokuA", "HansokuB", "Decision", "Status", "Court", "SubResults", "ScheduledAt", "ResultSource", "Round", "SideAID", "SideBID", "WinnerID"}); err != nil {
 		return err
 	}
 
@@ -415,6 +433,9 @@ func (s *Store) savePoolMatchesLocked(compID string, results []MatchResult, writ
 			r.ScheduledAt,
 			r.ResultSource,
 			strconv.Itoa(r.Round),
+			r.SideAID,
+			r.SideBID,
+			r.WinnerID,
 		}); err != nil {
 			return err
 		}

--- a/internal/state/pools_test.go
+++ b/internal/state/pools_test.go
@@ -50,6 +50,90 @@ func TestLoadPoolMatchesLocked_WithData(t *testing.T) {
 	assert.Equal(t, "Charlie", results[1].Winner)
 }
 
+// TestPoolMatches_SideIDsRoundTrip verifies the appended SideAID/SideBID
+// columns survive a save→load cycle (the league matrix relies on them to
+// disambiguate same-name participants from different dojos).
+func TestPoolMatches_SideIDsRoundTrip(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-pools-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "test-comp"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Test"}))
+
+	matches := []MatchResult{
+		{ID: "Pool A-0", SideA: "Tanaka Kenji", SideB: "Yamamoto Yuki", SideAID: "uuid-a", SideBID: "uuid-b", Status: MatchStatusScheduled},
+	}
+	require.NoError(t, store.SavePoolMatches(compID, matches))
+
+	results, err := store.LoadPoolMatchesLocked(compID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "uuid-a", results[0].SideAID)
+	assert.Equal(t, "uuid-b", results[0].SideBID)
+}
+
+// TestPoolMatches_LegacyFileWithoutIDs verifies a pool-matches.csv written
+// before the id columns existed (15 columns) still loads, leaving the id
+// fields empty so consumers fall back to name matching.
+func TestPoolMatches_LegacyFileWithoutIDs(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-pools-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "legacy-comp"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Legacy"}))
+
+	// 15-column legacy row (header + one data row), no SideAID/SideBID.
+	legacy := "PoolName,MatchIdx,SideA,SideB,Winner,IpponsA,IpponsB,HansokuA,HansokuB,Decision,Status,Court,SubResults,ScheduledAt,ResultSource\n" +
+		"Pool A,0,Alice,Bob,,,,0,0,,scheduled,A,,09:00,\n"
+	require.NoError(t, os.WriteFile(store.compPath(compID, "pool-matches.csv"), []byte(legacy), 0600))
+
+	results, err := store.LoadPoolMatchesLocked(compID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Alice", results[0].SideA)
+	assert.Empty(t, results[0].SideAID, "legacy row has no id column → empty")
+	assert.Empty(t, results[0].SideBID)
+}
+
+// TestPools_PlayerIDRoundTrip verifies the appended participant-id column in
+// pools.csv survives a save→load cycle so pool.players carry .ID for the
+// league matrix.
+func TestPools_PlayerIDRoundTrip(t *testing.T) {
+	dir, err := os.MkdirTemp("", "state-pools-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	compID := "test-comp"
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: "Test"}))
+
+	pools := []helper.Pool{{
+		PoolName: "Pool A",
+		Players: []helper.Player{
+			{Name: "Tanaka Kenji", Dojo: "Tokyo", ID: "uuid-1"},
+			{Name: "Yamamoto Yuki", Dojo: "Osaka", ID: "uuid-2"},
+		},
+	}}
+	require.NoError(t, store.SavePools(compID, pools))
+
+	loaded, err := store.LoadPools(compID)
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	require.Len(t, loaded[0].Players, 2)
+	assert.Equal(t, "uuid-1", loaded[0].Players[0].ID)
+	assert.Equal(t, "uuid-2", loaded[0].Players[1].ID)
+}
+
 func TestLoadPoolMatchesLocked_InvalidCompID(t *testing.T) {
 	dir, err := os.MkdirTemp("", "state-pools-test-*")
 	require.NoError(t, err)

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4908,7 +4908,7 @@ button.my-match__opp {
 }
 .match-detail-card__sub-score--right { text-align: right; }
 
-/* ---------- Pool Round-Robin Matrix (Viewer) ---------- */
+/* ---------- League Round-Robin Matrix (Viewer) ---------- */
 .league-matrix-wrap {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4909,23 +4909,23 @@ button.my-match__opp {
 .match-detail-card__sub-score--right { text-align: right; }
 
 /* ---------- Pool Round-Robin Matrix (Viewer) ---------- */
-.pool-matrix-wrap {
+.league-matrix-wrap {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
 
-.pool-matrix {
+.league-matrix {
   border-collapse: collapse;
   font-size: 11px;
   min-width: 100%;
 }
 
-.pool-matrix__corner {
+.league-matrix__corner {
   background: transparent;
   min-width: 80px;
 }
 
-.pool-matrix__col-head {
+.league-matrix__col-head {
   text-align: center;
   padding: 4px 6px;
   font-weight: 700;
@@ -4933,9 +4933,10 @@ button.my-match__opp {
   color: var(--ink-3);
   border-bottom: 2px solid var(--line);
   min-width: 36px;
+  cursor: help;
 }
 
-.pool-matrix__row-head {
+.league-matrix__row-head {
   padding: 6px 8px 6px 0;
   text-align: left;
   border-right: 1px solid var(--line);
@@ -4943,7 +4944,7 @@ button.my-match__opp {
   max-width: 120px;
 }
 
-.pool-matrix__num {
+.league-matrix__num {
   font-weight: 700;
   color: var(--ink-3);
   font-size: 11px;
@@ -4951,13 +4952,13 @@ button.my-match__opp {
   font-family: var(--font-mono);
 }
 
-.pool-matrix__pname {
+.league-matrix__pname {
   font-size: 11px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.pool-matrix__cell {
+.league-matrix__cell {
   text-align: center;
   padding: 4px 2px;
   font-weight: 700;
@@ -4966,22 +4967,22 @@ button.my-match__opp {
   border: 1px solid var(--line-light);
 }
 
-.pool-matrix__cell--self { color: var(--ink-4); background: var(--bg-2); }
-.pool-matrix__cell--empty { background: var(--bg-2); }
-.pool-matrix__cell--pending { color: var(--ink-3); }
-.pool-matrix__cell--live { color: var(--accent); }
-.pool-matrix__cell--win { background: rgba(22, 163, 74, 0.08); }
-.pool-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); }
-.pool-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); }
-.pool-matrix__cell[role="button"] { cursor: pointer; }
-.pool-matrix__cell[role="button"]:hover { filter: brightness(0.92); }
-.pool-matrix__cell[role="button"]:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.league-matrix__cell--self { color: var(--ink-4); background: var(--bg-2); }
+.league-matrix__cell--empty { background: var(--bg-2); }
+.league-matrix__cell--pending { color: var(--ink-3); }
+.league-matrix__cell--live { color: var(--accent); }
+.league-matrix__cell--win { background: rgba(22, 163, 74, 0.08); }
+.league-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); }
+.league-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); }
+.league-matrix__cell[role="button"] { cursor: pointer; }
+.league-matrix__cell[role="button"]:hover { filter: brightness(0.92); }
+.league-matrix__cell[role="button"]:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
-.pool-matrix__win { color: #16a34a; }
-.pool-matrix__loss { color: #dc2626; }
-.pool-matrix__draw { color: var(--ink-2); }
+.league-matrix__win { color: #16a34a; }
+.league-matrix__loss { color: #dc2626; }
+.league-matrix__draw { color: var(--ink-2); }
 
-.pool-matrix__legend {
+.league-matrix__legend {
   display: flex;
   gap: 12px;
   margin-top: 6px;
@@ -4991,14 +4992,14 @@ button.my-match__opp {
   align-items: center;
 }
 
-.pool-matrix__legend-item {
+.league-matrix__legend-item {
   padding: 1px 5px;
   border-radius: 3px;
   font-weight: 700;
 }
-.pool-matrix__legend-item--win { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
-.pool-matrix__legend-item--loss { color: #dc2626; background: rgba(220, 38, 38, 0.08); }
-.pool-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); }
+.league-matrix__legend-item--win { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
+.league-matrix__legend-item--loss { color: #dc2626; background: rgba(220, 38, 38, 0.08); }
+.league-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); }
 
 /* ---------- FoulCounter (Individual Scoring) ---------- */
 .sb-fouls {
@@ -6226,13 +6227,13 @@ button.my-match__opp {
 /* mp-wvkh: followed-player highlights */
 .pool__row--me { background: rgba(29,53,87,0.07); }
 /* Matrix row: top inset shadow on every cell so the highlight shows through win/loss/draw backgrounds */
-.pool-matrix__row--me td,
-.pool-matrix__row--me th { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35); }
-.pool-matrix__row--me .pool-matrix__row-head { background: rgba(29,53,87,0.07); font-weight: 700; }
+.league-matrix__row--me td,
+.league-matrix__row--me th { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35); }
+.league-matrix__row--me .league-matrix__row-head { background: rgba(29,53,87,0.07); font-weight: 700; }
 /* Matrix col: left inset shadow so it doesn't override win/loss/draw cell backgrounds */
-.pool-matrix__col--me { box-shadow: inset 2px 0 0 rgba(29,53,87,0.35); font-weight: 700; }
+.league-matrix__col--me { box-shadow: inset 2px 0 0 rgba(29,53,87,0.35); font-weight: 700; }
 /* Corner cell (row and col): combine both shadows */
-.pool-matrix__row--me .pool-matrix__col--me { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35), inset 2px 0 0 rgba(29,53,87,0.35); }
+.league-matrix__row--me .league-matrix__col--me { box-shadow: inset 0 2px 0 rgba(29,53,87,0.35), inset 2px 0 0 rgba(29,53,87,0.35); }
 .bc-match--my-match { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }
 .vsched-item--me { box-shadow: inset 3px 0 0 var(--accent, #1d3557); }
 

--- a/web-mobile/js/__tests__/api.test.jsx
+++ b/web-mobile/js/__tests__/api.test.jsx
@@ -114,6 +114,35 @@ describe('API Utils', () => {
       // No key — server-side omitempty drops it from the persisted record.
       expect('decidedByHantei' in result).toBe(false);
     });
+
+    // mp-jvzy: forward the winner's participant id so a same-name head-to-head
+    // is unambiguous on the backend. Without it, a tied/hantei scoreline leaves
+    // the backend unable to pick a side and the league matrix marks BOTH rows
+    // as winners. The scoring modal sets patch.winner to the winning SIDE object.
+    it('forwards winnerId from the winning side object', () => {
+      const match = { sideA: { id: 'id-a', name: 'Player A' }, sideB: { id: 'id-b', name: 'Player B' } };
+      const result = toBackendMatchResult({ winner: { id: 'id-a', name: 'Player A' }, status: 'complete', ipponsA: ['M'], ipponsB: [] }, match);
+      expect(result.winnerId).toBe('id-a');
+    });
+
+    it('forwards the correct winnerId for a same-name head-to-head (object winner)', () => {
+      const match = { sideA: { id: 'id-kenshikan', name: 'Tanaka Kenji' }, sideB: { id: 'id-mumeishi', name: 'Tanaka Kenji' } };
+      // Mumeishi won — even on a tied scoreline the id disambiguates the side.
+      const result = toBackendMatchResult({ winner: { id: 'id-mumeishi', name: 'Tanaka Kenji' }, status: 'complete', ipponsA: ['M'], ipponsB: ['M'], score: { type: 'ippon' }, decidedByHantei: true }, match);
+      expect(result.winnerId).toBe('id-mumeishi');
+    });
+
+    it('omits winnerId when same-name and the winner is a bare name (ambiguous)', () => {
+      const match = { sideA: { id: 'id-kenshikan', name: 'Tanaka Kenji' }, sideB: { id: 'id-mumeishi', name: 'Tanaka Kenji' } };
+      const result = toBackendMatchResult({ winner: 'Tanaka Kenji', status: 'complete', ipponsA: ['M'], ipponsB: ['M'] }, match);
+      expect('winnerId' in result).toBe(false); // backend infers from scoreline / name fallback
+    });
+
+    it('derives winnerId from the match sides for a distinct-name bare-name winner', () => {
+      const match = { sideA: { id: 'id-a', name: 'Player A' }, sideB: { id: 'id-b', name: 'Player B' } };
+      const result = toBackendMatchResult({ winner: 'Player B', status: 'complete', ipponsA: [], ipponsB: ['K'] }, match);
+      expect(result.winnerId).toBe('id-b');
+    });
   });
 
   describe('isHikiwake', () => {
@@ -274,6 +303,43 @@ describe('API Utils', () => {
       const map = buildPlayerMap(comp);
       expect(map['Alice'].id).toBe('uuid-aaa');
       expect(map['Bob'].id).toBe('uuid-bbb');
+    });
+
+    // mp-jvzy: two same-name participants (different dojos) collapse onto one
+    // NAME key — last-added wins. An additional id key per participant keeps
+    // each one's correct dojo/number, so normalizeMatch can resolve each side
+    // by the server's authoritative id and never show the wrong dojo.
+    it('keys by participant id so same-name players keep distinct dojo/number', () => {
+      const comp = {
+        players: [
+          { id: 'uuid-kenshikan', name: 'Tanaka Kenji', dojo: 'Kenshikan', number: 'K1' },
+          { id: 'uuid-mumeishi', name: 'Tanaka Kenji', dojo: 'Mumeishi', number: 'K2' },
+        ],
+      };
+      const map = buildPlayerMap(comp);
+      // Name key collapses to the last-added (Mumeishi).
+      expect(map['Tanaka Kenji'].dojo).toBe('Mumeishi');
+      // But each id key carries the correct, distinct metadata.
+      expect(map['uuid-kenshikan']).toMatchObject({ id: 'uuid-kenshikan', dojo: 'Kenshikan', number: 'K1' });
+      expect(map['uuid-mumeishi']).toMatchObject({ id: 'uuid-mumeishi', dojo: 'Mumeishi', number: 'K2' });
+    });
+
+    it('normalizeMatch attaches the CORRECT dojo to each same-name side via flat ids', () => {
+      const comp = {
+        players: [
+          { id: 'uuid-kenshikan', name: 'Tanaka Kenji', dojo: 'Kenshikan' },
+          { id: 'uuid-mumeishi', name: 'Tanaka Kenji', dojo: 'Mumeishi' },
+        ],
+      };
+      const map = buildPlayerMap(comp);
+      const m = normalizeMatch({
+        sideA: 'Tanaka Kenji', sideB: 'Tanaka Kenji', winner: 'Tanaka Kenji',
+        sideAId: 'uuid-kenshikan', sideBId: 'uuid-mumeishi', winnerId: 'uuid-kenshikan',
+        status: 'completed', ipponsA: ['M'], ipponsB: [],
+      }, map);
+      expect(m.sideA).toMatchObject({ id: 'uuid-kenshikan', dojo: 'Kenshikan' });
+      expect(m.sideB).toMatchObject({ id: 'uuid-mumeishi', dojo: 'Mumeishi' });
+      expect(m.winner).toMatchObject({ id: 'uuid-kenshikan', dojo: 'Kenshikan' });
     });
 
     it('falls back to name as id when no id field', () => {

--- a/web-mobile/js/__tests__/api.test.jsx
+++ b/web-mobile/js/__tests__/api.test.jsx
@@ -140,6 +140,27 @@ describe('API Utils', () => {
       expect(norm.sideB).toEqual({ id: 'Bob', name: 'Bob' }); // Fallback if not in map
     });
 
+    // mp-jvzy: the playerMap is keyed by NAME, so two same-name participants
+    // (allowed when dojos differ) collapse onto one id. When the server sends
+    // explicit per-side ids (sideAId/sideBId/winnerId from pool-matches.csv),
+    // those are authoritative and must override the collapsed lookup — without
+    // this the league matrix renders the same-name head-to-head inverted.
+    it('overrides name-collapsed ids with server sideAId/sideBId/winnerId', () => {
+      // Both "Tanaka Kenji" — name-keyed map holds only the last-added id.
+      const playerMap = { 'Tanaka Kenji': { id: 'uuid-mumeishi', name: 'Tanaka Kenji', dojo: 'Mumeishi' } };
+      const match = {
+        sideA: 'Tanaka Kenji', sideB: 'Tanaka Kenji', winner: 'Tanaka Kenji',
+        sideAId: 'uuid-kenshikan', sideBId: 'uuid-mumeishi', winnerId: 'uuid-kenshikan',
+        status: 'completed', ipponsA: ['M'], ipponsB: [],
+      };
+      const norm = normalizeMatch(match, playerMap);
+      expect(norm.sideA.id).toBe('uuid-kenshikan'); // flat id wins over collapsed map id
+      expect(norm.sideB.id).toBe('uuid-mumeishi');
+      expect(norm.winner.id).toBe('uuid-kenshikan');
+      // The shared playerMap object must NOT be mutated by the id stamp.
+      expect(playerMap['Tanaka Kenji'].id).toBe('uuid-mumeishi');
+    });
+
     it('should build score object from ippons for pool matches', () => {
       const match = {
         sideA: 'A', sideB: 'B', winner: 'A',

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -617,8 +617,8 @@ describe('TournamentInfo', () => {
   });
 });
 
-// mp-f4xo: PoolMatrix — clickable cross-table cells
-describe('PoolMatrix (mp-f4xo)', () => {
+// mp-f4xo: LeagueMatrix — clickable cross-table cells
+describe('LeagueMatrix (mp-f4xo)', () => {
   const realReact = global.React;
   let runtime;
   let PM;
@@ -671,7 +671,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
     savedIsHikiwake = global.window.isHikiwake;
     global.window.isHikiwake = vi.fn(() => false);
     vi.resetModules();
-    ({ PoolMatrix: PM } = await import('../viewer.jsx'));
+    ({ LeagueMatrix: PM } = await import('../viewer.jsx'));
   });
 
   afterEach(() => {
@@ -717,8 +717,8 @@ describe('PoolMatrix (mp-f4xo)', () => {
   it('renders W/L cells for a completed match', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {} });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
-    const lossCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--loss'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
+    const lossCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--loss'));
     expect(winCell).toBeTruthy();
     expect(lossCell).toBeTruthy();
   });
@@ -727,7 +727,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
     const spy = vi.fn();
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: spy });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
     expect(winCell.props.onClick).toBeTypeOf('function');
     winCell.props.onClick();
     expect(spy).toHaveBeenCalledTimes(1);
@@ -744,7 +744,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
     const spy = vi.fn();
     const tree = runtime.mount(PM, { pool, matches: [pendingMatch], tweaks: {}, onMatchClick: spy });
     const cells = allCells(tree);
-    const pendingCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--pending'));
+    const pendingCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--pending'));
     expect(pendingCell).toBeTruthy();
     pendingCell.props.onClick();
     expect(spy).toHaveBeenCalledTimes(1);
@@ -754,7 +754,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
     const spy = vi.fn();
     const tree = runtime.mount(PM, { pool, matches: [runningMatch], tweaks: {}, onMatchClick: spy });
     const cells = allCells(tree);
-    const liveCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--live'));
+    const liveCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--live'));
     expect(liveCell).toBeTruthy();
     liveCell.props.onClick();
     expect(spy).toHaveBeenCalledTimes(1);
@@ -763,8 +763,8 @@ describe('PoolMatrix (mp-f4xo)', () => {
   it('self-diagonal and empty cells have no onClick', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: vi.fn() });
     const cells = allCells(tree);
-    const selfCells = cells.filter(c => c.props?.className?.includes('pool-matrix__cell--self'));
-    const emptyCells = cells.filter(c => c.props?.className?.includes('pool-matrix__cell--empty'));
+    const selfCells = cells.filter(c => c.props?.className?.includes('league-matrix__cell--self'));
+    const emptyCells = cells.filter(c => c.props?.className?.includes('league-matrix__cell--empty'));
     expect(selfCells.length).toBeGreaterThan(0);
     selfCells.forEach(c => expect(c.props.onClick).toBeUndefined());
     emptyCells.forEach(c => expect(c.props.onClick).toBeUndefined());
@@ -773,7 +773,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
   it('interactive cells have role=button and tabIndex=0 for a11y', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: vi.fn() });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
     expect(winCell.props.role).toBe('button');
     expect(winCell.props.tabIndex).toBe(0);
   });
@@ -781,7 +781,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
   it('interactive cells have aria-label describing the matchup', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: vi.fn() });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
     expect(winCell.props['aria-label']).toContain('Alice');
     expect(winCell.props['aria-label']).toContain('Bob');
     expect(winCell.props['aria-label']).toContain('Win');
@@ -791,7 +791,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
     const spy = vi.fn();
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: spy });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
     const preventDefaultSpy = vi.fn();
     winCell.props.onKeyDown({ key: 'Enter', preventDefault: preventDefaultSpy });
     expect(spy).toHaveBeenCalledTimes(1);
@@ -802,7 +802,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
     const spy = vi.fn();
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {}, onMatchClick: spy });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
     const preventDefaultSpy = vi.fn();
     winCell.props.onKeyDown({ key: ' ', preventDefault: preventDefaultSpy });
     expect(spy).toHaveBeenCalledTimes(1);
@@ -812,7 +812,7 @@ describe('PoolMatrix (mp-f4xo)', () => {
   it('cells are not interactive when onMatchClick is not provided', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {} });
     const cells = allCells(tree);
-    const winCell = cells.find(c => c.props?.className?.includes('pool-matrix__cell--win'));
+    const winCell = cells.find(c => c.props?.className?.includes('league-matrix__cell--win'));
     expect(winCell.props.onClick).toBeUndefined();
     expect(winCell.props.role).toBeUndefined();
   });
@@ -833,13 +833,13 @@ describe('PoolMatrix (mp-f4xo)', () => {
     };
     const tree = runtime.mount(PM, { pool: numberedPool, matches: [completedMatch], tweaks: {} });
     const ths = allHeaders(tree);
-    const colHeaders = ths.filter(h => h.props?.className?.includes('pool-matrix__col-head'));
+    const colHeaders = ths.filter(h => h.props?.className?.includes('league-matrix__col-head'));
     expect(colHeaders.map(h => textContent(h))).toEqual(['A1', 'A2', 'A3']);
 
-    const rowHeads = allCells(tree).filter(c => c.props?.className?.includes('pool-matrix__row-head'));
+    const rowHeads = allCells(tree).filter(c => c.props?.className?.includes('league-matrix__row-head'));
     const rowNums = rowHeads.map(td => {
       const spans = [].concat(td.children || td.props?.children || []);
-      const numSpan = spans.find(s => s?.props?.className?.includes('pool-matrix__num'));
+      const numSpan = spans.find(s => s?.props?.className?.includes('league-matrix__num'));
       return textContent(numSpan);
     });
     expect(rowNums).toEqual(['A1', 'A2', 'A3']);
@@ -848,13 +848,13 @@ describe('PoolMatrix (mp-f4xo)', () => {
   it('omits numbers entirely when player.number is not set', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {} });
     const ths = allHeaders(tree);
-    const colHeaders = ths.filter(h => h.props?.className?.includes('pool-matrix__col-head'));
+    const colHeaders = ths.filter(h => h.props?.className?.includes('league-matrix__col-head'));
     expect(colHeaders.map(h => textContent(h))).toEqual(['', '', '']);
 
-    const rowHeads = allCells(tree).filter(c => c.props?.className?.includes('pool-matrix__row-head'));
+    const rowHeads = allCells(tree).filter(c => c.props?.className?.includes('league-matrix__row-head'));
     const rowNums = rowHeads.map(td => {
       const spans = [].concat(td.children || td.props?.children || []);
-      const numSpan = spans.find(s => s?.props?.className?.includes('pool-matrix__num'));
+      const numSpan = spans.find(s => s?.props?.className?.includes('league-matrix__num'));
       return numSpan;
     });
     expect(rowNums).toEqual([undefined, undefined, undefined]);

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -863,6 +863,65 @@ describe('LeagueMatrix (mp-f4xo)', () => {
     // row N and column N cross-reference the same player.
     expect(rowNums).toEqual(['1', '2', '3']);
   });
+
+  // Regression: two participants share a name but have different dojos/ids.
+  // Name-only cell indexing collapses both into one matchMap entry and shows
+  // the wrong result; id-based keys must keep them distinct. (Copilot #261)
+  it('disambiguates same-name participants by id when mapping cells', () => {
+    const samePool = {
+      poolName: 'Pool A',
+      players: [
+        { id: 'T1', name: 'Tanaka Kenji', dojo: 'Tokyo' },
+        { id: 'T2', name: 'Tanaka Kenji', dojo: 'Osaka' }, // same name, different id
+        { id: 'A1', name: 'Alice', dojo: 'Kyoto' },
+      ],
+    };
+    // T1 beat Alice; T2 lost to Alice. With name-only keys both
+    // "Tanaka Kenji vs Alice" cells resolve to the same (last-registered)
+    // match and show identical results.
+    const mWin = {
+      id: 'Pool A-0', sideA: { id: 'T1', name: 'Tanaka Kenji' }, sideB: { id: 'A1', name: 'Alice' },
+      sideAId: 'T1', sideBId: 'A1', status: 'completed', winner: { id: 'T1', name: 'Tanaka Kenji' },
+      ipponsA: ['M'], ipponsB: [], decision: 'fought',
+    };
+    const mLoss = {
+      id: 'Pool A-1', sideA: { id: 'T2', name: 'Tanaka Kenji' }, sideB: { id: 'A1', name: 'Alice' },
+      sideAId: 'T2', sideBId: 'A1', status: 'completed', winner: { id: 'A1', name: 'Alice' },
+      ipponsA: [], ipponsB: ['K'], decision: 'fought',
+    };
+    const tree = runtime.mount(PM, { pool: samePool, matches: [mWin, mLoss], tweaks: {} });
+    const labels = allCells(tree).map(c => c.props?.['aria-label']).filter(Boolean);
+    // The id-keyed mapping yields BOTH outcomes for the same name vs Alice —
+    // proof the two Tanakas resolved to different matches.
+    expect(labels).toContain('Match: Tanaka Kenji vs Alice — Win');
+    expect(labels).toContain('Match: Tanaka Kenji vs Alice — Loss');
+  });
+
+  // Regression: the head-to-head between two same-name participants. The
+  // winner is stored by name (ambiguous), so rowWon must resolve via
+  // winnerId — otherwise BOTH rows show the same result. (browser-found)
+  it('resolves the winner of a same-name head-to-head by id', () => {
+    const twoTanaka = {
+      poolName: 'Pool A',
+      players: [
+        { id: 'T1', name: 'Tanaka Kenji', dojo: 'Tokyo' },
+        { id: 'T2', name: 'Tanaka Kenji', dojo: 'Osaka' },
+      ],
+    };
+    // T1 beat T2. winner name "Tanaka Kenji" is ambiguous; winnerId 'T1' is not.
+    const headToHead = {
+      id: 'Pool A-0', sideA: { id: 'T1', name: 'Tanaka Kenji' }, sideB: { id: 'T2', name: 'Tanaka Kenji' },
+      sideAId: 'T1', sideBId: 'T2', winnerId: 'T1', status: 'completed',
+      winner: { id: 'T1', name: 'Tanaka Kenji' }, ipponsA: ['M'], ipponsB: [], decision: 'fought',
+    };
+    const tree = runtime.mount(PM, { pool: twoTanaka, matches: [headToHead], tweaks: {} });
+    const bodyCells = allCells(tree).filter(c => c.props?.className?.includes('league-matrix__cell--win') || c.props?.className?.includes('league-matrix__cell--loss'));
+    const wins = bodyCells.filter(c => c.props?.className?.includes('--win'));
+    const losses = bodyCells.filter(c => c.props?.className?.includes('--loss'));
+    // Exactly one win (T1's row) and one loss (T2's row) — NOT two wins.
+    expect(wins).toHaveLength(1);
+    expect(losses).toHaveLength(1);
+  });
 });
 
 // mp-7x4n: ViewerOverview opens MatchViewerModal in self-run mode,

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -845,19 +845,23 @@ describe('LeagueMatrix (mp-f4xo)', () => {
     expect(rowNums).toEqual(['A1', 'A2', 'A3']);
   });
 
-  it('omits numbers entirely when player.number is not set', () => {
+  it('falls back to draw-order index when player.number is not set', () => {
     const tree = runtime.mount(PM, { pool, matches: [completedMatch], tweaks: {} });
     const ths = allHeaders(tree);
     const colHeaders = ths.filter(h => h.props?.className?.includes('league-matrix__col-head'));
-    expect(colHeaders.map(h => textContent(h))).toEqual(['', '', '']);
+    // Column headers always show a visible label — the 1-based draw-order
+    // position index when the player has no assigned number.
+    expect(colHeaders.map(h => textContent(h))).toEqual(['1', '2', '3']);
 
     const rowHeads = allCells(tree).filter(c => c.props?.className?.includes('league-matrix__row-head'));
     const rowNums = rowHeads.map(td => {
       const spans = [].concat(td.children || td.props?.children || []);
       const numSpan = spans.find(s => s?.props?.className?.includes('league-matrix__num'));
-      return numSpan;
+      return textContent(numSpan);
     });
-    expect(rowNums).toEqual([undefined, undefined, undefined]);
+    // The number span is now always rendered, mirroring the column index so
+    // row N and column N cross-reference the same player.
+    expect(rowNums).toEqual(['1', '2', '3']);
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -892,9 +892,11 @@ describe('LeagueMatrix (mp-f4xo)', () => {
     const tree = runtime.mount(PM, { pool: samePool, matches: [mWin, mLoss], tweaks: {} });
     const labels = allCells(tree).map(c => c.props?.['aria-label']).filter(Boolean);
     // The id-keyed mapping yields BOTH outcomes for the same name vs Alice —
-    // proof the two Tanakas resolved to different matches.
-    expect(labels).toContain('Match: Tanaka Kenji vs Alice — Win');
-    expect(labels).toContain('Match: Tanaka Kenji vs Alice — Loss');
+    // proof the two Tanakas resolved to different matches. The aria-label also
+    // carries the disambiguating dojo (a11y: screen readers can't rely on the
+    // hover title), so the two Tanakas are distinguishable in the label itself.
+    expect(labels).toContain('Match: Tanaka Kenji (Tokyo) vs Alice (Kyoto) — Win');
+    expect(labels).toContain('Match: Tanaka Kenji (Osaka) vs Alice (Kyoto) — Loss');
   });
 
   // Regression: the head-to-head between two same-name participants. The

--- a/web-mobile/js/__tests__/viewer_league_overview.test.jsx
+++ b/web-mobile/js/__tests__/viewer_league_overview.test.jsx
@@ -156,6 +156,39 @@ describe('ViewerOverview league standings (mp-ldnr)', () => {
     expect(text).not.toContain('Final standings');
   });
 
+  // mp-jvzy: the "#" column must render the backend's authoritative
+  // PlayerStanding.rank (which folds in tiebreakers + manual overrides),
+  // NOT the array index. Pass ranks that deliberately differ from index+1
+  // and assert the rendered cells follow s.rank — locking the DRY contract.
+  it('league "#" column shows authoritative s.rank, not the row index', () => {
+    const standings = { League: [
+      { player: { id: 'a', name: 'Player A', dojo: '' }, wins: 3, losses: 0, draws: 0, ipponsGiven: 6, ipponsTaken: 0, rank: 10 },
+      { player: { id: 'b', name: 'Player B', dojo: '' }, wins: 2, losses: 1, draws: 0, ipponsGiven: 4, ipponsTaken: 2, rank: 20 },
+      { player: { id: 'c', name: 'Player C', dojo: '' }, wins: 1, losses: 2, draws: 0, ipponsGiven: 2, ipponsTaken: 4, rank: 30 },
+    ] };
+    const tree = runtime.mount(ViewerOverview, {
+      ...baseProps,
+      c: leagueComp('pools'),
+      standings,
+      pools,
+      poolMatches: mixedMatches(1, 2),
+    });
+    const container = findInTree(tree, n => n?.props?.['data-testid'] === 'league-overview-standings');
+    expect(container).not.toBeNull();
+    const rankCells = [];
+    (function walk(node) {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) { node.forEach(walk); return; }
+      if (node.type === 'tr') {
+        const kids = [].concat(node.props?.children || []).filter(Boolean);
+        const firstTd = kids.find(k => k && k.type === 'td');
+        if (firstTd) rankCells.push(collectText(firstTd));
+      }
+      walk(node.props?.children ?? node.children);
+    })(container);
+    expect(rankCells).toEqual(['10', '20', '30']); // s.rank, never 1/2/3
+  });
+
   it('completed league shows winner badge and final standings', () => {
     const standings = { League: makeStandings(4) };
     const tree = runtime.mount(ViewerOverview, {

--- a/web-mobile/js/api_serializers.jsx
+++ b/web-mobile/js/api_serializers.jsx
@@ -52,6 +52,24 @@ function toBackendMatchResult(patch, match) {
         decision: isHikiwake(score.type) ? "hikiwake" : "",
         status: toBackendStatus(patch.status || "scheduled"),
     };
+    // Carry the winner's participant id so a SAME-NAME head-to-head (the winner
+    // NAME matches both sides) is unambiguous on the backend. Without it, when
+    // the scoreline is tied (e.g. a hantei decision — equal ippon counts) the
+    // backend can't infer the winning side and leaves WinnerID empty, and the
+    // league matrix then marks BOTH same-name rows as winners. The scoring modal
+    // sets patch.winner to the winning SIDE object (m.sideA/m.sideB), so its id
+    // is available directly; fall back to deriving it from the match sides by
+    // name only when the names are distinct (unambiguous).
+    let winnerId = "";
+    if (patch.winner && typeof patch.winner === "object" && patch.winner.id) {
+        winnerId = patch.winner.id;
+    } else if (winnerName) {
+        const aId = (typeof match?.sideA === "object" ? match.sideA.id : null);
+        const bId = (typeof match?.sideB === "object" ? match.sideB.id : null);
+        if (winnerName === sideAName && winnerName !== sideBName) winnerId = aId || "";
+        else if (winnerName === sideBName && winnerName !== sideAName) winnerId = bId || "";
+    }
+    if (winnerId) result.winnerId = winnerId;
     if (patch.subResults) {
         result.subResults = patch.subResults;
     }
@@ -90,8 +108,16 @@ function normalizeMatch(m, playerMap) {
     // playerMap entry before stamping the id so the shared map object isn't
     // mutated across matches.
     const resolveSide = (name, flatId) => {
-        const p = playerMap?.[name];
-        const base = p ? { ...p } : { id: name, name };
+        // Prefer the id-keyed entry: it carries the CORRECT dojo/number even for
+        // same-name participants. The name-keyed entry collapses same-name
+        // players onto one identity, so only trust it when its id matches the
+        // server's flat id — otherwise we'd attach the wrong dojo to this side.
+        let p = flatId ? playerMap?.[flatId] : null;
+        if (!p) {
+            const byName = playerMap?.[name];
+            if (byName && (!flatId || byName.id === flatId)) p = byName;
+        }
+        const base = p ? { ...p } : { id: flatId || name, name };
         if (flatId) base.id = flatId;
         return base;
     };
@@ -157,12 +183,13 @@ function buildPlayerMap(comp) {
     const map = {};
     const add = (p) => {
         const norm = normalizePlayer(p);
+        if (!norm.name) return;
         // Carry the FULL competitor identity so bracket/match sides resolved by
         // name (e.g. a pool finisher seeded into the knockout) show the same
         // details — dojo, zekken display name, and assigned number (e.g. "K1") —
         // as the pool/schedule cards. Previously only {id,name,dojo,seed} were
         // carried, so a qualifier lost their number and zekken in the bracket.
-        if (norm.name) map[norm.name] = {
+        const entry = {
             id: norm.id || norm.name,
             name: norm.name,
             dojo: norm.dojo || "",
@@ -172,6 +199,14 @@ function buildPlayerMap(comp) {
             tag: norm.tag || "",
             danGrade: norm.danGrade || "",
         };
+        map[norm.name] = entry;
+        // ALSO key by participant id. The name key collapses same-name
+        // participants (two "Tanaka Kenji" from different dojos) onto whichever
+        // was added last, so a name-only lookup can attach the WRONG dojo/number
+        // to a side. A distinct id key preserves each one's correct metadata,
+        // letting normalizeMatch resolve by the server's authoritative side id.
+        // (UUID id keys never collide with display-name keys.)
+        if (norm.id) map[norm.id] = entry;
     };
     if (comp?.config?.players) comp.config.players.forEach(add);
     if (comp?.players) comp.players.forEach(add);

--- a/web-mobile/js/api_serializers.jsx
+++ b/web-mobile/js/api_serializers.jsx
@@ -79,23 +79,34 @@ function toBackendMatchResult(patch, match) {
 function normalizeMatch(m, playerMap) {
     if (!m) return m;
     const norm = { ...m };
-    // Normalize sideA/sideB from string to {id, name}
+    // Normalize sideA/sideB/winner from name-string to {id, name}.
+    //
+    // playerMap is keyed by NAME, which collapses same-name participants
+    // (e.g. two "Tanaka Kenji" from different dojos — the duplicate check
+    // only rejects same-name AND same-dojo) onto a single id. When the
+    // server provides an explicit per-side id (m.sideAId / m.sideBId /
+    // m.winnerId — populated from pool-matches.csv), it is the authoritative
+    // identity and overrides the name-collapsed lookup. We clone the
+    // playerMap entry before stamping the id so the shared map object isn't
+    // mutated across matches.
+    const resolveSide = (name, flatId) => {
+        const p = playerMap?.[name];
+        const base = p ? { ...p } : { id: name, name };
+        if (flatId) base.id = flatId;
+        return base;
+    };
     if (typeof norm.sideA === "string" && norm.sideA) {
-        const p = playerMap?.[norm.sideA];
-        norm.sideA = p || { id: norm.sideA, name: norm.sideA };
+        norm.sideA = resolveSide(norm.sideA, m.sideAId);
     } else if (!norm.sideA) {
         norm.sideA = { id: "", name: "" };
     }
     if (typeof norm.sideB === "string" && norm.sideB) {
-        const p = playerMap?.[norm.sideB];
-        norm.sideB = p || { id: norm.sideB, name: norm.sideB };
+        norm.sideB = resolveSide(norm.sideB, m.sideBId);
     } else if (!norm.sideB) {
         norm.sideB = { id: "", name: "" };
     }
-    // Normalize winner from string to object
     if (typeof norm.winner === "string" && norm.winner) {
-        const p = playerMap?.[norm.winner];
-        norm.winner = p || { id: norm.winner, name: norm.winner };
+        norm.winner = resolveSide(norm.winner, m.winnerId);
     }
     // Build score object from flat scoreA/scoreB if needed (bracket matches)
     if (!norm.score && (norm.scoreA || norm.scoreB) && norm.status === "completed") {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2258,6 +2258,11 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
   const handleCellKeyDown = (e, m) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleCellClick(m); } };
 
   const cellLabel = (rowPlayer, colPlayer, result) => `Match: ${rowPlayer.name} vs ${colPlayer.name} — ${result}`;
+  // Hover-tooltip label. Always include the dojo when present so two
+  // same-name participants are distinguishable on hover (the visible grid
+  // only shows the shared name). Hover-only, so the extra text is free.
+  const playerLabel = (p) => (p && p.dojo ? `${p.name} (${p.dojo})` : (p && p.name) || "");
+  const cellTitle = (rowPlayer, colPlayer, result) => `${playerLabel(rowPlayer)} vs ${playerLabel(colPlayer)} — ${result}`;
 
   return (
     <div className="league-matrix-wrap">
@@ -2266,14 +2271,14 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
           <tr>
             <th className="league-matrix__corner"></th>
             {players.map((p, i) => (
-              <th key={`${pkey(p)}#${i}`} scope="col" aria-label={p.name} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={isLeague ? (tweaks.showDojo ? p.name : shortName(p)) : p.name}>{p.number || (i + 1)}</th>
+              <th key={`${pkey(p)}#${i}`} scope="col" aria-label={p.name} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={playerLabel(p)}>{p.number || (i + 1)}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {players.map((rowPlayer, ri) => (
             <tr key={`${pkey(rowPlayer)}#${ri}`} className={isHighlighted(rowPlayer) ? "league-matrix__row--me" : ""}>
-              <td className="league-matrix__row-head" title={rowPlayer.name}>
+              <td className="league-matrix__row-head" title={playerLabel(rowPlayer)}>
                 <span className="league-matrix__num">{rowPlayer.number || (ri + 1)}</span>
                 <span className="league-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
               </td>
@@ -2283,7 +2288,7 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 // Look up the match by id-pair first (collision-free),
                 // then by name-pair for legacy/un-migrated data.
                 const m = matchMap[`${pkey(rowPlayer)}||${pkey(colPlayer)}`] || matchMap[`${rowPlayer.name}||${colPlayer.name}`];
-                if (!m) return <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell league-matrix__cell--empty${colMe}`}></td>;
+                if (!m) return <td key={`${pkey(colPlayer)}#${ci}`} title={cellTitle(rowPlayer, colPlayer, "not played")} className={`league-matrix__cell league-matrix__cell--empty${colMe}`}></td>;
 
                 const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
                 const winnerName = typeof m.winner === "object" ? m.winner?.name : m.winner;
@@ -2301,7 +2306,7 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 } : {};
 
                 if (m.status !== "completed") {
-                  return <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell league-matrix__cell--pending ${m.status === "running" ? "league-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
+                  return <td key={`${pkey(colPlayer)}#${ci}`} title={cellTitle(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} className={`league-matrix__cell league-matrix__cell--pending ${m.status === "running" ? "league-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
                     {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>●</span> : "–"}
                   </td>;
                 }
@@ -2332,7 +2337,7 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 }
 
                 return (
-                  <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell ${rowWon ? "league-matrix__cell--win" : isDraw ? "league-matrix__cell--draw" : "league-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
+                  <td key={`${pkey(colPlayer)}#${ci}`} title={cellTitle(rowPlayer, colPlayer, resultLabel)} className={`league-matrix__cell ${rowWon ? "league-matrix__cell--win" : isDraw ? "league-matrix__cell--draw" : "league-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
                     {cellContent}
                   </td>
                 );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2214,13 +2214,34 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
   if (players.length < 2) return null;
 
   const isHighlighted = (p) => isFollowedPlayer(p, highlightPlayer);
+
+  // Stable participant key. A name is NOT unique within a competition —
+  // two participants from different dojos may share one (the duplicate
+  // check only rejects same-name AND same-dojo), so name-only indexing
+  // collides and can show the wrong cell. Prefer the participant UUID,
+  // falling back to name for legacy data that predates id persistence.
+  const pkey = (x) => (x && x.id != null && x.id !== "" ? String(x.id) : (x && x.name) || "");
+  const sideId = (m, side) => (side === "a" ? m.sideAId : m.sideBId) || "";
+
+  // Index every match under BOTH its id-pair and its name-pair. The id
+  // entries are collision-free and used first; the name entries are a
+  // fallback for partially-migrated data (players carry ids but an older
+  // pool-matches.csv does not, or vice versa). Same-name collisions only
+  // affect the name fallback, which is the pre-existing behavior.
   const matchMap = {};
   matches.forEach(m => {
     const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
     const bName = typeof m.sideB === "object" ? m.sideB?.name : m.sideB;
+    const aKey = sideId(m, "a") || aName;
+    const bKey = sideId(m, "b") || bName;
+    if (aKey && bKey) {
+      matchMap[`${aKey}||${bKey}`] = m;
+      matchMap[`${bKey}||${aKey}`] = m;
+    }
     if (aName && bName) {
-      matchMap[`${aName}||${bName}`] = m;
-      matchMap[`${bName}||${aName}`] = m;
+      // Name fallback (does not clobber an existing id entry).
+      if (!matchMap[`${aName}||${bName}`]) matchMap[`${aName}||${bName}`] = m;
+      if (!matchMap[`${bName}||${aName}`]) matchMap[`${bName}||${aName}`] = m;
     }
   });
 
@@ -2245,26 +2266,32 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
           <tr>
             <th className="league-matrix__corner"></th>
             {players.map((p, i) => (
-              <th key={p.name} scope="col" aria-label={p.name} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={isLeague ? (tweaks.showDojo ? p.name : shortName(p)) : p.name}>{p.number || (i + 1)}</th>
+              <th key={`${pkey(p)}#${i}`} scope="col" aria-label={p.name} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={isLeague ? (tweaks.showDojo ? p.name : shortName(p)) : p.name}>{p.number || (i + 1)}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {players.map((rowPlayer, ri) => (
-            <tr key={rowPlayer.name} className={isHighlighted(rowPlayer) ? "league-matrix__row--me" : ""}>
+            <tr key={`${pkey(rowPlayer)}#${ri}`} className={isHighlighted(rowPlayer) ? "league-matrix__row--me" : ""}>
               <td className="league-matrix__row-head" title={rowPlayer.name}>
                 <span className="league-matrix__num">{rowPlayer.number || (ri + 1)}</span>
                 <span className="league-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
               </td>
               {players.map((colPlayer, ci) => {
                 const colMe = isHighlighted(colPlayer) ? " league-matrix__col--me" : "";
-                if (ri === ci) return <td key={colPlayer.name} className={`league-matrix__cell league-matrix__cell--self${colMe}`}>&mdash;</td>;
-                const m = matchMap[`${rowPlayer.name}||${colPlayer.name}`];
-                if (!m) return <td key={colPlayer.name} className={`league-matrix__cell league-matrix__cell--empty${colMe}`}></td>;
+                if (ri === ci) return <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell league-matrix__cell--self${colMe}`}>&mdash;</td>;
+                // Look up the match by id-pair first (collision-free),
+                // then by name-pair for legacy/un-migrated data.
+                const m = matchMap[`${pkey(rowPlayer)}||${pkey(colPlayer)}`] || matchMap[`${rowPlayer.name}||${colPlayer.name}`];
+                if (!m) return <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell league-matrix__cell--empty${colMe}`}></td>;
 
                 const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
                 const winnerName = typeof m.winner === "object" ? m.winner?.name : m.winner;
-                const rowIsAka = aName === rowPlayer.name;
+                // Which side is the row player? Match on id when both the
+                // match side and the player carry one; else by name.
+                const rowIsAka = (sideId(m, "a") && rowPlayer.id)
+                  ? sideId(m, "a") === rowPlayer.id
+                  : aName === rowPlayer.name;
 
                 const interactiveProps = onMatchClick ? {
                   role: "button",
@@ -2274,7 +2301,7 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 } : {};
 
                 if (m.status !== "completed") {
-                  return <td key={colPlayer.name} className={`league-matrix__cell league-matrix__cell--pending ${m.status === "running" ? "league-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
+                  return <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell league-matrix__cell--pending ${m.status === "running" ? "league-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
                     {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>●</span> : "–"}
                   </td>;
                 }
@@ -2282,7 +2309,13 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 const ipponsA = (m.ipponsA || []).filter(x => x && x !== "•");
                 const ipponsB = (m.ipponsB || []).filter(x => x && x !== "•");
                 const rowIppons = rowIsAka ? ipponsA : ipponsB;
-                const rowWon = winnerName && winnerName === rowPlayer.name;
+                // Prefer the winner id: when two participants share a name,
+                // the winner name alone can't tell them apart (e.g. the
+                // head-to-head between two same-name/different-dojo players).
+                // Fall back to name for legacy data without a winner id.
+                const rowWon = (m.winnerId && rowPlayer.id)
+                  ? m.winnerId === rowPlayer.id
+                  : (winnerName && winnerName === rowPlayer.name);
                 const isDraw = window.isHikiwake(m.decision) || window.isHikiwake(m.score?.type);
 
                 let cellContent;
@@ -2299,7 +2332,7 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 }
 
                 return (
-                  <td key={colPlayer.name} className={`league-matrix__cell ${rowWon ? "league-matrix__cell--win" : isDraw ? "league-matrix__cell--draw" : "league-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
+                  <td key={`${pkey(colPlayer)}#${ci}`} className={`league-matrix__cell ${rowWon ? "league-matrix__cell--win" : isDraw ? "league-matrix__cell--draw" : "league-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
                     {cellContent}
                   </td>
                 );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1535,7 +1535,9 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
           <tbody>
             {standings.length > 0 ? standings.map((s, i) => (
               <tr key={s.player?.id || s.player?.name || i}>
-                <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{i + 1}{s.isOverridden ? "*" : ""}</td>
+                {/* Rank-ordered: "#" is the authoritative standing rank (s.rank),
+                    DRY with the backend tiebreak/override logic, not the row index. */}
+                <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{s.rank || i + 1}{s.isOverridden ? "*" : ""}</td>
                 <td>
                   <div style={{ fontWeight: 500 }}>{s.player?.name || ""}</div>
                   {tweaks?.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</div> : null}
@@ -1996,7 +1998,10 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
             <tbody>
               {leagueStandings.slice(0, 5).map((s, i) => (
                 <tr key={s.player?.id || s.player?.name || i}>
-                  <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{i + 1}{s.isOverridden ? "*" : ""}</td>
+                  {/* Rank-ordered summary: "#" is the authoritative standing rank
+                      (s.rank), not the row index — DRY with the full standings and
+                      the backend tiebreak/override logic. */}
+                  <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{s.rank || i + 1}{s.isOverridden ? "*" : ""}</td>
                   <td>
                     <div style={{ fontWeight: 500 }}>
                       {s.player?.number ? <span className="num-prefix">{s.player.number}</span> : null}
@@ -2284,14 +2289,14 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) 
           <tr>
             <th className="league-matrix__corner"></th>
             {players.map((p, i) => (
-              <th key={`${pkey(p)}#${i}`} scope="col" aria-label={p.name} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={playerLabel(p)}>{p.number || (i + 1)}</th>
+              <th key={`${pkey(p)}#${i}`} scope="col" aria-label={playerLabel(p)} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={playerLabel(p)}>{p.number || (i + 1)}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {players.map((rowPlayer, ri) => (
             <tr key={`${pkey(rowPlayer)}#${ri}`} className={isHighlighted(rowPlayer) ? "league-matrix__row--me" : ""}>
-              <td className="league-matrix__row-head" title={playerLabel(rowPlayer)}>
+              <td className="league-matrix__row-head" title={playerLabel(rowPlayer)} aria-label={playerLabel(rowPlayer)}>
                 <span className="league-matrix__num">{rowPlayer.number || (ri + 1)}</span>
                 <span className="league-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
               </td>
@@ -2457,15 +2462,19 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
         }) : [];
 
         // Build playerKey→{rank, standingEntry} map from the rank-sorted standings array.
-        // Rank is 1-based (index + 1). Used to look up each draw-position row's rank
-        // without resorting the table (mp-938b: table is draw-order, not rank-order).
+        // Rank is the backend's authoritative PlayerStanding.rank (single source of
+        // truth — it already folds in tiebreakers and manual rank overrides; see
+        // engine/scoring.go). We do NOT re-derive it as index+1 here (DRY), falling
+        // back to index+1 only if a legacy payload omitted the field.
+        // Used to look up each draw-position row's rank without resorting the table
+        // (mp-938b: table is draw-order, not rank-order).
         // Key = player.id when available; falls back to "name||dojo" composite so that
         // duplicate names across different dojos don't collide — mirrors the lookup below.
         const rankByPlayerKey = new Map();
         if (poolStandings) {
           poolStandings.forEach((s, i) => {
             const key = s.player.id || `${s.player.name}||${s.player.dojo || ""}`;
-            rankByPlayerKey.set(key, { rank: i + 1, standing: s });
+            rankByPlayerKey.set(key, { rank: s.rank || i + 1, standing: s });
           });
         }
 
@@ -2516,7 +2525,19 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
 
                   return (
                     <tr key={p.id || `${p.name}||${p.dojo || ""}` || drawPos} className={rowClasses || undefined}>
-                      <td className="pool-standings__draw-pos" style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{drawPos}</td>
+                      {/* The "#" column means different things by format, and that is
+                          intentional and explicit:
+                          - League: the table is ordered by rank, so "#" shows the
+                            authoritative standing rank (s.rank). No separate rank
+                            badge — rank is shown exactly once here.
+                          - Pools: the table is in DRAW order (operators read it as a
+                            fight-order chart), so "#" is the draw position and the
+                            rank is surfaced separately by the badge next to the name. */}
+                      {isLeague ? (
+                        <td className="pool-standings__draw-pos" style={{ color: (s && s.isOverridden) ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: (s && s.isOverridden) ? 700 : 400 }}>{rank ?? drawPos}{s && s.isOverridden ? "*" : ""}</td>
+                      ) : (
+                        <td className="pool-standings__draw-pos" style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{drawPos}</td>
+                      )}
                       <td>
                         <div style={{ fontWeight: 500 }}>
                           {p.number ? <span className="num-prefix">{p.number}</span> : null}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1552,7 +1552,7 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
           </tbody>
         </table>
         {standings.length > 0 && (
-          <div className="pool-matrix__legend" style={{ marginTop: 8, fontSize: 11, color: "var(--ink-3)" }}>
+          <div className="league-matrix__legend" style={{ marginTop: 8, fontSize: 11, color: "var(--ink-3)" }}>
             Ranked by: wins → points scored (PW) → head-to-head.
           </div>
         )}
@@ -2207,9 +2207,9 @@ const PoolMatchRow = React.memo(({ m, onClick }) => {
 });
 PoolMatchRow.displayName = "PoolMatchRow";
 
-// Round-robin matrix for a single pool. Each off-diagonal cell shows the row
-// player's result (W/L/X) against the column player; diagonal cells are self.
-function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
+// Round-robin matrix for a single pool/league. Each off-diagonal cell shows the
+// row player's result (W/L/X) against the column player; diagonal cells are self.
+function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, isLeague }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
 
@@ -2239,28 +2239,28 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
   const cellLabel = (rowPlayer, colPlayer, result) => `Match: ${rowPlayer.name} vs ${colPlayer.name} — ${result}`;
 
   return (
-    <div className="pool-matrix-wrap">
-      <table className="pool-matrix">
+    <div className="league-matrix-wrap">
+      <table className="league-matrix">
         <thead>
           <tr>
-            <th className="pool-matrix__corner"></th>
-            {players.map((p) => (
-              <th key={p.name} scope="col" aria-label={p.name} className={`pool-matrix__col-head${isHighlighted(p) ? " pool-matrix__col--me" : ""}`} title={p.name}>{p.number || ""}</th>
+            <th className="league-matrix__corner"></th>
+            {players.map((p, i) => (
+              <th key={p.name} scope="col" aria-label={p.name} className={`league-matrix__col-head${isHighlighted(p) ? " league-matrix__col--me" : ""}`} title={isLeague ? (tweaks.showDojo ? p.name : shortName(p)) : p.name}>{p.number || (i + 1)}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {players.map((rowPlayer, ri) => (
-            <tr key={rowPlayer.name} className={isHighlighted(rowPlayer) ? "pool-matrix__row--me" : ""}>
-              <td className="pool-matrix__row-head" title={rowPlayer.name}>
-                {rowPlayer.number ? <span className="pool-matrix__num">{rowPlayer.number}</span> : null}
-                <span className="pool-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
+            <tr key={rowPlayer.name} className={isHighlighted(rowPlayer) ? "league-matrix__row--me" : ""}>
+              <td className="league-matrix__row-head" title={rowPlayer.name}>
+                <span className="league-matrix__num">{rowPlayer.number || (ri + 1)}</span>
+                <span className="league-matrix__pname">{tweaks.showDojo ? rowPlayer.name : shortName(rowPlayer)}</span>
               </td>
               {players.map((colPlayer, ci) => {
-                const colMe = isHighlighted(colPlayer) ? " pool-matrix__col--me" : "";
-                if (ri === ci) return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--self${colMe}`}>&mdash;</td>;
+                const colMe = isHighlighted(colPlayer) ? " league-matrix__col--me" : "";
+                if (ri === ci) return <td key={colPlayer.name} className={`league-matrix__cell league-matrix__cell--self${colMe}`}>&mdash;</td>;
                 const m = matchMap[`${rowPlayer.name}||${colPlayer.name}`];
-                if (!m) return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--empty${colMe}`}></td>;
+                if (!m) return <td key={colPlayer.name} className={`league-matrix__cell league-matrix__cell--empty${colMe}`}></td>;
 
                 const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
                 const winnerName = typeof m.winner === "object" ? m.winner?.name : m.winner;
@@ -2274,7 +2274,7 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
                 } : {};
 
                 if (m.status !== "completed") {
-                  return <td key={colPlayer.name} className={`pool-matrix__cell pool-matrix__cell--pending ${m.status === "running" ? "pool-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
+                  return <td key={colPlayer.name} className={`league-matrix__cell league-matrix__cell--pending ${m.status === "running" ? "league-matrix__cell--live" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Live" : "Pending")} {...interactiveProps}>
                     {m.status === "running" ? <span className="bc-live" style={{ fontSize: 9 }}>●</span> : "–"}
                   </td>;
                 }
@@ -2288,18 +2288,18 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
                 let cellContent;
                 let resultLabel;
                 if (isDraw) {
-                  cellContent = <span className="pool-matrix__draw">X</span>;
+                  cellContent = <span className="league-matrix__draw">X</span>;
                   resultLabel = "Draw";
                 } else if (rowWon) {
-                  cellContent = <span className="pool-matrix__win">{rowIppons.join("") || "W"}</span>;
+                  cellContent = <span className="league-matrix__win">{rowIppons.join("") || "W"}</span>;
                   resultLabel = "Win";
                 } else {
-                  cellContent = <span className="pool-matrix__loss">{rowIppons.join("") || "L"}</span>;
+                  cellContent = <span className="league-matrix__loss">{rowIppons.join("") || "L"}</span>;
                   resultLabel = "Loss";
                 }
 
                 return (
-                  <td key={colPlayer.name} className={`pool-matrix__cell ${rowWon ? "pool-matrix__cell--win" : isDraw ? "pool-matrix__cell--draw" : "pool-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
+                  <td key={colPlayer.name} className={`league-matrix__cell ${rowWon ? "league-matrix__cell--win" : isDraw ? "league-matrix__cell--draw" : "league-matrix__cell--loss"}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, resultLabel)} {...interactiveProps}>
                     {cellContent}
                   </td>
                 );
@@ -2308,10 +2308,10 @@ function PoolMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
           ))}
         </tbody>
       </table>
-      <div className="pool-matrix__legend">
-        <span className="pool-matrix__legend-item pool-matrix__legend-item--win">W = win</span>
-        <span className="pool-matrix__legend-item pool-matrix__legend-item--loss">L = loss</span>
-        <span className="pool-matrix__legend-item pool-matrix__legend-item--draw">X = draw</span>
+      <div className="league-matrix__legend">
+        <span className="league-matrix__legend-item league-matrix__legend-item--win">W = win</span>
+        <span className="league-matrix__legend-item league-matrix__legend-item--loss">L = loss</span>
+        <span className="league-matrix__legend-item league-matrix__legend-item--draw">X = draw</span>
         <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row player's result vs column player"}</span>
       </div>
     </div>
@@ -2526,7 +2526,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
             {/* Round-robin matrix — optional grid below the match list (individual only) */}
             {matches.length > 0 && !isTeam && (
               <div style={{ marginTop: 4 }}>
-                <PoolMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayer={highlightPlayer} />
+                <LeagueMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayer={highlightPlayer} isLeague={isLeague} />
               </div>
             )}
           </div>
@@ -2666,7 +2666,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, PoolMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, LeagueMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2235,10 +2235,10 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) 
   // collides and can show the wrong cell. Prefer the participant UUID,
   // falling back to name for legacy data that predates id persistence.
   const pkey = (x) => (x && x.id != null && x.id !== "" ? String(x.id) : (x && x.name) || "");
-  // Pull side/winner ids tolerant of BOTH the canonical object shape
-  // (`m.sideA.id` / `m.winner.id` from api_serializers.jsx) and the flat
-  // shape (`m.sideAId` / `m.winnerId`) some fixtures/CSV round-trips use.
-  const sideId = (m, side) => { const [aId, bId] = matchParticipantIds(m); return side === "a" ? aId : bId; };
+  // Winner id tolerant of BOTH the canonical object shape (`m.winner.id`
+  // from api_serializers.jsx) and the flat `m.winnerId` shape some
+  // fixtures/CSV round-trips use. (Side ids come from the shared
+  // matchParticipantIds helper; names from matchParticipantNames.)
   const winnerId = (m) => (m.winner && typeof m.winner === "object" ? m.winner.id : null) || m.winnerId || "";
 
   // Index every match under BOTH its id-pair and its name-pair. The id
@@ -2248,10 +2248,10 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) 
   // affect the name fallback, which is the pre-existing behavior.
   const matchMap = {};
   matches.forEach(m => {
-    const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
-    const bName = typeof m.sideB === "object" ? m.sideB?.name : m.sideB;
-    const aKey = sideId(m, "a") || aName;
-    const bKey = sideId(m, "b") || bName;
+    const [aName, bName] = matchParticipantNames(m);
+    const [aId, bId] = matchParticipantIds(m);
+    const aKey = aId || aName;
+    const bKey = bId || bName;
     if (aKey && bKey) {
       matchMap[`${aKey}||${bKey}`] = m;
       matchMap[`${bKey}||${aKey}`] = m;
@@ -2308,12 +2308,13 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) 
                 const m = matchMap[`${pkey(rowPlayer)}||${pkey(colPlayer)}`] || matchMap[`${rowPlayer.name}||${colPlayer.name}`];
                 if (!m) return <td key={`${pkey(colPlayer)}#${ci}`} title={cellTitle(rowPlayer, colPlayer, "not played")} className={`league-matrix__cell league-matrix__cell--empty${colMe}`}></td>;
 
-                const aName = typeof m.sideA === "object" ? m.sideA?.name : m.sideA;
+                const [aName] = matchParticipantNames(m);
+                const [aId] = matchParticipantIds(m);
                 const winnerName = typeof m.winner === "object" ? m.winner?.name : m.winner;
                 // Which side is the row player? Match on id when both the
                 // match side and the player carry one; else by name.
-                const rowIsAka = (sideId(m, "a") && rowPlayer.id)
-                  ? sideId(m, "a") === rowPlayer.id
+                const rowIsAka = (aId && rowPlayer.id)
+                  ? aId === rowPlayer.id
                   : aName === rowPlayer.name;
 
                 const interactiveProps = onMatchClick ? {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1704,7 +1704,12 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             <div className="viewer__title">{c.name}</div>
             <div className="viewer__sub">{competitionKindLabel(c)}</div>
           </div>
-          <StatusBadge status={c.status} showLiveDot format={c.format} />
+          {/* Suppress the "League" badge during pools: the active tab already
+              reads "League", so the badge is pure redundancy. Other statuses
+              (Playoffs / Completed) still carry information, so keep those. */}
+          {!(c.status === "pools" && c.format === "league") && (
+            <StatusBadge status={c.status} showLiveDot format={c.format} />
+          )}
           {authed && onEditCompetition && (
             <button className="viewer__admin-pill" onClick={() => onEditCompetition(c.id)}>✎ Edit</button>
           )}
@@ -1996,6 +2001,9 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
                     <div style={{ fontWeight: 500 }}>
                       {s.player?.number ? <span className="num-prefix">{s.player.number}</span> : null}
                       {s.player?.name || ""}
+                      {/* Rank badge for parity with the full League standings table.
+                          This summary is already rank-sorted, so rank === i + 1. */}
+                      <span className="rank-badge">{rankOrdinal(i + 1)}{s.isOverridden ? "*" : ""}</span>
                     </div>
                     {tweaks?.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</div> : null}
                   </td>
@@ -2209,7 +2217,7 @@ PoolMatchRow.displayName = "PoolMatchRow";
 
 // Round-robin matrix for a single pool/league. Each off-diagonal cell shows the
 // row player's result (W/L/X) against the column player; diagonal cells are self.
-function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, isLeague }) {
+function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
 
@@ -2221,7 +2229,11 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
   // collides and can show the wrong cell. Prefer the participant UUID,
   // falling back to name for legacy data that predates id persistence.
   const pkey = (x) => (x && x.id != null && x.id !== "" ? String(x.id) : (x && x.name) || "");
-  const sideId = (m, side) => (side === "a" ? m.sideAId : m.sideBId) || "";
+  // Pull side/winner ids tolerant of BOTH the canonical object shape
+  // (`m.sideA.id` / `m.winner.id` from api_serializers.jsx) and the flat
+  // shape (`m.sideAId` / `m.winnerId`) some fixtures/CSV round-trips use.
+  const sideId = (m, side) => { const [aId, bId] = matchParticipantIds(m); return side === "a" ? aId : bId; };
+  const winnerId = (m) => (m.winner && typeof m.winner === "object" ? m.winner.id : null) || m.winnerId || "";
 
   // Index every match under BOTH its id-pair and its name-pair. The id
   // entries are collision-free and used first; the name entries are a
@@ -2318,8 +2330,9 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                 // the winner name alone can't tell them apart (e.g. the
                 // head-to-head between two same-name/different-dojo players).
                 // Fall back to name for legacy data without a winner id.
-                const rowWon = (m.winnerId && rowPlayer.id)
-                  ? m.winnerId === rowPlayer.id
+                const wId = winnerId(m);
+                const rowWon = (wId && rowPlayer.id)
+                  ? wId === rowPlayer.id
                   : (winnerName && winnerName === rowPlayer.name);
                 const isDraw = window.isHikiwake(m.decision) || window.isHikiwake(m.score?.type);
 
@@ -2329,10 +2342,15 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
                   cellContent = <span className="league-matrix__draw">X</span>;
                   resultLabel = "Draw";
                 } else if (rowWon) {
-                  cellContent = <span className="league-matrix__win">{rowIppons.join("") || "W"}</span>;
+                  // Show the row player's ippon letters (M/K/D/T/H); the green
+                  // cell colour signals the win. No "W" fallback — W is not an
+                  // ippon. A win with no recorded ippons (walkover/hantei)
+                  // shows an empty green cell.
+                  cellContent = <span className="league-matrix__win">{rowIppons.join("")}</span>;
                   resultLabel = "Win";
                 } else {
-                  cellContent = <span className="league-matrix__loss">{rowIppons.join("") || "L"}</span>;
+                  // The loser's own ippons (red), or empty when they scored none.
+                  cellContent = <span className="league-matrix__loss">{rowIppons.join("")}</span>;
                   resultLabel = "Loss";
                 }
 
@@ -2347,9 +2365,10 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer, is
         </tbody>
       </table>
       <div className="league-matrix__legend">
-        <span className="league-matrix__legend-item league-matrix__legend-item--win">W = win</span>
-        <span className="league-matrix__legend-item league-matrix__legend-item--loss">L = loss</span>
+        <span className="league-matrix__legend-item league-matrix__legend-item--win">win</span>
+        <span className="league-matrix__legend-item league-matrix__legend-item--loss">loss</span>
         <span className="league-matrix__legend-item league-matrix__legend-item--draw">X = draw</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H)</span>
         <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row player's result vs column player"}</span>
       </div>
     </div>
@@ -2459,7 +2478,10 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
           : (pool.players || []);
 
         return (
-          <div key={pool.poolName} className="pool" style={{ padding: 14 }}>
+          // A lone pool (every league has exactly one) must span the full grid
+          // width. Otherwise the landscape 2-column `.pools-grid` renders it at
+          // half width, mismatching the full-width Overview standings table.
+          <div key={pool.poolName} className="pool" style={{ padding: 14, gridColumn: pools.length === 1 ? "1 / -1" : undefined }}>
             <div className="pool__head">
               <div className="pool__name">{isLeague ? (allMatchesComplete ? "Final standings" : "Standings") : pool.poolName}</div>
               <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
@@ -2564,7 +2586,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
             {/* Round-robin matrix — optional grid below the match list (individual only) */}
             {matches.length > 0 && !isTeam && (
               <div style={{ marginTop: 4 }}>
-                <LeagueMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayer={highlightPlayer} isLeague={isLeague} />
+                <LeagueMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayer={highlightPlayer} />
               </div>
             )}
           </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2001,9 +2001,10 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
                     <div style={{ fontWeight: 500 }}>
                       {s.player?.number ? <span className="num-prefix">{s.player.number}</span> : null}
                       {s.player?.name || ""}
-                      {/* Rank badge for parity with the full League standings table.
-                          This summary is already rank-sorted, so rank === i + 1. */}
-                      <span className="rank-badge">{rankOrdinal(i + 1)}{s.isOverridden ? "*" : ""}</span>
+                      {/* No rank badge here: this summary is rank-sorted, so the
+                          "#" column already IS the rank — a badge would just echo
+                          it. The rank badge only carries information when rows are
+                          in draw order (non-league pools), where rank ≠ position. */}
                     </div>
                     {tweaks?.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</div> : null}
                   </td>
@@ -2520,7 +2521,12 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                         <div style={{ fontWeight: 500 }}>
                           {p.number ? <span className="num-prefix">{p.number}</span> : null}
                           {p.name}
-                          {rank !== null ? (
+                          {/* The rank badge is only informative when rows are in
+                              DRAW order (non-league pools), where rank ≠ the "#"
+                              draw-position column. League standings are rank-sorted,
+                              so "#" already equals the rank and a badge would just
+                              duplicate it — suppress it there. */}
+                          {!isLeague && rank !== null ? (
                             <span className={`rank-badge${isAdvancing ? " rank-badge--adv" : ""}`}>
                               {rankOrdinal(rank)}{s && s.isOverridden ? "*" : ""}
                             </span>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2338,9 +2338,17 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) 
                 // head-to-head between two same-name/different-dojo players).
                 // Fall back to name for legacy data without a winner id.
                 const wId = winnerId(m);
+                // When both sides share a name and there is no winner id, the
+                // winner NAME is ambiguous — do NOT mark either row as winner
+                // (that would light up BOTH cells green for the one match). The
+                // id branch is the authoritative resolver; the name fallback is
+                // only safe for distinct-name matchups. (Source path now sends
+                // winnerId for same-name matches, so this is defense-in-depth
+                // for legacy data without ids.)
+                const namesAmbiguous = rowPlayer.name === colPlayer.name;
                 const rowWon = (wId && rowPlayer.id)
                   ? wId === rowPlayer.id
-                  : (winnerName && winnerName === rowPlayer.name);
+                  : (!namesAmbiguous && winnerName && winnerName === rowPlayer.name);
                 const isDraw = window.isHikiwake(m.decision) || window.isHikiwake(m.score?.type);
 
                 let cellContent;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2275,11 +2275,12 @@ function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayer }) 
 
   const handleCellKeyDown = (e, m) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleCellClick(m); } };
 
-  const cellLabel = (rowPlayer, colPlayer, result) => `Match: ${rowPlayer.name} vs ${colPlayer.name} — ${result}`;
-  // Hover-tooltip label. Always include the dojo when present so two
-  // same-name participants are distinguishable on hover (the visible grid
-  // only shows the shared name). Hover-only, so the extra text is free.
+  // Label including the dojo when present so two same-name participants are
+  // distinguishable. Used for BOTH the hover `title` AND the cell/header
+  // `aria-label` — screen readers don't reliably announce `title`, so the
+  // accessible name must carry the disambiguating dojo itself.
   const playerLabel = (p) => (p && p.dojo ? `${p.name} (${p.dojo})` : (p && p.name) || "");
+  const cellLabel = (rowPlayer, colPlayer, result) => `Match: ${playerLabel(rowPlayer)} vs ${playerLabel(colPlayer)} — ${result}`;
   const cellTitle = (rowPlayer, colPlayer, result) => `${playerLabel(rowPlayer)} vs ${playerLabel(colPlayer)} — ${result}`;
 
   return (


### PR DESCRIPTION
## Summary

- **League matrix readability**: row and column headers show a position index (`1…N`) so the round-robin grid is decipherable on touch — row N and column N cross-reference the same player. Headers and every cell carry a hover `title` tooltip with the player name **and dojo** (e.g. `Tanaka Kenji (Tokyo Kendo)`), so two same-name participants are distinguishable on hover. Renamed `PoolMatrix` → `LeagueMatrix` and all `pool-matrix*` CSS → `league-matrix*`.
- **Same-name disambiguation**: the matrix joined cells/keys by player **name**, which is not unique within a competition (`CheckDuplicateEntriesByNameDojo` only rejects same-name *and* same-dojo). Two participants from different dojos who share a name collided — cells mapped to the wrong match, and the same-name head-to-head showed the same result for both. Fixed by threading the participant **UUID** end-to-end and keying the matrix on it.

## Why

A name alone can't identify a participant when two share one across dojos, and pool/league match sides were stored as bare names (`pool-matches.csv`) — so a frontend-only fix was impossible. The participant UUID (already in `participants.csv`) is now carried through `pools.csv` → `pool-matches.csv` → API → matrix, and resolves the winner of a same-name head-to-head.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | `PoolMatrix`→`LeagueMatrix`; numbered headers; key matchMap/lookup/`rowIsAka`/`rowWon`/React keys by id (name fallback); dojo-bearing `title` on headers + all cells |
| `web-mobile/css/styles.css` | `pool-matrix*`→`league-matrix*`; `cursor: help`; section comment |
| `internal/state/models.go` | `MatchResult` gains `SideAID`/`SideBID`/`WinnerID` (+ transient `WinnerSide`) |
| `internal/state/pools.go` | persist/parse id columns in `pools.csv` + `pool-matches.csv` (append-only, optional; coexist with main's new `Round` column) |
| `internal/engine/pools.go` | stamp `SideAID`/`SideBID` from the roster at generation |
| `internal/engine/scoring.go`, `scoring_tx.go` | shared `backfillMatchIdentity` helper backfills ids + resolves `WinnerID` in **all four** score-write closures (non-Tx and the `/score` Tx path) |
| `internal/mobileapp/handlers_match.go` | quick-score sets `WinnerSide` from ippon counts |
| `*_test.go` | CSV round-trip (w/ + w/o ids), engine id-stamping + scoring backfill, **Tx-path** id preservation, frontend same-name cell + head-to-head |

## Screenshots

Captured via Python Playwright (headless Chromium). An **8-person league** with two `Tanaka Kenji` from different dojos (rows 1 & 2). Cells show **ippon letters** (M/K/D/T) for wins and the loser's score; the two same-name rows have correctly distinct, mirror-symmetric results — proving id-disambiguation.

![8-person league matrix](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/261/jvzy8-matrix.png)

## Test plan

- [x] `make go/build` passes
- [x] Go gate `go test ./cmd/... ./internal/... ./tests/...` — only failure is the pre-existing, unrelated `TestGlossaryAllSpecTermsRepresented/dojo`. Changed-pkg coverage ≥85% (mobileapp 84.9% is the pre-existing branch baseline, flaky ±0.1% on the SSE handlers — verified not moved by this PR)
- [x] Full web-mobile vitest suite green (1324 passed)
- [x] New unit tests: CSV round-trip incl. legacy back-compat, engine id-stamping + scoring backfill (non-Tx **and** Tx `/score` path), frontend same-name disambiguation + head-to-head winner
- [x] Manual browser verification — 8-person league with two same-name/different-dojo `Tanaka Kenji`, scored all 28 matches with real ippon letters via `/score`; verified ids persist through scoring, cells render ippon letters, the grid is symmetric, the head-to-head shows one Win + one Loss, and hovering any header/cell shows the name + dojo
- [x] Rebased onto main (resolved `pool-matches.csv` column collision: main's `Round` at 15, ids appended at 16–18)
- [x] Screenshot added above
- [x] No new console errors or warnings

Closes mp-jvzy
