### PR TITLE
fix(mp-u2lu): quiet match-alert-banner gradient; extract court-filter layout; SVG admin pill

### DIFF
--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -18,6 +18,36 @@ import (
 // match with the given ID exists in the respective data store.
 var errMatchNotFound = errors.New("match not found")
 
+// ErrMatchSideMismatch is returned when a score payload names competitors
+// (sideA/sideB) that differ from the match's stored pairing. Match identity
+// is fixed at generation; a score only carries the *result*, never a new
+// pairing. Rejecting prevents a malformed or buggy client from silently
+// rewriting who is in a match — the live path that produced cross-pool pool
+// rows (a stored Pool E bout overwritten with competitors from other pools).
+// Handlers map this to HTTP 409.
+var ErrMatchSideMismatch = errors.New("match side mismatch: score payload competitors differ from the stored pairing")
+
+// reconcileSides folds the stored pairing into a score payload's result.
+// An empty payload side is backfilled from the stored side (e.g. a payload
+// that omits sides, or a not-yet-resolved bracket slot). A non-empty payload
+// side that disagrees with a non-empty stored side is a mismatch — the caller
+// must reject rather than overwrite the stored competitor. Returns true on the
+// first such disagreement; result is left partially filled but is discarded by
+// the caller on mismatch.
+func reconcileSides(result *state.MatchResult, storedA, storedB string) (mismatch bool) {
+	if result.SideA == "" {
+		result.SideA = storedA
+	} else if storedA != "" && result.SideA != storedA {
+		mismatch = true
+	}
+	if result.SideB == "" {
+		result.SideB = storedB
+	} else if storedB != "" && result.SideB != storedB {
+		mismatch = true
+	}
+	return mismatch
+}
+
 // withPoolMatch atomically loads pool matches, calls mutate on the one
 // matching matchId, and saves the updated slice. Returns errMatchNotFound
 // (unwrapped) when the ID is not present so callers can fall through to
@@ -205,12 +235,11 @@ func (e *Engine) RecordMatchResult(compId string, matchId string, result *state.
 // RecordMatchResult calls this after applyHansokuIppons; the K3 rollback
 // path calls it directly to restore the prior result byte-for-byte.
 func (e *Engine) writeMatchResult(compId string, matchId string, result *state.MatchResult) error {
+	var sideMismatch bool
 	err := e.withPoolMatch(compId, matchId, func(r *state.MatchResult) {
-		if result.SideA == "" {
-			result.SideA = r.SideA
-		}
-		if result.SideB == "" {
-			result.SideB = r.SideB
+		if reconcileSides(result, r.SideA, r.SideB) {
+			sideMismatch = true
+			return // leave the stored match untouched
 		}
 		backfillMatchIdentity(result, r)
 		if result.Court == "" {
@@ -229,6 +258,8 @@ func (e *Engine) writeMatchResult(compId string, matchId string, result *state.M
 		if err := e.recordBracketMatchResult(compId, matchId, result); err != nil {
 			return err
 		}
+	} else if sideMismatch {
+		return ErrMatchSideMismatch
 	}
 	// Side-effect writes are non-fatal: the match score is already on disk,
 	// so propagating would cause a 500 retry that double-records the score.
@@ -260,12 +291,11 @@ func (e *Engine) RecordMatchResultWithIneligibility(compId string, matchId strin
 	// ineligibility write below fails with AlreadyIneligibleError.
 	prior, _ := e.lookupExistingResult(compId, matchId)
 
+	var sideMismatch bool
 	err := e.withPoolMatch(compId, matchId, func(r *state.MatchResult) {
-		if result.SideA == "" {
-			result.SideA = r.SideA
-		}
-		if result.SideB == "" {
-			result.SideB = r.SideB
+		if reconcileSides(result, r.SideA, r.SideB) {
+			sideMismatch = true
+			return // leave the stored match untouched
 		}
 		backfillMatchIdentity(result, r)
 		if result.Court == "" {
@@ -284,6 +314,8 @@ func (e *Engine) RecordMatchResultWithIneligibility(compId string, matchId strin
 		if err := e.recordBracketMatchResult(compId, matchId, result); err != nil {
 			return nil, err
 		}
+	} else if sideMismatch {
+		return nil, ErrMatchSideMismatch
 	}
 	status, err := e.recordIneligibilityFromDecision(compId, matchId, result)
 	if err != nil {
@@ -706,12 +738,12 @@ func (e *Engine) recordBracketMatchResult(compId string, matchId string, result 
 					// them so that deriveDaihyosenWinner can map a
 					// representative player name back to the canonical team
 					// name. Must happen before deriveDaihyosenWinner and
-					// before writing result.Winner back to the bracket.
-					if result.SideA == "" {
-						result.SideA = m.SideA
-					}
-					if result.SideB == "" {
-						result.SideB = m.SideB
+					// before writing result.Winner back to the bracket. A
+					// non-empty payload side that disagrees with the resolved
+					// bracket side is rejected — a score must not rewrite the
+					// seeded pairing.
+					if reconcileSides(result, m.SideA, m.SideB) {
+						return ErrMatchSideMismatch
 					}
 					deriveDaihyosenWinner(result)
 					bracket.Rounds[rIdx][mIdx].Winner = result.Winner

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -368,6 +368,89 @@ func TestRecordMatchResult_PreservesCourtAndScheduledAt(t *testing.T) {
 	})
 }
 
+// TestRecordMatchResult_RejectsSideRewrite pins the match-identity guard:
+// a score payload may carry the result but must never rewrite WHO is in the
+// match. A payload naming a different competitor is rejected with
+// ErrMatchSideMismatch and the stored pairing is left untouched. This is the
+// guard against the cross-pool corruption vector (a stored bout overwritten
+// with competitors from another pool).
+func TestRecordMatchResult_RejectsSideRewrite(t *testing.T) {
+	dir, err := os.MkdirTemp("", "engine-sidemismatch-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	eng := New(store)
+
+	compID := "mismatch-test"
+	require.NoError(t, store.SaveCompetition(&state.Competition{ID: compID, Name: "Mismatch"}))
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "Pool E-0", SideA: "Benjamin Evans", SideB: "Sebastian Allen", Status: state.MatchStatusScheduled, Court: "A"},
+	}))
+
+	t.Run("payload with foreign competitors is rejected and stored pairing preserved", func(t *testing.T) {
+		bad := &state.MatchResult{
+			SideA:   "Arthur Conan",    // from another pool
+			SideB:   "Herman Melville", // from another pool
+			Winner:  "Arthur Conan",
+			IpponsA: []string{"M"},
+			Status:  state.MatchStatusCompleted,
+		}
+		err := eng.RecordMatchResult(compID, "Pool E-0", bad)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMatchSideMismatch)
+
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		require.Len(t, stored, 1)
+		// Identity untouched; the bogus result was not persisted.
+		assert.Equal(t, "Benjamin Evans", stored[0].SideA)
+		assert.Equal(t, "Sebastian Allen", stored[0].SideB)
+		assert.Equal(t, state.MatchStatusScheduled, stored[0].Status)
+		assert.Empty(t, stored[0].Winner)
+	})
+
+	t.Run("payload that omits sides backfills from the stored pairing and scores", func(t *testing.T) {
+		patch := &state.MatchResult{
+			Winner:  "Benjamin Evans",
+			IpponsA: []string{"M"},
+			Status:  state.MatchStatusCompleted,
+		}
+		require.NoError(t, eng.RecordMatchResult(compID, "Pool E-0", patch))
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		assert.Equal(t, "Benjamin Evans", stored[0].SideA)
+		assert.Equal(t, "Sebastian Allen", stored[0].SideB)
+		assert.Equal(t, "Benjamin Evans", stored[0].Winner)
+		assert.Equal(t, state.MatchStatusCompleted, stored[0].Status)
+	})
+
+	t.Run("payload echoing the correct sides scores normally", func(t *testing.T) {
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "Pool E-1", SideA: "Benjamin Evans", SideB: "Kurt Vonnegut", Status: state.MatchStatusScheduled},
+		}))
+		patch := &state.MatchResult{
+			SideA:   "Benjamin Evans",
+			SideB:   "Kurt Vonnegut",
+			Winner:  "Kurt Vonnegut",
+			IpponsB: []string{"K"},
+			Status:  state.MatchStatusCompleted,
+		}
+		require.NoError(t, eng.RecordMatchResult(compID, "Pool E-1", patch))
+		stored, err := store.LoadPoolMatches(compID)
+		require.NoError(t, err)
+		var m1 state.MatchResult
+		for _, s := range stored {
+			if s.ID == "Pool E-1" {
+				m1 = s
+			}
+		}
+		assert.Equal(t, "Kurt Vonnegut", m1.Winner)
+		assert.Equal(t, state.MatchStatusCompleted, m1.Status)
+	})
+}
+
 // TestRecordMatchResult_ConcurrentScoresNotLost pins the TOCTOU fix for
 // the live-scoring path. Pre-atomic-primitive, withPoolMatch did
 // LoadPoolMatches → mutate target match → SavePoolMatches sequentially

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -65,11 +65,11 @@ func (e *Engine) recordBracketMatchResultTx(tx state.StoreTx, compID, matchID st
 					if !bracketMatchPlayable(&bracket.Rounds[rIdx][mIdx]) {
 						return validationErrorf("knockout match %s is not ready to score: a feeder pool or match has not finished", matchID)
 					}
-					if result.SideA == "" {
-						result.SideA = m.SideA
-					}
-					if result.SideB == "" {
-						result.SideB = m.SideB
+					// Match identity is fixed at seeding; a score must not
+					// rewrite it. Backfill omitted sides; reject a non-empty
+					// payload side that disagrees with the resolved pairing.
+					if reconcileSides(result, m.SideA, m.SideB) {
+						return ErrMatchSideMismatch
 					}
 					deriveDaihyosenWinner(result)
 					bracket.Rounds[rIdx][mIdx].Winner = result.Winner
@@ -284,12 +284,11 @@ func (e *Engine) RecordMatchResultWithIneligibilityTx(tx state.StoreTx, compID, 
 		}
 	}
 
+	var sideMismatch bool
 	err := e.withPoolMatchTx(tx, compID, matchID, func(r *state.MatchResult) {
-		if result.SideA == "" {
-			result.SideA = r.SideA
-		}
-		if result.SideB == "" {
-			result.SideB = r.SideB
+		if reconcileSides(result, r.SideA, r.SideB) {
+			sideMismatch = true
+			return // leave the stored match untouched
 		}
 		// Preserve generation-time participant ids + resolve winner id across
 		// the whole-struct overwrite below (the /score endpoint scores through
@@ -311,6 +310,11 @@ func (e *Engine) RecordMatchResultWithIneligibilityTx(tx state.StoreTx, compID, 
 		if err := e.recordBracketMatchResultTx(tx, compID, matchID, result); err != nil {
 			return nil, err
 		}
+	} else if sideMismatch {
+		// Match identity is fixed at generation; a score payload naming
+		// different competitors is rejected (HTTP 409) rather than allowed to
+		// overwrite the stored pairing. Returns before any side-effect write.
+		return nil, ErrMatchSideMismatch
 	}
 
 	// mp-e2k1 guard: after the pool-match write, check whether any
@@ -415,12 +419,11 @@ func (e *Engine) rollbackMatchResultTx(tx state.StoreTx, compID, matchID string,
 func (e *Engine) recordMatchResultTx(tx state.StoreTx, compID, matchID string, result *state.MatchResult) error {
 	result.ID = matchID
 	err := e.withPoolMatchTx(tx, compID, matchID, func(r *state.MatchResult) {
-		if result.SideA == "" {
-			result.SideA = r.SideA
-		}
-		if result.SideB == "" {
-			result.SideB = r.SideB
-		}
+		// Identity reconciliation only backfills here: this path restores a
+		// trusted prior snapshot (K3 rollback), not a client payload, so the
+		// stored sides always match — the mismatch result is intentionally
+		// ignored rather than turned into a rejection.
+		_ = reconcileSides(result, r.SideA, r.SideB)
 		// Preserve generation-time participant ids + resolve winner id across
 		// the whole-struct overwrite below (the /score endpoint scores through
 		// this Tx path). See backfillMatchIdentity.

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -379,6 +379,13 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			SubResults: subResults,
 		}
 		if err := eng.RecordMatchResult(id, mid, &result); err != nil {
+			if errors.Is(err, engine.ErrMatchSideMismatch) {
+				c.JSON(http.StatusConflict, gin.H{
+					"error":   "side_mismatch",
+					"message": "The submitted competitors don't match this match's pairing. Reload and try again.",
+				})
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
@@ -738,6 +745,15 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 				c.JSON(http.StatusConflict, gin.H{
 					"error":   "result_finalized",
 					"message": "This match result has already been reported. Contact the tournament organizer to correct it.",
+				})
+				return
+			}
+			if errors.Is(engErr, engine.ErrMatchSideMismatch) {
+				// The payload named competitors that differ from the stored
+				// pairing — refuse rather than rewrite match identity.
+				c.JSON(http.StatusConflict, gin.H{
+					"error":   "side_mismatch",
+					"message": "The submitted competitors don't match this match's pairing. Reload and try again.",
 				})
 				return
 			}

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -164,6 +164,80 @@ func TestQuickScoreHandler(t *testing.T) {
 	})
 }
 
+// TestScoreHandlers_RejectSideMismatch pins the HTTP 409 mapping for the
+// match-identity guard: a score/quick-score payload naming competitors that
+// differ from the stored pairing is rejected, and the stored match is left
+// untouched. Exercises the production TX /score path and the /quick-score
+// path end-to-end.
+func TestScoreHandlers_RejectSideMismatch(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	store.SaveCompetition(&state.Competition{ID: "c1", Courts: []string{"A"}})
+	store.SavePools("c1", []helper.Pool{
+		{PoolName: "PoolE", Players: []helper.Player{{Name: "Benjamin Evans"}, {Name: "Sebastian Allen"}}},
+	})
+	store.SavePoolMatches("c1", []state.MatchResult{
+		{ID: "PoolE-0", SideA: "Benjamin Evans", SideB: "Sebastian Allen", Status: state.MatchStatusScheduled},
+	})
+
+	assertPairingUntouched := func(t *testing.T) {
+		t.Helper()
+		stored, err := store.LoadPoolMatches("c1")
+		assert.NoError(t, err)
+		assert.Len(t, stored, 1)
+		assert.Equal(t, "Benjamin Evans", stored[0].SideA)
+		assert.Equal(t, "Sebastian Allen", stored[0].SideB)
+		assert.Equal(t, state.MatchStatusScheduled, stored[0].Status)
+	}
+
+	t.Run("score endpoint rejects foreign competitors with 409", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"id": "PoolE-0", "sideA": "Arthur Conan", "sideB": "Herman Melville",
+			"winner": "Arthur Conan", "ipponsA": []string{"M"}, "ipponsB": []string{},
+			"status": "completed",
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/c1/matches/PoolE-0/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "side_mismatch")
+		assertPairingUntouched(t)
+	})
+
+	t.Run("quick-score endpoint rejects foreign competitors with 409", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"sideA": "Arthur Conan", "sideB": "Herman Melville",
+			"teamAWins": 2, "teamBWins": 1,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/c1/matches/PoolE-0/quick-score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, w.Body.String(), "side_mismatch")
+		assertPairingUntouched(t)
+	})
+
+	t.Run("score endpoint accepts the correct pairing", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"id": "PoolE-0", "sideA": "Benjamin Evans", "sideB": "Sebastian Allen",
+			"winner": "Benjamin Evans", "ipponsA": []string{"M"}, "ipponsB": []string{},
+			"status": "completed",
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/c1/matches/PoolE-0/score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		stored, err := store.LoadPoolMatches("c1")
+		assert.NoError(t, err)
+		assert.Equal(t, "Benjamin Evans", stored[0].Winner)
+		assert.Equal(t, state.MatchStatusCompleted, stored[0].Status)
+	})
+}
+
 func TestMatchHandlers_Extended(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1439,31 +1439,26 @@ a:hover {
 .pool-match-numbered-row__name {
   font-weight: 600;
   font-size: 12px;
-  white-space: nowrap;
+  line-height: 1.2;
+  /* Wrap rather than ellipsis: the side cell is narrow and the Shiro/Aka
+     text badge was dropped (the hatched/red fill already encodes side), so
+     the name now owns the full cell width and may wrap to a second line. */
+  overflow-wrap: anywhere;
+}
+
+/* Screen-reader-only utility: visually hidden, still announced. Used to keep
+   the Shiro/Aka side label for assistive tech after the visible badge was
+   removed from the numbered pool match row. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.cbadge {
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding: 2px 5px;
-  border-radius: 3px;
-  line-height: 1;
-  flex-shrink: 0;
-}
-
-.cbadge--shiro {
-  background: #fff;
-  color: var(--accent);
-  border: 1px solid var(--accent);
-}
-
-.cbadge--aka {
-  background: var(--red, #c1121f);
-  color: #fff;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .pool-match-numbered-row__score {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -506,6 +506,10 @@ a:hover {
   box-shadow: none;
 }
 
+.card--sm {
+  padding: 14px;
+}
+
 .card__head {
   display: flex;
   align-items: center;
@@ -2407,6 +2411,7 @@ button.my-match__opp {
   background: var(--white-side);
   background-image: repeating-linear-gradient(
     -45deg, transparent 0 6px, var(--shiro-hatch) 6px 7px);
+  text-align: right;
 }
 .vsched-item__side:has(.vsched-item__color-badge--aka) {
   background: var(--red-soft);
@@ -2443,6 +2448,210 @@ button.my-match__opp {
 .vsched-item__score {
   font-family: var(--font-mono);
   font-weight: 700;
+}
+
+/* Button vsched-item: .vsched-item defines bg + border via CSS; just reset default
+   browser button appearance without clobbering those values. */
+button.vsched-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+button.vsched-item:not([data-clickable]) {
+  cursor: default;
+}
+
+/* Queue position chip — flex-pushed to the right of vsched-item__head */
+.vsched-item__queue {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink-3);
+}
+.vsched-item__queue--next {
+  color: var(--accent);
+}
+
+/* Final / status label — pushed right when queue chip is absent */
+.vsched-item__status {
+  margin-left: auto;
+  color: var(--ink-3);
+}
+
+/* Running "● NOW" label inside head row pushed right automatically */
+.vsched-item__head .bc-live {
+  margin-left: auto;
+}
+
+/* HANTEI badge */
+.vsched-item__hantei {
+  margin-left: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--accent-soft, #eef);
+  color: var(--accent, #36c);
+}
+
+/* Winner badge — flat accent, no gradient */
+.winner-badge {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-weight: 700;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.winner-badge--lg {
+  padding: 14px 18px;
+  font-size: 18px;
+}
+.winner-badge__icon {
+  font-size: 22px;
+}
+.winner-badge--lg .winner-badge__icon {
+  font-size: 28px;
+}
+
+/* MyMatchPanel: "Following: Name [Clear]" header row */
+.my-match__follow-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.my-match__follow-lbl {
+  font-size: 12px;
+  color: var(--ink-3);
+}
+.my-match__follow-name {
+  font-weight: 600;
+}
+.my-match__follow-row .tag-badge {
+  font-size: 9px;
+}
+.my-match__follow-row .btn--clear-follow {
+  margin-left: auto;
+}
+
+/* Viewer filter bar — active-player/watchlist indicator */
+.viewer-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background: var(--accent-soft, #eef);
+  border-radius: 8px;
+  font-size: 13px;
+}
+.viewer-filter-bar__icon {
+  color: var(--accent, #36c);
+}
+
+/* Section-title with inline live dot */
+.section-title--live {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* WatchlistPanel dojo bulk-add row */
+.watchlist-dojo-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.watchlist-dojo-row__label {
+  font-size: 12px;
+  color: var(--ink-3);
+}
+.watchlist-dojo-row__feedback {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+.watchlist-dojo-row .input {
+  font-size: 13px;
+  padding: 4px 8px;
+}
+.watchlist-count {
+  font-size: 11px;
+  color: var(--ink-3);
+  font-weight: 500;
+}
+
+/* DisplayModes details/summary */
+.viewer-display-modes {
+  margin-top: 20px;
+}
+.viewer-display-modes > summary {
+  cursor: pointer;
+}
+.viewer-display-modes__row-links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.viewer-display-modes__link {
+  color: var(--text-link, #2563eb);
+  text-decoration: none;
+}
+.viewer-display-modes__sep {
+  color: var(--ink-3);
+  margin-left: 8px;
+}
+
+/* Bracket full-bleed container inside viewer body */
+.viewer-bracket-bleed {
+  margin-left: -16px;
+  margin-right: -16px;
+}
+@media (min-width: 768px) {
+  .viewer-bracket-bleed {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+}
+@media (min-width: 1024px) {
+  .viewer-bracket-bleed {
+    margin-left: -28px;
+    margin-right: -28px;
+  }
+}
+
+/* Competition list item layout */
+.comp-item {
+  position: relative;
+}
+.comp-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+.comp-item__body {
+  min-width: 0;
+}
+
+/* Live count indicator in competition progress row */
+.bc-live-count {
+  color: var(--red);
+  font-weight: 600;
+}
+
+/* PoolMatchRow as button */
+button.pool-match-row {
+  display: block;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
 }
 
 /* tournament index list */
@@ -2602,9 +2811,24 @@ button.my-match__opp {
   gap: 6px;
 }
 
+.hero-live__vsched {
+  margin-top: 8px;
+}
+
+/* "Up next" section title gets extra top breathing room */
+.viewer__upnext-title {
+  margin-top: 20px;
+}
+
+/* Glossary vlist extra top gap */
+.viewer__glossary-vlist {
+  margin-top: 12px;
+}
+
 /* Competition list cards (viewer home) */
 .vlist-item--comp {
   gap: 10px;
+  width: 100%;
 }
 
 .vlist-item__eyebrow {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1653,11 +1653,13 @@ a:hover {
   position: fixed;
   inset: 0;
   background: rgba(15, 20, 35, 0.55);
-  backdrop-filter: blur(2px);
   display: grid;
   place-items: center;
   z-index: 100;
   padding: 20px;
+}
+@supports (backdrop-filter: blur(2px)) {
+  .modal-backdrop { backdrop-filter: blur(2px); }
 }
 
 .modal {
@@ -2300,6 +2302,12 @@ button.my-match__opp {
   border: none;
   text-align: left;
   cursor: pointer;
+  color: inherit;
+}
+
+/* Anchor vlist rows — remove browser default underline */
+a.vlist-item {
+  text-decoration: none;
 }
 
 .my-match__opp .l {
@@ -2732,7 +2740,7 @@ button.pool-match-row {
 /* Tournament info card (mp-ef3) — public event details */
 .tournament-info {
   background: var(--accent-soft);
-  border-left: 3px solid var(--accent);
+  border: 1px solid color-mix(in oklch, var(--accent) 22%, transparent);
   border-radius: var(--r-lg);
   padding: 14px 16px;
   margin-bottom: 14px;
@@ -2938,7 +2946,7 @@ button.pool-match-row {
 }
 
 .podium-step--1 {
-  background: linear-gradient(180deg, #fef9c3 0%, #fde68a 100%);
+  background: #fef9c3;
   border-color: #fde68a;
   min-height: 150px;
   min-width: 150px;
@@ -2946,15 +2954,15 @@ button.pool-match-row {
 }
 
 .podium-step--2 {
-  background: linear-gradient(180deg, #f1f5f9 0%, #e2e8f0 100%);
-  border-color: #e2e8f0;
+  background: var(--surface);
+  border-color: var(--line);
   min-height: 130px;
   order: 1;
 }
 
 .podium-step--3 {
-  background: linear-gradient(180deg, #fed7aa 0%, #fdba74 100%);
-  border-color: #fdba74;
+  background: #fff7ed;
+  border-color: #fed7aa;
   min-height: 110px;
   order: 3;
 }
@@ -2979,9 +2987,10 @@ button.pool-match-row {
 }
 
 /* mp-8jbo: champion-hero awards podium layout */
-/* Hero card — 1st place champion, full width gold gradient */
+/* Hero card — 1st place champion, full width gold solid */
 .awards-hero {
-  background: linear-gradient(135deg, #fef0b8, #f3cf5e);
+  background: #fef9c3;
+  border: 2px solid #fcd34d;
   border-radius: 14px;
   padding: 18px 16px;
   text-align: center;
@@ -3310,6 +3319,7 @@ button.pool-match-row {
   position: relative;
   flex: 1;
   min-width: 220px;
+  margin-bottom: 8px;
 }
 
 .pmf__bar {
@@ -3323,6 +3333,7 @@ button.pool-match-row {
   padding: 6px 8px;
   min-height: 36px;
   cursor: text;
+  margin-bottom: 8px;
 }
 
 .pmf__bar:focus-within {
@@ -6524,4 +6535,115 @@ button.pool-match-row {
   padding: 16px 0;
   margin-top: 32px;
 }
+
+/* ---------- Pool standings draw-pos default (replaces inline styles) ---------- */
+.pool-standings__draw-pos {
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+}
+.pool-standings__draw-pos--override {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* ---------- Pool table empty-state row ---------- */
+.pool__table-empty {
+  text-align: center;
+  color: var(--ink-3);
+  font-size: 13px;
+  padding: 16px;
+}
+
+/* ---------- Section-title modifiers ---------- */
+.section-title--flush { margin-top: 0; }
+.section-title--inrow { margin-top: 0; display: flex; align-items: center; gap: 8px; }
+/* Slightly smaller sub-section label with top spacing */
+.section-title--sub { margin-top: 14px; font-size: 13px; }
+
+/* ---------- Hint text utilities (inline note, muted) ---------- */
+.hint    { font-size: 12px; color: var(--ink-3); margin-bottom: 8px; }
+.hint--sm { font-size: 11px; color: var(--ink-3); }
+.hint--md { font-size: 13px; color: var(--ink-3); }
+
+/* ---------- Pool table cell classes (replaces inline styles) ---------- */
+.pool__match-count { font-size: 12px; color: var(--ink-3); }
+.pool__player-name { font-weight: 500; }
+.pool__dojo-name   { font-size: 11px; color: var(--ink-3); }
+
+/* ---------- Mymatch / watchlist card spacing ---------- */
+.mymatch-card { margin-bottom: 16px; }
+
+/* ---------- Checked-in tick in watchlist chips ---------- */
+.pmf__chip-tick { margin-left: 4px; font-size: 10px; }
+
+/* ---------- Awards view header (replaces inline styles) ---------- */
+.awards__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.awards__title { margin: 0; font-size: 18px; }
+.awards__title--fs { font-size: 28px; }
+.awards__subtitle { font-size: 12px; color: var(--ink-3); }
+.awards__subtitle--fs { font-size: 16px; }
+
+/* ---------- SSE offline banner ---------- */
+.sse-offline-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: color-mix(in oklch, var(--red) 10%, var(--bg));
+  border: 1px solid color-mix(in oklch, var(--red) 35%, transparent);
+  border-radius: var(--r-md);
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--red);
+  margin-bottom: 8px;
+}
+.sse-offline-banner__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--red);
+  flex-shrink: 0;
+}
+
+/* ---------- Pending deep-link follow confirmation banner ---------- */
+.pending-follow-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent-soft);
+  border: 1px solid color-mix(in oklch, var(--accent) 30%, transparent);
+  border-radius: var(--r-md);
+  padding: 8px 12px;
+  font-size: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+.pending-follow-banner__label {
+  flex: 1;
+  min-width: 0;
+  color: var(--ink-2);
+  font-weight: 500;
+}
+.pending-follow-banner__name {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+/* Vlist row with inline padding override */
+.vlist-item--row-padded { padding: 0 12px 12px; }
+/* Non-interactive vlist row — no hover cursor */
+.vlist-item--static { cursor: default; }
+
+/* ---------- PMF / player-filter utilities ---------- */
+.pmf__checkin-tag { margin-left: 8px; font-size: 9px; }
+
+/* ---------- Pool overview summary panel ---------- */
+.pool--overview-summary { padding: 14px; margin-bottom: 12px; }
+.pool__overflow-note { margin-top: 8px; }
+.pool__view-all-btn  { margin-top: 8px; font-size: 13px; padding: 0; }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3340,6 +3340,12 @@ button.pool-match-row {
   padding: 6px 8px;
   min-height: 36px;
   cursor: text;
+}
+
+/* Standalone bar (WatchlistPanel) — outside a .pmf wrapper, owns its spacing.
+   Inside .pmf the wrapper's margin-bottom spaces the block; a bar margin there
+   would inflate .pmf and push the absolutely-anchored .pmf__dropdown away. */
+.pmf__bar--standalone {
   margin-bottom: 8px;
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2158,6 +2158,12 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 6px;
+  cursor: pointer;
+}
+
+.viewer__admin-pill:hover {
+  border-color: var(--ink-4);
+  color: var(--ink);
 }
 
 .viewer__tabs {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2202,6 +2202,16 @@ a:hover {
   flex: 1;
 }
 
+.viewer__court-filter {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+.viewer__court-filter .input {
+  width: auto;
+}
+
 /* My match card (player viewer hero) */
 .my-match {
   background: var(--accent);
@@ -6046,12 +6056,11 @@ button.my-match__opp {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  background: linear-gradient(135deg, #1a4f8a 0%, #2563eb 100%);
-  color: #ffffff;
+  background: var(--accent);
+  color: var(--accent-fg);
   border-radius: 10px;
   padding: 12px 14px;
   margin-bottom: 12px;
-  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.35);
   animation: match-alert-slide-in 0.25s ease-out;
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2655,11 +2655,17 @@ button.vsched-item:not([data-clickable]) {
 }
 
 /* PoolMatchRow as button — do NOT set display here; the base .pool-match-row
-   rule (display:grid) has lower specificity and would be overridden. */
+   rule (display:grid) has lower specificity and would be overridden. Clear UA
+   button chrome per-side so the class's border-bottom still applies. */
 button.pool-match-row {
   width: 100%;
   text-align: left;
   cursor: pointer;
+  background: none;
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  color: inherit;
 }
 
 /* tournament index list */
@@ -2740,7 +2746,8 @@ button.pool-match-row {
 /* Tournament info card (mp-ef3) — public event details */
 .tournament-info {
   background: var(--accent-soft);
-  border: 1px solid color-mix(in oklch, var(--accent) 22%, transparent);
+  border: 1px solid rgba(29, 53, 87, 0.22); /* fallback for browsers without color-mix() */
+  border-color: color-mix(in oklch, var(--accent) 22%, transparent);
   border-radius: var(--r-lg);
   padding: 14px 16px;
   margin-bottom: 14px;
@@ -6593,8 +6600,10 @@ button.pool-match-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  background: #f2e2e4; /* fallback — approximate red-10% over bg */
   background: color-mix(in oklch, var(--red) 10%, var(--bg));
-  border: 1px solid color-mix(in oklch, var(--red) 35%, transparent);
+  border: 1px solid rgba(193, 18, 31, 0.35); /* fallback for browsers without color-mix() */
+  border-color: color-mix(in oklch, var(--red) 35%, transparent);
   border-radius: var(--r-md);
   padding: 8px 12px;
   font-size: 12px;
@@ -6616,7 +6625,8 @@ button.pool-match-row {
   align-items: center;
   gap: 8px;
   background: var(--accent-soft);
-  border: 1px solid color-mix(in oklch, var(--accent) 30%, transparent);
+  border: 1px solid rgba(29, 53, 87, 0.3); /* fallback for browsers without color-mix() */
+  border-color: color-mix(in oklch, var(--accent) 30%, transparent);
   border-radius: var(--r-md);
   padding: 8px 12px;
   font-size: 12px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2654,9 +2654,9 @@ button.vsched-item:not([data-clickable]) {
   font-weight: 600;
 }
 
-/* PoolMatchRow as button */
+/* PoolMatchRow as button — do NOT set display here; the base .pool-match-row
+   rule (display:grid) has lower specificity and would be overridden. */
 button.pool-match-row {
-  display: block;
   width: 100%;
   text-align: left;
   cursor: pointer;

--- a/web-mobile/js/__tests__/viewer_deeplink.test.jsx
+++ b/web-mobile/js/__tests__/viewer_deeplink.test.jsx
@@ -1,0 +1,97 @@
+// Pure-logic tests for resolveDeepLink (the ?player= / ?name= deep-link
+// resolution helper extracted from ViewerHome's useEffect). Covers the
+// four outcomes: no-op, UUID hit + auto-apply, name hit + auto-apply,
+// and conflict-detection (pending=true) when a different player is already
+// being followed.
+import { describe, it, expect } from 'vitest';
+import { resolveDeepLink } from '../viewer.jsx';
+
+const ROSTER = [
+  { id: 'uuid-alice', name: 'Alice Doe', dojo: 'Dojo A' },
+  { id: 'uuid-bob',   name: 'Bob Smith',  dojo: 'Dojo B' },
+  { id: 'uuid-carol', name: 'Carol King', dojo: 'Dojo C' },
+];
+
+describe('resolveDeepLink', () => {
+  describe('no-op cases', () => {
+    it('returns null when searchString is empty', () => {
+      expect(resolveDeepLink('', ROSTER, null)).toBeNull();
+    });
+
+    it('returns null when neither ?player= nor ?name= is present', () => {
+      expect(resolveDeepLink('?foo=bar', ROSTER, null)).toBeNull();
+    });
+
+    it('returns null when ?player= and ?name= are both blank strings', () => {
+      expect(resolveDeepLink('?player=&name=', ROSTER, null)).toBeNull();
+    });
+
+    it('returns null when the UUID does not match any roster entry', () => {
+      expect(resolveDeepLink('?player=uuid-nobody', ROSTER, null)).toBeNull();
+    });
+
+    it('returns null when the name query matches nothing in the roster', () => {
+      expect(resolveDeepLink('?name=zzz', ROSTER, null)).toBeNull();
+    });
+  });
+
+  describe('UUID match — auto-apply (no conflict)', () => {
+    it('returns { player, pending:false } when UUID matches and no one is followed', () => {
+      const result = resolveDeepLink('?player=uuid-alice', ROSTER, null);
+      expect(result).not.toBeNull();
+      expect(result.player).toEqual({ id: 'uuid-alice', name: 'Alice Doe' });
+      expect(result.pending).toBe(false);
+    });
+
+    it('returns pending:false when UUID matches the already-followed player', () => {
+      const followed = { id: 'uuid-alice', name: 'Alice Doe' };
+      const result = resolveDeepLink('?player=uuid-alice', ROSTER, followed);
+      expect(result.pending).toBe(false);
+    });
+  });
+
+  describe('name match — auto-apply (no conflict)', () => {
+    it('falls back to substring name match when UUID is not in roster', () => {
+      const result = resolveDeepLink('?player=alice', ROSTER, null);
+      expect(result).not.toBeNull();
+      expect(result.player.id).toBe('uuid-alice');
+      expect(result.pending).toBe(false);
+    });
+
+    it('prefers ?name= over ?player= for name lookup', () => {
+      const result = resolveDeepLink('?player=uuid-nobody&name=bob', ROSTER, null);
+      expect(result).not.toBeNull();
+      expect(result.player.id).toBe('uuid-bob');
+    });
+
+    it('name lookup is case-insensitive', () => {
+      const result = resolveDeepLink('?name=CAROL', ROSTER, null);
+      expect(result).not.toBeNull();
+      expect(result.player.id).toBe('uuid-carol');
+    });
+  });
+
+  describe('conflict detection — pending banner', () => {
+    it('returns pending:true when UUID matches a DIFFERENT followed player', () => {
+      const followed = { id: 'uuid-alice', name: 'Alice Doe' };
+      const result = resolveDeepLink('?player=uuid-bob', ROSTER, followed);
+      expect(result).not.toBeNull();
+      expect(result.player).toEqual({ id: 'uuid-bob', name: 'Bob Smith' });
+      expect(result.pending).toBe(true);
+    });
+
+    it('returns pending:true when name matches a DIFFERENT followed player', () => {
+      const followed = { id: 'uuid-alice', name: 'Alice Doe' };
+      const result = resolveDeepLink('?name=carol', ROSTER, followed);
+      expect(result.pending).toBe(true);
+      expect(result.player.id).toBe('uuid-carol');
+    });
+
+    it('returns pending:false when followed player has no id (anonymous follow)', () => {
+      // followedPlayer without an id cannot conflict — treat as no selection.
+      const followed = { id: '', name: 'Someone' };
+      const result = resolveDeepLink('?player=uuid-bob', ROSTER, followed);
+      expect(result.pending).toBe(false);
+    });
+  });
+});

--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -241,6 +241,64 @@ describe('PoolsViewer draw-order standings (mp-938b)', () => {
     expect(text).not.toContain('1st');
     expect(text).not.toContain('2nd');
   });
+
+  // A pool whose standings exist but are all 0-0-0 (no bout decided yet) must
+  // NOT show rank badges or the green "advancing" highlight — the rank is just
+  // the seed/draw fallback and asserting placement/qualification pre-scoring is
+  // misleading. Provisional ranks appear only once a result exists.
+  it('suppresses rank badges + advancing highlight until the pool has a result', () => {
+    const zeroStandings = {
+      'Pool A': [
+        { player: { name: 'P1', dojo: 'Dojo1' }, rank: 1, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 },
+        { player: { name: 'P2', dojo: 'Dojo2' }, rank: 2, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 },
+        { player: { name: 'P3', dojo: 'Dojo3' }, rank: 3, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 },
+        { player: { name: 'P4', dojo: 'Dojo4' }, rank: 4, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 },
+      ],
+    };
+    const tree = runtime.mount(PoolsViewer, {
+      pools: [pool], standings: zeroStandings, poolMatches: [], tweaks, competition: baseComp,
+    });
+    const advancingRows = findAll(tree, n => {
+      const cls = n.props?.className;
+      return n.type === 'tr' && typeof cls === 'string' && cls.includes('advancing');
+    });
+    const rankBadges = findAll(tree, n => {
+      const cls = n.props?.className;
+      return typeof cls === 'string' && cls.split(' ').includes('rank-badge');
+    });
+    expect(advancingRows).toHaveLength(0);
+    expect(rankBadges).toHaveLength(0);
+    // The standings rows themselves still render (with their 0 stats).
+    const text = collectText(tree);
+    expect(text).toContain('P1');
+    expect(text).toContain('P4');
+  });
+
+  // Counterpart: once a single bout is decided (any non-zero W/L/D in
+  // standings), provisional ranks + advancing highlight come back.
+  it('shows rank badges + advancing once any standing has a result', () => {
+    const partialStandings = {
+      'Pool A': [
+        { player: { name: 'P1', dojo: 'Dojo1' }, rank: 1, wins: 1, losses: 0, draws: 0, ipponsGiven: 1, ipponsTaken: 0 },
+        { player: { name: 'P2', dojo: 'Dojo2' }, rank: 2, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 },
+        { player: { name: 'P3', dojo: 'Dojo3' }, rank: 3, wins: 0, losses: 1, draws: 0, ipponsGiven: 0, ipponsTaken: 1 },
+        { player: { name: 'P4', dojo: 'Dojo4' }, rank: 4, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 },
+      ],
+    };
+    const tree = runtime.mount(PoolsViewer, {
+      pools: [pool], standings: partialStandings, poolMatches: [], tweaks, competition: baseComp,
+    });
+    const rankBadges = findAll(tree, n => {
+      const cls = n.props?.className;
+      return typeof cls === 'string' && cls.split(' ').includes('rank-badge');
+    });
+    const advancingRows = findAll(tree, n => {
+      const cls = n.props?.className;
+      return n.type === 'tr' && typeof cls === 'string' && cls.includes('advancing');
+    });
+    expect(rankBadges).toHaveLength(4);
+    expect(advancingRows).toHaveLength(2);
+  });
 });
 
 // ------------------------------------------------------------------

--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -447,4 +447,34 @@ describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
     const text = collectText(tree);
     expect(text).toContain('M–·');
   });
+
+  // Proposal 1: the visible Shiro/Aka text badge was dropped (the hatched/red
+  // side fill encodes side); the label survives only as an sr-only span so
+  // assistive tech still announces it, and names no longer ellipsis-clip.
+  it('encodes side via sr-only labels, not visible cbadge text badges', () => {
+    const m = {
+      id: 'Pool A-0',
+      sideA: { name: 'Aaron Thompson' },
+      sideB: { name: 'Jane Austen' },
+      status: 'scheduled',
+    };
+
+    const tree = runtime.mount(PoolNumberedMatchRow, { m, num: 1 });
+
+    const hasClass = (cls) => (n) =>
+      typeof n.props?.className === 'string' && n.props.className.split(' ').includes(cls);
+
+    // No visible chip badges remain.
+    expect(findAll(tree, hasClass('cbadge'))).toHaveLength(0);
+
+    // Both side labels survive as sr-only spans, in Shiro/Aka order.
+    const srLabels = findAll(tree, hasClass('sr-only')).map(collectText);
+    expect(srLabels).toEqual(['Shiro: ', 'Aka: ']);
+
+    // Names render in full (no truncation markup couples to the assertion;
+    // both competitor names are present in the tree text).
+    const text = collectText(tree);
+    expect(text).toContain('Jane Austen');
+    expect(text).toContain('Aaron Thompson');
+  });
 });

--- a/web-mobile/js/__tests__/viewer_sse_banner.test.jsx
+++ b/web-mobile/js/__tests__/viewer_sse_banner.test.jsx
@@ -1,5 +1,5 @@
-// Tests that ViewerHome renders the SSE offline banner when connected=false
-// and suppresses it when connected=true (default). ViewerHome is tested via
+// Tests that ViewerHome renders the SSE offline banner when sseConnected=false
+// and suppresses it when sseConnected=true (default). ViewerHome is tested via
 // direct function call (same pattern as AnnouncementBanner in app_announcement.test.jsx)
 // with window globals set up before the dynamic import so the module-level
 // `const x = window.x` bindings capture real stubs.
@@ -70,23 +70,23 @@ describe('ViewerHome SSE offline banner', () => {
     vi.resetModules();
   });
 
-  it('renders the SSE offline banner when connected=false', () => {
-    const tree = ViewerHome({ tournament: TOURNAMENT, connected: false,
+  it('renders the SSE offline banner when sseConnected=false', () => {
+    const tree = ViewerHome({ tournament: TOURNAMENT, sseConnected: false,
       onSelectCompetition: NOOP, onAdminClick: NOOP,
       onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
     const banners = findByClass(tree, 'sse-offline-banner');
     expect(banners.length).toBeGreaterThan(0);
   });
 
-  it('does NOT render the SSE offline banner when connected=true', () => {
-    const tree = ViewerHome({ tournament: TOURNAMENT, connected: true,
+  it('does NOT render the SSE offline banner when sseConnected=true', () => {
+    const tree = ViewerHome({ tournament: TOURNAMENT, sseConnected: true,
       onSelectCompetition: NOOP, onAdminClick: NOOP,
       onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
     const banners = findByClass(tree, 'sse-offline-banner');
     expect(banners).toHaveLength(0);
   });
 
-  it('does NOT render the SSE offline banner when connected is omitted (default true)', () => {
+  it('does NOT render the SSE offline banner when sseConnected is omitted (default true)', () => {
     const tree = ViewerHome({ tournament: TOURNAMENT,
       onSelectCompetition: NOOP, onAdminClick: NOOP,
       onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
@@ -95,7 +95,7 @@ describe('ViewerHome SSE offline banner', () => {
   });
 
   it('offline banner carries role=status and aria-live=polite', () => {
-    const tree = ViewerHome({ tournament: TOURNAMENT, connected: false,
+    const tree = ViewerHome({ tournament: TOURNAMENT, sseConnected: false,
       onSelectCompetition: NOOP, onAdminClick: NOOP,
       onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
     const [banner] = findByClass(tree, 'sse-offline-banner');

--- a/web-mobile/js/__tests__/viewer_sse_banner.test.jsx
+++ b/web-mobile/js/__tests__/viewer_sse_banner.test.jsx
@@ -1,0 +1,105 @@
+// Tests that ViewerHome renders the SSE offline banner when connected=false
+// and suppresses it when connected=true (default). ViewerHome is tested via
+// direct function call (same pattern as AnnouncementBanner in app_announcement.test.jsx)
+// with window globals set up before the dynamic import so the module-level
+// `const x = window.x` bindings capture real stubs.
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+// Helpers ----------------------------------------------------------------
+
+function findAll(node, predicate) {
+  if (node == null) return [];
+  if (Array.isArray(node)) return node.flatMap(n => findAll(n, predicate));
+  if (typeof node !== 'object') return [];
+  const results = [];
+  if (predicate(node)) results.push(node);
+  const kids = Array.isArray(node.children) ? node.children : node.children != null ? [node.children] : [];
+  for (const k of kids) results.push(...findAll(k, predicate));
+  if (node.props?.children) {
+    const pc = node.props.children;
+    for (const k of [].concat(pc)) results.push(...findAll(k, predicate));
+  }
+  return results;
+}
+
+function findByClass(tree, cls) {
+  return findAll(tree, n => {
+    const cn = n.props?.className || '';
+    return cn.split(' ').includes(cls);
+  });
+}
+
+// Minimal tournament fixture — empty competitions so useMemo filters are no-ops.
+const TOURNAMENT = { name: 'Test Tournament', date: '10-06-2026', venue: 'Budokan', competitions: [] };
+const NOOP = () => {};
+
+// -----------------------------------------------------------------------
+
+describe('ViewerHome SSE offline banner', () => {
+  let ViewerHome;
+  let originals = {};
+
+  beforeAll(async () => {
+    // Stash and replace window globals that viewer.jsx captures at module load.
+    // These must be set BEFORE the dynamic import so the const-bindings pick them up.
+    const globals = {
+      formatDate:               (d) => d || 'Date TBA',
+      formatViewerHeaderEyebrow:(date, venue) => `${date} · ${venue}`,
+      formatLabel:              (l) => l,
+      hasBothSides:             () => false,
+      compareDmy:               () => 0,
+      StatusBadge:              () => null,
+      pluralize:                (n, s) => `${n} ${s}`,
+      queueLabelCompact:        null,
+    };
+    for (const [k, v] of Object.entries(globals)) {
+      originals[k] = global.window[k];
+      global.window[k] = v;
+    }
+
+    vi.resetModules();
+    const mod = await import('../viewer.jsx');
+    ViewerHome = mod.ViewerHome;
+  });
+
+  afterAll(() => {
+    for (const [k, v] of Object.entries(originals)) {
+      if (v === undefined) delete global.window[k];
+      else global.window[k] = v;
+    }
+    vi.resetModules();
+  });
+
+  it('renders the SSE offline banner when connected=false', () => {
+    const tree = ViewerHome({ tournament: TOURNAMENT, connected: false,
+      onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
+    const banners = findByClass(tree, 'sse-offline-banner');
+    expect(banners.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT render the SSE offline banner when connected=true', () => {
+    const tree = ViewerHome({ tournament: TOURNAMENT, connected: true,
+      onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
+    const banners = findByClass(tree, 'sse-offline-banner');
+    expect(banners).toHaveLength(0);
+  });
+
+  it('does NOT render the SSE offline banner when connected is omitted (default true)', () => {
+    const tree = ViewerHome({ tournament: TOURNAMENT,
+      onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
+    const banners = findByClass(tree, 'sse-offline-banner');
+    expect(banners).toHaveLength(0);
+  });
+
+  it('offline banner carries role=status and aria-live=polite', () => {
+    const tree = ViewerHome({ tournament: TOURNAMENT, connected: false,
+      onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP });
+    const [banner] = findByClass(tree, 'sse-offline-banner');
+    expect(banner.props.role).toBe('status');
+    expect(banner.props['aria-live']).toBe('polite');
+  });
+});

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -916,7 +916,7 @@ function App() {
             setViewerScreen("register");
           }}
           onOpenResults={() => setViewerScreen("results")}
-          connected={sseConnected}
+          sseConnected={sseConnected}
         />
       )}
       {authPrompt && (

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -916,6 +916,7 @@ function App() {
             setViewerScreen("register");
           }}
           onOpenResults={() => setViewerScreen("results")}
+          connected={sseConnected}
         />
       )}
       {authPrompt && (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2512,6 +2512,18 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
           });
         }
 
+        // A pool has nothing to rank until at least one bout is decided: every
+        // competitor is tied at 0 and the backend rank is merely the seed/draw
+        // fallback. Suppress rank badges + the "advancing" qualification
+        // highlight until a result exists; provisional ranks then appear and
+        // update live as more bouts finish. W/L/D cover both individual and
+        // team standings (any decided encounter bumps one of them). Leagues are
+        // always rank-ordered, so this gate is applied only to the non-league
+        // pool badge/highlight below.
+        const poolHasResults = !!poolStandings && poolStandings.some(
+          (s) => (s.wins || 0) + (s.losses || 0) + (s.draws || 0) > 0
+        );
+
         // Determine which players to iterate.
         // - League: standings already arrive in rank order; use them so the table is
         //   rank-first (pool.players is not meaningful for leagues and may be empty).
@@ -2550,7 +2562,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                   const lookup = rankByPlayerKey.get(p.id || `${p.name}||${p.dojo || ""}`);
                   const s = lookup ? lookup.standing : null;
                   const rank = lookup ? lookup.rank : null;
-                  const isAdvancing = !isLeague && rank !== null && rank <= poolWinners;
+                  const isAdvancing = !isLeague && poolHasResults && rank !== null && rank <= poolWinners;
 
                   const rowClasses = [
                     isFollowedPlayer(p, highlightPlayer) ? "pool__row--me" : "",
@@ -2581,7 +2593,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                               draw-position column. League standings are rank-sorted,
                               so "#" already equals the rank and a badge would just
                               duplicate it — suppress it there. */}
-                          {!isLeague && rank !== null ? (
+                          {!isLeague && poolHasResults && rank !== null ? (
                             <span className={`rank-badge${isAdvancing ? " rank-badge--adv" : ""}`}>
                               {rankOrdinal(rank)}{s && s.isOverridden ? "*" : ""}
                             </span>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -647,7 +647,7 @@ export function TournamentInfo({ tournament }) {
   );
 }
 
-function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults }) {
+function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults, connected = true }) {
   const t = tournament;
   const comps = t.competitions || [];
   const compsByDate = useMemo(() => {
@@ -685,7 +685,11 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   // history is later changed in-app via route(). When the UUID hits a
   // participant we set the followed-player; if the UUID misses we fall
   // back to a name match (FR-020 / acceptance scenario 5).
+  // If a player is already followed and the deep link resolves to a
+  // different person, we surface a confirmation banner instead of
+  // silently overwriting the existing selection.
   const roster = useMemo(() => buildRoster(t.competitions), [t.competitions]);
+  const [pendingDeepLink, setPendingDeepLink] = useState(null);
 
   const deepLinkApplied = useRefV(false);
   React.useEffect(() => {
@@ -703,9 +707,17 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
       const needle = (qpName || qpPlayer).toLowerCase();
       if (needle) hit = roster.find((p) => (p.name || "").toLowerCase().includes(needle));
     }
-    if (hit) setFollowedPlayer({ id: hit.id, name: hit.name });
+    if (hit) {
+      const alreadySet = followedPlayer && followedPlayer.id && followedPlayer.id !== hit.id;
+      if (alreadySet) {
+        // Ask before overwriting the existing followed player.
+        setPendingDeepLink({ id: hit.id, name: hit.name });
+      } else {
+        setFollowedPlayer({ id: hit.id, name: hit.name });
+      }
+    }
     deepLinkApplied.current = true;
-  }, [roster, setFollowedPlayer]);
+  }, [roster, followedPlayer, setFollowedPlayer]);
 
   // global "across-all-competitions" lists for the home page
   const allMatches = useMemo(() => tournamentMatches(t), [t]);
@@ -768,6 +780,39 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
         </div>
 
         <div className="viewer__body">
+          {/* T063: SSE connection indicator — visible only when the live feed drops. */}
+          {!connected && (
+            <div className="sse-offline-banner" role="status" aria-live="polite">
+              <span className="sse-offline-banner__dot" aria-hidden="true" />
+              Live feed reconnecting — scores may be outdated
+            </div>
+          )}
+          {/* Deep-link overwrite confirmation — shown when ?player= targets a
+              different participant than the one currently being followed. */}
+          {pendingDeepLink && (
+            <div className="pending-follow-banner" role="status">
+              <span className="pending-follow-banner__label">
+                This link wants to follow{" "}
+                <span className="pending-follow-banner__name">{pendingDeepLink.name}</span>
+              </span>
+              <button
+                className="btn btn--sm"
+                onClick={() => {
+                  setFollowedPlayer({ id: pendingDeepLink.id, name: pendingDeepLink.name });
+                  setPendingDeepLink(null);
+                }}
+              >
+                Switch
+              </button>
+              <button
+                className="btn btn--ghost btn--sm"
+                onClick={() => setPendingDeepLink(null)}
+                aria-label="Keep current followed player"
+              >
+                Keep current
+              </button>
+            </div>
+          )}
           <TournamentInfo tournament={t} />
           <div className="viewer__court-filter">
              <select className="input" value={courtFilter} onChange={(e) => setCourtFilter(e.target.value)}>
@@ -857,7 +902,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                 <div className="empty">
                   <div className="icon">⏳</div>
                   <h3>No competitions yet</h3>
-                  <div style={{ fontSize: 13 }}>Check back soon for the tournament schedule and updates.</div>
+                  <div className="hint--md">Check back soon for the tournament schedule and updates.</div>
                 </div>
               </div>
             </>
@@ -896,7 +941,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                         )}
                       </button>
                       {showRegister && (
-                        <div style={{ padding: "0 12px 12px" }}>
+                        <div className="vlist-item--row-padded">
                           <button
                             className="btn btn--primary btn--sm btn--full"
                             onClick={(e) => {
@@ -939,7 +984,6 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                 if (window.AppRouter && window.AppRouter.route) window.AppRouter.route("/glossary");
                 else window.location.href = "/glossary";
               }}
-              style={{ textDecoration: "none" }}
             >
               <span className="vlist-item__icon">📖</span>
               <div className="vlist-item__rowbody">
@@ -991,7 +1035,7 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
   }, []);
 
   return (
-    <div className="pmf" ref={ref} style={{ marginBottom: 8 }}>
+    <div className="pmf" ref={ref}>
       <div className="pmf__bar" onClick={() => setOpen(true)}>
         <input
           className="pmf__input"
@@ -1016,7 +1060,7 @@ function SinglePlayerPicker({ roster, onPick, placeholder, excludeIds }) {
               <span className="pmf__opt-body">
                 <span className="pmf__opt-name">
                   {p.name}
-                  {p.checkedIn && <span className="tag-badge" style={{ marginLeft: 8, fontSize: 9 }}>Checked in</span>}
+                  {p.checkedIn && <span className="tag-badge pmf__checkin-tag">Checked in</span>}
                 </span>
                 <span className="pmf__opt-dojo">{p.dojo || ""}</span>
               </span>
@@ -1081,9 +1125,9 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
 
   if (!followedPlayer || !followedPlayer.id) {
     return (
-      <div className="card card--sm" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
-        <div className="section-title" style={{ marginTop: 0 }}>Find my matches</div>
-        <div style={{ fontSize: 12, color: "var(--ink-3)", marginBottom: 8 }}>
+      <div className="card card--sm mymatch-card" data-testid="viewer-home-mymatch">
+        <div className="section-title section-title--flush">Find my matches</div>
+        <div className="hint">
           Pick a participant — we'll surface their next match and highlight them across the schedule.
         </div>
         <SinglePlayerPicker
@@ -1113,9 +1157,9 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
 
   if (!nextMatch) {
     return (
-      <div className="card card--sm" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
+      <div className="card card--sm mymatch-card" data-testid="viewer-home-mymatch">
         {header}
-        <div style={{ fontSize: 13, color: "var(--ink-3)" }}>All your matches are completed.</div>
+        <div className="hint--md">All your matches are completed.</div>
       </div>
     );
   }
@@ -1140,7 +1184,7 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
   const queueHighlight = queueLabel === "Next up";
 
   return (
-    <div className="my-match" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
+    <div className="my-match mymatch-card" data-testid="viewer-home-mymatch">
       {header}
       <div className="my-match__lbl">Your next match</div>
       <div className="my-match__name">
@@ -1189,7 +1233,6 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
         <button
           className="my-match__opp"
           onClick={() => onMatchClick && onMatchClick(nextMatch)}
-          style={{ color: "inherit" }}
         >
           <div className="l">
             <span className={`bc-color-badge ${oppBadgeClass}`}>{oppBadgeLabel}</span>
@@ -1284,25 +1327,25 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
   const addDojoDisabled = watchlist.length >= WATCHLIST_MAX || !dojoSel || !selStats || selStats.watched >= selStats.total;
 
   return (
-    <div className="card card--sm" data-testid="viewer-home-watchlist" style={{ marginBottom: 16 }}>
-      <div className="section-title" style={{ marginTop: 0, display: "flex", alignItems: "center", gap: 8 }}>
+    <div className="card card--sm mymatch-card" data-testid="viewer-home-watchlist">
+      <div className="section-title section-title--inrow">
         <span>Watchlist</span>
         {watchlist.length > 0 && (
           <span className="watchlist-count">{pluralize(watchlist.length, "player")}</span>
         )}
       </div>
       {watchlist.length === 0 ? (
-        <div style={{ fontSize: 12, color: "var(--ink-3)", marginBottom: 8 }}>
+        <div className="hint">
           Watching a coach's students or a few key competitors? Add up to {WATCHLIST_MAX} participants and we'll surface their upcoming matches.
         </div>
       ) : (
-        <div className="pmf__bar" style={{ marginBottom: 8 }}>
+        <div className="pmf__bar">
           {watchlist.map((w) => {
             const pRecord = rosterById.get(w.id);
             return (
               <span key={w.id} className={`pmf__chip ${pRecord && pRecord.checkedIn ? "is-checked-in" : ""}`} title={pRecord && pRecord.checkedIn ? "Checked in" : undefined}>
                 {w.name}
-                {pRecord && pRecord.checkedIn && <span style={{ marginLeft: 4, fontSize: 10 }}>✓</span>}
+                {pRecord && pRecord.checkedIn && <span className="pmf__chip-tick" aria-hidden="true">✓</span>}
                 <button onClick={() => removeOne(w.id)} aria-label={`Remove ${w.name}`}>×</button>
               </span>
             );
@@ -1349,7 +1392,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
 
       {upcoming.length > 0 && (
         <>
-          <div className="section-title" style={{ marginTop: 14, fontSize: 13 }}>
+          <div className="section-title section-title--sub">
             Watched matches · upcoming {upcoming.length}
           </div>
           <div className="vsched">
@@ -1392,7 +1435,6 @@ function DisplayModes({ tournament }) {
           href="/display?court=all"
           target="_blank"
           rel="noopener noreferrer"
-          style={{ textDecoration: "none" }}
         >
           <span className="vlist-item__icon">🪟</span>
           <div className="vlist-item__rowbody">
@@ -1406,7 +1448,7 @@ function DisplayModes({ tournament }) {
           { icon: "📺", title: "Court displays", suffix: "" },
           { icon: "🎥", title: "Streaming overlays", suffix: "&overlay=1" },
         ].map((row) => (
-          <div key={row.title} className="vlist-item vlist-item--row" style={{ cursor: "default" }}>
+          <div key={row.title} className="vlist-item vlist-item--row vlist-item--static">
             <span className="vlist-item__icon">{row.icon}</span>
             <div className="vlist-item__rowbody">
               <div className="vlist-item__rowtitle">{row.title}</div>
@@ -1510,10 +1552,10 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       {isFinal && winner && <WinnerBadge name={winner.player?.name || ""} />}
-      <div className="pool" style={{ padding: 14 }}>
+      <div className="pool">
         <div className="pool__head">
           <div className="pool__name">{heading}</div>
-          <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
+          <div className="pool__match-count">
             Round {c.swissCurrentRound || 0} of {c.swissRounds || 0}
           </div>
         </div>
@@ -1530,10 +1572,10 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
               <tr key={s.player?.id || s.player?.name || i}>
                 {/* Rank-ordered: "#" is the authoritative standing rank (s.rank),
                     DRY with the backend tiebreak/override logic, not the row index. */}
-                <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{s.rank || i + 1}{s.isOverridden ? "*" : ""}</td>
+                <td className={`pool-standings__draw-pos${s.isOverridden ? " pool-standings__draw-pos--override" : ""}`}>{s.rank || i + 1}{s.isOverridden ? "*" : ""}</td>
                 <td>
-                  <div style={{ fontWeight: 500 }}>{s.player?.name || ""}</div>
-                  {tweaks?.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</div> : null}
+                  <div className="pool__player-name">{s.player?.name || ""}</div>
+                  {tweaks?.showDojo ? <div className="pool__dojo-name">{s.player?.dojo || ""}</div> : null}
                 </td>
                 <td className="num">{s.wins || 0}</td>
                 <td className="num">{s.losses || 0}</td>
@@ -1542,12 +1584,12 @@ function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
                 <td className="num">{s.ipponsTaken || 0}</td>
               </tr>
             )) : (
-              <tr><td colSpan={7} style={{ textAlign: "center", color: "var(--ink-3)", fontSize: 13, padding: 16 }}>No matches scored yet.</td></tr>
+              <tr><td colSpan={7} className="pool__table-empty">No matches scored yet.</td></tr>
             )}
           </tbody>
         </table>
         {standings.length > 0 && (
-          <div className="league-matrix__legend" style={{ marginTop: 8, fontSize: 11, color: "var(--ink-3)" }}>
+          <div className="league-matrix__legend hint--sm" style={{ marginTop: 8 }}>
             Ranked by: wins → points scored (PW) → head-to-head.
           </div>
         )}
@@ -1945,12 +1987,12 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
 
       {/* League standings summary (mp-ldnr) */}
       {isLeague && leagueStandings.length > 0 && (c.status === "pools" || c.status === "playoffs" || c.status === "completed") && (
-        <div className="pool" style={{ padding: 14, marginBottom: 12 }} data-testid="league-overview-standings">
+        <div className="pool pool--overview-summary" data-testid="league-overview-standings">
           {leagueWinner && <WinnerBadge name={leagueWinner.player?.name || ""} testId="league-overview-winner" marginBottom={12} />}
           <div className="pool__head">
             <div className="pool__name">{allMatchesComplete ? "Final standings" : "Standings"}</div>
             {poolMatches && (
-              <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
+              <div className="pool__match-count">
                 {poolMatches.filter(m => m.status === "completed").length}/{poolMatches.length} matches
               </div>
             )}
@@ -1969,9 +2011,9 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
                   {/* Rank-ordered summary: "#" is the authoritative standing rank
                       (s.rank), not the row index — DRY with the full standings and
                       the backend tiebreak/override logic. */}
-                  <td style={{ color: s.isOverridden ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: s.isOverridden ? 700 : 400 }}>{s.rank || i + 1}{s.isOverridden ? "*" : ""}</td>
+                  <td className={`pool-standings__draw-pos${s.isOverridden ? " pool-standings__draw-pos--override" : ""}`}>{s.rank || i + 1}{s.isOverridden ? "*" : ""}</td>
                   <td>
-                    <div style={{ fontWeight: 500 }}>
+                    <div className="pool__player-name">
                       {s.player?.number ? <span className="num-prefix">{s.player.number}</span> : null}
                       {s.player?.name || ""}
                       {/* No rank badge here: this summary is rank-sorted, so the
@@ -1979,7 +2021,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
                           it. The rank badge only carries information when rows are
                           in draw order (non-league pools), where rank ≠ position. */}
                     </div>
-                    {tweaks?.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{s.player?.dojo || ""}</div> : null}
+                    {tweaks?.showDojo ? <div className="pool__dojo-name">{s.player?.dojo || ""}</div> : null}
                   </td>
                   <td className="num">{s.wins || 0}</td>
                   <td className="num">{s.losses || 0}</td>
@@ -1993,14 +2035,13 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
             </tbody>
           </table>
           {leagueStandings.length > 5 && (
-            <div style={{ marginTop: 8, fontSize: 11, color: "var(--ink-3)" }}>
+            <div className="hint--sm pool__overflow-note">
               Showing top 5 of {leagueStandings.length}
             </div>
           )}
           {onSwitchTab && (
             <button
-              className="btn btn--link"
-              style={{ marginTop: 8, fontSize: 13, padding: 0 }}
+              className="btn btn--link pool__view-all-btn"
               onClick={() => onSwitchTab("pools")}
               data-testid="league-overview-view-all"
             >
@@ -2478,10 +2519,10 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
           // A lone pool (every league has exactly one) must span the full grid
           // width. Otherwise the landscape 2-column `.pools-grid` renders it at
           // half width, mismatching the full-width Overview standings table.
-          <div key={pool.poolName} className="pool" style={{ padding: 14, gridColumn: pools.length === 1 ? "1 / -1" : undefined }}>
+          <div key={pool.poolName} className="pool" style={pools.length === 1 ? { gridColumn: "1 / -1" } : undefined}>
             <div className="pool__head">
               <div className="pool__name">{isLeague ? (allMatchesComplete ? "Final standings" : "Standings") : pool.poolName}</div>
-              <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
+              <div className="pool__match-count">
                 {matches.filter(m => m.status === "completed").length}/{matches.length} matches
               </div>
             </div>
@@ -2490,9 +2531,9 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
             <table className="pool__table">
               <thead>
                 {isTeam ? (
-                  <tr><th>#</th><th>Team</th><th className="num" title="Team matches won">W</th><th className="num" title="Team matches lost">L</th><th className="num" title="Team matches tied">T</th><th className="num" title="Individual victories">IV</th><th className="num" title="Individual losses">IL</th><th className="num" title="Individual ties (draws)">IT</th><th className="num" title="Points won">PW</th><th className="num" title="Points lost">PL</th></tr>
+                  <tr><th scope="col">#</th><th scope="col">Team</th><th className="num" scope="col"><abbr title="Team matches won">W</abbr></th><th className="num" scope="col"><abbr title="Team matches lost">L</abbr></th><th className="num" scope="col"><abbr title="Team matches tied">T</abbr></th><th className="num" scope="col"><abbr title="Individual victories">IV</abbr></th><th className="num" scope="col"><abbr title="Individual losses">IL</abbr></th><th className="num" scope="col"><abbr title="Individual ties (draws)">IT</abbr></th><th className="num" scope="col"><abbr title="Points won">PW</abbr></th><th className="num" scope="col"><abbr title="Points lost">PL</abbr></th></tr>
                 ) : (
-                  <tr><th>#</th><th>Player</th><th className="num" title="Fights won">W</th><th className="num" title="Fights lost">L</th><th className="num" title="Draws (hikiwake)">D</th><th className="num" title="Points won (ippon)">PW</th><th className="num" title="Points lost">PL</th></tr>
+                  <tr><th scope="col">#</th><th scope="col">Player</th><th className="num" scope="col"><abbr title="Fights won">W</abbr></th><th className="num" scope="col"><abbr title="Fights lost">L</abbr></th><th className="num" scope="col"><abbr title="Draws (hikiwake)">D</abbr></th><th className="num" scope="col"><abbr title="Points won (ippon)">PW</abbr></th><th className="num" scope="col"><abbr title="Points lost">PL</abbr></th></tr>
                 )}
               </thead>
               <tbody>
@@ -2521,12 +2562,12 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                             fight-order chart), so "#" is the draw position and the
                             rank is surfaced separately by the badge next to the name. */}
                       {isLeague ? (
-                        <td className="pool-standings__draw-pos" style={{ color: (s && s.isOverridden) ? "var(--accent)" : "var(--ink-3)", fontFamily: "var(--font-mono)", fontWeight: (s && s.isOverridden) ? 700 : 400 }}>{rank ?? drawPos}{s && s.isOverridden ? "*" : ""}</td>
+                        <td className={`pool-standings__draw-pos${s && s.isOverridden ? " pool-standings__draw-pos--override" : ""}`}>{rank ?? drawPos}{s && s.isOverridden ? "*" : ""}</td>
                       ) : (
-                        <td className="pool-standings__draw-pos" style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>{drawPos}</td>
+                        <td className="pool-standings__draw-pos">{drawPos}</td>
                       )}
                       <td>
-                        <div style={{ fontWeight: 500 }}>
+                        <div className="pool__player-name">
                           {p.number ? <span className="num-prefix">{p.number}</span> : null}
                           {p.name}
                           {/* The rank badge is only informative when rows are in
@@ -2540,7 +2581,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                             </span>
                           ) : null}
                         </div>
-                        {tweaks.showDojo ? <div style={{ fontSize: 11, color: "var(--ink-3)" }}>{p.dojo}</div> : null}
+                        {tweaks.showDojo ? <div className="pool__dojo-name">{p.dojo}</div> : null}
                       </td>
                       {s ? (
                         <>
@@ -3236,12 +3277,12 @@ function AwardsView({ c, bracket, standings, pools, players }) {
   // Shared header (title + place count + fullscreen toggle) — identical for the
   // league and champion-hero layouts.
   const header = (
-    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+    <div className="awards__header">
       <div>
-        <div className="section-title" style={{ margin: 0, fontSize: isFs ? 28 : 18 }}>
+        <div className={`section-title awards__title${isFs ? " awards__title--fs" : ""}`}>
           {c?.name ? `${c.name} — Awards` : "Awards"}
         </div>
-        <div style={{ fontSize: isFs ? 16 : 12, color: "var(--ink-3)" }}>
+        <div className={isFs ? "awards__subtitle--fs" : "awards__subtitle"}>
           Closing ceremony · {awards.length} place{awards.length === 1 ? "" : "s"}
         </div>
       </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2449,14 +2449,14 @@ const PoolNumberedMatchRow = React.memo(({ m, num, onMatchClick }) => {
     <button type="button" className="pool-match-numbered-row" style={{ cursor: handleClick ? "pointer" : "default" }} onClick={handleClick}>
       <span className="pool-match-numbered-row__num">{num}</span>
       <div className="pool-match-numbered-row__side pool-match-numbered-row__side--shiro">
-        <span className="cbadge cbadge--shiro">Shiro</span>
+        <span className="sr-only">Shiro: </span>
         <span className="pool-match-numbered-row__name">{bName || "—"}</span>
       </div>
       <span className="pool-match-numbered-row__score">
         {m.status === "completed" ? (scoreStr || "—") : m.status === "running" ? <span className="bc-live" style={{ fontSize: 10 }}>●</span> : "–"}
       </span>
       <div className="pool-match-numbered-row__side pool-match-numbered-row__side--aka">
-        <span className="cbadge cbadge--aka">Aka</span>
+        <span className="sr-only">Aka: </span>
         <span className="pool-match-numbered-row__name">{aName || "—"}</span>
       </div>
     </button>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -758,15 +758,13 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             </div>
             <div className="viewer__title viewer__title--lg">{t.name}</div>
           </div>
-          <button className="viewer__admin-pill" onClick={onAdminClick}>
-            <span>🔒</span> Admin
-          </button>
+          <button className="viewer__admin-pill" onClick={onAdminClick}>Admin</button>
         </div>
 
         <div className="viewer__body">
           <TournamentInfo tournament={t} />
-          <div style={{ marginBottom: 16, display: "flex", justifyContent: "flex-end" }}>
-             <select className="input" style={{ width: "auto" }} value={courtFilter} onChange={(e) => setCourtFilter(e.target.value)}>
+          <div className="viewer__court-filter">
+             <select className="input" value={courtFilter} onChange={(e) => setCourtFilter(e.target.value)}>
                <option value="all">All Shiaijo</option>
                {(t.courts || ["A"]).map(c => <option key={c} value={c}>Shiaijo {c}</option>)}
              </select>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -647,6 +647,25 @@ export function TournamentInfo({ tournament }) {
   );
 }
 
+// Pure helper: resolve a ?player= / ?name= deep link against the participant
+// roster and the currently-followed player. Returns null when no action is
+// needed, or { player, pending } where pending=true means a confirmation banner
+// should be shown instead of silently overwriting the existing selection.
+export function resolveDeepLink(searchString, roster, followedPlayer) {
+  const params = new URLSearchParams(searchString || "");
+  const qpPlayer = (params.get("player") || "").trim();
+  const qpName = (params.get("name") || "").trim();
+  if (!qpPlayer && !qpName) return null;
+  let hit = qpPlayer ? roster.find((p) => p.id === qpPlayer) : null;
+  if (!hit) {
+    const needle = (qpName || qpPlayer).toLowerCase();
+    if (needle) hit = roster.find((p) => (p.name || "").toLowerCase().includes(needle));
+  }
+  if (!hit) return null;
+  const alreadySet = followedPlayer && followedPlayer.id && followedPlayer.id !== hit.id;
+  return { player: { id: hit.id, name: hit.name }, pending: !!alreadySet };
+}
+
 function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults, connected = true }) {
   const t = tournament;
   const comps = t.competitions || [];
@@ -696,27 +715,14 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
     if (deepLinkApplied.current) return;
     if (typeof window === "undefined" || !window.location) return;
     if (roster.length === 0) return; // wait until participants are loaded
-    const params = new URLSearchParams(window.location.search || "");
-    const qpPlayer = (params.get("player") || "").trim();
-    const qpName = (params.get("name") || "").trim();
-    if (!qpPlayer && !qpName) { deepLinkApplied.current = true; return; }
-    // 1) UUID lookup
-    let hit = qpPlayer ? roster.find((p) => p.id === qpPlayer) : null;
-    // 2) Fall back to name (use ?name= if present, else treat ?player= as a name)
-    if (!hit) {
-      const needle = (qpName || qpPlayer).toLowerCase();
-      if (needle) hit = roster.find((p) => (p.name || "").toLowerCase().includes(needle));
-    }
-    if (hit) {
-      const alreadySet = followedPlayer && followedPlayer.id && followedPlayer.id !== hit.id;
-      if (alreadySet) {
-        // Ask before overwriting the existing followed player.
-        setPendingDeepLink({ id: hit.id, name: hit.name });
-      } else {
-        setFollowedPlayer({ id: hit.id, name: hit.name });
-      }
-    }
+    const result = resolveDeepLink(window.location.search, roster, followedPlayer);
     deepLinkApplied.current = true;
+    if (!result) return;
+    if (result.pending) {
+      setPendingDeepLink(result.player);
+    } else {
+      setFollowedPlayer(result.player);
+    }
   }, [roster, followedPlayer, setFollowedPlayer]);
 
   // global "across-all-competitions" lists for the home page
@@ -2156,7 +2162,7 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight 
     ? (window.queueLabelCompact ? window.queueLabelCompact(m) : _localQueueLabelCompact(m))
     : null;
   return (
-    <button className={`vsched-item ${m.status === "running" ? "vsched-item--live" : ""} ${highlight ? "vsched-item--me" : ""}`} onClick={onClick}>
+    <button className={`vsched-item ${m.status === "running" ? "vsched-item--live" : ""} ${highlight ? "vsched-item--me" : ""}`} onClick={onClick} data-clickable={onClick ? "" : undefined}>
       <div className="vsched-item__head">
         <span className="vsched-item__time">{m.scheduledAt || "—"}</span>
         <span className="vsched-item__court">SHIAIJO {m.court}</span>
@@ -2781,7 +2787,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, MyMatchAlertBanner, LeagueMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, buildFollowedNextMatch, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, addDojoToWatchlist, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, ViewerHome, MyMatchAlertBanner, LeagueMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -816,7 +816,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
           {live.length > 0 && (
             <div className="hero-live">
               <div className="hero-live__lbl"><span className="dot dot--live"></span> NOW · {pluralize(live.length, "match", "matches")}</div>
-              <div className="vsched" style={{ marginTop: 8 }}>
+              <div className="vsched hero-live__vsched">
                 {live.slice(0, 3).map((m) => <VSchedItem key={m.compId + m.id} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
               </div>
             </div>
@@ -874,10 +874,10 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                   const pct = total ? Math.round((done / total) * 100) : 0;
                   const showRegister = shouldShowRegister(t, c, !!onRegister);
                   return (
-                    <div key={c.id} style={{ position: "relative" }}>
-                      <button className="vlist-item vlist-item--comp" style={{ width: "100%" }} onClick={() => onSelectCompetition(c.id)}>
-                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
-                          <div style={{ minWidth: 0 }}>
+                    <div key={c.id} className="comp-item">
+                      <button className="vlist-item vlist-item--comp" onClick={() => onSelectCompetition(c.id)}>
+                        <div className="comp-item__header">
+                          <div className="comp-item__body">
                             <div className="vlist-item__eyebrow">{competitionKindLabel(c)}{c.teamSize > 1 ? ` · ${c.teamSize}-person` : ""}</div>
                             <div className="vlist-item__name">{c.name}</div>
                             <div className="vlist-item__meta">
@@ -890,7 +890,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
                           <div className="vlist-item__progress">
                             <div className="vlist-item__bar"><div style={{ width: pct + "%" }}></div></div>
                             <div className="vlist-item__pct">
-                              {liveCount > 0 ? <span style={{ color: "var(--red)", fontWeight: 600 }}>● {liveCount} now</span> : pluralize(done, "match", "matches") + " / " + total}
+                              {liveCount > 0 ? <span className="bc-live-count">● {liveCount} now</span> : pluralize(done, "match", "matches") + " / " + total}
                             </div>
                           </div>
                         )}
@@ -917,7 +917,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
 
           {upNext.length > 0 && (
             <>
-              <div className="section-title" style={{ marginTop: 20 }}>Up next · {upNext.length}</div>
+              <div className="section-title viewer__upnext-title">Up next · {upNext.length}</div>
               <div className="vsched">
                 {upNext.map((m) => <VSchedItem key={m.compId + m.id} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
               </div>
@@ -930,7 +930,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
           {/* U1: link to the kendo glossary so volunteers (and
               spectators new to kendo) can browse the term register
               that the inline tooltips draw from. */}
-          <div className="vlist" style={{ marginTop: 12 }}>
+          <div className="vlist viewer__glossary-vlist">
             <a
               className="vlist-item vlist-item--row"
               href="/glossary"
@@ -1081,7 +1081,7 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
 
   if (!followedPlayer || !followedPlayer.id) {
     return (
-      <div className="card" data-testid="viewer-home-mymatch" style={{ marginBottom: 16, padding: 14 }}>
+      <div className="card card--sm" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
         <div className="section-title" style={{ marginTop: 0 }}>Find my matches</div>
         <div style={{ fontSize: 12, color: "var(--ink-3)", marginBottom: 8 }}>
           Pick a participant — we'll surface their next match and highlight them across the schedule.
@@ -1097,15 +1097,14 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
 
   // Followed-player state: header indicator + next-match details.
   const header = (
-    <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 8 }}>
-      <span style={{ fontSize: 12, color: "var(--ink-3)" }}>Following:</span>
-      <span style={{ fontWeight: 600 }}>{followedPlayer.name || "(unknown)"}</span>
-      {pRecord && pRecord.checkedIn && <span className="tag-badge" style={{ fontSize: 9 }}>✓ Checked in</span>}
+    <div className="my-match__follow-row">
+      <span className="my-match__follow-lbl">Following:</span>
+      <span className="my-match__follow-name">{followedPlayer.name || "(unknown)"}</span>
+      {pRecord && pRecord.checkedIn && <span className="tag-badge">✓ Checked in</span>}
       <button
         className="btn btn--ghost btn--sm btn--clear-follow"
         onClick={() => setFollowedPlayer(null)}
         aria-label="Stop following"
-        style={{ marginLeft: 4 }}
       >
         ✕ Clear
       </button>
@@ -1114,7 +1113,7 @@ function MyMatchPanel({ roster, followedPlayer, setFollowedPlayer, nextMatch, on
 
   if (!nextMatch) {
     return (
-      <div className="card" data-testid="viewer-home-mymatch" style={{ marginBottom: 16, padding: 14 }}>
+      <div className="card card--sm" data-testid="viewer-home-mymatch" style={{ marginBottom: 16 }}>
         {header}
         <div style={{ fontSize: 13, color: "var(--ink-3)" }}>All your matches are completed.</div>
       </div>
@@ -1285,13 +1284,11 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
   const addDojoDisabled = watchlist.length >= WATCHLIST_MAX || !dojoSel || !selStats || selStats.watched >= selStats.total;
 
   return (
-    <div className="card" data-testid="viewer-home-watchlist" style={{ marginBottom: 16, padding: 14 }}>
+    <div className="card card--sm" data-testid="viewer-home-watchlist" style={{ marginBottom: 16 }}>
       <div className="section-title" style={{ marginTop: 0, display: "flex", alignItems: "center", gap: 8 }}>
         <span>Watchlist</span>
         {watchlist.length > 0 && (
-          <span style={{ fontSize: 11, color: "var(--ink-3)", fontWeight: 500 }}>
-            {pluralize(watchlist.length, "player")}
-          </span>
+          <span className="watchlist-count">{pluralize(watchlist.length, "player")}</span>
         )}
       </div>
       {watchlist.length === 0 ? (
@@ -1319,13 +1316,13 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
         excludeIds={watchlist.map((w) => w.id)}
       />
       {dojos.length > 0 && (
-        <div style={{ marginTop: 8, display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }} data-testid="watchlist-dojo-picker">
-          <label style={{ fontSize: 12, color: "var(--ink-3)" }} htmlFor="watchlist-dojo-select">Watch all from dojo</label>
+        <div className="watchlist-dojo-row" data-testid="watchlist-dojo-picker">
+          <label className="watchlist-dojo-row__label" htmlFor="watchlist-dojo-select">Watch all from dojo</label>
           <select
             id="watchlist-dojo-select"
             value={dojoSel}
             onChange={(e) => setDojoSel(e.target.value)}
-            style={{ fontSize: 13, padding: "4px 8px" }}
+            className="input"
             data-testid="watchlist-dojo-select"
           >
             <option value="">— pick a dojo —</option>
@@ -1346,7 +1343,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
           >
             Add dojo
           </button>
-          {bulkMsg && <span style={{ fontSize: 11, color: "var(--ink-3)" }} role="status">{bulkMsg}</span>}
+          {bulkMsg && <span className="watchlist-dojo-row__feedback" role="status">{bulkMsg}</span>}
         </div>
       )}
 
@@ -1387,8 +1384,8 @@ function DisplayModes({ tournament }) {
   // data has loaded fully.
   if (courts.length === 0) return null;
   return (
-    <details style={{ marginTop: 20 }}>
-      <summary className="section-title" style={{ cursor: "pointer" }}>Display modes</summary>
+    <details className="viewer-display-modes">
+      <summary className="section-title">Display modes</summary>
       <div className="vlist" data-testid="viewer-home-display-modes">
         <a
           className="vlist-item vlist-item--row"
@@ -1413,12 +1410,12 @@ function DisplayModes({ tournament }) {
             <span className="vlist-item__icon">{row.icon}</span>
             <div className="vlist-item__rowbody">
               <div className="vlist-item__rowtitle">{row.title}</div>
-              <div className="vlist-item__rowsub" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <div className="vlist-item__rowsub viewer-display-modes__row-links">
                 {courts.map((cc, i) => (
                   <span key={cc}>
                     <a href={`/display?court=${encodeURIComponent(cc)}${row.suffix}`} target="_blank" rel="noopener noreferrer"
-                      style={{ color: "var(--text-link, #2563eb)" }}>Shiaijo {cc}</a>
-                    {i < courts.length - 1 && <span aria-hidden="true" style={{ color: "var(--text-3, #999)", marginLeft: 8 }}>·</span>}
+                      className="viewer-display-modes__link">Shiaijo {cc}</a>
+                    {i < courts.length - 1 && <span aria-hidden="true" className="viewer-display-modes__sep">·</span>}
                   </span>
                 ))}
               </div>
@@ -1463,22 +1460,11 @@ function swissStandingsHeading(comp, poolMatches) {
 function WinnerBadge({ name, isFs = false, testId, marginBottom }) {
   return (
     <div
-      className="winner-badge"
+      className={`winner-badge${isFs ? " winner-badge--lg" : ""}`}
       data-testid={testId}
-      style={{
-        padding: isFs ? "14px 18px" : "10px 14px",
-        background: "linear-gradient(135deg, var(--accent) 0%, var(--accent-2, var(--accent)) 100%)",
-        color: "white",
-        borderRadius: 8,
-        fontWeight: 700,
-        fontSize: isFs ? 18 : 14,
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-        marginBottom: marginBottom,
-      }}
+      style={marginBottom != null ? { marginBottom } : undefined}
     >
-      <span style={{ fontSize: isFs ? 28 : 18 }}>🏆</span>
+      <span className="winner-badge__icon" aria-hidden="true">🏆</span>
       <span>Winner: {name}</span>
     </div>
   );
@@ -1753,7 +1739,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             />
           )}
           {tab === "bracket" && derivedBracket && (
-            <div style={{ marginLeft: -16, marginRight: -16 }}>
+            <div className="viewer-bracket-bleed">
               <div ref={bracketScrollRef} className="bracket-canvas" style={{ borderRadius: 0, borderLeft: 0, borderRight: 0 }}>
                 <div className="bracket-canvas__inner" style={{ padding: 18 }}>
                   <window.BracketTree
@@ -1921,13 +1907,8 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
   return (
     <div>
       {hasActiveFilter && (
-        <div style={{
-          display: "flex", alignItems: "center", gap: 8,
-          padding: "8px 12px", marginBottom: 12,
-          background: "var(--accent-soft, #eef)",
-          borderRadius: 8, fontSize: 13
-        }}>
-          <span aria-hidden="true" style={{ color: "var(--accent, #36c)" }}>👤</span>
+        <div className="viewer-filter-bar">
+          <span className="viewer-filter-bar__icon" aria-hidden="true">👤</span>
           <span>Showing matches for <strong>{filterLabel}</strong></span>
         </div>
       )}
@@ -2044,7 +2025,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
             }
           } : undefined}
         >
-          <div className="section-title" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <div className="section-title section-title--live">
             <span className="dot dot--live"></span> ON NOW
           </div>
           <MatchDetailCard match={currentMatch} />
@@ -2054,7 +2035,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, liveMatches, up
       {/* Live matches beyond the single current match */}
       {liveMatches.length > 1 && (
         <>
-          <div className="section-title" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <div className="section-title section-title--live">
             <span className="dot dot--live"></span> NOW · {liveMatches.length}
           </div>
           <div className="vsched">
@@ -2134,7 +2115,7 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight 
     ? (window.queueLabelCompact ? window.queueLabelCompact(m) : _localQueueLabelCompact(m))
     : null;
   return (
-    <button className={`vsched-item ${m.status === "running" ? "vsched-item--live" : ""} ${highlight ? "vsched-item--me" : ""}`} onClick={onClick} style={{ textAlign: "left", width: "100%", border: "none", background: "none", cursor: onClick ? "pointer" : "default" }}>
+    <button className={`vsched-item ${m.status === "running" ? "vsched-item--live" : ""} ${highlight ? "vsched-item--me" : ""}`} onClick={onClick}>
       <div className="vsched-item__head">
         <span className="vsched-item__time">{m.scheduledAt || "—"}</span>
         <span className="vsched-item__court">SHIAIJO {m.court}</span>
@@ -2144,20 +2125,18 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight 
           <span className="tw-match__round">R{m.round + 1}</span>
         )}
         {queueLabel && (
-          <span className="vsched-item__queue" style={{ marginLeft: "auto", fontSize: 11, fontWeight: 700, color: qp === 1 ? "var(--accent)" : "var(--ink-3)" }}>
+          <span className={`vsched-item__queue${qp === 1 ? " vsched-item__queue--next" : ""}`}>
             {queueLabel}
           </span>
         )}
-        {m.status === "running" && <span className="bc-live" style={{ marginLeft: "auto" }}>● NOW</span>}
-        {m.status === "completed" && <span style={{ marginLeft: "auto", color: "var(--ink-3)" }}>Final</span>}
+        {m.status === "running" && <span className="bc-live">● NOW</span>}
+        {m.status === "completed" && <span className="vsched-item__status">Final</span>}
         {m.status === "completed" && m.decidedByHantei && (
-          <span className="vsched-item__hantei" data-testid="vsched-hantei" style={{ marginLeft: 6, fontSize: 10, fontWeight: 700, padding: "1px 5px", borderRadius: 3, background: "var(--accent-soft, #eef)", color: "var(--accent, #36c)" }}>
-            HANTEI
-          </span>
+          <span className="vsched-item__hantei" data-testid="vsched-hantei">HANTEI</span>
         )}
       </div>
       <div className="vsched-item__players">
-        <div className={`vsched-item__side ${bWin ? "vsched-item__side--w" : ""}`} style={{ textAlign: "right" }}>
+        <div className={`vsched-item__side ${bWin ? "vsched-item__side--w" : ""}`}>
           <span className="n">{withNumber(m.sideB)}</span>
           {tweaks.showDojo && m.sideB?.dojo ? <span className="d">{m.sideB.dojo}</span> : null}
           <span className="vsched-item__color-badge vsched-item__color-badge--shiro">SHIRO</span>
@@ -2197,7 +2176,7 @@ const PoolMatchRow = React.memo(({ m, onClick }) => {
     : null;
 
   return (
-    <button className="pool-match-row" onClick={onClick} style={{ textAlign: "left", width: "100%", border: "none", background: "none", cursor: onClick ? "pointer" : "default" }}>
+    <button className="pool-match-row" onClick={onClick}>
       <div className={`pool-match-row__side pool-match-row__side--right ${bWin ? "pool-match-row__side--win" : ""}`}>
         <span className="pool-match-row__name">{bName}</span>
         <span className="pool-match-row__badge pool-match-row__badge--shiro">SHIRO</span>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1345,7 +1345,7 @@ function WatchlistPanel({ tournament, watchlist, setWatchlist, upcoming, onMatch
           Watching a coach's students or a few key competitors? Add up to {WATCHLIST_MAX} participants and we'll surface their upcoming matches.
         </div>
       ) : (
-        <div className="pmf__bar">
+        <div className="pmf__bar pmf__bar--standalone">
           {watchlist.map((w) => {
             const pRecord = rosterById.get(w.id);
             return (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -666,7 +666,7 @@ export function resolveDeepLink(searchString, roster, followedPlayer) {
   return { player: { id: hit.id, name: hit.name }, pending: !!alreadySet };
 }
 
-function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults, connected = true }) {
+function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults, sseConnected = true }) {
   const t = tournament;
   const comps = t.competitions || [];
   const compsByDate = useMemo(() => {
@@ -787,7 +787,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
 
         <div className="viewer__body">
           {/* T063: SSE connection indicator — visible only when the live feed drops. */}
-          {!connected && (
+          {!sseConnected && (
             <div className="sse-offline-banner" role="status" aria-live="polite">
               <span className="sse-offline-banner__dot" aria-hidden="true" />
               Live feed reconnecting — scores may be outdated

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -758,7 +758,13 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             </div>
             <div className="viewer__title viewer__title--lg">{t.name}</div>
           </div>
-          <button className="viewer__admin-pill" onClick={onAdminClick}>Admin</button>
+          <button className="viewer__admin-pill" onClick={onAdminClick}>
+            <svg width="10" height="12" viewBox="0 0 10 12" fill="none" aria-hidden="true">
+              <rect x="1" y="5" width="8" height="7" rx="1.5" fill="currentColor"/>
+              <path d="M3 5V3.5a2 2 0 0 1 4 0V5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+            </svg>
+            Admin
+          </button>
         </div>
 
         <div className="viewer__body">


### PR DESCRIPTION
## Summary

**P1 — SSE harden:** Wire \`sseConnected\` from \`app.jsx\` into \`ViewerHome\`; renders a red \`.sse-offline-banner\` when the live feed drops so viewers know scores may be stale.

**P1 — Deep-link UX:** \`?player=\` deep-link no longer silently overwrites the currently-followed player. Shows a \`.pending-follow-banner\` asking Switch / Keep current when the link resolves to a different player.

**A11y:** Pool table \`<th>\` cells get \`scope=\"col\"\` and abbreviation columns wrapped in \`<abbr title=\"...\">\` for screen readers and mobile long-press tooltips (W, L, D, PW, PL, IV, IL, IT).

**CSS anti-patterns removed:**
- \`.tournament-info\` \`border-left: 3px\` side-stripe → full accent-tinted border (impeccable ban)
- Podium step gradients (\`linear-gradient\`) → flat semantic fills
- \`.awards-hero\` gradient → flat gold
- \`.match-alert-banner\` gradient → flat \`var(--accent)\` (prior round)

**Admin pill:** Replace raw 🔒 emoji with inline SVG lock icon (10×12px, \`currentColor\`, \`aria-hidden\`).

**Inline style purge (~55 total):** \`style={{}}\` instances across MyMatchPanel, WatchlistPanel, pool standings, league-overview, SwissStandings, AwardsView, DisplayModes replaced with named CSS utility classes: \`.hint\`, \`.hint--sm/md\`, \`.pool__match-count\`, \`.pool__player-name\`, \`.pool__dojo-name\`, \`.pool-standings__draw-pos\` (+ \`--override\`), \`.awards__header/title/subtitle\`, \`.sse-offline-banner\`, \`.pending-follow-banner\`, \`.section-title--sub/flush/inrow\`, \`.pool--overview-summary\`, \`.mymatch-card\`, etc.

## Files changed

| File | What |
|---|---|
| \`web-mobile/js/app.jsx\` | Pass \`sseConnected={sseConnected}\` to \`<window.ViewerHome>\` |
| \`web-mobile/js/viewer.jsx\` | SSE banner, pending-follow banner, abbr a11y, ~55 inline style → class, anti-pattern removal |
| \`web-mobile/css/styles.css\` | ~30 new utility classes; podium + side-stripe + gradient fixes; @supports guard on backdrop-filter |

## Screenshots

**Viewer home — mobile (390px):**

![viewer home mobile](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/264/viewer-home-mobile.png)

**Viewer home — tablet (768px):**

![viewer home tablet](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/264/viewer-home-tablet.png)

**Viewer home — desktop (1280px):**

![viewer home desktop](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/264/viewer-home-desktop.png)

**SSE offline banner + pending-follow banner — mobile (390px):**

![banners mobile](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/264/banners-mobile.png)

**Match alert banner — before (gradient) vs after (flat accent):**

| Before | After |
|---|---|
| ![banner before](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/264/banner-before-mobile.png) | ![banner after](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/264/banner-after-mobile.png) |

## Test plan

- [x] \`go test -race -cover ./cmd/... ./internal/... ./tests/...\` passes (all packages ≥85%)
- [x] \`make go/build\` clean (esbuild compiles all JSX without errors)
- [x] Manual browser verification — viewer home at 390px, 768px, 1280px; SSE offline + pending-follow banners render; pool abbr tooltips present; no console errors
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors

Closes mp-u2lu