### PR TITLE
fix(mp-eqvi): admin UX hardening sweep + native dialog migration

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -2,7 +2,7 @@
 
 ## Register
 
-bracket-creator
+product
 
 ## Users
 Both organizers (admin) managing the tournament and attendees (competitors, coaches, spectators) viewing live results. Context includes noisy, bright tournament halls, often using mobile devices on the go.

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -142,10 +142,11 @@ func validateURLHasHost(field, val string) error {
 
 // validateSubBout enforces FIK sub-bout invariants on a single SubMatchResult.
 // Both encho and hantei are valid ONLY for the daihyosen representative bout
-// (Position == -1): regular numbered bouts have fixed regulation time (no
-// overtime) and are never decided by hantei.
+// (Position == -1): regular numbered bouts have fixed regulation time and are
+// never decided by hantei. Hantei does NOT require encho, though — a tied
+// daihyosen may be decided by judges directly (the encho gate was removed).
 //
-// The winner/encho/tied-scoreline/decision checks here intentionally mirror the
+// The winner/tied-scoreline/decision checks here intentionally mirror the
 // top-level DecidedByHantei block in ScoreRequest.Validate. Keep them in sync:
 // the sub-bout variant adds the Position guards and omits the top-level-only
 // Status/DecisionBy checks (SubMatchResult has no such fields).
@@ -182,9 +183,6 @@ func validateSubBout(prefix string, sr *state.SubMatchResult) error {
 	if sr.Winner == "" {
 		return &ValidationError{Field: prefix + "decidedByHantei", Message: "requires winner to be set"}
 	}
-	if sr.Encho == nil || sr.Encho.PeriodCount <= 0 {
-		return &ValidationError{Field: prefix + "decidedByHantei", Message: "requires encho with at least one period"}
-	}
 	if len(sr.IpponsA) != len(sr.IpponsB) {
 		return &ValidationError{Field: prefix + "decidedByHantei", Message: "requires a tied scoreline — ippon counts must be equal"}
 	}
@@ -194,7 +192,7 @@ func validateSubBout(prefix string, sr *state.SubMatchResult) error {
 	default:
 		return &ValidationError{
 			Field:   prefix + "decidedByHantei",
-			Message: fmt.Sprintf("incompatible with decision %q — hantei declares a winner from a tied encho; use '', 'fought', or 'daihyosen'", sr.Decision),
+			Message: fmt.Sprintf("incompatible with decision %q — hantei declares a winner from a tied bout; use '', 'fought', or 'daihyosen'", sr.Decision),
 		}
 	}
 	return nil
@@ -392,13 +390,13 @@ func (r *ScoreRequest) Validate() error {
 			return err
 		}
 	}
-	// DecidedByHantei encodes a rules-level invariant: judges' decision after
-	// tied encho (FIK 7-5 / 29-6). A winner must be present, the status (if
-	// supplied) must be completed, and encho must have been played (PeriodCount
-	// > 0) — rejecting decidedByHantei=true without overtime context prevents
-	// persisting an "HT" suffix outside a real encho-decided match.
-	// The winner/encho/tied/decision checks below mirror validateSubBout;
-	// keep both in sync.
+	// DecidedByHantei records a referee judges' decision that declares a winner
+	// from a tied bout. A winner must be present, the status (if supplied) must
+	// be completed, and the scoreline must be tied (equal ippon counts). Encho
+	// is NOT required: operators may take a tied match straight to hantei
+	// without an overtime period (the encho gate was removed deliberately).
+	// The winner/tied/decision checks below mirror validateSubBout; keep both
+	// in sync.
 	if r.DecidedByHantei != nil && *r.DecidedByHantei {
 		if r.Winner == "" {
 			return &ValidationError{
@@ -412,12 +410,6 @@ func (r *ScoreRequest) Validate() error {
 				Message: "only valid on completed matches",
 			}
 		}
-		if r.Encho == nil || r.Encho.PeriodCount <= 0 {
-			return &ValidationError{
-				Field:   "decidedByHantei",
-				Message: "requires encho with at least one period",
-			}
-		}
 		if len(r.IpponsA) != len(r.IpponsB) {
 			return &ValidationError{
 				Field:   "decidedByHantei",
@@ -425,7 +417,7 @@ func (r *ScoreRequest) Validate() error {
 			}
 		}
 		// Hantei is a referee judges' decision that produces a winner from a
-		// tied encho. Any other special decision (hikiwake=draw, kiken=withdrawal,
+		// tied bout. Any other special decision (hikiwake=draw, kiken=withdrawal,
 		// fusenpai=no-show, daihyosen=rep-bout…) is semantically incompatible —
 		// persisting both would render contradictory suffixes like "Kiken (E) HT".
 		// Only the neutral values ("" and "fought") are allowed alongside hantei.
@@ -435,7 +427,7 @@ func (r *ScoreRequest) Validate() error {
 		default:
 			return &ValidationError{
 				Field:   "decidedByHantei",
-				Message: fmt.Sprintf("incompatible with decision %q — hantei declares a winner from a tied encho; use '' or 'fought'", r.Decision),
+				Message: fmt.Sprintf("incompatible with decision %q — hantei declares a winner from a tied bout; use '' or 'fought'", r.Decision),
 			}
 		}
 		if r.DecisionBy != "" {

--- a/internal/mobileapp/validation_test.go
+++ b/internal/mobileapp/validation_test.go
@@ -719,7 +719,9 @@ func TestScoreRequestValidate_DecidedByHantei(t *testing.T) {
 		assert.Equal(t, "decidedByHantei", verr.Field)
 	})
 
-	t.Run("invalid hantei: no encho set", func(t *testing.T) {
+	t.Run("valid hantei: no encho set (encho is not required)", func(t *testing.T) {
+		// Encho was decoupled from hantei — a tied match may be taken straight
+		// to a judges' decision without an overtime period.
 		req := ScoreRequest{
 			SideA:           "Alice",
 			SideB:           "Bob",
@@ -727,14 +729,10 @@ func TestScoreRequestValidate_DecidedByHantei(t *testing.T) {
 			Status:          state.MatchStatusCompleted,
 			DecidedByHantei: boolPtr(true),
 		}
-		err := req.Validate()
-		require.Error(t, err)
-		var verr *ValidationError
-		require.True(t, errors.As(err, &verr))
-		assert.Equal(t, "decidedByHantei", verr.Field)
+		assert.NoError(t, req.Validate())
 	})
 
-	t.Run("invalid hantei: encho period count is zero", func(t *testing.T) {
+	t.Run("valid hantei: encho period count is zero", func(t *testing.T) {
 		req := ScoreRequest{
 			SideA:           "Alice",
 			SideB:           "Bob",
@@ -743,11 +741,7 @@ func TestScoreRequestValidate_DecidedByHantei(t *testing.T) {
 			DecidedByHantei: boolPtr(true),
 			Encho:           &state.EnchoMetadata{PeriodCount: 0},
 		}
-		err := req.Validate()
-		require.Error(t, err)
-		var verr *ValidationError
-		require.True(t, errors.As(err, &verr))
-		assert.Equal(t, "decidedByHantei", verr.Field)
+		assert.NoError(t, req.Validate())
 	})
 
 	t.Run("valid hantei: tied 1-1 scoreline", func(t *testing.T) {
@@ -965,7 +959,9 @@ func TestScoreRequestValidate_SubBoutDecidedByHantei(t *testing.T) {
 		assert.Equal(t, "subResults[0].decidedByHantei", verr.(*ValidationError).Field)
 	})
 
-	t.Run("invalid: daihyosen hantei without encho", func(t *testing.T) {
+	t.Run("valid: daihyosen hantei without encho (encho not required)", func(t *testing.T) {
+		// Encho was decoupled from hantei — a tied daihyosen may be decided by
+		// judges without an overtime period.
 		req := ScoreRequest{
 			SubResults: []state.SubMatchResult{
 				{
@@ -975,9 +971,7 @@ func TestScoreRequestValidate_SubBoutDecidedByHantei(t *testing.T) {
 				},
 			},
 		}
-		verr := req.Validate()
-		require.IsType(t, &ValidationError{}, verr)
-		assert.Equal(t, "subResults[0].decidedByHantei", verr.(*ValidationError).Field)
+		assert.NoError(t, req.Validate())
 	})
 
 	t.Run("invalid: daihyosen hantei with non-tied scoreline", func(t *testing.T) {
@@ -1059,8 +1053,8 @@ func TestScoreRequestValidate_SubBoutDecidedByHantei(t *testing.T) {
 				},
 				{
 					Position: -1, SideA: "TeamA", SideB: "TeamB",
-					IpponsA: []string{"M"}, IpponsB: []string{"K"},
-					Winner: "TeamA", DecidedByHantei: true, Encho: nil, // invalid: no encho
+					IpponsA: []string{"M", "K"}, IpponsB: []string{"K"}, // invalid: non-tied scoreline
+					Winner: "TeamA", DecidedByHantei: true, Encho: enchoOne,
 				},
 			},
 		}
@@ -1131,7 +1125,7 @@ func TestValidateBulkScoreLengths_SubBoutDecidedByHantei(t *testing.T) {
 		assert.Equal(t, "subResults[0].decidedByHantei", verr.(*ValidationError).Field)
 	})
 
-	t.Run("invalid: daihyosen hantei without encho rejected on bulk path", func(t *testing.T) {
+	t.Run("valid: daihyosen hantei without encho accepted on bulk path", func(t *testing.T) {
 		r := &state.MatchResult{
 			SubResults: []state.SubMatchResult{
 				{
@@ -1141,9 +1135,7 @@ func TestValidateBulkScoreLengths_SubBoutDecidedByHantei(t *testing.T) {
 				},
 			},
 		}
-		verr := validateBulkScoreLengths(r)
-		require.IsType(t, &ValidationError{}, verr)
-		assert.Equal(t, "subResults[0].decidedByHantei", verr.(*ValidationError).Field)
+		assert.NoError(t, validateBulkScoreLengths(r))
 	})
 
 	t.Run("invalid: daihyosen hantei with non-tied scoreline rejected on bulk path", func(t *testing.T) {

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -538,9 +538,10 @@ type MatchResult struct {
 	Encho          *EnchoMetadata   `json:"encho,omitempty" yaml:"encho,omitempty"`
 	QueuePosition  int              `json:"queuePosition,omitempty" yaml:"-"`
 	// DecidedByHantei is true when the winner was declared by referee
-	// hantei after an encho remained tied (FIK Article 7-5 / 29-6).
-	// Distinguishes a judges' decision from an ippon-derived win for
-	// stats, audit, and display. Zero value omitted from the wire.
+	// hantei on a tied bout (FIK Article 7-5 / 29-6). Overtime is not a
+	// precondition: a tied scoreline may be taken straight to a judges'
+	// decision. Distinguishes a judges' decision from an ippon-derived win
+	// for stats, audit, and display. Zero value omitted from the wire.
 	//
 	// Pointer semantics at the API boundary: when a client omits the
 	// field (nil) on a BRACKET-match score request, the engine preserves

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2664,9 +2664,11 @@ components:
         decidedByHantei:
           type: boolean
           description: >
-            True when the winner was declared by referee hantei after a tied encho
-            (FIK Art. 7-5 / 29-6). On a bracket-match score request, omitting the field
-            preserves the stored value; sending an explicit true/false applies it.
+            True when the winner was declared by referee hantei on a tied bout
+            (FIK Art. 7-5 / 29-6). Overtime is not required — a tied scoreline may be
+            taken straight to a judges' decision. On a bracket-match score request,
+            omitting the field preserves the stored value; sending an explicit
+            true/false applies it.
 
     SubMatchResult:
       type: object
@@ -2702,20 +2704,21 @@ components:
             `""` (normal victory), `"hikiwake"` (draw/tie), or `"fusensho"`
             (per-bout default win). The daihyosen representative bout
             (`position: -1`) always carries `"daihyosen"` — including when its
-            winner is declared by hantei after a tied encho (the frontend emits
+            winner is declared by hantei on a tied bout (the frontend emits
             `decision: "daihyosen"` together with `decidedByHantei: true`). The
             server also tolerates `""` or `"fought"` alongside hantei, but
             `"daihyosen"` is the canonical persisted value for the rep bout.
         decidedByHantei:
           type: boolean
           description: >
-            True when this sub-bout's winner was declared by referee hantei after a
-            tied encho. Valid ONLY for the daihyosen representative bout (`position: -1`)
-            AND only when `encho.periodCount > 0`; regular numbered bouts have fixed
-            regulation time and are never decided by hantei. The accompanying `decision`
-            is `"daihyosen"` (the value the frontend persists for the rep bout); the
-            server additionally accepts `""` or `"fought"`. `winner` must be set — the
-            server rejects hantei without encho or with any other decision code.
+            True when this sub-bout's winner was declared by referee hantei on a
+            tied bout. Valid ONLY for the daihyosen representative bout (`position: -1`);
+            regular numbered bouts have fixed regulation time and are never decided by
+            hantei. Overtime is NOT required — a tied daihyosen may be decided by judges
+            directly (`encho` is optional). The accompanying `decision` is `"daihyosen"`
+            (the value the frontend persists for the rep bout); the server additionally
+            accepts `""` or `"fought"`. `winner` must be set and the scoreline must be
+            tied — the server rejects hantei with any other decision code.
         encho:
           allOf:
             - $ref: '#/components/schemas/EnchoMetadata'
@@ -2768,7 +2771,7 @@ components:
           $ref: '#/components/schemas/EnchoMetadata'
         decidedByHantei:
           type: boolean
-          description: True when the match winner was declared by referee hantei after a tied encho.
+          description: True when the match winner was declared by referee hantei on a tied bout (overtime not required).
         subResults:
           type: array
           description: >

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6658,3 +6658,69 @@ button.pool-match-row {
 .pool__overflow-note { margin-top: 8px; }
 .pool__view-all-btn  { margin-top: 8px; font-size: 13px; padding: 0; }
 
+
+/* ---------- Toast internals (mp: ops-console toast contract) ---------- */
+/* Lay out the icon, message, and (error-only) dismiss control on one row.
+   The base .toast keeps its pill shape and single-slot positioning; this just
+   arranges the children inline and gives error toasts a tappable dismiss. */
+.toast { display: flex; align-items: center; gap: 10px; }
+.toast__icon { line-height: 1; flex: 0 0 auto; }
+.toast__msg  { flex: 1 1 auto; }
+.toast__dismiss {
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0.7;
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 4px;
+  margin: -2px -8px -2px 0;
+  cursor: pointer;
+  pointer-events: auto; /* base .toast is pointer-events:none — re-enable so the X is clickable */
+}
+.toast__dismiss:hover { opacity: 1; }
+@media (pointer: coarse) {
+  .toast__dismiss { padding: 8px 10px; margin: -8px -10px -8px 0; }
+}
+
+/* ---------- Competition shell fallback (not-found / loading) ---------- */
+.comp-shell-actions { margin-bottom: 16px; }
+.comp-shell-msg {
+  margin: 8px auto 0;
+  max-width: 42ch;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-3);
+}
+
+/* ---------- Start-all confirm/progress/result modal ---------- */
+.start-all__lead { margin: 0 0 12px; font-size: 14px; color: var(--ink-2); }
+.start-all__list {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+}
+.start-all__list--failed { list-style: none; padding-left: 0; }
+.start-all__list--failed li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  border-left: 3px solid var(--red);
+}
+.start-all__failed-name { font-weight: 600; color: var(--ink-1); }
+.start-all__failed-reason { font-size: 12px; color: var(--ink-3); }
+.start-all__running {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  font-size: 14px;
+  color: var(--ink-2);
+}

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -329,7 +329,10 @@ a:hover {
 
 .page-head__actions {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 10px;
+  row-gap: 8px;
   align-items: center;
 }
 
@@ -1719,6 +1722,14 @@ a:hover {
   font-size: 18px;
   color: var(--ink-3);
   padding: 4px 8px;
+  min-width: 36px;
+  min-height: 36px;
+}
+@media (pointer: coarse) {
+  .modal__close {
+    min-width: 44px;
+    min-height: 44px;
+  }
 }
 
 /* ---------- Auth modal ---------- */

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -485,6 +485,19 @@ a:hover {
   outline-offset: 2px;
 }
 
+/* Consolidated keyboard focus ring for buttons + court chips. Only a handful
+   of :focus-visible rules existed, so .btn and the court chips fell back to
+   the UA default outline. Use the project's 3px --accent-soft ring language
+   (matches the input focus ring in §6 Accessibility / .lined-textarea). The
+   .ipt-btn focus is owned elsewhere — deliberately not included here. */
+.btn:focus-visible,
+.court-popover button:focus-visible,
+.live-strip__chip:focus-visible,
+.radio-pill:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
 .score-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
@@ -592,7 +605,9 @@ a:hover {
 .lined-textarea__nums {
   padding: 9px 8px;
   background: var(--surface-2);
-  color: var(--ink-3);
+  /* --ink-3 on --surface-2 (#f1f5f9) is only 4.41:1 — just under AA for this
+     gutter. Step to --ink-2 (9.37:1) so the line numbers clear 4.5:1. */
+  color: var(--ink-2);
   font-family: var(--font-mono);
   font-size: 13px;
   line-height: 1.55;
@@ -3584,7 +3599,9 @@ button.pool-match-row {
 
 .tw-court__sub {
   font-size: 11px;
-  color: var(--ink-3);
+  /* Sits in .tw-court__head (background: --line-2 #eef0f4). --ink-3 there is
+     only 4.24:1; step to --ink-2 (9.0:1 on --line-2) to clear 4.5:1. */
+  color: var(--ink-2);
 }
 
 .tw-court__list {
@@ -6539,7 +6556,10 @@ button.pool-match-row {
 .app-version-footer {
   text-align: center;
   font-size: 11px;
-  color: var(--ink-4);
+  /* --ink-4 (#6c7480) is only 4.44:1 on --bg — just under AA. Step to the
+     darker --ink-2 (#3a414e, 9.66:1 on --bg). Site-specific darken; do NOT
+     mutate --ink-4 itself (it's the shared fine-print floor). */
+  color: var(--ink-2);
   padding: 16px 0;
   margin-top: 32px;
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6771,3 +6771,16 @@ button.pool-match-row {
   font-size: 14px;
   color: var(--ink-2);
 }
+
+/* confirmDialog()/promptDialog() — shared modal primitive (ui.jsx DialogHost).
+   Reuses .modal-backdrop/.modal/.modal__* ; only the message + prompt input
+   need their own rules. */
+.dialog-msg {
+  margin: 0;
+  line-height: 1.5;
+  color: var(--ink-2);
+}
+.dialog-prompt-input {
+  width: 100%;
+  margin-top: 12px;
+}

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6104,6 +6104,33 @@ button.pool-match-row {
   gap: 6px;
 }
 
+/* --- Touch-target floor for compact ippon buttons --------------------- *
+   The compact rules above (.editor-modal--compact .sb-points-grid .ipt-btn
+   and .editor-modal--compact .team-sub-match__btns .ipt-btn) set a 34px/32px
+   min-height for fine pointers (laptop scoring). On the tablets operators
+   actually score on, those out-specified the generic
+   `@media (pointer: coarse) .ipt-btn { min-height: 44px }` rule and shrank
+   the most-tapped control below the DESIGN.md §6 ≥44px coarse-pointer floor.
+   Restore the floor at equal-or-greater specificity, placed AFTER the compact
+   blocks so source order also favours it. Fine pointers keep the dense 34px. */
+@media (pointer: coarse) {
+  .editor-modal--compact .sb-points-grid .ipt-btn,
+  .editor-modal--compact .team-sub-match__btns .ipt-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+/* --- Keyboard focus ring for ippon buttons ---------------------------- *
+   Operators tab through the scoring grid; make the focused ippon button
+   obvious with the accent ring language (DESIGN.md §6 / §3). Scoped to the
+   .ipt-btn family this region owns. */
+.ipt-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
 /* --- Decision prompt motion (compact + roomy) -------------------------- */
 .decision-prompt {
   animation: decision-prompt-in 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;

--- a/web-mobile/js/__tests__/admin_elevated.test.jsx
+++ b/web-mobile/js/__tests__/admin_elevated.test.jsx
@@ -95,45 +95,49 @@ describe('API elevated-password header (X-Admin-Password)', () => {
 });
 
 describe('promptAdminPassword', () => {
-  beforeEach(() => { setCachedAuthConfig(null); });
-  afterEach(() => { vi.restoreAllMocks(); setCachedAuthConfig(null); });
+  // promptAdminPassword is now async and collects the password via the shared
+  // window.promptDialog primitive (themed, masked input) instead of the native
+  // window.prompt. ui.jsx isn't imported here, so we install a window.promptDialog
+  // mock per test and assert against it.
+  beforeEach(() => { setCachedAuthConfig(null); window.promptDialog = vi.fn(); });
+  afterEach(() => { vi.restoreAllMocks(); setCachedAuthConfig(null); delete window.promptDialog; });
 
-  it('returns "" (no prompt) when the gate is inactive', () => {
+  it('returns "" (no dialog) when the gate is inactive', async () => {
     setCachedAuthConfig({ mode: 'file', elevatedRequired: false });
-    const spy = vi.spyOn(window, 'prompt');
-    expect(promptAdminPassword()).toBe('');
-    expect(spy).not.toHaveBeenCalled();
+    await expect(promptAdminPassword()).resolves.toBe('');
+    expect(window.promptDialog).not.toHaveBeenCalled();
   });
 
-  it('returns "" when authConfig is unset (loading / fail-open)', () => {
-    expect(promptAdminPassword()).toBe('');
+  it('returns "" when authConfig is unset (loading / fail-open)', async () => {
+    await expect(promptAdminPassword()).resolves.toBe('');
+    expect(window.promptDialog).not.toHaveBeenCalled();
   });
 
-  it('alerts and returns null when required but not configured (locked, env unset)', () => {
+  it('alerts and returns null when required but not configured (locked, env unset)', async () => {
     setCachedAuthConfig({ mode: 'locked', elevatedRequired: true, elevatedConfigured: false });
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
-    const promptSpy = vi.spyOn(window, 'prompt');
-    expect(promptAdminPassword()).toBeNull();
+    await expect(promptAdminPassword()).resolves.toBeNull();
     expect(alertSpy).toHaveBeenCalled();
-    expect(promptSpy).not.toHaveBeenCalled();
+    expect(window.promptDialog).not.toHaveBeenCalled();
   });
 
-  it('prompts and returns the typed password when required + configured', () => {
+  it('prompts and returns the typed password when required + configured', async () => {
     setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
-    vi.spyOn(window, 'prompt').mockReturnValue('typed-secret');
-    expect(promptAdminPassword()).toBe('typed-secret');
+    window.promptDialog.mockResolvedValue('typed-secret');
+    await expect(promptAdminPassword()).resolves.toBe('typed-secret');
+    expect(window.promptDialog).toHaveBeenCalledWith(expect.objectContaining({ password: true }));
   });
 
-  it('returns null when the operator cancels the prompt', () => {
+  it('returns null when the operator cancels the dialog', async () => {
     setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
-    vi.spyOn(window, 'prompt').mockReturnValue(null);
-    expect(promptAdminPassword()).toBeNull();
+    window.promptDialog.mockResolvedValue(null);
+    await expect(promptAdminPassword()).resolves.toBeNull();
   });
 
-  it('returns null on empty submit (empty is never a valid admin password)', () => {
+  it('returns null on empty submit (empty is never a valid admin password)', async () => {
     setCachedAuthConfig({ mode: 'file', elevatedRequired: true, elevatedConfigured: true });
-    vi.spyOn(window, 'prompt').mockReturnValue('');
-    expect(promptAdminPassword()).toBeNull();
+    window.promptDialog.mockResolvedValue('');
+    await expect(promptAdminPassword()).resolves.toBeNull();
   });
 
   it('cache is shared via window across import sites', () => {

--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -254,10 +254,10 @@ describe('prevEnchoPeriod (the − button)', () => {
 });
 
 describe('initialEnchoPeriodsForMatch (mp-4pc daihyosen re-open)', () => {
-  // Regression: a hantei-decided daihyosen persists encho on the rep-bout
-  // sub (wire position -1), NOT the top-level match. On re-open the count
-  // must be restored from the sub — else decidedByHantei replays without
-  // encho and the backend rejects the next save.
+  // Regression: a daihyosen that went to overtime persists encho on the
+  // rep-bout sub (wire position -1), NOT the top-level match. On re-open the
+  // count must be restored from the sub so the overtime history survives a
+  // re-save (encho is independent of the hantei decision).
 
   it('reads encho from the daihyosen sub when one exists', () => {
     const m = {
@@ -290,9 +290,10 @@ describe('initialEnchoPeriodsForMatch (mp-4pc daihyosen re-open)', () => {
 });
 
 describe('daihyosenEnchoFields (mp-4pc encho/hantei wire gating)', () => {
-  // Backend invariant (validation.go validateSubBout): hantei is rejected
-  // without encho.periodCount > 0. The builder must mirror that so a
-  // reduced-to-0 counter never replays a now-invalid decidedByHantei.
+  // Encho is decoupled from hantei (validation.go validateSubBout): a tied
+  // daihyosen may be decided by judges with or without overtime. The builder
+  // emits the two fields independently — encho when the counter is > 0,
+  // decidedByHantei when armed on a tied scoreline.
 
   it('emits encho + decidedByHantei when armed and encho > 0', () => {
     expect(daihyosenEnchoFields({ enchoPeriodCount: 2, daihyosenTied: true, daihyosenHantei: 'a' }))
@@ -306,16 +307,22 @@ describe('daihyosenEnchoFields (mp-4pc encho/hantei wire gating)', () => {
       .toEqual({ encho: { periodCount: 1 } });
   });
 
-  it('emits NEITHER field when encho is reduced to 0 even with hantei armed', () => {
-    // The regression: operator arms hantei, then drops the counter to 0.
-    // decidedByHantei must NOT survive — the backend would 400 it.
+  it('emits hantei WITHOUT encho when armed on a tied bout and no overtime', () => {
+    // Decoupled: a tied daihyosen taken straight to a judges' decision with
+    // no overtime sends decidedByHantei alone — the backend accepts it.
     expect(daihyosenEnchoFields({ enchoPeriodCount: 0, daihyosenTied: true, daihyosenHantei: 'a' }))
-      .toEqual({});
+      .toEqual({ decidedByHantei: true });
   });
 
-  it('emits nothing for negative/NaN encho (defensive)', () => {
-    expect(daihyosenEnchoFields({ enchoPeriodCount: -1, daihyosenTied: true, daihyosenHantei: 'a' })).toEqual({});
-    expect(daihyosenEnchoFields({ enchoPeriodCount: NaN, daihyosenTied: true, daihyosenHantei: 'a' })).toEqual({});
+  it('omits encho but keeps hantei for negative/NaN encho (defensive)', () => {
+    expect(daihyosenEnchoFields({ enchoPeriodCount: -1, daihyosenTied: true, daihyosenHantei: 'a' }))
+      .toEqual({ decidedByHantei: true });
+    expect(daihyosenEnchoFields({ enchoPeriodCount: NaN, daihyosenTied: true, daihyosenHantei: 'a' }))
+      .toEqual({ decidedByHantei: true });
+  });
+
+  it('emits nothing when no encho and hantei not armed', () => {
+    expect(daihyosenEnchoFields({ enchoPeriodCount: 0, daihyosenTied: false, daihyosenHantei: '' })).toEqual({});
   });
 });
 

--- a/web-mobile/js/__tests__/mp_turx_knockout.test.jsx
+++ b/web-mobile/js/__tests__/mp_turx_knockout.test.jsx
@@ -372,7 +372,7 @@ describe('AdminCompetition: page-head has no Start-knockout affordance (mp-turx)
     }).not.toThrow();
   });
 
-  it('bracket tab label is "Bracket — now" for a running competition', () => {
+  it('bracket tab label is "Bracket" (live, not preview) for a running competition', () => {
     const tree = runtime.mount(AdminCompetition, {
       ...baseProps,
       section: 'overview',
@@ -380,22 +380,22 @@ describe('AdminCompetition: page-head has no Start-knockout affordance (mp-turx)
       bracket: liveBracket,
     });
     const text = collectText(tree);
-    expect(text).toContain('Bracket — now');
-    expect(text).not.toContain('Bracket — preview');
+    expect(text).toContain('Bracket');
+    expect(text).not.toContain('Bracket (preview)');
   });
 
-  it('bracket tab label is "Bracket — preview" only for draw-ready competitions', () => {
+  it('bracket tab label is "Bracket (preview)" only for draw-ready competitions', () => {
     const tree = runtime.mount(AdminCompetition, {
       ...baseProps,
       section: 'overview',
       competition: mkMixedComp({ status: 'draw-ready' }),
       bracket: liveBracket,
     });
-    expect(collectText(tree)).toContain('Bracket — preview');
+    expect(collectText(tree)).toContain('Bracket (preview)');
   });
 
-  it('bracket tab label is NOT "Bracket — preview" for mixed comp with preview=true bracket but status=pools', () => {
-    // Previously bracket.preview=true would force "Bracket — preview" label.
+  it('bracket tab label is NOT "Bracket (preview)" for mixed comp with preview=true bracket but status=pools', () => {
+    // Previously bracket.preview=true would force the preview label.
     // Now only draw-ready status matters.
     const tree = runtime.mount(AdminCompetition, {
       ...baseProps,
@@ -404,9 +404,9 @@ describe('AdminCompetition: page-head has no Start-knockout affordance (mp-turx)
       bracket: placeholderBracket, // preview: true
     });
     const text = collectText(tree);
-    // status is 'pools' (not draw-ready), so label should be "Bracket — now"
-    expect(text).toContain('Bracket — now');
-    expect(text).not.toContain('Bracket — preview');
+    // status is 'pools' (not draw-ready), so the live "Bracket" label shows
+    expect(text).toContain('Bracket');
+    expect(text).not.toContain('Bracket (preview)');
   });
 
   it('AdminBracket vnode receives bracket props regardless of bracket.preview', () => {

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -379,7 +379,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       // Caught by /deep-review iterative pass after round-11 swept
       // updateTournament to tRef/onUpdateRef but missed the unmount
       // guard the other handlers carry.
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) return false;
       // Re-read tRef.current AFTER the await — additional SSE events may
       // have landed during the save. The patch we just persisted is
       // applied on top of the freshest snapshot.
@@ -698,9 +698,12 @@ function normalizeCreatedRecord(created) {
 // while phase === "running".
 function StartAllModal({ state, onConfirm, onRetry, onClose }) {
   const dismissable = state.phase !== "running";
-  // Only wire Escape when we're allowed to close; passing a no-op keeps the
-  // running phase non-dismissable without conditionally calling the hook.
-  window.useEscapeToClose(dismissable ? onClose : () => {});
+  // Only wire Escape when we're allowed to close. Pass undefined (NOT a no-op)
+  // in the running phase: useEscapeToClose calls preventDefault() for ANY
+  // function callback, so a no-op would swallow Escape while doing nothing.
+  // undefined leaves Escape untouched. Matches the busyType ? undefined
+  // pattern in admin_shell.jsx.
+  window.useEscapeToClose(dismissable ? onClose : undefined);
 
   const { phase, comps = [], failed = [] } = state;
 

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -215,7 +215,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     // inactive (proceed) and null when cancelled/not-configured (abort).
     let admin = "";
     if (next && next.players != null) {
-      admin = window.promptAdminPassword();
+      admin = await window.promptAdminPassword();
       if (admin === null) return;
     }
     let updated;

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -110,6 +110,16 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
   // sole screen exposing the Announce button. (Other screens reach the
   // composer via the Edit-details page.)
   const [announceOpen, setAnnounceOpen] = useStateA(false);
+  // mp: "Start all" is a high-blast-radius action (it starts every eligible
+  // setup competition at once), so it runs through an explicit modal instead
+  // of a one-click red button + transient toast. State machine:
+  //   phase: "confirm" → operator sees the affected comps and confirms
+  //          "running" → Promise.allSettled in flight, inline progress
+  //          "result"  → persistent summary; NAMES failures, offers retry
+  // `comps` is the working set for the current phase (the comps we will/did
+  // start); `failed` is the subset whose start rejected (kept so "Retry
+  // failed" can re-run only those). Closed by setting startAll to null.
+  const [startAll, setStartAll] = useStateA(null);
 
   // Expose a navigation helper used by AdminTopbar's live-strip chips,
   // avoiding prop-drilling through every screen. Set once per mount.
@@ -286,46 +296,43 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     return created;
   };
 
-  const startAllCompetitions = async () => {
+  // Opens the confirm modal (does NOT start anything). The dashboard's
+  // "Start all" button calls this; confirmation happens inside the modal.
+  const startAllCompetitions = () => {
     const setupComps = (t.competitions || []).filter(c => c.status === "setup" && (c.players || []).length >= 2);
     if (setupComps.length === 0) return;
+    setStartAll({ phase: "confirm", comps: setupComps, failed: [] });
+  };
 
-    showToast(`Starting ${setupComps.length} competitions…`);
+  // Runs the actual start for a given set of competitions. Used both for the
+  // initial confirm and for "Retry failed" (which passes only the failures).
+  // Keeps the tRef/onUpdateRef/mountedRef discipline of the other handlers.
+  const runStartAll = async (comps) => {
+    setStartAll({ phase: "running", comps, failed: [] });
 
-    setAdminLoading(true);
-    const results = await Promise.allSettled(setupComps.map(c => window.API.startCompetition(c.id, password)));
+    const results = await Promise.allSettled(comps.map(c => window.API.startCompetition(c.id, password)));
 
-    let success = 0, fail = 0;
+    const failed = [];
     results.forEach((r, i) => {
-      if (r.status === "fulfilled") success++;
-      else {
-        console.error(`Failed to start ${setupComps[i].name}:`, r.reason);
-        fail++;
+      if (r.status === "rejected") {
+        console.error(`Failed to start ${comps[i].name}:`, r.reason);
+        failed.push({ comp: comps[i], reason: (r.reason && r.reason.message) || String(r.reason) });
       }
     });
 
-    // Wrap the refresh in try/finally so a fetchCompetitions() reject
-    // doesn't leave setAdminLoading=true latched on (the loading spinner
-    // would stay visible indefinitely until the next view change). The
-    // mountedRef gate is preserved — if the user navigated away during
-    // the start, we still skip setState but always clear the loading
-    // flag via finally to avoid stale-state-on-remount surprises.
+    // Best-effort refresh — a refresh failure must not mask which comps
+    // actually started (the result summary below is authoritative).
     try {
-      const comps = await window.API.fetchCompetitions();
-      if (!mountedRef.current) return;
-      onUpdateRef.current(mergeCompetitionsIntoTournament(tRef.current, () => comps));
+      const fresh = await window.API.fetchCompetitions();
+      if (mountedRef.current) onUpdateRef.current(mergeCompetitionsIntoTournament(tRef.current, () => fresh));
     } catch (e) {
       console.error("startAllCompetitions: post-start refresh failed", e);
       if (mountedRef.current) showToast("Failed to refresh after start. Try reloading.", "error");
-    } finally {
-      if (mountedRef.current) setAdminLoading(false);
     }
 
-    if (fail > 0) {
-      showToast(`Started ${success} competitions, but ${fail} failed.`, "error");
-    } else if (success > 0) {
-      showToast(`Successfully started all ${success} competitions.`);
-    }
+    if (!mountedRef.current) return;
+    // Persistent result — does NOT auto-dismiss. Operator closes it.
+    setStartAll({ phase: "result", comps, failed, succeeded: comps.length - failed.length });
   };
 
   const startCompetition = async (cid) => {
@@ -378,9 +385,11 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       // applied on top of the freshest snapshot.
       onUpdateRef.current(mergeTournamentPatch(tRef.current, patch, password, locked));
       showToast("Tournament updated");
+      return true;
     } catch (e) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) return false;
       showToast(e.message, "error");
+      return false;
     }
   };
 
@@ -538,6 +547,12 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
         showToast={showToast}
         onClose={() => setAnnounceOpen(false)}
       />}
+      {startAll && <StartAllModal
+        state={startAll}
+        onConfirm={() => runStartAll(startAll.comps)}
+        onRetry={() => runStartAll(startAll.failed.map(f => f.comp))}
+        onClose={() => setStartAll(null)}
+      />}
     </>;
   }
 
@@ -562,7 +577,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     return <AdminEditTournament
       tournament={t}
       onCancel={() => setView({ kind: "dashboard" })}
-      onSave={(patch) => { updateTournament(patch); setView({ kind: "dashboard" }); }}
+      onSave={async (patch) => { const ok = await updateTournament(patch); if (ok && mountedRef.current) setView({ kind: "dashboard" }); }}
       onLogout={onLogout}
       onViewerMode={onViewerMode}
       authConfig={authConfig}
@@ -613,10 +628,34 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
 
   if (view.kind === "competition") {
     const c = t.competitions.find((cc) => cc.id === view.id);
-    if (!c) return <div className="page"><div className="empty"><h3>Competition not found</h3></div></div>;
+    if (!c) return (
+      <div className="page">
+        <div className="comp-shell-actions">
+          <button className="btn btn--ghost" onClick={() => setView({ kind: "dashboard" })}>← Back to dashboard</button>
+        </div>
+        <div className="empty">
+          <h3>Competition not available</h3>
+          {/* Two indistinguishable causes for the operator: the comp was
+              deleted, OR this view is briefly ahead of the server while SSE
+              catches up. Word it so going back / reloading is clearly safe. */}
+          <p className="comp-shell-msg">
+            This competition may have been removed, or your view is briefly out of
+            sync while live updates catch up. Going back to the dashboard or
+            reloading the page is safe — if it still exists, it will reappear.
+          </p>
+        </div>
+      </div>
+    );
     // Only use adminCompData when it matches the current view; otherwise it's stale.
     const detail = adminCompData && adminCompData.config && adminCompData.config.id === view.id ? adminCompData : null;
-    if (adminLoading && !detail) return <div className="page"><div className="loading">Loading details...</div></div>;
+    if (adminLoading && !detail) return (
+      <div className="page">
+        <div className="comp-shell-actions">
+          <button className="btn btn--ghost" onClick={() => setView({ kind: "dashboard" })}>← Back to dashboard</button>
+        </div>
+        <div className="loading">Loading details...</div>
+      </div>
+    );
 
     return <AdminCompetition
       tournament={t}
@@ -649,6 +688,79 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
 // Defense-in-depth alongside the server-side fix.
 function normalizeCreatedRecord(created) {
   return { ...created, players: created.players ?? [] };
+}
+
+// StartAllModal — three-phase dialog for the dashboard "Start all" action.
+// Follows the shared .modal-backdrop / .modal pattern (mirrors
+// AnnouncementModal). The confirm and result phases are dismissable (backdrop
+// click + Escape); the running phase is NOT — closing mid-start would orphan
+// in-flight requests with no feedback, so the close affordances are withheld
+// while phase === "running".
+function StartAllModal({ state, onConfirm, onRetry, onClose }) {
+  const dismissable = state.phase !== "running";
+  // Only wire Escape when we're allowed to close; passing a no-op keeps the
+  // running phase non-dismissable without conditionally calling the hook.
+  window.useEscapeToClose(dismissable ? onClose : () => {});
+
+  const { phase, comps = [], failed = [] } = state;
+
+  let title = "Start all competitions";
+  if (phase === "running") title = "Starting competitions…";
+  else if (phase === "result") title = failed.length === 0 ? "All competitions started" : "Some competitions failed";
+
+  return (
+    <div className="modal-backdrop" onClick={dismissable ? onClose : undefined}>
+      <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label={title}>
+        <div className="modal__head">
+          <div className="modal__title">{title}</div>
+          {dismissable && <button className="modal__close" onClick={onClose} aria-label="Close">&times;</button>}
+        </div>
+        <div className="modal__body">
+          {phase === "confirm" && <>
+            <p className="start-all__lead">
+              This will start {window.pluralize(comps.length, "competition")} now. Once a
+              competition starts, its pools and bracket are generated and scoring opens.
+            </p>
+            <ul className="start-all__list">
+              {comps.map(c => <li key={c.id}>{c.name}</li>)}
+            </ul>
+          </>}
+          {phase === "running" && (
+            <div className="start-all__running">
+              <span className="spinner" aria-hidden="true"></span>
+              <span aria-live="polite">Starting {window.pluralize(comps.length, "competition")}…</span>
+            </div>
+          )}
+          {phase === "result" && <>
+            <p className="start-all__lead" aria-live="polite">
+              Started {state.succeeded} of {comps.length}.
+              {failed.length > 0 && ` ${window.pluralize(failed.length, "competition")} failed to start.`}
+            </p>
+            {failed.length > 0 && (
+              <ul className="start-all__list start-all__list--failed">
+                {failed.map(f => (
+                  <li key={f.comp.id}>
+                    <span className="start-all__failed-name">{f.comp.name}</span>
+                    {f.reason && <span className="start-all__failed-reason">{f.reason}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>}
+        </div>
+        <div className="modal__foot">
+          {phase === "confirm" && <>
+            <button className="btn btn--ghost" onClick={onClose}>Cancel</button>
+            <button className="btn btn--primary" onClick={onConfirm}>Start {window.pluralize(comps.length, "competition")}</button>
+          </>}
+          {phase === "result" && <>
+            {failed.length > 0 && <button className="btn btn--primary" onClick={onRetry}>Retry failed</button>}
+            <button className="btn" onClick={onClose}>Close</button>
+          </>}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 window.AdminApp = AdminApp;

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -100,7 +100,7 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   };
 
   const handleLogoDelete = async () => {
-    if (!window.confirm("Remove the tournament logo?")) return;
+    if (!(await window.confirmDialog({ message: "Remove the tournament logo?", confirmLabel: "Remove logo", danger: true }))) return;
     setBusy(true);
     try {
       await window.API.deleteBrandingLogo(password);

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -276,6 +276,10 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
   const { total, done, live } = compMatchStats(statsSource);
   const pct = total ? Math.round((done / total) * 100) : 0;
   const effectiveBracket = bracket ?? c.bracket;
+  // Honour the OS reduced-motion preference for the progress-bar animation.
+  const prefersReducedMotion = typeof window !== "undefined" && window.matchMedia
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
   return (
     <div>
       <div className="stats-strip">
@@ -286,8 +290,20 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
       </div>
       <div className="card" style={{ marginBottom: 16 }}>
         <div className="card__head"><div className="card__title">Progress</div><div className="card__sub">{pct}%</div></div>
-        <div style={{ height: 8, background: "var(--line-2)", borderRadius: 999, overflow: "hidden" }}>
-          <div style={{ height: "100%", width: pct + "%", background: "var(--accent)", transition: "width 300ms" }}></div>
+        {/* Animate via transform: scaleX (compositor-only) rather than width,
+            which forced a layout/paint each frame. The inner bar is full-width
+            and scaled from the left edge; the rounded track clips it so the
+            visual is equivalent. Transition is dropped under
+            prefers-reduced-motion. */}
+        <div style={{ height: 8, background: "var(--line-2)", borderRadius: 999, overflow: "hidden" }} role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100}>
+          <div style={{
+            height: "100%",
+            width: "100%",
+            background: "var(--accent)",
+            transformOrigin: "left center",
+            transform: `scaleX(${pct / 100})`,
+            transition: prefersReducedMotion ? "none" : "transform 300ms",
+          }}></div>
         </div>
       </div>
       <div className="row">
@@ -1554,12 +1570,12 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         // Show pools/bracket in nav when draw is ready (preview) or running.
         // Use .length checks: the state store returns [] / {rounds:[]} (never null)
         // when files are absent, so plain truthiness would always show the items.
-        (pools?.length || (isDrawReady && c.format !== "playoffs" && c.format !== "swiss")) ? { id: "pools", label: (c.format === "league" ? "League" : "Pools") + " — " + (isDrawReady ? "preview" : "now") } : null,
+        (pools?.length || (isDrawReady && c.format !== "playoffs" && c.format !== "swiss")) ? { id: "pools", label: (c.format === "league" ? "League" : "Pools") + (isDrawReady ? " (preview)" : "") } : null,
         // T191 (FR-050d): Swiss competitions surface a dedicated round
         // management panel for the "Generate next round" workflow.
-        c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds — manage" } : null,
-        (bracket?.rounds?.length || (isDrawReady && c.format === "playoffs")) ? { id: "bracket", label: isDrawReady ? "Bracket — preview" : "Bracket — now" } : null,
-        !isDrawReady ? { id: "scores", label: "Scores — edit" } : null,
+        c.format === "swiss" && !isDrawReady ? { id: "swiss", label: "Swiss rounds" } : null,
+        (bracket?.rounds?.length || (isDrawReady && c.format === "playoffs")) ? { id: "bracket", label: isDrawReady ? "Bracket (preview)" : "Bracket" } : null,
+        !isDrawReady ? { id: "scores", label: "Scores" } : null,
       ].filter(Boolean)
     },
     {

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -252,13 +252,13 @@ const LiveMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMoveCo
         </div>
       )}
       <div style={{ marginTop: 14, paddingTop: 14, borderTop: "1px dashed var(--line)" }}>
-        <button className="btn btn--sm btn--full" onClick={() => {
-          // prompt() returns "   " for whitespace-only input — which is
-          // truthy under `if (name)` and would persist a whitespace key
-          // as `m.Winner` on the backend (and then mismatch the canonical
-          // SideA / SideB names downstream). Trim defensively and only
-          // override when there's a real value to record.
-          const raw = prompt("Enter the name of the winner to override:", match.winner?.name || match.sideA?.name);
+        <button className="btn btn--sm btn--full" onClick={async () => {
+          // promptDialog returns null on empty/cancel and a string otherwise.
+          // A whitespace-only value would be truthy under `if (name)` and would
+          // persist a whitespace key as `m.Winner` on the backend (and then
+          // mismatch the canonical SideA / SideB names downstream). Trim
+          // defensively and only override when there's a real value to record.
+          const raw = await window.promptDialog({ title: "Override winner", message: "Enter the name of the winner to override:", defaultValue: match.winner?.name || match.sideA?.name });
           const name = raw?.trim();
           if (name) onOverride(name);
         }}>Force winner (manual override)</button>
@@ -352,7 +352,7 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
   const updateField = (idx, field, val) => { setDirty(true); setAwards(prev => prev.map((a, i) => i === idx ? { ...a, [field]: val } : a)); };
 
   const save = async () => {
-    const admin = window.promptAdminPassword ? window.promptAdminPassword() : null;
+    const admin = window.promptAdminPassword ? await window.promptAdminPassword() : null;
     if (admin === null) return;
     setSaving(true);
     try {
@@ -1030,8 +1030,8 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
         {(local.status === "pools" || local.status === "playoffs") && (
           <div>
             <button className="btn btn--danger btn--ghost" disabled={invalidating || deleting} onClick={async () => {
-              if (confirm(`Mark "${local.name}" as invalid? It will be excluded from results and can be deleted afterwards.`)) {
-                const admin = window.promptAdminPassword();
+              if (await window.confirmDialog({ message: `Mark "${local.name}" as invalid? It will be excluded from results and can be deleted afterwards.`, confirmLabel: "Mark invalid", danger: true })) {
+                const admin = await window.promptAdminPassword();
                 if (admin === null) return;
                 setInvalidating(true);
                 try {
@@ -1067,8 +1067,8 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           const msg = started
             ? `"${local.name}" has already started. Deleting it will remove ALL matches and results. This cannot be undone. Continue?`
             : `Are you sure you want to delete "${local.name}"? This action cannot be undone.`;
-          if (confirm(msg)) {
-            const admin = window.promptAdminPassword();
+          if (await window.confirmDialog({ message: msg, confirmLabel: "Delete competition", danger: true })) {
+            const admin = await window.promptAdminPassword();
             if (admin === null) return;
             setDeleting(true);
             try {
@@ -1423,18 +1423,20 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
 
   // Confirm before a draw/start that would drop non-checked-in participants.
   // Returns false when the operator cancels.
-  const confirmCheckInExclusion = () => {
+  const confirmCheckInExclusion = async () => {
     if (excludedFromDraw === 0) return true;
     const plural = excludedFromDraw === 1 ? "" : "s";
     const verb = excludedFromDraw === 1 ? "is" : "are";
-    return confirm(
-      `${excludedFromDraw} participant${plural} ${verb} not checked in and will be excluded from the draw.\n\n` +
-      `Only checked-in participants will be drawn. Continue?`
-    );
+    return await window.confirmDialog({
+      message:
+        `${excludedFromDraw} participant${plural} ${verb} not checked in and will be excluded from the draw.\n\n` +
+        `Only checked-in participants will be drawn. Continue?`,
+      danger: true,
+    });
   };
 
   const generateDraw = async () => {
-    if (!confirmCheckInExclusion()) return;
+    if (!(await confirmCheckInExclusion())) return;
     setGenerating(true);
     try {
       await window.API.generateDraw(c.id, password);
@@ -1453,8 +1455,8 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const discardDraw = async () => {
-    if (!confirm(`Discard the generated draw for "${c.name}"? The pools/bracket will be removed and you can regenerate.`)) return;
-    const admin = window.promptAdminPassword();
+    if (!(await window.confirmDialog({ message: `Discard the generated draw for "${c.name}"? The pools/bracket will be removed and you can regenerate.`, confirmLabel: "Discard draw", danger: true }))) return;
+    const admin = await window.promptAdminPassword();
     if (admin === null) return;
     setDiscarding(true);
     try {
@@ -1472,10 +1474,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const regenerateDraw = async () => {
-    if (!confirmCheckInExclusion()) return;
+    if (!(await confirmCheckInExclusion())) return;
     // Regenerate discards the existing draw first (DELETE /draw is gated),
     // so collect the elevated password up front before any work begins.
-    const admin = window.promptAdminPassword();
+    const admin = await window.promptAdminPassword();
     if (admin === null) return;
     setGenerating(true);
     try {
@@ -1503,7 +1505,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   const start = async () => {
     // draw-ready → running does not regenerate the draw; skip the confirmation
     // there to avoid showing stale exclusion counts against an already-fixed draw.
-    if (c.status !== "draw-ready" && !confirmCheckInExclusion()) return;
+    if (c.status !== "draw-ready" && !(await confirmCheckInExclusion())) return;
     showToast(`Starting ${c.name}…`);
 
     setStarting(true);

--- a/web-mobile/js/admin_helpers.jsx
+++ b/web-mobile/js/admin_helpers.jsx
@@ -372,11 +372,15 @@ function getCachedAuthConfig() {
 //     the typed value, or null if the operator cancels or submits empty
 //     (the caller aborts).
 //
-// Caller contract: `const a = promptAdminPassword(); if (a === null) return;`
+// Caller contract (now async): `const a = await promptAdminPassword(); if (a === null) return;`
 // then pass `a` as the trailing adminPassword arg to the API method. A wrong
 // password surfaces as the API's 401 error (caught/toasted by the caller);
 // the operator simply retries the action, which re-prompts.
-function promptAdminPassword(message) {
+//
+// Returns a Promise so the password is collected via the app's themed,
+// accessible promptDialog (masked input) instead of window.prompt, which
+// renders the password in plaintext in some browsers and can't be styled.
+async function promptAdminPassword(message) {
   const cfg = getCachedAuthConfig();
   if (!cfg || !cfg.elevatedRequired) return "";
   if (cfg.elevatedConfigured === false) {
@@ -386,7 +390,12 @@ function promptAdminPassword(message) {
     );
     return null;
   }
-  const pw = window.prompt(message || "This action requires the admin (destructive-ops) password:");
+  const pw = await window.promptDialog({
+    title: "Admin password required",
+    message: message || "This action requires the admin (destructive-ops) password:",
+    password: true,
+    confirmLabel: "Confirm",
+  });
   return pw ? pw : null;
 }
 

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -519,7 +519,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     const name = addName.trim(), dojo = addDojo.trim(), danGrade = addDanGrade.trim();
     const zekken = addZekken.trim();
     if (!name || !dojo) { showToast("Name and dojo are required", "error"); return; }
-    const admin = window.promptAdminPassword();
+    const admin = await window.promptAdminPassword();
     if (admin === null) return;
     setAddLoading(true);
     try {
@@ -551,7 +551,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     const oldName = replaceTarget.name;
     const targetId = replaceTarget.id;
     const targetTag = replaceTarget.tag || "";
-    const admin = window.promptAdminPassword();
+    const admin = await window.promptAdminPassword();
     if (admin === null) return;
     setReplaceLoading(true);
     try {

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -489,7 +489,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     const targets = (c.players || []).filter(p => p.dojo === dojo && !p.checkedIn);
     if (targets.length === 0) return;
 
-    if (!confirm(`Mark all ${targets.length} participants from ${dojo} as checked-in?`)) return;
+    if (!(await window.confirmDialog({ message: `Mark all ${targets.length} participants from ${dojo} as checked-in?`, confirmLabel: "Check in all" }))) return;
 
     const results = await Promise.allSettled(targets.map(p => window.API.toggleCheckIn(c.id, p.id ?? p.name, true, password)));
     const failed = results.filter(r => r.status === "rejected").length;

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -209,7 +209,7 @@ function RankInput({ initial, className, onCommit, style }) {
 
 function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, password }) {
   const resetOverrides = async () => {
-    if (!confirm("Are you sure you want to reset ALL manual overrides (ranks and winners) for this competition?")) return;
+    if (!(await window.confirmDialog({ message: "Are you sure you want to reset ALL manual overrides (ranks and winners) for this competition?", confirmLabel: "Reset overrides", danger: true }))) return;
     const admin = window.promptAdminPassword();
     if (admin === null) return;
     try {

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -210,7 +210,7 @@ function RankInput({ initial, className, onCommit, style }) {
 function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, password }) {
   const resetOverrides = async () => {
     if (!(await window.confirmDialog({ message: "Are you sure you want to reset ALL manual overrides (ranks and winners) for this competition?", confirmLabel: "Reset overrides", danger: true }))) return;
-    const admin = window.promptAdminPassword();
+    const admin = await window.promptAdminPassword();
     if (admin === null) return;
     try {
       await window.API.resetOverrides(c.id, password, admin);

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -1260,6 +1260,16 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, pa
         const nextActiveMatch = openIdx >= 0
           ? sameCourt.slice(openIdx + 1).find(m => m.status !== 'completed') || null
           : null;
+        // Minimal "start" patch (status → running, empty score). Mirrors the
+        // modal's own buildPatch("running") for an unscored match and works for
+        // both individual and team matches (subResults is omitted, which the
+        // serializer treats as "no bouts scored yet"). The server routes this
+        // through eng.StartMatchTx, so all start-gating (eligibility 409,
+        // ≥players checks) still runs — a 409 throws and is caught below.
+        const startPatch = () => ({
+          status: "running", winner: null, ipponsA: [], ipponsB: [], hansokuA: 0, hansokuB: 0,
+          score: { type: "ippon", winnerPts: 0, loserPts: 0, ippons: [], fouls: { a: 0, b: 0 }, live: true, corrected: false },
+        });
         return (
           <ScoreEditorModal
             key={openMatch.compId + '-' + openMatch.id}
@@ -1272,7 +1282,19 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, pa
             onSubmit={async (patch) => {
               try {
                 await onEditScore(openMatch.compId, openMatch.id, patch, openMatch);
-                if (mountedRef.current) setOpenMatch(null);
+                if (!mountedRef.current) return;
+                // ▶ Start Match: keep the operator IN the scoring surface rather
+                // than dumping them back to the list (which forced a re-find +
+                // reopen per match). A "start" patch is status:running with no
+                // winner — flip the open match's status optimistically so the
+                // modal re-renders as the live scoring board (the background
+                // refresh/SSE then reconciles the canonical state). Any other
+                // submit (finish/correction/draw) closes as before.
+                if (patch.status === "running" && !patch.winner) {
+                  setOpenMatch(prev => prev ? { ...prev, status: "running" } : prev);
+                } else {
+                  setOpenMatch(null);
+                }
               } catch (_err) {
                 // Error handled by onEditScore/toast, but we catch here to keep modal open
               }
@@ -1280,7 +1302,20 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, pa
             onSubmitAndNext={nextActiveMatch ? async (patch) => {
               try {
                 await onEditScore(openMatch.compId, openMatch.id, patch, openMatch);
-                if (mountedRef.current) setOpenMatch(nextActiveMatch);
+                if (!mountedRef.current) return;
+                // "Finish + Start Next →": land on the next match on the SAME
+                // shiaijo AND actually start it (honest to the label). If the
+                // next match is already running/completed, just open it. Start
+                // gating runs server-side (StartMatchTx); a 409 throws — we
+                // catch it so the operator still lands on the next match (in
+                // pre-match) to resolve the eligibility issue manually.
+                setOpenMatch(nextActiveMatch);
+                if (nextActiveMatch.status === "scheduled") {
+                  try {
+                    await onEditScore(nextActiveMatch.compId, nextActiveMatch.id, startPatch(), nextActiveMatch);
+                    if (mountedRef.current) setOpenMatch(prev => prev ? { ...prev, status: "running" } : prev);
+                  } catch (_startErr) { /* gate rejected the start; stay on the next match in pre-match */ }
+                }
               } catch (_err) { /* keep modal open on error */ }
             } : null}
             password={password}

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -31,6 +31,81 @@ function getValidPointKeys(isNaginata) {
   return isNaginata ? "MKDTSH" : "MKDTH";
 }
 
+// IPPON_LETTER_LEGEND — the M/K/D/T/H (+S for naginata) ippon-type letters
+// and their kendo meaning. The strike-target names mirror the kendo glossary
+// (internal/domain/glossary.go datapoint "datapoint"/"sune"/"hansoku"). H is
+// the hansoku-derived free point ("Two hansoku … give the opponent one free
+// point", glossary "hansoku"). The viewer glossary doesn't define these
+// single letters as terms, so the wording is authored here for the operator.
+const IPPON_LETTER_LEGEND = [
+  ["M", "Men — head strike"],
+  ["K", "Kote — wrist strike"],
+  ["D", "Do — torso strike"],
+  ["T", "Tsuki — throat thrust"],
+  ["S", "Sune — shin strike (naginata)"],
+  ["H", "Hansoku point — opponent's 2nd foul"],
+];
+
+// IpponLegend — compact, always-present key mapping each scoring letter to its
+// kendo meaning, so the admin scoring modal isn't dependent on the viewer-only
+// glossary. The "S" (Sune) row only shows for naginata competitions. Styled
+// inline with DESIGN tokens (this region of styles.css is owned elsewhere).
+function IpponLegend({ isNaginata }) {
+  const rows = IPPON_LETTER_LEGEND.filter(([letter]) => letter !== "S" || isNaginata);
+  return (
+    <details
+      data-testid="scoring-modal-ippon-legend"
+      style={{ marginTop: 10, fontSize: 12, color: "var(--ink-3)" }}
+    >
+      <summary style={{ cursor: "pointer", fontWeight: 600, color: "var(--ink-2)", userSelect: "none" }}>
+        <span aria-hidden="true" style={{
+          display: "inline-block", width: 16, height: 16, lineHeight: "16px",
+          textAlign: "center", borderRadius: 999, border: "1px solid var(--line)",
+          color: "var(--ink-2)", fontWeight: 700, marginRight: 6,
+        }}>?</span>
+        Ippon-type key
+      </summary>
+      <dl style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "4px 10px", margin: "8px 0 0", padding: 0 }}>
+        {rows.map(([letter, meaning]) => (
+          <React.Fragment key={letter}>
+            <dt style={{
+              fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--ink-1)",
+              margin: 0, textAlign: "center",
+            }}>{letter}</dt>
+            <dd style={{ margin: 0, color: "var(--ink-2)" }}>{meaning}</dd>
+          </React.Fragment>
+        ))}
+      </dl>
+    </details>
+  );
+}
+
+// ScoringShortcutHint — quiet, always-present reminder of the keyboard
+// shortcuts the modal supports. Rendered below the prev/next nav so the
+// affordance sits where operators look for navigation. Clarity over
+// decoration: plain muted text, no animation. Styled inline (this region of
+// styles.css is owned elsewhere).
+function ScoringShortcutHint() {
+  const kbd = {
+    fontFamily: "var(--font-mono)", fontSize: 11, padding: "1px 5px",
+    border: "1px solid var(--line)", borderRadius: 4, background: "var(--surface)",
+    color: "var(--ink-3)", margin: "0 1px",
+  };
+  return (
+    <div
+      data-testid="scoring-modal-shortcut-hint"
+      aria-hidden="true"
+      style={{ marginTop: 6, fontSize: 12, color: "var(--ink-3)", textAlign: "center", display: "flex", gap: 4, justifyContent: "center", alignItems: "center", flexWrap: "wrap" }}
+    >
+      <kbd style={kbd}>←</kbd><kbd style={kbd}>→</kbd>
+      <span>prev/next</span>
+      <span aria-hidden="true">·</span>
+      <kbd style={kbd}>Esc</kbd>
+      <span>close</span>
+    </div>
+  );
+}
+
 // applyFusenshoToggle — pure reducer for the per-bout Fusensho button in
 // TeamScoreEditorModal. Implements three behaviours on top of the sub
 // state {aPts, bPts, aFouls, bFouls, fusensho, _preFusensho?}:
@@ -874,9 +949,13 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []); // listener registered once; reads fresh state via kbRef
 
+  // a11y: label the dialog with the match/court context so screen readers
+  // announce who is fighting and on which shiaijo when the modal opens.
+  const dialogLabel = `Score editor — ${m.sideB?.name || "Shiro"} vs ${m.sideA?.name || "Aka"}${m.court ? ` · Shiaijo ${m.court}` : ""}`;
+
   return (
     <div className="modal-backdrop" data-testid="scoring-modal-root" onClick={handleDismiss}>
-      <div className="editor-modal editor-modal--lg editor-modal--compact" onClick={(e) => e.stopPropagation()}>
+      <div className="editor-modal editor-modal--lg editor-modal--compact" role="dialog" aria-modal="true" aria-label={dialogLabel} onClick={(e) => e.stopPropagation()}>
         <div className="editor-modal__head">
           <div style={{ flex: 1 }}>
             <div className="editor-modal__eyebrow">
@@ -1035,6 +1114,11 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
               </div>
           </div>
 
+          {/* Ippon-type letter legend — discoverable "?" affordance mapping
+              M/K/D/T/H (+S in naginata) to their kendo meaning, so operators
+              don't depend on the viewer-only glossary. */}
+          <IpponLegend isNaginata={isNaginata} />
+
           {/* T093–T098: decision (kiken/fusenpai) controls + remaining-matches
               follow-up. Sits between the scoring board and the footer so the
               flow is: enter score OR record a decision → either way the modal
@@ -1127,6 +1211,8 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
               <button className="btn btn--sm score-nav__next" onClick={onNext} disabled={submitting} title={nextMatch.sideA?.name + " vs " + nextMatch.sideB?.name}>Next →</button>
             ) : <span />}
           </div>
+          {/* Quiet, always-present keyboard-shortcut reminder. */}
+          <ScoringShortcutHint />
         </div>
       </div>
     </div>
@@ -1575,9 +1661,13 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
     { key: "a", name: m.sideA?.name || m.sideA, label: "AKA (Red)", color: "aka", iv: ivA, pw: pwA },
   ];
 
+  // a11y: label the dialog with the match/court context (mirrors the
+  // individual ScoreEditorModal).
+  const dialogLabel = `Team score editor — ${m.sideB?.name || m.sideB || "Shiro"} vs ${m.sideA?.name || m.sideA || "Aka"}${m.court ? ` · Shiaijo ${m.court}` : ""}`;
+
   return (
     <div className="modal-backdrop" data-testid="scoring-modal-root" onClick={handleDismiss}>
-      <div className={`editor-modal editor-modal--team ${useCompact ? "editor-modal--compact" : ""}`} onClick={(e) => e.stopPropagation()}>
+      <div className={`editor-modal editor-modal--team ${useCompact ? "editor-modal--compact" : ""}`} role="dialog" aria-modal="true" aria-label={dialogLabel} onClick={(e) => e.stopPropagation()}>
         <div className="editor-modal__head">
           <div style={{ flex: 1 }}>
             <div className="editor-modal__eyebrow">
@@ -1952,6 +2042,10 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
             );
           })()}
 
+          {/* Ippon-type letter legend — same affordance as the individual
+              editor; the per-bout buttons use the same M/K/D/T/H letters. */}
+          <IpponLegend isNaginata={isNaginataTeam} />
+
           {/* T093–T098: decision (kiken/fusenpai) controls for the overall
               team match. Per-bout Fusensho lives on each sub-match row
               (see the row-level "Fusensho" button per side, T096). */}
@@ -2032,6 +2126,8 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
               <button className="btn btn--sm score-nav__next" onClick={onNext} disabled={submitting}>Next →</button>
             ) : <span />}
           </div>
+          {/* Quiet, always-present keyboard-shortcut reminder. */}
+          <ScoringShortcutHint />
         </div>
       </div>
     </div>

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -644,25 +644,35 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
       // as the error body when the kiken-undo would invalidate a
       // downstream match. Re-prompt the operator and retry with force.
       if (!opts.force && /decision_locked/i.test(msg)) {
-        if (mountedRef.current && confirm(
-          "A subsequent match for one of these competitors has already started.\n\n" +
-          "Overwriting the prior decision now may make those downstream results inconsistent. Proceed anyway?"
-        )) {
+        const ok = mountedRef.current && await window.confirmDialog({
+          message:
+            "A subsequent match for one of these competitors has already started.\n\n" +
+            "Overwriting the prior decision now may make those downstream results inconsistent. Proceed anyway?",
+          confirmLabel: "Proceed anyway",
+          danger: true,
+        });
+        if (!mountedRef.current) return;
+        if (ok) {
           await submitDecision(kind, { decisionBy, decisionReason }, { force: true });
           return;
         }
-        if (mountedRef.current) setDecisionErr("Override cancelled.");
+        setDecisionErr("Override cancelled.");
       } else if (!opts.force && /max_encho_exceeded/i.test(msg)) {
         // T104/CHK029: the server caps encho periods per competition.
         // Same confirm-and-retry-with-force shape as decision_locked.
-        if (mountedRef.current && confirm(
-          "This decision would exceed the configured maximum encho periods.\n\n" +
-          "Record it anyway?"
-        )) {
+        const ok = mountedRef.current && await window.confirmDialog({
+          message:
+            "This decision would exceed the configured maximum encho periods.\n\n" +
+            "Record it anyway?",
+          confirmLabel: "Record anyway",
+          danger: true,
+        });
+        if (!mountedRef.current) return;
+        if (ok) {
           await submitDecision(kind, { decisionBy, decisionReason }, { force: true });
           return;
         }
-        if (mountedRef.current) setDecisionErr("Override cancelled.");
+        setDecisionErr("Override cancelled.");
       } else if (mountedRef.current) {
         setDecisionErr(msg);
       }
@@ -798,12 +808,12 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     isDrawToggled !== initialIsDrawToggled ||
     enchoPeriodCount !== initialEnchoPeriods ||
     decidedByHantei !== initialDecidedByHantei;
-  const handleDismiss = () => {
+  const handleDismiss = async () => {
     // Don't close while any save/decision request is in flight — letting
     // the modal unmount would orphan the pending fetch and lose the
     // setState landing.
     if (submitting || decisionSubmitting) return;
-    if (isDirty && !confirm("Discard unsaved scoring changes?")) return;
+    if (isDirty && !(await window.confirmDialog({ message: "Discard unsaved scoring changes?", confirmLabel: "Discard changes", danger: true }))) return;
     onClose();
   };
 
@@ -1350,24 +1360,34 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
     } catch (e) {
       const msg = e?.message || "Failed to record decision";
       if (!opts.force && /decision_locked/i.test(msg)) {
-        if (mountedRef.current && confirm(
-          "A subsequent match for one of these teams has already started.\n\n" +
-          "Overwriting the prior decision now may make those downstream results inconsistent. Proceed anyway?"
-        )) {
+        const ok = mountedRef.current && await window.confirmDialog({
+          message:
+            "A subsequent match for one of these teams has already started.\n\n" +
+            "Overwriting the prior decision now may make those downstream results inconsistent. Proceed anyway?",
+          confirmLabel: "Proceed anyway",
+          danger: true,
+        });
+        if (!mountedRef.current) return;
+        if (ok) {
           await submitDecision(kind, { decisionBy, decisionReason }, { force: true });
           return;
         }
-        if (mountedRef.current) setDecisionErr("Override cancelled.");
+        setDecisionErr("Override cancelled.");
       } else if (!opts.force && /max_encho_exceeded/i.test(msg)) {
         // T104/CHK029: encho-cap override, same shape as decision_locked.
-        if (mountedRef.current && confirm(
-          "This decision would exceed the configured maximum encho periods.\n\n" +
-          "Record it anyway?"
-        )) {
+        const ok = mountedRef.current && await window.confirmDialog({
+          message:
+            "This decision would exceed the configured maximum encho periods.\n\n" +
+            "Record it anyway?",
+          confirmLabel: "Record anyway",
+          danger: true,
+        });
+        if (!mountedRef.current) return;
+        if (ok) {
           await submitDecision(kind, { decisionBy, decisionReason }, { force: true });
           return;
         }
-        if (mountedRef.current) setDecisionErr("Override cancelled.");
+        setDecisionErr("Override cancelled.");
       } else if (mountedRef.current) {
         setDecisionErr(msg);
       }
@@ -1541,11 +1561,11 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
   // (setState-after-unmount), AND confirm-then-discard when the user has
   // unsaved sub-match edits. The earlier version only checked submitting,
   // so an accidental backdrop/Esc silently lost up to 9 sub-match scores.
-  const handleDismiss = () => {
+  const handleDismiss = async () => {
     // Same contract as ScoreEditorModal: never close while a save,
     // decision, or daihyosen request is mid-flight.
     if (submitting || decisionSubmitting || daihyosenBusy) return;
-    if (isDirty && !confirm("Discard unsaved scoring changes?")) return;
+    if (isDirty && !(await window.confirmDialog({ message: "Discard unsaved scoring changes?", confirmLabel: "Discard changes", danger: true }))) return;
     onClose();
   };
 

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -280,14 +280,14 @@ function initialEnchoPeriodsForMatch(m) {
 // daihyosenEnchoFields — pure builder for the encho/decidedByHantei wire
 // fields on the daihyosen representative bout (position -1). The backend
 // invariant (validation.go validateSubBout) is: encho and hantei are valid
-// ONLY on the daihyosen, and decidedByHantei REQUIRES encho.periodCount > 0.
-// So if the operator arms hantei then reduces the counter back to 0, we must
-// emit NEITHER field — otherwise the save 400s ("requires encho with at least
-// one period"). Returns the fields to merge into the entry (possibly empty).
-// Exported for vitest.
+// ONLY on the daihyosen. Encho is OPTIONAL for hantei — a tied daihyosen may
+// be taken straight to a judges' decision without overtime — so the two
+// fields are emitted independently: encho whenever the counter is > 0, and
+// decidedByHantei whenever it is armed on a tied scoreline. Returns the fields
+// to merge into the entry (possibly empty). Exported for vitest.
 function daihyosenEnchoFields({ enchoPeriodCount, daihyosenTied, daihyosenHantei }) {
-  if (!(enchoPeriodCount > 0)) return {};
-  const fields = { encho: { periodCount: enchoPeriodCount } };
+  const fields = {};
+  if (enchoPeriodCount > 0) fields.encho = { periodCount: enchoPeriodCount };
   if (daihyosenTied && daihyosenHantei) fields.decidedByHantei = true;
   return fields;
 }
@@ -663,13 +663,6 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     return () => { cancelled = true; };
   }, [m.compId]);
 
-  // Auto-clear decidedByHantei when encho (overtime) period count is 0
-  useEffectA(() => {
-    if (enchoPeriodCount === 0 && decidedByHantei) {
-      setDecidedByHantei(false);
-    }
-  }, [enchoPeriodCount, decidedByHantei]);
-
   // T093/T094: shared decision-submit path for kiken & fusenpai.
   // - decisionBy is "shiro" or "aka" per the server contract.
   // - encho rides along when the operator has marked overtime so the server
@@ -807,9 +800,9 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
     return { winner, ipponsA: aFinal, ipponsB: bFinal, hansokuA: aFouls, hansokuB: bFouls, status: "completed", score: { type: "ippon", winnerPts: ippons.length, loserPts: (winnerSide === "a" ? bFinal : aFinal).length, ippons, fouls, corrected: isComplete }, ...enchoBlock(), ...hanteiClear };
   };
 
-  // Hantei submit: tied at end of encho. Operator picks a side; we send a
-  // completed patch with the chosen side as winner, the *entered* ippon
-  // arrays preserved (so a 1–1 encho score stays visible alongside the HT
+  // Hantei submit: tied scoreline (with or without encho). Operator picks a
+  // side; we send a completed patch with the chosen side as winner, the
+  // *entered* ippon arrays preserved (so a 1–1 score stays visible alongside the HT
   // marker — clearing them would lose the tied score history that the
   // viewer/Excel renderers display under the hantei suffix), and the
   // decidedByHantei flag set. This is a dedicated affordance because the
@@ -994,11 +987,12 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
             setEnchoPeriodCount={setEnchoPeriodCount}
             maxEnchoPeriods={maxEnchoPeriods}
           />
-          {/* FIK 7-5 / 29-6: in encho a still-tied match is decided by
-              referee hantei. Surface a dedicated affordance so the
-              winner is recorded with the hantei flag — distinguishable
+          {/* A tied match may be decided by referee hantei. Surface the
+              affordance whenever the scoreline is tied — encho is optional,
+              not required (operators may go straight to a judges' decision).
+              The winner is recorded with the hantei flag, distinguishable
               from an ippon-derived win for stats, audit, and Excel. */}
-          {enchoPeriodCount > 0 && (
+          {aTotal === bTotal && (
             <div className="hantei-row" data-testid="scoring-modal-hantei-row" style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 8px", marginBottom: 6, background: "var(--card-2, #fafafa)", borderRadius: 6, fontSize: 12 }}>
               <span style={{ fontWeight: 600, color: "var(--ink-2)" }}>Hantei</span>
               <span style={{ color: "var(--ink-3)" }}>(judges' decision)</span>
@@ -1008,20 +1002,19 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                   className="btn btn--sm"
                   data-testid="scoring-modal-hantei-arm"
                   onClick={() => setDecidedByHantei(true)}
-                  // Hantei is only valid when the bout is genuinely tied
-                  // at end of encho (FIK 7-5 / 29-6). Disable the arm
-                  // button when totals are unequal (ippon-derived win already
-                  // decided), when the bout is already decided by ippons
-                  // (boutDecided), or when a draw is already toggled.
-                  // (0-0 is still a valid tied state.)
-                  disabled={submitting || decisionSubmitting || aTotal !== bTotal || boutDecided || isDrawToggled || enchoPeriodCount <= 0}
+                  // Hantei declares a winner from a genuinely tied bout. Disable
+                  // the arm button when totals are unequal (an ippon-derived win
+                  // is already decided), when the bout is already decided by
+                  // ippons (boutDecided), or when a draw is already toggled.
+                  // (0-0 is still a valid tied state. Encho is NOT required.)
+                  disabled={submitting || decisionSubmitting || aTotal !== bTotal || boutDecided || isDrawToggled}
                   title={
                     submitting || decisionSubmitting
                       ? "Saving…"
                       : isDrawToggled
                         ? "Cancel the draw toggle before using hantei"
-                        : aTotal !== bTotal || boutDecided || enchoPeriodCount <= 0
-                          ? "Hantei applies only to tied matches in encho"
+                        : aTotal !== bTotal || boutDecided
+                          ? "Hantei applies only to a tied scoreline"
                           : "Record a judges' decision"
                   }
                   style={{ marginLeft: "auto" }}
@@ -1316,8 +1309,8 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
   const [daihyosenErr, setDaihyosenErr] = useStateA("");
   const [daihyosenBusy, setDaihyosenBusy] = useStateA(false);
   // mp-4pc: the daihyosen is the only team sub-bout that may be decided
-  // by hantei (judges' decision after a tied encho, FIK 7-5 / 29-6).
-  // Mirrors the individual ScoreEditorModal hantei flow but scoped to the
+  // by hantei (judges' decision on a tied bout, FIK 7-5 / 29-6 — encho
+  // optional). Mirrors the individual ScoreEditorModal hantei flow but scoped to the
   // position -1 row. "" = score-decided; "a"/"b" = hantei winner side.
   const initialDaihyosenHantei = existingDaihyosen?.decidedByHantei
     ? (existingDaihyosen.winner === (typeof m.sideA === "object" ? m.sideA?.name : m.sideA) ? "a" : "b")
@@ -1571,7 +1564,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
       // Hansoku Hs already in pts arrays via applyFoulIncrement — no fold.
       const aAll = s.aPts.slice(0, MAX_IPPONS_PER_SIDE);
       const bAll = s.bPts.slice(0, MAX_IPPONS_PER_SIDE);
-      // The daihyosen winner may come from hantei (tied encho); fall back
+      // The daihyosen winner may come from hantei (tied bout); fall back
       // to the score-derived winner otherwise.
       const wKey = isDaihyo ? daihyosenWinner : t.winner;
       const w = wKey === "a" ? m.sideA : wKey === "b" ? m.sideB : null;
@@ -1593,9 +1586,8 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
         decision,
       };
       // mp-4pc: encho + hantei are valid ONLY on the daihyosen
-      // (validation.go validateSubBout). daihyosenEnchoFields encodes the
-      // backend invariant (hantei requires encho > 0) so a reduced-to-0
-      // counter doesn't replay a now-invalid decidedByHantei.
+      // (validation.go validateSubBout). daihyosenEnchoFields emits the two
+      // independently — encho is optional for a hantei decision.
       if (isDaihyo) {
         Object.assign(entry, daihyosenEnchoFields({ enchoPeriodCount, daihyosenTied, daihyosenHantei }));
       }
@@ -1971,12 +1963,12 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
           </div>
 
           {/* mp-4pc: hantei affordance for the daihyosen — the rep bout is
-              the only team sub-bout that may be decided by judges after a
-              tied encho (FIK 7-5 / 29-6). Mounts only when a daihyosen
-              exists and overtime is active; arming requires a tied
-              scoreline. The chosen winner rides onto the position -1 sub
-              (decidedByHantei) when the operator saves. */}
-          {hasDaihyosen && enchoPeriodCount > 0 && (() => {
+              the only team sub-bout that may be decided by judges (FIK 7-5 /
+              29-6). Encho is optional: a tied daihyosen may be taken straight
+              to a judges' decision. Mounts whenever a daihyosen exists;
+              arming requires a tied scoreline. The chosen winner rides onto
+              the position -1 sub (decidedByHantei) when the operator saves. */}
+          {hasDaihyosen && (() => {
             const dt = subTotals[daihyosenIdx];
             const tiedScore = dt.aTotal === dt.bTotal;
             return (
@@ -1990,7 +1982,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                     data-testid="team-daihyosen-hantei-arm"
                     onClick={() => setDaihyosenHanteiArmed(true)}
                     disabled={submitting || decisionSubmitting || !tiedScore}
-                    title={!tiedScore ? "Hantei applies only to a tied daihyosen in encho" : "Record a judges' decision"}
+                    title={!tiedScore ? "Hantei applies only to a tied daihyosen" : "Record a judges' decision"}
                     style={{ marginLeft: "auto" }}
                   >
                     Decide by hantei…

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -882,7 +882,7 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
   const doImport = async () => {
     if (!files.length) return;
     if (!(await window.confirmDialog({ message: "Are you sure you want to import these competitions? This will add new competitions to the tournament.", confirmLabel: "Import competitions" }))) return;
-    const admin = window.promptAdminPassword();
+    const admin = await window.promptAdminPassword();
     if (admin === null) return;
     setLoading(true);
     setError(null);

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -881,7 +881,7 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
 
   const doImport = async () => {
     if (!files.length) return;
-    if (!confirm("Are you sure you want to import these competitions? This will add new competitions to the tournament.")) return;
+    if (!(await window.confirmDialog({ message: "Are you sure you want to import these competitions? This will add new competitions to the tournament.", confirmLabel: "Import competitions" }))) return;
     const admin = window.promptAdminPassword();
     if (admin === null) return;
     setLoading(true);

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -352,6 +352,12 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
 
   const running = comps.filter((c) => c.status === "pools" || c.status === "playoffs");
 
+  // Derive the tournament-level status from competition activity instead of
+  // trusting t.status, which can read "Pending" (setup) even while competitions
+  // are mid-pools — a contradiction next to the "Currently running" list below.
+  const allCompleted = comps.length > 0 && comps.every((c) => c.status === "completed");
+  const tournamentInProgress = running.length > 0;
+
   return (
     <div className="app">
       <AdminTopbar onLogout={onLogout} onViewerMode={onViewerMode} tournament={t} />
@@ -360,7 +366,9 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
           <div>
             <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
               <h1 className="page-head__title">{t.name}</h1>
-              <StatusBadge status={t.status} />
+              {tournamentInProgress
+                ? <span className="badge badge--pools">In progress</span>
+                : <StatusBadge status={allCompleted ? "completed" : "setup"} />}
             </div>
             <div className="page-head__sub">
               {formatAdminHeaderSub(
@@ -406,7 +414,11 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
 
         {running.length > 0 && (<>
           <div className="section-title" style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <span className="dot dot--live"></span> Currently running
+            {/* Static dot, not dot--live: these are started competitions, which
+                is not the same as a match being live right now. The pulsing
+                live signal is reserved for actual live matches (topbar
+                live-strip + match rows) per DESIGN.md Principle 3. */}
+            <span className="dot"></span> Currently running
           </div>
           <div className="tlist" style={{ marginBottom: 24 }}>
             {running.map((c) => <CompCard key={c.id} c={c} onOpen={() => onOpenCompetition(c.id, "scores")} onStart={() => onStartCompetition(c.id)} tournament={t} showToast={showToast} />)}

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -250,7 +250,7 @@ function AllWinnersModal({ comps, onClose }) {
             <div key={comp.id} className="card" style={{ padding: "12px 16px" }}>
               <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                 <div style={{ fontWeight: 700, fontSize: 15 }}>{comp.name}</div>
-                <div style={{ fontSize: 12, color: "var(--ink-3)", background: "var(--surface-2, #f0f0f0)", borderRadius: 4, padding: "1px 6px" }}>
+                <div style={{ fontSize: 12, color: "var(--ink-3)", background: "var(--surface-2)", borderRadius: 4, padding: "1px 6px" }}>
                   {window.competitionKindLabel(comp)}
                 </div>
               </div>
@@ -502,7 +502,7 @@ function ShareRegistrationModal({ url, onClose, showToast }) {
         </div>
         <div className="modal__body" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
           <canvas ref={canvasRef} style={{ display: "block", imageRendering: "pixelated" }} />
-          <div style={{ width: "100%", background: "var(--surface-2, #f5f5f5)", borderRadius: 6, padding: "8px 12px", fontFamily: "monospace", fontSize: 13, wordBreak: "break-all", userSelect: "all" }}>
+          <div style={{ width: "100%", background: "var(--surface-2)", borderRadius: 6, padding: "8px 12px", fontFamily: "monospace", fontSize: 13, wordBreak: "break-all", userSelect: "all" }}>
             {url}
           </div>
           <p style={{ margin: 0, fontSize: 13, color: "var(--ink-3)", textAlign: "center" }}>
@@ -583,7 +583,7 @@ function ExportPdfModal({ tournament, password, onClose, showToast }) {
             Each download is a ZIP. Generation can take up to a minute.
           </p>
           {PDF_EXPORT_TYPES.map(({ type, label, hint }) => (
-            <div key={type} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, padding: "6px 0", borderBottom: "1px solid var(--surface-2, #eee)" }}>
+            <div key={type} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, padding: "6px 0", borderBottom: "1px solid var(--line)" }}>
               <div>
                 <div style={{ fontWeight: 600 }}>{label}</div>
                 <div style={{ fontSize: 12, color: "var(--ink-3)" }}>{hint}</div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -20,6 +20,16 @@ const formatAdminHeaderSub = window.formatAdminHeaderSub;
 // "+N more" overflow indicator kicks in.
 const LIVE_STRIP_MAX_CHIPS = 6;
 
+// Plain-language expansions for the insider format codes emitted by
+// formatLabelShort (ui.jsx): "P+KO" / "KO". Used as a tooltip + aria-label at
+// the call site so the abbreviation stays legible to new operators.
+const FORMAT_LABEL_LONG = {
+  mixed: "Pools then knockout",
+  league: "League (round-robin)",
+  swiss: "Swiss rounds",
+  playoffs: "Knockout (direct elimination)",
+};
+
 function Breadcrumbs({ items }) {
   return (
     <div className="crumbs">
@@ -27,7 +37,14 @@ function Breadcrumbs({ items }) {
         <React.Fragment key={i}>
           {i > 0 && <span className="sep">/</span>}
           {item.onClick ? (
-            <button onClick={() => { document.activeElement?.blur(); item.onClick(); }}>
+            // No document.activeElement.blur() here: it dumped keyboard focus
+            // to <body> after every breadcrumb navigation, stranding tab order.
+            // The clicked button keeps focus naturally; the destination view
+            // manages its own focus. (The old blur appeared to target a mobile
+            // keyboard / hover dismissal, but a blanket blur is the wrong tool —
+            // it breaks keyboard users for a problem the browser already handles
+            // when the navigated-away input unmounts.)
+            <button onClick={() => item.onClick()}>
               {i === 0 && <span style={{ marginRight: 4 }}>←</span>}
               {item.label}
             </button>
@@ -53,6 +70,24 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
       .flatMap(cc => window.compMatches(cc))
       .filter(m => m.status === "running" && sideName(m.sideA) && sideName(m.sideB));
   }, [tournament]);
+
+  // Connection-state indicator (PRODUCT.md: "never leave the user guessing
+  // about the tournament state"). The admin chrome previously showed nothing
+  // when the SSE stream dropped, so stale data sat silently. We open our own
+  // lightweight subscription purely to read the connection status exposed by
+  // API.subscribeToEvents' second (onStatus) callback — 'open' vs 'error'.
+  // The callback arg is a no-op here: the dashboard already drives data
+  // refreshes off its own subscription; this one only observes liveness.
+  const [connected, setConnected] = useStateA(true);
+  useEffectA(() => {
+    if (!window.API || typeof window.API.subscribeToEvents !== "function") return;
+    const unsub = window.API.subscribeToEvents(
+      () => {},
+      (status) => setConnected(status === "open")
+    );
+    return unsub;
+  }, []);
+
   const onOpenScore = (m) => {
     if (typeof window.__adminNavigateToScore === "function") {
       window.__adminNavigateToScore(m.compId);
@@ -74,6 +109,31 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
           </div>
         </div>
         <div className="topbar__spacer"></div>
+        {/* Calm connection indicator: a dot + label that reflects the SSE
+            stream state. Green-tinted "Live" when connected; amber-tinted
+            "Reconnecting…" when the stream has dropped. role=status +
+            aria-live=polite so a screen reader hears the change without it
+            being alarmist. Uses tokens inline (no new CSS classes). */}
+        <span
+          role="status"
+          aria-live="polite"
+          title={connected ? "Live feed connected" : "Live feed disconnected — reconnecting"}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 12,
+            fontWeight: 600,
+            color: connected ? "var(--ink-2)" : "var(--red)",
+          }}
+        >
+          <span
+            aria-hidden="true"
+            className={connected ? "dot dot--live" : "dot"}
+            style={connected ? undefined : { background: "var(--red)" }}
+          ></span>
+          {connected ? "Live" : "Reconnecting…"}
+        </span>
         <button className="viewer-toggle" onClick={onViewerMode}>👁 Public viewer</button>
         <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
       </div>
@@ -575,7 +635,11 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
         <div className="tcard__stats">
           <div className="tcard__stat"><div className="v">{playerCount}</div><div className="l">{pluralize(playerCount, c.kind === "team" ? "Team" : "Player")}</div></div>
           <div className="tcard__stat"><div className="v">{courts.length}</div><div className="l">{pluralize(courts.length, "Shiaijo", "Shiaijo")}</div></div>
-          <div className="tcard__stat"><div className="v">{formatLabelShort(c.format)}</div><div className="l">Format</div></div>
+          {/* formatLabelShort lives in ui.jsx (not owned here); it emits the
+              insider codes "P+KO" / "KO". Add a plain-language tooltip + a11y
+              label inline so the abbreviation is legible without forking the
+              shared helper. */}
+          <div className="tcard__stat" title={FORMAT_LABEL_LONG[c.format] || "Format"}><div className="v" aria-label={FORMAT_LABEL_LONG[c.format] || undefined}>{formatLabelShort(c.format)}</div><div className="l">Format</div></div>
           {liveCount > 0 && <div className="tcard__stat"><div className="v" style={{ color: "var(--red)" }}>{liveCount}</div><div className="l">Now</div></div>}
         </div>
         <div className="tcard__actions">
@@ -608,27 +672,90 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
 
 function CourtPicker({ value, courts, onChange, btnClassName = "", label = "", align = "left" }) {
   const [open, setOpen] = useStateA(false);
+  // Active option index for arrow-key navigation inside the open popover.
+  const [activeIdx, setActiveIdx] = useStateA(0);
   const ref = useRefA(null);
+  const triggerRef = useRefA(null);
+  const optionRefs = useRefA([]);
+
   useEffectA(() => {
     if (!open) return;
     const close = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
   }, [open]);
+
+  // On open, seed the active option to the current court and move focus into
+  // the popover. On close, return focus to the trigger so keyboard users
+  // aren't dropped to <body>.
+  useEffectA(() => {
+    if (open) {
+      const cur = Math.max(0, courts.indexOf(value));
+      setActiveIdx(cur);
+    } else {
+      triggerRef.current && triggerRef.current.focus();
+    }
+  }, [open]);
+
+  // Focus the active option element whenever it changes while open.
+  useEffectA(() => {
+    if (open && optionRefs.current[activeIdx]) {
+      optionRefs.current[activeIdx].focus();
+    }
+  }, [open, activeIdx]);
+
+  const select = (cc) => { setOpen(false); if (cc !== value) onChange(cc); };
+
+  const onPopoverKeyDown = (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(false);
+    } else if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      e.preventDefault();
+      setActiveIdx((i) => (i + 1) % courts.length);
+    } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      e.preventDefault();
+      setActiveIdx((i) => (i - 1 + courts.length) % courts.length);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveIdx(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveIdx(courts.length - 1);
+    } else if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      select(courts[activeIdx]);
+    }
+  };
+
   return (
     <div ref={ref} style={{ position: "relative", display: "inline-block" }}>
       <button
+        ref={triggerRef}
         className={btnClassName}
         onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
         title="Change shiaijo"
+        aria-haspopup="listbox"
+        aria-expanded={open}
       >{label}{value} ▾</button>
       {open && (
-        <div className="court-popover" style={{ [align === "right" ? "right" : "left"]: 0, top: "100%", marginTop: 4 }}>
-          {courts.map((cc) => (
+        <div
+          className="court-popover"
+          role="listbox"
+          aria-label="Choose shiaijo"
+          onKeyDown={onPopoverKeyDown}
+          style={{ [align === "right" ? "right" : "left"]: 0, top: "100%", marginTop: 4 }}
+        >
+          {courts.map((cc, idx) => (
             <button
               key={cc}
+              ref={(el) => { optionRefs.current[idx] = el; }}
+              role="option"
+              aria-selected={cc === value}
+              tabIndex={idx === activeIdx ? 0 : -1}
               className={cc === value ? "is-current" : ""}
-              onClick={(e) => { e.stopPropagation(); setOpen(false); if (cc !== value) onChange(cc); }}
+              onClick={(e) => { e.stopPropagation(); select(cc); }}
             >{cc}</button>
           ))}
         </div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -13,6 +13,7 @@ const compMatchStats = window.compMatchStats;
 const pluralize = window.pluralize;
 const StatusBadge = window.StatusBadge;
 const formatDate = window.formatDate;
+const Icon = window.Icon;
 const formatLabelShort = window.formatLabelShort;
 const formatAdminHeaderSub = window.formatAdminHeaderSub;
 
@@ -134,7 +135,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament }) {
           ></span>
           {connected ? "Live" : "Reconnecting…"}
         </span>
-        <button className="viewer-toggle" onClick={onViewerMode}>👁 Public viewer</button>
+        <button className="viewer-toggle" onClick={onViewerMode}><Icon name="eye" /> Public viewer</button>
         <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
       </div>
       {liveMatches.length > 0 && (
@@ -233,7 +234,7 @@ function AllWinnersModal({ comps, onClose }) {
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal" style={{ maxWidth: 640, width: "95%" }} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="All winners">
         <div className="modal__head">
-          <div className="modal__title">🏅 All winners</div>
+          <div className="modal__title" style={{ display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="trophy" size={18} />All winners</div>
           <button className="modal__close" onClick={onClose} aria-label="Close">✕</button>
         </div>
         <div className="modal__body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -381,10 +382,10 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             </div>
           </div>
           <div className="page-head__actions">
-            <button className="btn" onClick={onAnnounce}>📣 Announce</button>
-            <button className="btn" onClick={() => setExportPdfOpen(true)}>🖨 Export PDFs</button>
+            <button className="btn" onClick={onAnnounce}><Icon name="megaphone" />Announce</button>
+            <button className="btn" onClick={() => setExportPdfOpen(true)}><Icon name="printer" />Export PDFs</button>
             {comps.some(c => c.status === "completed") && (
-              <button className="btn" onClick={() => setAllWinnersOpen(true)}>🏅 All winners</button>
+              <button className="btn" onClick={() => setAllWinnersOpen(true)}><Icon name="trophy" />All winners</button>
             )}
             <button className="btn" onClick={onEditTournament}>Edit details</button>
             {comps.some(c => c.status === "setup" && (c.players || []).length >= 2) && (
@@ -403,11 +404,11 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
 
         <div className="row" style={{ marginBottom: 24 }}>
           <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenSchedule}>
-            <div className="card__title" style={{ marginBottom: 6 }}>🗓 Tournament schedule →</div>
+            <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="calendar" size={18} />Tournament schedule →</div>
             <div className="card__sub">All matches across courts. Move matches between shiaijo, filter by player.</div>
           </button>
           <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenScoreEditor}>
-            <div className="card__title" style={{ marginBottom: 6 }}>✎ Score editor →</div>
+            <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="pencil" size={18} />Score editor →</div>
             <div className="card__sub">Update results or correct past matches across the tournament.</div>
           </button>
         </div>
@@ -434,7 +435,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>Individual or Team</div>
           </button>
           <button className="tcard tcard--add" onClick={onOpenImport}>
-            <div style={{ fontSize: 28, color: "var(--ink-3)" }}>📂</div>
+            <div style={{ color: "var(--ink-3)" }}><Icon name="folder" size={28} /></div>
             <div style={{ fontWeight: 600, marginTop: 4 }}>Import competitions</div>
             <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>From folder with manifest.yaml</div>
           </button>
@@ -723,7 +724,13 @@ function CourtPicker({ value, courts, onChange, btnClassName = "", label = "", a
       e.preventDefault();
       e.stopPropagation();
       setOpen(false);
-    } else if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      return;
+    }
+    // Every branch below indexes into `courts`; with no courts there's nothing
+    // to navigate or select, so bail before any `% courts.length` (÷0 → NaN) or
+    // `courts[activeIdx]` (undefined) can run.
+    if (!courts.length) return;
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") {
       e.preventDefault();
       setActiveIdx((i) => (i + 1) % courts.length);
     } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {

--- a/web-mobile/js/admin_sponsors.jsx
+++ b/web-mobile/js/admin_sponsors.jsx
@@ -57,7 +57,7 @@ function SponsorsManager({ tournament, password, showToast, maxSponsors }) {
   };
 
   const handleDelete = async (idx, label) => {
-    if (!window.confirm(`Remove sponsor "${label}"?`)) return;
+    if (!(await window.confirmDialog({ message: `Remove sponsor "${label}"?`, confirmLabel: "Remove sponsor", danger: true }))) return;
     setBusy(true);
     try {
       await window.API.deleteSponsor(idx, password);

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1367,6 +1367,10 @@ window.fireNotification = fireNotification;
 ReactDOM.createRoot(document.getElementById("root")).render(
   <ErrorBoundary>
     <App />
+    {/* Single host for confirmDialog()/promptDialog() — sibling to App so it
+        is always mounted exactly once, on every screen (incl. the pre-auth
+        login screen's "Forgot password?" confirm). */}
+    <window.DialogHost />
   </ErrorBoundary>
 );
 

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1032,12 +1032,12 @@ function AuthModal({ onClose, onSuccess, onForgotPassword, resetEnabled }) {
             <button
               type="button"
               className="btn btn--ghost btn--sm"
-              onClick={() => {
+              onClick={async () => {
                 // Confirm intent: reset is global (everyone's
                 // re-authenticated) — see resetPassword's tournament
                 // broadcast. Cheaper to ask twice than to surprise an
                 // operator who clicked the wrong link.
-                if (window.confirm("Reset the tournament password? This will sign out all other admins.")) {
+                if (await window.confirmDialog({ message: "Reset the tournament password? This will sign out all other admins.", confirmLabel: "Reset password", danger: true })) {
                   onForgotPassword();
                 }
               }}

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -48,11 +48,13 @@ const TOAST_SUCCESS_DWELL_MS = 2700;
 const TOAST_ERROR_DWELL_MS = 8000;
 
 // Toast renders a single visible slot. The host (app.jsx) keeps one toast in
-// state and re-mounts <Toast> with new props on each showToast call, so the
-// component holds its OWN copy of the message/type and ignores a parent prop
-// change that would overwrite a still-visible ERROR with a later non-error
-// toast. This protects ops-critical failures from being silently replaced by
-// a routine success, without requiring the host to track dwell windows.
+// state and RE-RENDERS the same <Toast> instance with new props on each
+// showToast call (no changing key, so it is not remounted). Toast latches the
+// payload it is currently showing in its OWN `shown` state and ignores a
+// parent prop change that would overwrite a still-visible ERROR with a later
+// non-error toast. This protects ops-critical failures from being silently
+// replaced by a routine success, without requiring the host to track dwell
+// windows.
 //
 //  - success/info: role=status + aria-live=polite, short auto-dismiss.
 //  - error: role=alert + aria-live=assertive, long dwell (>=8s) plus a manual

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -213,6 +213,126 @@ function formatLabelShort(format) {
   return "KO";
 }
 
+// --- Imperative dialog primitive ------------------------------------------
+// confirmDialog(opts)/promptDialog(opts) return a Promise resolved by the
+// user's choice, backed by a single <DialogHost/> mounted once at the app
+// root. They replace native window.confirm/window.prompt across the admin
+// SPA so destructive/elevated prompts use the app's themed, accessible modal
+// (Escape to cancel, focus management, consistent styling) instead of browser
+// chrome that can't be styled, labelled, or (for prompt) mask a password.
+//
+// Contract preserved from the natives they replace:
+//   confirmDialog  → resolves true on confirm, false on cancel/Escape/backdrop.
+//   promptDialog   → resolves the typed string on OK, or null on cancel/Escape/
+//                    backdrop (an empty submit resolves null, matching the old
+//                    `pw ? pw : null` callers).
+let _dialogReq = null; // the active request, or null
+const _dialogListeners = new Set();
+function _setDialogReq(req) {
+  _dialogReq = req;
+  _dialogListeners.forEach((fn) => fn(_dialogReq));
+}
+
+function confirmDialog(opts = {}) {
+  const o = typeof opts === "string" ? { message: opts } : (opts || {});
+  return new Promise((resolve) => {
+    _setDialogReq({
+      kind: "confirm",
+      title: o.title || "Please confirm",
+      message: o.message || "",
+      confirmLabel: o.confirmLabel || "Confirm",
+      cancelLabel: o.cancelLabel || "Cancel",
+      danger: !!o.danger,
+      _resolve: resolve,
+    });
+  });
+}
+
+function promptDialog(opts = {}) {
+  const o = typeof opts === "string" ? { message: opts } : (opts || {});
+  return new Promise((resolve) => {
+    _setDialogReq({
+      kind: "prompt",
+      title: o.title || "Enter a value",
+      message: o.message || "",
+      defaultValue: o.defaultValue != null ? String(o.defaultValue) : "",
+      placeholder: o.placeholder || "",
+      password: !!o.password,
+      confirmLabel: o.confirmLabel || "OK",
+      cancelLabel: o.cancelLabel || "Cancel",
+      _resolve: resolve,
+    });
+  });
+}
+
+// Mounted once (app root). Renders the active request and resolves its promise.
+// Idle state renders null so it costs nothing when no dialog is open.
+function DialogHost() {
+  const [req, setReq] = React.useState(_dialogReq);
+  const [value, setValue] = React.useState("");
+  const inputRef = React.useRef(null);
+
+  React.useEffect(() => {
+    const fn = (r) => { setReq(r); if (r && r.kind === "prompt") setValue(r.defaultValue || ""); };
+    _dialogListeners.add(fn);
+    // Pick up a request created before this host finished mounting.
+    if (_dialogReq) fn(_dialogReq);
+    return () => { _dialogListeners.delete(fn); };
+  }, []);
+
+  // Focus + select the prompt input when a prompt opens so a typed default
+  // (e.g. a name to override) can be replaced immediately.
+  React.useEffect(() => {
+    if (req && req.kind === "prompt" && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [req]);
+
+  const close = (result) => {
+    const r = req;
+    setReq(null);
+    if (_dialogReq && _dialogReq._resolve === (r && r._resolve)) _dialogReq = null;
+    if (r && r._resolve) r._resolve(result);
+  };
+
+  const cancelResult = req ? (req.kind === "confirm" ? false : null) : false;
+  useEscapeToClose(req ? () => close(cancelResult) : undefined);
+
+  if (!req) return null;
+  const onCancel = () => close(cancelResult);
+  const onConfirm = () => close(req.kind === "confirm" ? true : (value || null));
+
+  return (
+    <div className="modal-backdrop" onClick={onCancel}>
+      <div className="modal" role="dialog" aria-modal="true" aria-label={req.title} onClick={(e) => e.stopPropagation()}>
+        <div className="modal__head">
+          <div className="modal__title">{req.title}</div>
+          <button className="modal__close" onClick={onCancel} aria-label="Cancel">&times;</button>
+        </div>
+        <div className="modal__body">
+          {req.message && <p className="dialog-msg">{req.message}</p>}
+          {req.kind === "prompt" && (
+            <input
+              ref={inputRef}
+              className="input dialog-prompt-input"
+              type={req.password ? "password" : "text"}
+              value={value}
+              placeholder={req.placeholder}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onConfirm(); } }}
+            />
+          )}
+        </div>
+        <div className="modal__foot">
+          <button className="btn btn--ghost" onClick={onCancel}>{req.cancelLabel}</button>
+          <button className={`btn ${req.danger ? "btn--danger" : "btn--primary"}`} onClick={onConfirm}>{req.confirmLabel}</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Hook: register an Escape key listener that always calls the latest onClose
 // without re-registering on every render (listener registered once, ref kept fresh).
 function useEscapeToClose(onClose) {
@@ -247,7 +367,7 @@ function isInteractiveTarget(el) {
   return tag === "input" || tag === "textarea" || tag === "select" || tag === "button" || tag === "a" || !!el.isContentEditable;
 }
 
-export { StatusBadge, formatDate, Toast, StableInput, pluralize, useEscapeToClose, isTextEntry, isInteractiveTarget, formatAdminHeaderSub, formatViewerHeaderEyebrow };
+export { StatusBadge, formatDate, Toast, StableInput, pluralize, useEscapeToClose, isTextEntry, isInteractiveTarget, formatAdminHeaderSub, formatViewerHeaderEyebrow, confirmDialog, promptDialog, DialogHost };
 
 if (typeof window !== "undefined") {
   window.StatusBadge = StatusBadge;
@@ -262,5 +382,8 @@ if (typeof window !== "undefined") {
   window.isInteractiveTarget = isInteractiveTarget;
   window.formatAdminHeaderSub = formatAdminHeaderSub;
   window.formatViewerHeaderEyebrow = formatViewerHeaderEyebrow;
+  window.confirmDialog = confirmDialog;
+  window.promptDialog = promptDialog;
+  window.DialogHost = DialogHost;
 }
 

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -231,6 +231,7 @@ function formatLabelShort(format) {
 //                    backdrop (an empty submit resolves null, matching the old
 //                    `pw ? pw : null` callers).
 let _dialogReq = null; // the active request, or null
+let _dialogSeq = 0;     // monotonic id, used as the dialog node's React key
 const _dialogListeners = new Set();
 function _setDialogReq(req) {
   // Defensive: if a dialog is somehow still open when a new one is requested
@@ -240,6 +241,12 @@ function _setDialogReq(req) {
   if (_dialogReq && _dialogReq._resolve && req) {
     _dialogReq._resolve(_dialogReq.kind === "confirm" ? false : null);
   }
+  // Stamp a unique id so a request that REPLACES an open one gets a fresh React
+  // key on the dialog node — forcing a remount so the callback ref re-runs and
+  // re-captures the trigger / re-focuses the new input (otherwise the trap and
+  // focus would stay pinned to the first dialog). Cheap insurance for the
+  // defensive replace path above.
+  if (req) req._id = ++_dialogSeq;
   _dialogReq = req;
   _dialogListeners.forEach((fn) => fn(_dialogReq));
 }
@@ -347,9 +354,9 @@ function DialogHost() {
     if (r && r._resolve) r._resolve(result);
   };
 
-  const cancelResult = req ? (req.kind === "confirm" ? false : null) : false;
-
   if (!req) return null;
+  // req is guaranteed truthy past the guard, so no need to handle the null case.
+  const cancelResult = req.kind === "confirm" ? false : null;
   const onCancel = () => close(cancelResult);
   const onConfirm = () => close(req.kind === "confirm" ? true : (value || null));
 
@@ -366,7 +373,7 @@ function DialogHost() {
 
   return (
     <div className="modal-backdrop" onClick={onCancel}>
-      <div className="modal" ref={dialogRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={req.title} onKeyDown={onDialogKeyDown} onClick={(e) => e.stopPropagation()}>
+      <div key={req._id} className="modal" ref={dialogRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={req.title} onKeyDown={onDialogKeyDown} onClick={(e) => e.stopPropagation()}>
         <div className="modal__head">
           <div className="modal__title">{req.title}</div>
           <button className="modal__close" onClick={onCancel} aria-label="Cancel">&times;</button>

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -312,6 +312,11 @@ function DialogHost() {
   const dialogRefCb = React.useCallback((node) => {
     if (node) {
       triggerRef.current = document.activeElement;
+      // Save the baseline inline overflow so close restores EXACTLY it, rather
+      // than blindly clearing to "" (which would clobber a pre-existing inline
+      // value). DialogHost is the only body-overflow manager, and the callback
+      // ref guarantees a paired open/close, so this can't get stuck-locked.
+      const prevOverflow = document.body.style.overflow;
       document.body.style.overflow = "hidden";
       const onKeyDown = (e) => {
         if (e.key !== "Tab") return;
@@ -333,13 +338,13 @@ function DialogHost() {
         if (inputRef.current) { inputRef.current.focus(); inputRef.current.select(); }
         else { (node.querySelector("button") || node).focus(); }
       }, 0);
-      trapRef.current = { onKeyDown, focusTimer };
+      trapRef.current = { onKeyDown, focusTimer, prevOverflow };
     } else {
       const t = trapRef.current;
       if (t) {
         clearTimeout(t.focusTimer);
         document.removeEventListener("keydown", t.onKeyDown, true);
-        document.body.style.overflow = "";
+        document.body.style.overflow = t.prevOverflow;
         trapRef.current = null;
       }
       const trig = triggerRef.current;

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -229,6 +229,13 @@ function formatLabelShort(format) {
 let _dialogReq = null; // the active request, or null
 const _dialogListeners = new Set();
 function _setDialogReq(req) {
+  // Defensive: if a dialog is somehow still open when a new one is requested
+  // (dialogs are normally sequential/user-driven, but a concurrent trigger
+  // must not hang), resolve the previous promise with its cancel value so its
+  // awaiter unblocks rather than waiting forever.
+  if (_dialogReq && _dialogReq._resolve && req) {
+    _dialogReq._resolve(_dialogReq.kind === "confirm" ? false : null);
+  }
   _dialogReq = req;
   _dialogListeners.forEach((fn) => fn(_dialogReq));
 }

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -39,9 +39,11 @@ function formatDate(d) {
 // Toast — single visible slot. Success toasts auto-dismiss quickly and are
 // polite (announced when the SR is idle). ERROR toasts dwell ≥8s, expose a
 // manual dismiss control, and are assertive (announced immediately) so an
-// operator in a noisy hall doesn't miss a failed action. The host (app.jsx)
-// is responsible for not overwriting a still-visible error with a later
-// non-error toast — see TOAST_ERROR_DWELL_MS, exported for the host's guard.
+// operator in a noisy hall doesn't miss a failed action. The Toast component
+// itself (not the host) refuses to overwrite a still-visible error with a
+// later non-error toast — it latches the shown payload and ignores a
+// suppressed prop change (see the effect below). These dwell constants are
+// module-local; they are not exported.
 const TOAST_SUCCESS_DWELL_MS = 2700;
 const TOAST_ERROR_DWELL_MS = 8000;
 
@@ -380,6 +382,30 @@ function DialogHost() {
   );
 }
 
+// Icon — small single-stroke inline SVG set (lucide geometry) for primary admin
+// chrome, replacing OS emoji so glyphs inherit the token palette via
+// `currentColor`, render identically across the tablets/laptops operators use,
+// and stay on-brand for a serious tournament tool. Decorative by default
+// (aria-hidden) since it always sits beside a text label. Add new glyphs to the
+// map as needed rather than reaching for emoji.
+function Icon({ name, size = 16, className }) {
+  const inner = {
+    megaphone: <><path d="m3 11 18-5v12L3 14v-3z" /><path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" /></>,
+    printer: <><path d="M6 9V2h12v7" /><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" /><path d="M6 14h12v8H6z" /></>,
+    trophy: <><path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" /><path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" /><path d="M4 22h16" /><path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" /><path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" /><path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" /></>,
+    eye: <><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" /><circle cx="12" cy="12" r="3" /></>,
+    calendar: <><rect width="18" height="18" x="3" y="4" rx="2" /><path d="M3 10h18" /><path d="M8 2v4" /><path d="M16 2v4" /></>,
+    pencil: <><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.4 2.6a2 2 0 0 1 2.8 2.8L11 15.6 7 17l1.4-4z" /></>,
+    folder: <><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" /></>,
+  }[name];
+  if (!inner) return null;
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" style={{ flexShrink: 0, verticalAlign: "-3px" }}>{inner}</svg>
+  );
+}
+
 // Hook: register an Escape key listener that always calls the latest onClose
 // without re-registering on every render (listener registered once, ref kept fresh).
 function useEscapeToClose(onClose) {
@@ -414,7 +440,7 @@ function isInteractiveTarget(el) {
   return tag === "input" || tag === "textarea" || tag === "select" || tag === "button" || tag === "a" || !!el.isContentEditable;
 }
 
-export { StatusBadge, formatDate, Toast, StableInput, pluralize, useEscapeToClose, isTextEntry, isInteractiveTarget, formatAdminHeaderSub, formatViewerHeaderEyebrow, confirmDialog, promptDialog, DialogHost };
+export { StatusBadge, formatDate, Toast, StableInput, pluralize, useEscapeToClose, isTextEntry, isInteractiveTarget, formatAdminHeaderSub, formatViewerHeaderEyebrow, confirmDialog, promptDialog, DialogHost, Icon };
 
 if (typeof window !== "undefined") {
   window.StatusBadge = StatusBadge;
@@ -432,5 +458,6 @@ if (typeof window !== "undefined") {
   window.confirmDialog = confirmDialog;
   window.promptDialog = promptDialog;
   window.DialogHost = DialogHost;
+  window.Icon = Icon;
 }
 

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -348,15 +348,25 @@ function DialogHost() {
   };
 
   const cancelResult = req ? (req.kind === "confirm" ? false : null) : false;
-  useEscapeToClose(req ? () => close(cancelResult) : undefined);
 
   if (!req) return null;
   const onCancel = () => close(cancelResult);
   const onConfirm = () => close(req.kind === "confirm" ? true : (value || null));
 
+  // Escape-to-cancel is handled ON the dialog container (not via the global
+  // useEscapeToClose window listener). The dialog frequently opens on top of a
+  // surface that ALSO has a window-level Escape handler (e.g. the scoring
+  // modal's handleDismiss). A window listener would let one Escape fire BOTH —
+  // cancelling the dialog and re-dismissing the underlying modal. Because focus
+  // is trapped inside the dialog, the keydown bubbles through this container
+  // first; stopPropagation() keeps it from reaching any window listener.
+  const onDialogKeyDown = (e) => {
+    if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); onCancel(); }
+  };
+
   return (
     <div className="modal-backdrop" onClick={onCancel}>
-      <div className="modal" ref={dialogRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={req.title} onClick={(e) => e.stopPropagation()}>
+      <div className="modal" ref={dialogRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={req.title} onKeyDown={onDialogKeyDown} onClick={(e) => e.stopPropagation()}>
         <div className="modal__head">
           <div className="modal__title">{req.title}</div>
           <button className="modal__close" onClick={onCancel} aria-label="Cancel">&times;</button>
@@ -370,6 +380,11 @@ function DialogHost() {
               type={req.password ? "password" : "text"}
               value={value}
               placeholder={req.placeholder}
+              // Accessible name: the field has no visible <label>, so name it
+              // from the dialog's own prompt (message preferred, title as
+              // fallback) — otherwise screen readers announce a bare text field.
+              aria-label={req.message || req.title}
+              autoComplete={req.password ? "current-password" : "off"}
               onChange={(e) => setValue(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onConfirm(); } }}
             />

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -81,13 +81,19 @@ function Toast({ message, type, onClose }) {
     setVisible(true);
   }, [message, type]);
 
+  // Auto-dismiss sequence, keyed on the SHOWN payload identity — NOT on
+  // `visible`. t1 hides at dwell; t2 fires onClose (host setToast(null) →
+  // unmount) 300ms later. `visible` must NOT be a dep: when t1 flips it false
+  // the effect would re-run, and its cleanup would clear the still-pending t2
+  // before it could fire — so onClose never ran and the toast stuck on screen
+  // forever (no CSS hides a non-is-visible toast). Re-triggering on the shown
+  // payload restarts the dwell for each new toast, which is the intent.
   React.useEffect(() => {
-    if (!visible) return undefined;
     const dwell = shownIsError ? TOAST_ERROR_DWELL_MS : TOAST_SUCCESS_DWELL_MS;
     const t1 = setTimeout(() => setVisible(false), dwell);
     const t2 = setTimeout(() => onCloseRef.current && onCloseRef.current(), dwell + 300);
     return () => { clearTimeout(t1); clearTimeout(t2); };
-  }, [visible, shown.message, shown.type, shownIsError]);
+  }, [shown.message, shown.type, shownIsError]);
 
   const role = shownIsError ? 'alert' : 'status';
   const ariaLive = shownIsError ? 'assertive' : 'polite';

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -36,18 +36,73 @@ function formatDate(d) {
   return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
 }
 
+// Toast — single visible slot. Success toasts auto-dismiss quickly and are
+// polite (announced when the SR is idle). ERROR toasts dwell ≥8s, expose a
+// manual dismiss control, and are assertive (announced immediately) so an
+// operator in a noisy hall doesn't miss a failed action. The host (app.jsx)
+// is responsible for not overwriting a still-visible error with a later
+// non-error toast — see TOAST_ERROR_DWELL_MS, exported for the host's guard.
+const TOAST_SUCCESS_DWELL_MS = 2700;
+const TOAST_ERROR_DWELL_MS = 8000;
+
+// Toast renders a single visible slot. The host (app.jsx) keeps one toast in
+// state and re-mounts <Toast> with new props on each showToast call, so the
+// component holds its OWN copy of the message/type and ignores a parent prop
+// change that would overwrite a still-visible ERROR with a later non-error
+// toast. This protects ops-critical failures from being silently replaced by
+// a routine success, without requiring the host to track dwell windows.
+//
+//  - success/info: role=status + aria-live=polite, short auto-dismiss.
+//  - error: role=alert + aria-live=assertive, long dwell (>=8s) plus a manual
+//    dismiss control; cannot be clobbered by an incoming non-error toast.
 function Toast({ message, type, onClose }) {
+  // Latch the first non-trivial payload this mount sees. The host re-renders
+  // this component (not remounts) when state.toast changes, so without this
+  // latch an incoming success prop would overwrite a live error in place.
+  const [shown, setShown] = React.useState({ message, type });
   const [visible, setVisible] = React.useState(true);
+  const onCloseRef = React.useRef(onClose);
+  React.useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+
+  const shownIsError = shown.type === 'error';
+
+  // Accept an incoming prop change only when it is NOT being suppressed: a
+  // later non-error toast is ignored while an error is still visible; anything
+  // else (error→error, error→after-dismiss, non-error→anything) replaces.
   React.useEffect(() => {
-    const t1 = setTimeout(() => setVisible(false), 2700);
-    const t2 = setTimeout(onClose, 3000);
+    const incomingIsError = type === 'error';
+    if (shownIsError && visible && !incomingIsError) return; // protect the error
+    if (message === shown.message && type === shown.type) return; // no change
+    setShown({ message, type });
+    setVisible(true);
+  }, [message, type]);
+
+  React.useEffect(() => {
+    if (!visible) return undefined;
+    const dwell = shownIsError ? TOAST_ERROR_DWELL_MS : TOAST_SUCCESS_DWELL_MS;
+    const t1 = setTimeout(() => setVisible(false), dwell);
+    const t2 = setTimeout(() => onCloseRef.current && onCloseRef.current(), dwell + 300);
     return () => { clearTimeout(t1); clearTimeout(t2); };
-  }, [onClose]);
+  }, [visible, shown.message, shown.type, shownIsError]);
+
+  const role = shownIsError ? 'alert' : 'status';
+  const ariaLive = shownIsError ? 'assertive' : 'polite';
 
   return (
-    <div className={`toast toast--${type || 'info'} ${visible ? 'is-visible' : ''}`}>
-      <div className="toast__icon">{type === 'error' ? '⚠️' : '✅'}</div>
-      <div className="toast__msg">{message}</div>
+    <div
+      className={`toast toast--${shown.type || 'info'} ${visible ? 'is-visible' : ''}`}
+      role={role}
+      aria-live={ariaLive}
+    >
+      <div className="toast__icon">{shownIsError ? '⚠️' : '✅'}</div>
+      <div className="toast__msg">{shown.message}</div>
+      {shownIsError && (
+        <button
+          className="toast__dismiss"
+          aria-label="Dismiss"
+          onClick={() => { setVisible(false); if (onCloseRef.current) onCloseRef.current(); }}
+        >&times;</button>
+      )}
     </div>
   );
 }

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -94,7 +94,7 @@ function Toast({ message, type, onClose }) {
       role={role}
       aria-live={ariaLive}
     >
-      <div className="toast__icon">{shownIsError ? '⚠️' : '✅'}</div>
+      <div className="toast__icon" aria-hidden="true">{shownIsError ? '⚠️' : '✅'}</div>
       <div className="toast__msg">{shown.message}</div>
       {shownIsError && (
         <button
@@ -278,6 +278,8 @@ function DialogHost() {
   const [req, setReq] = React.useState(_dialogReq);
   const [value, setValue] = React.useState("");
   const inputRef = React.useRef(null);
+  const triggerRef = React.useRef(null);
+  const trapRef = React.useRef(null);
 
   React.useEffect(() => {
     const fn = (r) => { setReq(r); if (r && r.kind === "prompt") setValue(r.defaultValue || ""); };
@@ -287,14 +289,52 @@ function DialogHost() {
     return () => { _dialogListeners.delete(fn); };
   }, []);
 
-  // Focus + select the prompt input when a prompt opens so a typed default
-  // (e.g. a name to override) can be replaced immediately.
-  React.useEffect(() => {
-    if (req && req.kind === "prompt" && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
+  // Modal focus management (WCAG 2.4.3 / ARIA APG dialog) via a callback ref on
+  // the dialog node — fires synchronously on mount (open) and unmount (close),
+  // which is more reliable here than a [req] effect. On open: remember the
+  // trigger, move focus into the dialog (prompt → input; confirm → the dialog
+  // container, so no button is "armed" for an accidental Enter), trap Tab, and
+  // lock background scroll. On close: tear all that down and restore focus to
+  // the trigger. NB: DialogHost renders *inside* #root, so we must NOT set
+  // `inert` on #root (it would disable the dialog itself) — the focus trap plus
+  // aria-modal carry the background-isolation contract instead.
+  const dialogRefCb = React.useCallback((node) => {
+    if (node) {
+      triggerRef.current = document.activeElement;
+      document.body.style.overflow = "hidden";
+      const onKeyDown = (e) => {
+        if (e.key !== "Tab") return;
+        const f = [...node.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')]
+          .filter((el) => !el.disabled && el.offsetParent !== null);
+        if (f.length === 0) { e.preventDefault(); return; }
+        const first = f[0], last = f[f.length - 1], active = document.activeElement;
+        if (e.shiftKey && (active === first || active === node)) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus(); }
+      };
+      document.addEventListener("keydown", onKeyDown, true);
+      // Move focus into the dialog on a 0ms timer: focusing synchronously
+      // during the commit phase gets reset afterwards, and rAF doesn't fire in
+      // non-painting/headless contexts — setTimeout(0) defers past commit and
+      // still fires. Prompt → input (focus+select the default); confirm → the
+      // first real focusable (the close "×", whose Enter is a safe cancel),
+      // since a tabindex=-1 container doesn't reliably take programmatic focus.
+      const focusTimer = setTimeout(() => {
+        if (inputRef.current) { inputRef.current.focus(); inputRef.current.select(); }
+        else { (node.querySelector("button") || node).focus(); }
+      }, 0);
+      trapRef.current = { onKeyDown, focusTimer };
+    } else {
+      const t = trapRef.current;
+      if (t) {
+        clearTimeout(t.focusTimer);
+        document.removeEventListener("keydown", t.onKeyDown, true);
+        document.body.style.overflow = "";
+        trapRef.current = null;
+      }
+      const trig = triggerRef.current;
+      if (trig && typeof trig.focus === "function" && document.contains(trig)) trig.focus();
     }
-  }, [req]);
+  }, []);
 
   const close = (result) => {
     const r = req;
@@ -312,7 +352,7 @@ function DialogHost() {
 
   return (
     <div className="modal-backdrop" onClick={onCancel}>
-      <div className="modal" role="dialog" aria-modal="true" aria-label={req.title} onClick={(e) => e.stopPropagation()}>
+      <div className="modal" ref={dialogRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={req.title} onClick={(e) => e.stopPropagation()}>
         <div className="modal__head">
           <div className="modal__title">{req.title}</div>
           <button className="modal__close" onClick={onCancel} aria-label="Cancel">&times;</button>


### PR DESCRIPTION
## Summary

Implements every finding from the `/impeccable critique` of the admin SPA (`web-mobile/js/admin.jsx`, scored 26/40), across three clusters plus two follow-ups the critique flagged. User-visible highlights:

- **High-stakes flows are no longer one-click-and-pray.** "Start all" opens a confirmation listing the affected competitions, shows progress, then a persistent result that names any failures with "Retry failed". Editing tournament details now waits for the save and only navigates on success (a failed save keeps your form). The "Competition not available" screen has chrome + a Back button and explains deleted-vs-still-syncing.
- **Toasts are ops-grade.** Errors announce assertively (`role=alert`), dwell ≥8s, are manually dismissable, and can't be silently overwritten by a later success; successes stay polite and brief.
- **The scoring loop is tighter.** Starting a match keeps you in the scoring surface (no eject-and-reopen); "Finish + Start Next" actually starts the next bout on the same shiaijo; ippon buttons hold 44px on touch devices; the modal has proper dialog semantics, a visible `← → / Esc` hint, and an Ippon-type key (M/K/D/T/H).
- **Accessibility + chrome.** CourtPicker is fully keyboard-driven (listbox, arrows, Esc, focus return); breadcrumbs no longer dump focus to `<body>`; a calm SSE connection indicator ("Live" / "Reconnecting…") sits in the topbar; `:focus-visible` rings now cover `.btn`/chips/ippon buttons; three sub-AA contrast misses fixed (footer 4.44→9.66:1, gutter 4.41→9.37:1, court sub-label 4.24→9.0:1); a `width` transition became a compositor `transform`.
- **Native browser dialogs are gone.** A shared `confirmDialog()` / `promptDialog()` primitive (themed, accessible, Escape-to-cancel, **masked** password input) replaces all 18 native `confirm()`/`prompt()` calls across the admin SPA, including the elevated-password gate (`promptAdminPassword` is now async).
- **Status no longer contradicts itself.** The tournament badge is derived from competition activity ("In progress" instead of "Pending" while matches run), and the "Currently running" header no longer pulses a live dot when nothing is live.
- **Hantei is no longer gated behind overtime (rules change).** A referee/judges' decision (hantei, FIK Art. 7-5 / 29-6) on a tied bout previously required first starting an encho period. Per FIK rules a tied scoreline may be taken straight to a judges' decision, so the "Decide by hantei…" affordance now appears whenever the scoreline is tied — encho is optional, not a precondition. Applies to any tied bout including pools, and to the daihyosen representative bout. Backend (`validation.go`) no longer rejects hantei without encho.

## Why

The critique found the engineering-driven UX (state freshness, optimistic patches) was strong, but reassurance was inverted: low-stakes actions (settings autosave) had the best feedback while the highest-stakes ones (start-all, destructive resets, save-and-navigate) had a 2.7s toast or nothing. This PR closes that gap and removes the un-themable, un-maskable native dialogs that sat beside the polished modal system.

Also corrects `PRODUCT.md`'s `Register` from the invalid `bracket-creator` to the canonical `product`.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/ui.jsx` | New `confirmDialog`/`promptDialog`/`DialogHost` primitive; toast `role`/dwell/dismiss + error-overwrite protection |
| `web-mobile/js/app.jsx` | Mount `DialogHost` at app root; migrate AuthModal reset confirm |
| `web-mobile/js/admin.jsx` | Start-all confirm→progress→named-failure modal; await-then-navigate edit save; not-found/loading chrome; await `promptAdminPassword` |
| `web-mobile/js/admin_shell.jsx` | Breadcrumb focus fix; CourtPicker keyboard; SSE indicator; `:focus-visible` for `.btn`/chips; derived tournament status; nav-label copy |
| `web-mobile/js/admin_scoring_modal.jsx` | Dialog ARIA; keep-modal-open-on-start; ippon legend; shortcut hint; `.ipt-btn:focus-visible`; confirm migration + post-await mountedRef guards; **hantei row renders on a tied scoreline (was: encho started); daihyosen hantei decoupled from encho** |
| `internal/mobileapp/validation.go` | **Drop "requires encho" check from individual `ScoreRequest.Validate` and daihyosen `validateSubBout` — encho optional for hantei** |
| `internal/state/models.go`, `specs/openapi.yaml` | **Doc/comment: hantei does not require overtime** |
| `internal/mobileapp/validation_test.go`, `web-mobile/js/__tests__/admin_scoring_modal.test.jsx` | **Hantei-without-encho test cases (Go + JS)** |
| `web-mobile/js/admin_schedule.jsx` | Start keeps scoring surface open; Finish+Start-Next starts the next bout (court-scoped) |
| `web-mobile/js/admin_competition.jsx` | `width`→`transform` progress bar (+`role=progressbar`); nav-label copy; confirm/prompt + `promptAdminPassword` migration (incl. async caller chain) |
| `web-mobile/js/admin_helpers.jsx` | `promptAdminPassword` is async, uses masked `promptDialog` |
| `web-mobile/js/admin_branding.jsx`, `admin_sponsors.jsx`, `admin_participants.jsx`, `admin_pools.jsx`, `admin_setup.jsx` | Migrate remaining native `confirm()` calls |
| `web-mobile/css/styles.css` | Coarse-pointer 44px ippon rule; `:focus-visible` block; 3 contrast fixes; dialog styles |
| `web-mobile/js/__tests__/mp_turx_knockout.test.jsx` | Update nav-label assertions for clarified copy |
| `web-mobile/js/__tests__/admin_elevated.test.jsx` | `promptAdminPassword` is async via `promptDialog` |
| `PRODUCT.md` | Restore `Register: product` (was invalid `bracket-creator`) |

## Screenshots

**Dashboard — derived "In progress" status badge (was "Pending") + "Live" SSE indicator**
![dashboard](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/265/01-dashboard.png)

**"Start all" confirmation — names the competitions, with progress + named-failure result (note "In progress" badge behind it)**
![start all confirm](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/265/02-startall-confirm.png)

**Scoring modal — dialog ARIA, Aka/Shiro badges, scored ippons (2–1), expanded Ippon-type key legend (M/K/D/T/H), `← → / Esc` shortcut hint, clarified nav labels**
![scoring modal](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/265/03-scoring-modal.png)

**New themed confirm dialog (replaces native `confirm`) over a dirty scoring modal**
![confirm dialog](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/265/04-confirm-dialog.png)

Screenshots captured via headless Chrome driving the real app (`mobile-app` on local data). Additional behaviours were verified by DOM/computed-style assertions in-browser (see Test plan): contrast ratios, `role=dialog`/`aria-modal`, `role=status`/`role=alert` on toasts, CourtPicker `role=listbox` + Escape-returns-focus, 44px coarse-pointer ippon resolution, and confirm/prompt promise resolution (true / false / typed-string / null).


**Page-head action row wraps on narrow widths (polish) — buttons reflow to multiple rows instead of overflowing; note the derived "In progress" status badge**
![page-head wrap mobile](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/265/05-pagehead-wrap-mobile.png)

**Hantei without overtime (rules change) — a tied 0-0 pool match in PRE-MATCH state. The "Overtime" control is collapsed (no encho started) yet "Decide by hantei…" is present and enabled. Entering a 1-0 score removes the row.**
![hantei tied no encho](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/265/hantei-tied-no-encho.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — golangci-lint clean, ESLint clean, **1434/1434 JS tests**, all Go packages ≥85% coverage
- [x] Hantei-without-encho verified in-browser — opened a tied 0-0 pool match (overtime collapsed); "Decide by hantei…" present + enabled; entering a 1-0 ippon removed the hantei row; reset to 0-0 restored it (screenshot above, captured headless Chrome on `mobile-app`)
- [x] New/updated unit tests cover the change — `admin_elevated.test.jsx` rewritten for async `promptAdminPassword`/`promptDialog`; `mp_turx_knockout.test.jsx` updated for clarified nav copy
- [x] Manual browser verification — exercised live in Chrome: not-found shell + Back; start-all confirm→progress→"Started 2 of 2" result; edit-tournament save success (navigates + toast, name persists); scoring modal stays open on Start (● NOW), Finish+Start-Next starts next bout on same shiaijo, ←/→ nav, ippon legend, 44px ippon under coarse pointer; CourtPicker keyboard (arrows/Enter/Esc, focus returns to trigger); breadcrumb focus retained; SSE "Live" indicator; "In progress" badge replaces "Pending"; confirmDialog resolves true/false, promptDialog resolves typed-string/null (masked), discard-changes confirm fires from the real handler
- [x] Screenshots added above
- [x] No new console errors or warnings — console error log empty across the session

Closes mp-eqvi

🤖 Generated with [Claude Code](https://claude.com/claude-code)



