### PR TITLE
feat(ui): Edit Tournament redesign + global button fixes (mp-sspn, mp-nubo)

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6658,3 +6658,95 @@ button.pool-match-row {
 .pool__overflow-note { margin-top: 8px; }
 .pool__view-all-btn  { margin-top: 8px; font-size: 13px; padding: 0; }
 
+/* ---------- Edit-tournament form stack ----------
+   The edit page is a long form split into concern-grouped cards
+   (basics, schedule, public info, access). A flex stack gives every
+   card a consistent 16px separation; the Branding + Sponsors cards
+   that follow carry their own margin-top:16px to continue the rhythm. */
+.edit-stack { display: flex; flex-direction: column; gap: 16px; }
+.edit-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 2px;
+}
+.edit-actions__note {
+  flex: 1 1 320px;
+  min-width: 240px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-3);
+}
+.edit-actions__buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+.edit-actions__dirty {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+/* Inline field-level validation error (mp-sspn) — sits directly under the
+   offending input so the message is read at its cause, not just the top banner. */
+.field__error {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--red);
+}
+
+/* Disclosure header (mp-sspn) — a card__head that toggles a collapsible
+   section. Full-width reset button so the whole header row is the hit target. */
+.disclosure {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.disclosure__chevron {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--ink-3);
+  transition: transform 150ms ease;
+}
+.disclosure[aria-expanded="true"] .disclosure__chevron { transform: rotate(90deg); }
+.disclosure__text { display: flex; flex-direction: column; gap: 2px; }
+.disclosure:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: var(--r-sm);
+}
+@media (prefers-reduced-motion: reduce) {
+  .disclosure__chevron { transition: none; }
+}
+
+/* ---------- Branding section (mp-scf) — accent header band ----------
+   Committed-color treatment: a tinted accent band leads the card, with
+   the configuration fields below. Replaces the generic card--pad-lg
+   wrapper so the brand-identity section reads as its own surface. */
+.branding { background: var(--surface); border-radius: var(--r-lg); overflow: hidden; box-shadow: var(--shadow-sm); }
+.branding__head { padding: 20px 28px; background: var(--accent-soft); }
+.branding__title { font-size: 17px; font-weight: 700; margin: 0 0 5px; color: var(--accent); }
+.branding__hint { font-size: 13px; margin: 0; line-height: 1.45; color: var(--ink-2); }
+.branding__body { padding: 20px 28px 24px; }
+.branding__body .field { margin-bottom: 16px; }
+.branding__colors { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
+.branding__colors .field { flex: 1 1 0; min-width: 160px; margin-bottom: 0; }
+.branding__finprint { font-size: 12px; color: var(--ink-3); margin-bottom: 16px; }
+.branding__logo { border-top: 1px solid var(--line); padding-top: 16px; margin-top: 4px; }
+.branding__logo-title { font-weight: 600; margin-bottom: 8px; }
+.branding__logo-preview { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; padding: 8px 12px; border: 1px solid var(--line); border-radius: 8px; }
+.branding__logo-actions { display: flex; justify-content: flex-end; }
+

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6687,7 +6687,8 @@ button.pool-match-row {
    The edit page is a long form split into concern-grouped cards
    (basics, schedule, public info, access). A flex stack gives every
    card a consistent 16px separation; the Branding + Sponsors cards
-   that follow carry their own margin-top:16px to continue the rhythm. */
+   render inside the same stack, so the gap owns their spacing (neither
+   carries its own margin-top). */
 .edit-stack { display: flex; flex-direction: column; gap: 16px; }
 .edit-actions {
   display: flex;
@@ -6770,7 +6771,7 @@ button.pool-match-row {
 .branding__body .field { margin-bottom: 16px; }
 .branding__colors { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
 .branding__colors .field { flex: 1 1 0; min-width: 160px; margin-bottom: 0; }
-.branding__finprint { font-size: 12px; color: var(--ink-3); margin-bottom: 16px; }
+.branding__fineprint { font-size: 12px; color: var(--ink-3); margin-bottom: 16px; }
 .branding__logo { border-top: 1px solid var(--line); padding-top: 16px; margin-top: 4px; }
 .branding__logo-title { font-weight: 600; margin-bottom: 8px; }
 .branding__logo-preview { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; padding: 8px 12px; border: 1px solid var(--line); border-radius: 8px; }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6701,11 +6701,14 @@ button.pool-match-row {
 }
 
 /* Disclosure header (mp-sspn) — a card__head that toggles a collapsible
-   section. Full-width reset button so the whole header row is the hit target. */
+   section. Matches the existing CourtPacePanel convention (card__title flex
+   row with a +/− indicator on the right), but uses a real <button> so
+   keyboard activation and semantics come for free. Full-width hit target. */
 .disclosure {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
+  justify-content: space-between;
+  gap: 12px;
   width: 100%;
   padding: 0;
   background: none;
@@ -6715,21 +6718,19 @@ button.pool-match-row {
   color: inherit;
   font: inherit;
 }
-.disclosure__chevron {
-  flex-shrink: 0;
-  margin-top: 2px;
-  color: var(--ink-3);
-  transition: transform 150ms ease;
-}
-.disclosure[aria-expanded="true"] .disclosure__chevron { transform: rotate(90deg); }
 .disclosure__text { display: flex; flex-direction: column; gap: 2px; }
+.disclosure__toggle {
+  flex-shrink: 0;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--ink-3);
+}
+.disclosure:hover .disclosure__toggle { color: var(--ink-2); }
 .disclosure:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
   border-radius: var(--r-sm);
-}
-@media (prefers-reduced-motion: reduce) {
-  .disclosure__chevron { transition: none; }
 }
 
 /* ---------- Branding section (mp-scf) — accent header band ----------

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -50,6 +50,12 @@
   --bg-2: #f1f5f9;
   --surface-2: #f1f5f9;
 
+  /* Heading type scale (mp-p1tw) — one size per heading role so components
+     stop inventing their own. page title / card-or-section title / overline. */
+  --fs-title-page: 26px;
+  --fs-title-card: 14px;
+  --fs-overline: 11px;
+
   --r-sm: 6px;
   --r: 10px;
   --r-lg: 14px;
@@ -318,7 +324,7 @@ a:hover {
 }
 
 .page-head__title {
-  font-size: 26px;
+  font-size: var(--fs-title-page);
   font-weight: 600;
   letter-spacing: -0.02em;
   margin: 0;
@@ -539,8 +545,18 @@ a:hover {
 
 .card__title {
   font-weight: 600;
-  font-size: 14px;
+  font-size: var(--fs-title-card);
   letter-spacing: -0.01em;
+}
+
+/* Overline / eyebrow utility (mp-p1tw) — replaces ~10 hand-rolled inline
+   copies that drifted across 10.5/11/12px and 0.06/0.08/0.1em. */
+.overline {
+  font-size: var(--fs-overline);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-3);
 }
 
 .card__sub {
@@ -6765,7 +6781,9 @@ button.pool-match-row {
    wrapper so the brand-identity section reads as its own surface. */
 .branding { background: var(--surface); border-radius: var(--r-lg); overflow: hidden; box-shadow: var(--shadow-sm); }
 .branding__head { padding: 20px 28px; background: var(--accent-soft); }
-.branding__title { font-size: 17px; font-weight: 700; margin: 0 0 5px; color: var(--accent); }
+/* Folded into the card-title scale (mp-p1tw); brand emphasis is carried by
+   the accent colour + tinted band, not by an outsized heading. */
+.branding__title { font-size: var(--fs-title-card); font-weight: 600; letter-spacing: -0.01em; margin: 0 0 5px; color: var(--accent); }
 .branding__hint { font-size: 13px; margin: 0; line-height: 1.45; color: var(--ink-2); }
 .branding__body { padding: 20px 28px 24px; }
 .branding__body .field { margin-bottom: 16px; }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -22,6 +22,10 @@
 
 :root {
   --accent: #1d3557;
+  /* Darkened accent for filled-button hover (primary, active score button).
+     applyTheme() recomputes this from a runtime Branding accent so the hover
+     tracks the configured colour instead of a hard-coded navy (mp-nubo). */
+  --accent-strong: #16263f;
   --accent-soft: #e7eaf3;
   --accent-fg: #ffffff;
   --red: #c1121f;
@@ -371,11 +375,27 @@ a:hover {
   color: var(--ink);
   font-weight: 500;
   font-size: 13.5px;
-  transition: all 120ms;
+  /* Enumerate the animated properties — `all` also animated the focus
+     outline (it should snap in) and risks animating layout (mp-nubo P3). */
+  transition: background-color 120ms, border-color 120ms, color 120ms;
 }
 
 .btn:hover {
   border-color: var(--ink-4);
+}
+
+/* Pressed feedback — a 1px nudge reads as a press without color churn, and
+   is instant (transform isn't in the transition list) (mp-nubo P3). */
+.btn:active {
+  transform: translateY(1px);
+}
+
+/* Match the app's focus-visible convention (.score-btn / .input / .disclosure
+   all use a 2px accent ring); without this .btn fell back to the UA default
+   1px ring, which is low-contrast on the navy primary button (mp-nubo). */
+.btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .btn--primary {
@@ -385,8 +405,8 @@ a:hover {
 }
 
 .btn--primary:hover {
-  background: #16263f;
-  border-color: #16263f;
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
 }
 
 .btn--danger {
@@ -463,8 +483,8 @@ a:hover {
 }
 
 .score-btn--active:hover {
-  background-color: #16263f;
-  border-color: #16263f;
+  background-color: var(--accent-strong);
+  border-color: var(--accent-strong);
   color: var(--accent-fg);
 }
 
@@ -3297,6 +3317,11 @@ button.pool-match-row {
 }
 
 @media (pointer: coarse) {
+  /* Touch devices: meet the 44px target on every button. Desktop (fine
+     pointer) keeps the denser 34px so admin tables stay compact (mp-nubo). */
+  .btn {
+    min-height: 44px;
+  }
   .btn--icon-sm {
     min-width: 44px;
     min-height: 44px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6781,9 +6781,7 @@ button.pool-match-row {
    branding-specific. */
 .branding__colors { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
 .branding__colors .field { flex: 1 1 0; min-width: 160px; margin-bottom: 0; }
-.branding__fineprint { font-size: 12px; color: var(--ink-3); margin-bottom: 16px; }
 .branding__logo { border-top: 1px solid var(--line); padding-top: 16px; margin-top: 4px; }
-.branding__logo-title { font-weight: 600; margin-bottom: 8px; }
 .branding__logo-preview { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; padding: 8px 12px; border: 1px solid var(--line); border-radius: 8px; }
 .branding__logo-actions { display: flex; justify-content: flex-end; }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6775,18 +6775,10 @@ button.pool-match-row {
   border-radius: var(--r-sm);
 }
 
-/* ---------- Branding section (mp-scf) — accent header band ----------
-   Committed-color treatment: a tinted accent band leads the card, with
-   the configuration fields below. Replaces the generic card--pad-lg
-   wrapper so the brand-identity section reads as its own surface. */
-.branding { background: var(--surface); border-radius: var(--r-lg); overflow: hidden; box-shadow: var(--shadow-sm); }
-.branding__head { padding: 20px 28px; background: var(--accent-soft); }
-/* Folded into the card-title scale (mp-p1tw); brand emphasis is carried by
-   the accent colour + tinted band, not by an outsized heading. */
-.branding__title { font-size: var(--fs-title-card); font-weight: 600; letter-spacing: -0.01em; margin: 0 0 5px; color: var(--accent); }
-.branding__hint { font-size: 13px; margin: 0; line-height: 1.45; color: var(--ink-2); }
-.branding__body { padding: 20px 28px 24px; }
-.branding__body .field { margin-bottom: 16px; }
+/* ---------- Branding section (mp-scf) ----------
+   Uses the standard .card / .card__head / .card__title chrome like every
+   other settings card (mp-p1tw) — only the field-layout helpers below are
+   branding-specific. */
 .branding__colors { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
 .branding__colors .field { flex: 1 1 0; min-width: 160px; margin-bottom: 0; }
 .branding__fineprint { font-size: 12px; color: var(--ink-3); margin-bottom: 16px; }

--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveCompetitionName, validatePoolSettings, validateSwissSettings } from '../admin_setup.jsx';
+import { deriveCompetitionName, validatePoolSettings, validateSwissSettings, normTheme } from '../admin_setup.jsx';
 
 describe('deriveCompetitionName', () => {
   // Copilot round-8 finding: AdminCreateCompetition.create used
@@ -230,5 +230,33 @@ describe('validateSwissSettings (T190 / FR-050a)', () => {
       const r = validateSwissSettings('swiss', -3);
       expect(r.ok).toBe(false);
     });
+  });
+});
+
+describe('normTheme (mp-sspn dirty tracking)', () => {
+  // Copilot PR #266 round 2: branding colours/title ride on "Save changes" via
+  // theme, so they must count toward the dirty cue — but the raw tournament.theme
+  // and BrandingManager's mount-synced (defaults-filled) object differ, which
+  // would false-dirty on load. normTheme normalizes both to the same shape.
+
+  it('returns null for absent / empty configs (logo-only or null)', () => {
+    expect(normTheme(null)).toBe(null);
+    expect(normTheme(undefined)).toBe(null);
+    expect(normTheme({})).toBe(null);
+    expect(normTheme({ logoPath: 'x' })).toBe(null); // unrelated keys don't count
+  });
+
+  it('fills BrandingManager defaults so raw and synced themes compare equal', () => {
+    const raw = { primaryColor: '#aabbcc' };
+    const synced = { primaryColor: '#aabbcc', accentSoftColor: '#e7eaf3', windowTitle: '' };
+    expect(JSON.stringify(normTheme(raw))).toBe(JSON.stringify(normTheme(synced)));
+    expect(normTheme(raw)).toEqual({ primaryColor: '#aabbcc', accentSoftColor: '#e7eaf3', windowTitle: '' });
+  });
+
+  it('preserves a fully-specified theme and treats windowTitle-only as configured', () => {
+    expect(normTheme({ primaryColor: '#111', accentSoftColor: '#222', windowTitle: 'Cup' }))
+      .toEqual({ primaryColor: '#111', accentSoftColor: '#222', windowTitle: 'Cup' });
+    expect(normTheme({ windowTitle: 'Cup' }))
+      .toEqual({ primaryColor: '#1d3557', accentSoftColor: '#e7eaf3', windowTitle: 'Cup' });
   });
 });

--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { deriveCompetitionName, validatePoolSettings, validateSwissSettings, normTheme } from '../admin_setup.jsx';
+import { deriveCompetitionName, validatePoolSettings, validateSwissSettings } from '../admin_setup.jsx';
+import { normalizeTheme } from '../admin_branding.jsx';
 
 describe('deriveCompetitionName', () => {
   // Copilot round-8 finding: AdminCreateCompetition.create used
@@ -233,30 +234,30 @@ describe('validateSwissSettings (T190 / FR-050a)', () => {
   });
 });
 
-describe('normTheme (mp-sspn dirty tracking)', () => {
+describe('normalizeTheme (mp-sspn dirty tracking)', () => {
   // Copilot PR #266 round 2: branding colours/title ride on "Save changes" via
   // theme, so they must count toward the dirty cue — but the raw tournament.theme
   // and BrandingManager's mount-synced (defaults-filled) object differ, which
-  // would false-dirty on load. normTheme normalizes both to the same shape.
+  // would false-dirty on load. normalizeTheme normalizes both to the same shape.
 
   it('returns null for absent / empty configs (logo-only or null)', () => {
-    expect(normTheme(null)).toBe(null);
-    expect(normTheme(undefined)).toBe(null);
-    expect(normTheme({})).toBe(null);
-    expect(normTheme({ logoPath: 'x' })).toBe(null); // unrelated keys don't count
+    expect(normalizeTheme(null)).toBe(null);
+    expect(normalizeTheme(undefined)).toBe(null);
+    expect(normalizeTheme({})).toBe(null);
+    expect(normalizeTheme({ logoPath: 'x' })).toBe(null); // unrelated keys don't count
   });
 
   it('fills BrandingManager defaults so raw and synced themes compare equal', () => {
     const raw = { primaryColor: '#aabbcc' };
     const synced = { primaryColor: '#aabbcc', accentSoftColor: '#e7eaf3', windowTitle: '' };
-    expect(JSON.stringify(normTheme(raw))).toBe(JSON.stringify(normTheme(synced)));
-    expect(normTheme(raw)).toEqual({ primaryColor: '#aabbcc', accentSoftColor: '#e7eaf3', windowTitle: '' });
+    expect(JSON.stringify(normalizeTheme(raw))).toBe(JSON.stringify(normalizeTheme(synced)));
+    expect(normalizeTheme(raw)).toEqual({ primaryColor: '#aabbcc', accentSoftColor: '#e7eaf3', windowTitle: '' });
   });
 
   it('preserves a fully-specified theme and treats windowTitle-only as configured', () => {
-    expect(normTheme({ primaryColor: '#111', accentSoftColor: '#222', windowTitle: 'Cup' }))
+    expect(normalizeTheme({ primaryColor: '#111', accentSoftColor: '#222', windowTitle: 'Cup' }))
       .toEqual({ primaryColor: '#111', accentSoftColor: '#222', windowTitle: 'Cup' });
-    expect(normTheme({ windowTitle: 'Cup' }))
+    expect(normalizeTheme({ windowTitle: 'Cup' }))
       .toEqual({ primaryColor: '#1d3557', accentSoftColor: '#e7eaf3', windowTitle: 'Cup' });
   });
 });

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -372,15 +372,17 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       // Caught by /deep-review iterative pass after round-11 swept
       // updateTournament to tRef/onUpdateRef but missed the unmount
       // guard the other handlers carry.
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) return false;
       // Re-read tRef.current AFTER the await — additional SSE events may
       // have landed during the save. The patch we just persisted is
       // applied on top of the freshest snapshot.
       onUpdateRef.current(mergeTournamentPatch(tRef.current, patch, password, locked));
       showToast("Tournament updated");
+      return true;
     } catch (e) {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) return false;
       showToast(e.message, "error");
+      return false;
     }
   };
 
@@ -562,7 +564,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     return <AdminEditTournament
       tournament={t}
       onCancel={() => setView({ kind: "dashboard" })}
-      onSave={(patch) => { updateTournament(patch); setView({ kind: "dashboard" }); }}
+      onSave={async (patch) => { const ok = await updateTournament(patch); if (ok) setView({ kind: "dashboard" }); return ok; }}
       onLogout={onLogout}
       onViewerMode={onViewerMode}
       authConfig={authConfig}

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -144,7 +144,7 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
             <div className="field__hint">Used for row highlights and badges. Default: #e7eaf3.</div>
           </div>
         </div>
-        <div className="branding__finprint">Save the tournament form below to persist color changes.</div>
+        <div className="branding__fineprint">Save the tournament form below to persist color changes.</div>
         <div className="branding__logo">
           <div className="branding__logo-title">Tournament logo</div>
           <div className="field__hint" style={{ marginBottom: 12 }}>PNG or JPEG, up to 1 MB. Replaces the default kendo logo on all screens. Falls back to the default logo if removed.</div>

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -8,6 +8,31 @@
 
 const { useState: useStateBr, useRef: useRefBr, useEffect: useEffectBr } = React;
 
+// Canonical defaults for the branding theme (mp-scf). Single source of truth so
+// admin_setup.jsx's dirty-tracking snapshot stays in lockstep with the values
+// BrandingManager emits — without this, changing a default here would silently
+// false-dirty the form on load until admin_setup was patched in tandem.
+const BRANDING_DEFAULTS = Object.freeze({
+  primaryColor: "#1d3557",
+  accentSoftColor: "#e7eaf3",
+  windowTitle: "",
+});
+
+// Normalize a raw theme to BrandingManager's emitted shape, or null when no
+// colour/title field is set (empty {} — e.g. logo-only — counts as absent so
+// the PUT payload stays clean). Exported and reused by admin_setup.jsx for
+// dirty tracking, ensuring the pre-mount raw theme and the post-mount synced
+// theme compare equal in the dirty snapshot.
+function normalizeTheme(t) {
+  const has = t && (t.primaryColor || t.accentSoftColor || t.windowTitle);
+  if (!has) return null;
+  return {
+    primaryColor: t.primaryColor || BRANDING_DEFAULTS.primaryColor,
+    accentSoftColor: t.accentSoftColor || BRANDING_DEFAULTS.accentSoftColor,
+    windowTitle: t.windowTitle || BRANDING_DEFAULTS.windowTitle,
+  };
+}
+
 function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   const theme = (tournament && tournament.theme) || {};
 
@@ -31,20 +56,14 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   // tournament.theme is explicitly set — passing null when absent keeps
   // the parent PUT payload clean (theme block omitted unless configured).
   useEffectBr(() => {
-    const rawTheme = tournament && tournament.theme;
-    // Treat a theme object that carries no meaningful fields as "absent":
-    // when only a logo is configured, the server returns theme:{} because
-    // LogoPath has json:"-". Propagating defaults in that case would persist
-    // unwanted color values on the next Save.
-    const hasThemeConfig = rawTheme &&
-      (rawTheme.primaryColor || rawTheme.accentSoftColor || rawTheme.windowTitle);
-    const pc = (rawTheme && rawTheme.primaryColor) || "#1d3557";
-    const asc = (rawTheme && rawTheme.accentSoftColor) || "#e7eaf3";
-    const wt = (rawTheme && rawTheme.windowTitle) || "";
-    setPrimaryColor(pc);
-    setAccentSoftColor(asc);
-    setWindowTitle(wt);
-    if (onThemeChange) onThemeChange(hasThemeConfig ? { primaryColor: pc, accentSoftColor: asc, windowTitle: wt } : null);
+    const norm = normalizeTheme(tournament && tournament.theme);
+    // Update the pickers with effective values even when no theme is set, so
+    // they show defaults rather than empty; only propagate to the parent when
+    // a theme is actually configured (norm !== null).
+    setPrimaryColor((norm && norm.primaryColor) || BRANDING_DEFAULTS.primaryColor);
+    setAccentSoftColor((norm && norm.accentSoftColor) || BRANDING_DEFAULTS.accentSoftColor);
+    setWindowTitle((norm && norm.windowTitle) || BRANDING_DEFAULTS.windowTitle);
+    if (onThemeChange) onThemeChange(norm);
   }, [tournament]);
 
   const handleColorChange = (field, value) => {
@@ -146,9 +165,8 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
             <div className="field__hint">Used for row highlights and badges. Default: #e7eaf3.</div>
           </div>
         </div>
-        <div className="branding__fineprint">Save the tournament form below to persist color changes.</div>
         <div className="branding__logo">
-          <div className="branding__logo-title">Tournament logo</div>
+          <div className="field__label" style={{ marginBottom: 8 }}>Tournament logo</div>
           <div className="field__hint" style={{ marginBottom: 12 }}>PNG or JPEG, up to 1 MB. Replaces the default kendo logo on all screens. Falls back to the default logo if removed.</div>
           {hasLogo && (
             <div className="branding__logo-preview">
@@ -174,4 +192,4 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
 }
 
 window.BrandingManager = BrandingManager;
-export { BrandingManager };
+export { BrandingManager, normalizeTheme, BRANDING_DEFAULTS };

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -115,12 +115,14 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   };
 
   return (
-    <div className="branding">
-      <div className="branding__head">
-        <div className="branding__title">Branding</div>
-        <div className="branding__hint">Customize the browser tab title, accent colors, and the tournament logo shown on the viewer, lobby, and admin screens.</div>
+    <div className="card card--pad-lg">
+      <div className="card__head">
+        <div>
+          <div className="card__title">Branding</div>
+          <div className="card__sub">Customize the browser tab title, accent colors, and the tournament logo shown on the viewer, lobby, and admin screens.</div>
+        </div>
       </div>
-      <div className="branding__body">
+      <div>
         <div className="field">
           <label className="field__label">Browser tab / window title</label>
           <input type="text" value={windowTitle} maxLength={100} placeholder="Bracket Creator Mobile"

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -115,99 +115,57 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
   };
 
   return (
-    <div className="card card--pad-lg" style={{ marginTop: 16 }}>
-      <div className="card__title">Branding</div>
-      <div className="field__hint" style={{ marginBottom: 16 }}>
-        Customize the browser tab title, accent colors, and the tournament logo
-        shown on the viewer, lobby, and admin screens. Colors and title preview
-        instantly; the logo takes effect on next page load.
+    <div className="branding">
+      <div className="branding__head">
+        <div className="branding__title">Branding</div>
+        <div className="branding__hint">Customize the browser tab title, accent colors, and the tournament logo shown on the viewer, lobby, and admin screens.</div>
       </div>
-
-      <div className="field" style={{ marginBottom: 16 }}>
-        <label className="field__label">Browser tab / window title</label>
-        <input
-          type="text"
-          value={windowTitle}
-          maxLength={100}
-          placeholder="Bracket Creator Mobile"
-          onChange={(e) => handleWindowTitleChange(e.target.value)}
-          style={{ width: "100%", boxSizing: "border-box" }}
-        />
-        <div className="field__hint">
-          Shown in the browser tab and title bar on all pages. Defaults to
-          "Bracket Creator Mobile" when blank.
+      <div className="branding__body">
+        <div className="field">
+          <label className="field__label">Browser tab / window title</label>
+          <input type="text" value={windowTitle} maxLength={100} placeholder="Bracket Creator Mobile"
+            onChange={(e) => handleWindowTitleChange(e.target.value)}
+            style={{ width: "100%", boxSizing: "border-box" }} />
+          <div className="field__hint">Shown in the browser tab and title bar on all pages. Defaults to "Bracket Creator Mobile" when blank.</div>
         </div>
-      </div>
-
-      <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 16 }}>
-        <div className="field" style={{ flex: 1, minWidth: 160 }}>
-          <label className="field__label">Primary accent color</label>
-          <input
-            type="color"
-            value={primaryColor}
-            onChange={(e) => handleColorChange("primaryColor", e.target.value)}
-            style={{ width: "100%", height: 36, cursor: "pointer", border: "1px solid var(--line)", borderRadius: 6 }}
-          />
-          <div className="field__hint">
-            Used for buttons, headers, and highlights. Default: #1d3557.
-          </div>
-        </div>
-        <div className="field" style={{ flex: 1, minWidth: 160 }}>
-          <label className="field__label">Soft accent (background tint)</label>
-          <input
-            type="color"
-            value={accentSoftColor}
-            onChange={(e) => handleColorChange("accentSoftColor", e.target.value)}
-            style={{ width: "100%", height: 36, cursor: "pointer", border: "1px solid var(--line)", borderRadius: 6 }}
-          />
-          <div className="field__hint">
-            Used for row highlights and badges. Default: #e7eaf3.
-          </div>
-        </div>
-      </div>
-
-      <div className="field__hint" style={{ marginBottom: 16, fontSize: 12, color: "var(--ink-3)" }}>
-        Save the tournament form below to persist color changes.
-      </div>
-
-      <div style={{ borderTop: "1px solid var(--line)", paddingTop: 16, marginTop: 4 }}>
-        <div style={{ fontWeight: 600, marginBottom: 8 }}>Tournament logo</div>
-        <div className="field__hint" style={{ marginBottom: 12 }}>
-          PNG or JPEG, up to 1 MB. Replaces the default kendo logo on all screens.
-          Falls back to the default logo if removed.
-        </div>
-
-        {hasLogo && (
-          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 12, padding: "8px 12px", border: "1px solid var(--line)", borderRadius: 8 }}>
-            <img
-              key={logoKey}
-              src={`/api/branding/logo?v=${logoKey}`}
-              alt="Tournament logo"
-              style={{ height: 48, width: "auto", maxWidth: 120, objectFit: "contain" }}
-            />
-            <div style={{ flex: 1 }}>Current logo</div>
-            <button
-              className="btn btn--danger"
-              disabled={busy}
-              onClick={handleLogoDelete}
-            >
-              Remove
-            </button>
-          </div>
-        )}
-
-        <form onSubmit={handleLogoUpload} style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <div className="branding__colors">
           <div className="field">
-            <label className="field__label">{hasLogo ? "Replace logo" : "Upload logo"} (PNG or JPEG, ≤1 MB)</label>
-            <input ref={fileRef} type="file" accept="image/png,image/jpeg" />
-            <div className="field__hint">Square image recommended — non-square images will be cropped to fit the top bar icon.</div>
+            <label className="field__label">Primary accent color</label>
+            <input type="color" value={primaryColor}
+              onChange={(e) => handleColorChange("primaryColor", e.target.value)}
+              style={{ width: "100%", height: 36, cursor: "pointer", border: "1px solid var(--line)", borderRadius: 6 }} />
+            <div className="field__hint">Used for buttons, headers, and highlights. Default: #1d3557.</div>
           </div>
-          <div style={{ display: "flex", justifyContent: "flex-end" }}>
-            <button type="submit" className="btn btn--primary" disabled={busy}>
-              {busy ? "Uploading…" : hasLogo ? "Replace logo" : "Upload logo"}
-            </button>
+          <div className="field">
+            <label className="field__label">Soft accent (background tint)</label>
+            <input type="color" value={accentSoftColor}
+              onChange={(e) => handleColorChange("accentSoftColor", e.target.value)}
+              style={{ width: "100%", height: 36, cursor: "pointer", border: "1px solid var(--line)", borderRadius: 6 }} />
+            <div className="field__hint">Used for row highlights and badges. Default: #e7eaf3.</div>
           </div>
-        </form>
+        </div>
+        <div className="branding__finprint">Save the tournament form below to persist color changes.</div>
+        <div className="branding__logo">
+          <div className="branding__logo-title">Tournament logo</div>
+          <div className="field__hint" style={{ marginBottom: 12 }}>PNG or JPEG, up to 1 MB. Replaces the default kendo logo on all screens. Falls back to the default logo if removed.</div>
+          {hasLogo && (
+            <div className="branding__logo-preview">
+              <img key={logoKey} src={`/api/branding/logo?v=${logoKey}`} alt="Tournament logo" style={{ height: 48, width: "auto", maxWidth: 120, objectFit: "contain" }} />
+              <div style={{ flex: 1 }}>Current logo</div>
+              <button className="btn btn--danger" disabled={busy} onClick={handleLogoDelete}>Remove</button>
+            </div>
+          )}
+          <form onSubmit={handleLogoUpload} style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            <div className="field">
+              <label className="field__label">{hasLogo ? "Replace logo" : "Upload logo"} (PNG or JPEG, ≤1 MB)</label>
+              <input ref={fileRef} type="file" accept="image/png,image/jpeg" />
+              <div className="field__hint">Square image recommended — non-square images will be cropped to fit the top bar icon.</div>
+            </div>
+            <div className="branding__logo-actions">
+              <button type="submit" className="btn btn--primary" disabled={busy}>{busy ? "Uploading…" : hasLogo ? "Replace logo" : "Upload logo"}</button>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -192,7 +192,7 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
     <div className="page" data-testid="lineup-form-root" style={{ padding: 24, maxWidth: 640 }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
         <div>
-          <div style={{ fontSize: 11, color: "var(--ink-3)", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
+          <div className="overline">
             {comp?.name} · Round {round + 1}
           </div>
           <h2 style={{ margin: "4px 0 0 0", fontSize: 22, fontWeight: 700 }}>
@@ -302,7 +302,7 @@ function AdminTeamLineupsList({ comp, password, showToast }) {
     <div>
       <div style={{ display: "flex", gap: 12, alignItems: "center", marginBottom: 16, padding: "0 24px", paddingTop: 24 }}>
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <span style={{ fontSize: 11, fontWeight: 600, color: "var(--ink-3)", textTransform: "uppercase", letterSpacing: "0.1em" }}>Team</span>
+          <span className="overline">Team</span>
           <select
             className="input"
             value={teamId}
@@ -315,7 +315,7 @@ function AdminTeamLineupsList({ comp, password, showToast }) {
           </select>
         </label>
         <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <span style={{ fontSize: 11, fontWeight: 600, color: "var(--ink-3)", textTransform: "uppercase", letterSpacing: "0.1em" }}>Round</span>
+          <span className="overline">Round</span>
           <input
             className="input"
             type="number"

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -520,7 +520,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
               </table>
               {pm.length > 0 && (
                 <div style={{ marginTop: 12, borderTop: "1px dashed var(--line)", paddingTop: 8 }}>
-                  <div style={{ fontSize: 11, fontWeight: 700, color: "var(--ink-3)", textTransform: "uppercase", marginBottom: 6 }}>Matches</div>
+                  <div className="overline" style={{ marginBottom: 6 }}>Matches</div>
                   <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                     {pm.map(m => (
                       // Fixed grid columns keep the names from reflowing when a

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -995,7 +995,7 @@ function MatchLineupPanel({ match, tournament, password, showToast, onClose }) {
       }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16 }}>
           <div>
-            <div style={{ fontSize: 11, color: "var(--ink-3)", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
+            <div className="overline">
               {comp?.name} · {m.scheduledAt || m.round || ""}
             </div>
             <h2 style={{ margin: "4px 0 0", fontSize: 20, fontWeight: 700 }}>Lineup for this match</h2>
@@ -1008,7 +1008,7 @@ function MatchLineupPanel({ match, tournament, password, showToast, onClose }) {
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}>
           <div style={{ borderRight: "1px solid var(--line, #e5e7eb)", paddingRight: 20 }}>
-            <div style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--ink-3)", letterSpacing: "0.08em", marginBottom: 8 }}>
+            <div className="overline" style={{ marginBottom: 8 }}>
               SHIRO (white)
             </div>
             {teamB ? (
@@ -1026,7 +1026,7 @@ function MatchLineupPanel({ match, tournament, password, showToast, onClose }) {
             )}
           </div>
           <div>
-            <div style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", color: "var(--ink-3)", letterSpacing: "0.08em", marginBottom: 8 }}>
+            <div className="overline" style={{ marginBottom: 8 }}>
               AKA (red)
             </div>
             {teamA ? (

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -139,6 +139,12 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   // gates the post-await setSaving so a successful save (which unmounts this
   // view via navigation) doesn't setState on a torn-down component.
   const [saving, setSaving] = useStateA(false);
+  // The `saving` STATE drives the button label/disabled; the savingRef LATCH
+  // is the actual re-entry guard. State updates are async, so two rapid
+  // Ctrl+S / clicks could both pass an `if (saving)` check before the
+  // re-render flips it and fire duplicate PUTs. The ref is mutated and read
+  // synchronously within the same tick, so the second call sees it.
+  const savingRef = useRefA(false);
   const mountedRef = useRefA(true);
   useEffectA(() => () => { mountedRef.current = false; }, []);
 
@@ -224,7 +230,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   };
 
   const handleSave = async () => {
-    if (saving) return; // guard against double-submit while a save is in flight
+    if (savingRef.current) return; // synchronous re-entry guard (see savingRef)
     // Trim early and send the trimmed value. The empty-name check below
     // already used `name.trim()`, but the onSave payload was passing the
     // raw `name` — so " Tournament " on the wire would round-trip to the
@@ -242,6 +248,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     }
     setError("");
     setErrorField(null);
+    savingRef.current = true; // latch set synchronously, before the first await
     setSaving(true);
     try {
       await onSave({
@@ -266,8 +273,10 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
         theme: theme || undefined,
       });
     } finally {
-      // On success onSave navigates away (this view unmounts); the guard
-      // skips the setState. On failure we stay put so the user can retry.
+      // Release the latch so a failed save can be retried. On success onSave
+      // navigates away (this view unmounts); the mountedRef guard skips the
+      // setState, but the ref reset is harmless either way.
+      savingRef.current = false;
       if (mountedRef.current) setSaving(false);
     }
   };

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -1101,7 +1101,7 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
       <AdminTopbar onLogout={onLogout} onViewerMode={onViewerMode} tournament={tournament} />
       <div className="page">
         <Breadcrumbs items={[{ label: tournament?.name || "Tournament", onClick: onBack }, { label: "Import competitions" }]} />
-        <h2 style={{ margin: "0 0 16px" }}>Import competitions</h2>
+        <div className="page-head"><h1 className="page-head__title">Import competitions</h1></div>
 
         <div className="card" style={{ marginBottom: 16 }}>
           <div className="card__title">Select files</div>

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -126,8 +126,55 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const nextKeyRef = useRefA((tournament.contacts || []).length);
   const [pass, setPass] = useStateA(""); // Leave empty to keep existing, unless changed
   const [error, setError] = useStateA("");
+  // mp-sspn: which field the current validation error belongs to, so the
+  // message renders inline beside its cause instead of only at the page top.
+  // null = no field-scoped error (general errors still use the top banner).
+  const [errorField, setErrorField] = useStateA(null);
   // mp-scf: theme colors (updated live by BrandingManager via onThemeChange).
   const [theme, setTheme] = useStateA(tournament.theme || null);
+
+  // mp-sspn: in-flight save state — disables the primary button and swaps its
+  // label to "Saving…" so the long form's primary action gives feedback
+  // (previously it fired-and-navigated with no on-button cue). mountedRef
+  // gates the post-await setSaving so a successful save (which unmounts this
+  // view via navigation) doesn't setState on a torn-down component.
+  const [saving, setSaving] = useStateA(false);
+  const mountedRef = useRefA(true);
+  useEffectA(() => () => { mountedRef.current = false; }, []);
+
+  // mp-sspn: refs for the four validated fields so a failed save can focus +
+  // scroll the offending input into view — on a 4-card form the top banner
+  // alone lands off-screen when Save is clicked from the bottom.
+  const nameRef = useRefA(null);
+  const dateRef = useRefA(null);
+  const daysRef = useRefA(null);
+  const courtsRef = useRefA(null);
+  const fieldRefs = { name: nameRef, date: dateRef, durationDays: daysRef, courts: courtsRef };
+
+  // mp-sspn: progressive disclosure for the long optional public-info block.
+  // Open by default only when the tournament already has public data, so
+  // existing values are never hidden behind a collapsed section.
+  const hasPublicInfo = !!(publicURL || venueAddress || venueMapURL || openingTime ||
+    closingTime || rulesURL || awardsNote || infoNotes || (contacts && contacts.length));
+  const [publicOpen, setPublicOpen] = useStateA(hasPublicInfo);
+
+  // mp-sspn: dirty tracking for the unsaved-changes cue + cancel guard.
+  // Snapshot the editable form fields (theme is excluded — BrandingManager's
+  // mount-time onThemeChange sync would otherwise register a false change).
+  const initialSnapRef = useRefA(null);
+  const [dirty, setDirty] = useStateA(false);
+  useEffectA(() => {
+    const snap = JSON.stringify({
+      name, venue, date, durationDays, courts, openingBlock, lunchBlock, closingBlock,
+      publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
+      awardsNote, infoNotes, pass,
+      contacts: contacts.map(c => ({ label: c.label || "", value: c.value || "" })),
+    });
+    if (initialSnapRef.current === null) { initialSnapRef.current = snap; return; }
+    setDirty(snap !== initialSnapRef.current);
+  }, [name, venue, date, durationDays, courts, openingBlock, lunchBlock, closingBlock,
+    publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
+    awardsNote, infoNotes, pass, contacts]);
 
   // Elevated (destructive-ops) password — spec 004 / mp-e21. File mode only;
   // in locked mode it's the TOURNAMENT_ADMIN_PASSWORD_HASH env var (read-only
@@ -158,57 +205,113 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     }
   };
 
-  const handleSave = () => {
+  // mp-sspn: set a field-scoped error, then focus + scroll its input so the
+  // message is visible at its cause. Returns false so callers can `return
+  // failField(...)` in one line. The public-info fields aren't validated
+  // here, so failField only targets the four basics that are.
+  const failField = (field, message) => {
+    setError(message);
+    setErrorField(field);
+    const ref = fieldRefs[field];
+    if (ref && ref.current) {
+      try { ref.current.focus({ preventScroll: true }); } catch (_e) { ref.current.focus(); }
+      ref.current.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+    return false;
+  };
+
+  const handleSave = async () => {
+    if (saving) return; // guard against double-submit while a save is in flight
     // Trim early and send the trimmed value. The empty-name check below
     // already used `name.trim()`, but the onSave payload was passing the
     // raw `name` — so " Tournament " on the wire would round-trip to the
     // backend's trim and produce a canonical "Tournament" that diverges
     // from what the user sees in the input until next refresh.
     const trimmedName = name.trim();
-    if (!trimmedName) { setError("Tournament name is required."); return; }
+    if (!trimmedName) return failField("name", "Tournament name is required.");
     const { norm, error: dateError } = validateAndNormalizeDate(date);
-    if (dateError) { setError(dateError); return; }
+    if (dateError) return failField("date", dateError);
     if (!Number.isInteger(durationDays) || durationDays < 1 || durationDays > MAX_TOURNAMENT_DURATION_DAYS) {
-      setError(`Number of days must be a whole number between 1 and ${MAX_TOURNAMENT_DURATION_DAYS}.`);
-      return;
+      return failField("durationDays", `Number of days must be a whole number between 1 and ${MAX_TOURNAMENT_DURATION_DAYS}.`);
     }
-    if (!Number.isInteger(courts) || courts < 1 || courts > MAX_COURTS) { setError(`Number of courts must be a whole number between 1 and ${MAX_COURTS}.`); return; }
-    onSave({
-      name: trimmedName,
-      venue: venue.trim(),
-      date: norm,
-      durationDays,
-      password: pass || undefined,
-      courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i)),
-      openingBlock: openingBlock.trim() || undefined,
-      lunchBlock: lunchBlock.trim() || undefined,
-      closingBlock: closingBlock.trim() || undefined,
-      publicURL: publicURL.trim() || undefined,
-      venueAddress: venueAddress.trim() || undefined,
-      venueMapURL: venueMapURL.trim() || undefined,
-      openingTime: openingTime.trim() || undefined,
-      closingTime: closingTime.trim() || undefined,
-      rulesURL: rulesURL.trim() || undefined,
-      awardsNote: awardsNote.trim() || undefined,
-      infoNotes: infoNotes.trim() || undefined,
-      contacts: contacts.filter(c => (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
-      theme: theme || undefined,
-    });
+    if (!Number.isInteger(courts) || courts < 1 || courts > MAX_COURTS) {
+      return failField("courts", `Number of courts must be a whole number between 1 and ${MAX_COURTS}.`);
+    }
+    setError("");
+    setErrorField(null);
+    setSaving(true);
+    try {
+      await onSave({
+        name: trimmedName,
+        venue: venue.trim(),
+        date: norm,
+        durationDays,
+        password: pass || undefined,
+        courts: Array.from({ length: courts }, (_, i) => String.fromCharCode(65 + i)),
+        openingBlock: openingBlock.trim() || undefined,
+        lunchBlock: lunchBlock.trim() || undefined,
+        closingBlock: closingBlock.trim() || undefined,
+        publicURL: publicURL.trim() || undefined,
+        venueAddress: venueAddress.trim() || undefined,
+        venueMapURL: venueMapURL.trim() || undefined,
+        openingTime: openingTime.trim() || undefined,
+        closingTime: closingTime.trim() || undefined,
+        rulesURL: rulesURL.trim() || undefined,
+        awardsNote: awardsNote.trim() || undefined,
+        infoNotes: infoNotes.trim() || undefined,
+        contacts: contacts.filter(c => (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
+        theme: theme || undefined,
+      });
+    } finally {
+      // On success onSave navigates away (this view unmounts); the guard
+      // skips the setState. On failure we stay put so the user can retry.
+      if (mountedRef.current) setSaving(false);
+    }
   };
+
+  // mp-sspn: guard navigation away from unsaved edits.
+  const handleCancel = () => {
+    if (dirty && !window.confirm("Discard unsaved changes?")) return;
+    onCancel();
+  };
+
+  // mp-sspn: keyboard accelerators — Cmd/Ctrl+S saves, Esc cancels. Latest
+  // handlers are read through refs so the once-bound listener never calls a
+  // stale closure (handleSave/handleCancel close over current form state).
+  const handleSaveRef = useRefA(handleSave);
+  handleSaveRef.current = handleSave;
+  const handleCancelRef = useRefA(handleCancel);
+  handleCancelRef.current = handleCancel;
+  useEffectA(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "s" || e.key === "S")) {
+        e.preventDefault();
+        handleSaveRef.current();
+      } else if (e.key === "Escape") {
+        handleCancelRef.current();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <div className="app">
       <AdminTopbar onLogout={onLogout} onViewerMode={onViewerMode} tournament={tournament} />
       <div className="page" style={{ maxWidth: 720 }}>
         <Breadcrumbs items={[
-          { label: tournament.name, onClick: onCancel },
+          { label: tournament.name, onClick: handleCancel },
           { label: "Edit details" }
         ]} />
         <div className="page-head"><h1 className="page-head__title">Edit tournament details</h1></div>
-        {error && <div className="auth__error" style={{ marginBottom: 16 }}>{error}</div>}
+        {/* mp-sspn: top banner is only for general (non-field) errors; field- */}
+        {/* scoped validation renders inline beside its input instead. */}
+        {error && !errorField && <div className="auth__error" role="alert" style={{ marginBottom: 16 }}>{error}</div>}
+        <div className="edit-stack">
         <div className="card card--pad-lg">
+          <div className="card__head"><div className="card__title">Tournament details</div></div>
+          <div className="field"><label className="field__label">Name</label><input ref={nameRef} className="input" value={name} onChange={(e) => { setName(e.target.value); setError(""); }} />{errorField === "name" && error && <div className="field__error" role="alert">{error}</div>}</div>
           <div className="row">
-            <div className="field"><label className="field__label">Name</label><input className="input" value={name} onChange={(e) => { setName(e.target.value); setError(""); }} /></div>
             <div className="field">
               <label className="field__label">Start date (Day 1)</label>
               {/* Picker bounds mirror AdminSettings's date input in */}
@@ -216,14 +319,16 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               {/* that validateAndNormalizeDate enforces at handleSave — */}
               {/* keeps the picker from offering years the validator */}
               {/* will then reject on submit. */}
-              <input className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(date)} onChange={(e) => { setDate(isoToDmy(e.target.value)); setError(""); }} />
+              <input ref={dateRef} className="input" type="date" min={`${MIN_YEAR}-01-01`} max={`${MAX_YEAR}-12-31`} value={dmyToIso(date)} onChange={(e) => { setDate(isoToDmy(e.target.value)); setError(""); }} />
               <div className="field__hint">Pick the first day of the tournament.</div>
+              {errorField === "date" && error && <div className="field__error" role="alert">{error}</div>}
             </div>
             <div className="field">
               <label className="field__label">Number of days</label>
               {/* decideNumericUpdate stores NaN for cleared input so render */}
               {/* side can use Number.isFinite check (same pattern as courts). */}
               <input
+                ref={daysRef}
                 className="input"
                 type="number"
                 min="1"
@@ -234,34 +339,39 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
                 style={{ maxWidth: 100 }}
               />
               <div className="field__hint">{`Duration in days (1–${MAX_TOURNAMENT_DURATION_DAYS}). Multi-day tournaments constrain competitions to their day.`}</div>
+              {errorField === "durationDays" && error && <div className="field__error" role="alert">{error}</div>}
             </div>
           </div>
-          <div className="field"><label className="field__label">Venue</label><input className="input" value={venue} onChange={(e) => { setVenue(e.target.value); setError(""); }} /></div>
-          <div className="field">
-            <label className="field__label">Number of Shiaijo (courts)</label>
-            {/* decideNumericUpdate stores NaN for an empty input; render */}
-            {/* NaN as "" so React doesn't warn ("Received NaN for the value */}
-            {/* attribute") and the cleared input stays visually empty. */}
-            {/* handleSave's Number.isInteger(courts) && courts >= 1 && */}
-            {/* courts <= MAX_COURTS guard catches NaN, so the explicit Save */}
-            {/* click can't push an invalid value to onSave. MAX_COURTS */}
-            {/* mirrors helper.MaxCourts (admin_helpers.jsx). */}
-            <input
-              className="input"
-              type="number"
-              min="1"
-              max={MAX_COURTS}
-              step="1"
-              value={Number.isFinite(courts) ? courts : ""}
-              onChange={(e) => { setCourts(decideNumericUpdate(e.target.value, 1).value); setError(""); }}
-            />
-            <div className="field__hint">{`Enter a number (1-${MAX_COURTS}). Courts will be automatically labeled A, B, C, etc.`}</div>
+          <div className="row">
+            <div className="field"><label className="field__label">Venue</label><input className="input" value={venue} onChange={(e) => { setVenue(e.target.value); setError(""); }} /></div>
+            <div className="field">
+              <label className="field__label">Number of Shiaijo (courts)</label>
+              {/* decideNumericUpdate stores NaN for an empty input; render */}
+              {/* NaN as "" so React doesn't warn ("Received NaN for the value */}
+              {/* attribute") and the cleared input stays visually empty. */}
+              {/* handleSave's Number.isInteger(courts) && courts >= 1 && */}
+              {/* courts <= MAX_COURTS guard catches NaN, so the explicit Save */}
+              {/* click can't push an invalid value to onSave. MAX_COURTS */}
+              {/* mirrors helper.MaxCourts (admin_helpers.jsx). */}
+              <input
+                ref={courtsRef}
+                className="input"
+                type="number"
+                min="1"
+                max={MAX_COURTS}
+                step="1"
+                value={Number.isFinite(courts) ? courts : ""}
+                onChange={(e) => { setCourts(decideNumericUpdate(e.target.value, 1).value); setError(""); }}
+              />
+              <div className="field__hint">{`Enter a number (1-${MAX_COURTS}). Courts will be automatically labeled A, B, C, etc.`}</div>
+              {errorField === "courts" && error && <div className="field__error" role="alert">{error}</div>}
+            </div>
           </div>
           {/* Tournament type (mp-7h7): read-only after creation. Displayed
               for information — it affects the auth boundary (officiated:
               main password gates everything; self-run: only destructive
               actions require a password). Never submitted on PUT. */}
-          <div className="field" style={{ marginTop: 16 }}>
+          <div className="field" style={{ marginBottom: 0 }}>
             <label className="field__label">Tournament type</label>
             <div className="field__hint" style={{ marginTop: 4 }}>
               <strong>{tournamentMode === "self-run" ? "Self-run" : "Officiated"}</strong>
@@ -271,29 +381,53 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               {" "}This setting was fixed at creation and cannot be changed.
             </div>
           </div>
-          {/* mp-zoh Phase 5: ceremony block duration inputs. These feed the */}
-          {/* schedule estimator (backend Tournament.OpeningBlock etc.). */}
-          {/* Duration strings like "30m", "1h", "1h30m". Leave blank to omit. */}
-          <div className="row" style={{ marginTop: 16 }}>
-            <div className="field">
-              <label className="field__label">Opening ceremony <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
-              <input className="input" value={openingBlock} onChange={(e) => setOpeningBlock(e.target.value)} placeholder="e.g. 30m" />
-              <div className="field__hint">Duration of the opening ceremony block (e.g. "30m", "1h"). Leave blank if none.</div>
-            </div>
-            <div className="field">
-              <label className="field__label">Lunch break <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
-              <input className="input" value={lunchBlock} onChange={(e) => setLunchBlock(e.target.value)} placeholder="e.g. 1h" />
-              <div className="field__hint">Duration of the lunch break block (e.g. "1h", "45m"). Leave blank if none.</div>
-            </div>
-            <div className="field">
-              <label className="field__label">Closing ceremony <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
-              <input className="input" value={closingBlock} onChange={(e) => setClosingBlock(e.target.value)} placeholder="e.g. 30m" />
-              <div className="field__hint">Duration of the closing ceremony block. Leave blank if none.</div>
+        </div>
+        {/* mp-zoh Phase 5: ceremony block duration inputs. These feed the */}
+        {/* schedule estimator (backend Tournament.OpeningBlock etc.). */}
+        {/* Duration strings like "30m", "1h", "1h30m". Leave blank to omit. */}
+        <div className="card card--pad-lg">
+          <div className="card__head">
+            <div>
+              <div className="card__title">Schedule blocks</div>
+              <div className="card__sub">Durations feed the schedule estimator. Leave blank to omit a block.</div>
             </div>
           </div>
-          {/* mp-ef3: Tournament Information (Public) */}
-          <div style={{ borderTop: "1px solid var(--line)", marginTop: 20, paddingTop: 20 }}>
-            <div style={{ fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--ink-3)", marginBottom: 12 }}>Tournament Information (Public)</div>
+          <div className="row-3" style={{ marginBottom: 0 }}>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label className="field__label">Opening ceremony <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
+              <input className="input" value={openingBlock} onChange={(e) => setOpeningBlock(e.target.value)} placeholder="e.g. 30m" />
+              <div className="field__hint">Duration of the opening ceremony block (e.g. "30m", "1h").</div>
+            </div>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label className="field__label">Lunch break <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
+              <input className="input" value={lunchBlock} onChange={(e) => setLunchBlock(e.target.value)} placeholder="e.g. 1h" />
+              <div className="field__hint">Duration of the lunch break block (e.g. "1h", "45m").</div>
+            </div>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label className="field__label">Closing ceremony <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(duration)</span></label>
+              <input className="input" value={closingBlock} onChange={(e) => setClosingBlock(e.target.value)} placeholder="e.g. 30m" />
+              <div className="field__hint">Duration of the closing ceremony block.</div>
+            </div>
+          </div>
+        </div>
+        {/* mp-ef3: Tournament Information (Public) */}
+        {/* mp-sspn: collapsible — all fields here are optional, so the section */}
+        {/* is a disclosure that opens by default only when data already exists. */}
+        <div className="card card--pad-lg">
+          <button
+            type="button"
+            className="disclosure"
+            aria-expanded={publicOpen}
+            onClick={() => setPublicOpen((o) => !o)}
+          >
+            <span className="disclosure__chevron" aria-hidden="true">▸</span>
+            <span className="disclosure__text">
+              <span className="card__title">Public information</span>
+              <span className="card__sub">Shown to attendees on the public tournament page.{!publicOpen && hasPublicInfo ? " Configured." : ""}</span>
+            </span>
+          </button>
+          {publicOpen && (
+          <div style={{ marginTop: 16 }}>
             {/* mp-s1gl: Public URL — single source of truth for externally-shareable links */}
             <div className="field">
               <label className="field__label">Public URL</label>
@@ -363,6 +497,10 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               )}
             </div>
           </div>
+          )}
+        </div>
+        <div className="card card--pad-lg">
+          <div className="card__head"><div className="card__title">Access &amp; security</div></div>
           {locked ? (
             <div className="field">
               <label className="field__label">Admin Password</label>
@@ -379,14 +517,14 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           )}
           {/* Elevated (destructive-ops) password — spec 004 / mp-e21. */}
           {locked ? (
-            <div className="field">
+            <div className="field" style={{ marginBottom: 0 }}>
               <label className="field__label">Destructive-ops password</label>
               <div className="field__hint" style={{ marginTop: 4 }}>
                 This server is in locked mode. The destructive-ops password comes from <code>TOURNAMENT_ADMIN_PASSWORD_HASH</code> and can only be changed by restarting the server with a new hash. If unset, destructive actions (delete competition, discard draw, roster changes, import) return 503.
               </div>
             </div>
           ) : (
-            <div className="field">
+            <div className="field" style={{ marginBottom: 0 }}>
               <label className="field__label">Destructive-ops password {elevatedConfigured ? "(set)" : "(not set)"}</label>
               {elevatedConfigured && (
                 <input className="input" type="password" value={adminCurrent} onChange={(e) => setAdminCurrent(e.target.value)} placeholder="Current destructive-ops password" autoComplete="off" style={{ marginBottom: 8 }} />
@@ -402,11 +540,21 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               </div>
             </div>
           )}
-          <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
-            <button className="btn" onClick={onCancel}>Cancel</button>
-            <button className="btn btn--primary" onClick={handleSave}>Save changes</button>
-          </div>
         </div>
+        {/* mp-scf: branding (colors + logo). Appears before sponsors so the
+            brand-identity section leads the page. onThemeChange propagates
+            color changes back to this component's theme state so they are
+            included in the tournament PUT payload when Save is clicked.
+            Sits above the action bar because the colors/title it edits ARE
+            committed by "Save changes"; the logo self-saves on upload. */}
+        {window.BrandingManager && (
+          <window.BrandingManager
+            tournament={tournament}
+            password={password}
+            showToast={showToast}
+            onThemeChange={setTheme}
+          />
+        )}
         {/* mp-c38: sponsor management lives on the same edit page so admins
             don't need to navigate elsewhere. SponsorsManager owns its own
             sponsors list (seeded from the tournament prop, updated locally
@@ -419,17 +567,24 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
             showToast={showToast}
           />
         )}
-        {/* mp-scf: branding (colors + logo). onThemeChange propagates color
-            changes back to this component's theme state so they are included
-            in the tournament PUT payload when Save is clicked. */}
-        {window.BrandingManager && (
-          <window.BrandingManager
-            tournament={tournament}
-            password={password}
-            showToast={showToast}
-            onThemeChange={setTheme}
-          />
-        )}
+        {/* Action bar is the page's final commit, sitting below every card it
+            (partly) persists. Branding colors + main password ride along on
+            this Save; logo, sponsors and the destructive-ops password
+            self-save via their own buttons. */}
+        <div className="edit-actions">
+          {/* mp-sspn: make the split persistence model explicit so the single */}
+          {/* Save button's scope isn't a guess. */}
+          <div className="edit-actions__note">
+            Saves tournament details, ceremony blocks, public info, branding colours and the admin password.
+            The logo, sponsors and destructive-ops password save on their own buttons.
+          </div>
+          <div className="edit-actions__buttons">
+            {dirty && <span className="edit-actions__dirty" aria-live="polite">Unsaved changes</span>}
+            <button className="btn" onClick={handleCancel} disabled={saving}>Cancel</button>
+            <button className="btn btn--primary" onClick={handleSave} disabled={saving}>{saving ? "Saving…" : "Save changes"}</button>
+          </div>
+        </div>
+        </div>
       </div>
     </div>
   );

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -89,21 +89,10 @@ function validateSwissSettings(format, swissRounds) {
   return { ok: true, error: null };
 }
 
-// Normalize a theme object to the canonical {primaryColor, accentSoftColor,
-// windowTitle} shape BrandingManager emits, or null when no colour/title is
-// configured (an empty {} — e.g. a logo-only config — counts as absent). The
-// defaults mirror BrandingManager so the dirty-tracking snapshot compares equal
-// before and after BrandingManager's mount-time onThemeChange sync (mp-sspn).
-// Exported for vitest at __tests__/admin_setup.test.jsx.
-function normTheme(t) {
-  const has = t && (t.primaryColor || t.accentSoftColor || t.windowTitle);
-  if (!has) return null;
-  return {
-    primaryColor: t.primaryColor || "#1d3557",
-    accentSoftColor: t.accentSoftColor || "#e7eaf3",
-    windowTitle: t.windowTitle || "",
-  };
-}
+// Theme normalization lives next to its canonical user, BrandingManager, so the
+// dirty-tracking snapshot here can't drift from the shape BrandingManager emits
+// (mp-sspn). Importing keeps the defaults in one place.
+import { normalizeTheme } from './admin_branding.jsx';
 
 function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerMode, authConfig, password, showToast }) {
   // In locked mode the on-disk Password is irrelevant — auth comes
@@ -185,7 +174,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   // theme), so they MUST count toward dirty or a branding-only edit is silently
   // lost on cancel/navigate. The reason theme was tricky: BrandingManager fires
   // onThemeChange on mount with a *defaults-filled* object, which differs from
-  // the raw tournament.theme and would false-dirty on load. normTheme mirrors
+  // the raw tournament.theme and would false-dirty on load. normalizeTheme mirrors
   // BrandingManager's own normalization (same defaults; empty/logo-only config
   // -> null) so the pre- and post-sync snapshots compare equal.
   const initialSnapRef = useRefA(null);
@@ -196,7 +185,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
       awardsNote, infoNotes, pass,
       contacts: contacts.map(c => ({ label: c.label || "", value: c.value || "" })),
-      theme: normTheme(theme),
+      theme: normalizeTheme(theme),
     });
     if (initialSnapRef.current === null) { initialSnapRef.current = snap; return; }
     setDirty(snap !== initialSnapRef.current);
@@ -303,8 +292,12 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     }
   };
 
-  // mp-sspn: guard navigation away from unsaved edits.
+  // mp-sspn: guard navigation away from unsaved edits AND while a save is in
+  // flight. The Cancel button is disabled via `saving`, but Esc and the
+  // breadcrumb back-link bypass that — block them too so the user can't
+  // navigate away mid-PUT and contradict the disabled affordance.
   const handleCancel = () => {
+    if (savingRef.current) return;
     if (dirty && !window.confirm("Discard unsaved changes?")) return;
     onCancel();
   };
@@ -318,10 +311,23 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   handleCancelRef.current = handleCancel;
   useEffectA(() => {
     const onKey = (e) => {
+      // Ignore IME composition keys (CJK input, accented chars). Without this
+      // the Escape used to cancel composition would also fire the discard
+      // confirm — silent loss of edits is the failure mode.
+      if (e.isComposing || e.keyCode === 229) return;
       if ((e.metaKey || e.ctrlKey) && (e.key === "s" || e.key === "S")) {
         e.preventDefault();
         handleSaveRef.current();
       } else if (e.key === "Escape") {
+        // Escape is widely used by editable controls to dismiss their own UI
+        // (date picker calendar, native select dropdown, color picker, the
+        // address-bar autocomplete). When focus is in such a control, leave
+        // the key to the control rather than hijacking it to confirm-cancel
+        // the whole form. defaultPrevented also covers controls that have
+        // already handled the key.
+        if (e.defaultPrevented) return;
+        const t = e.target;
+        if (t && (/^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName || "") || t.isContentEditable)) return;
         handleCancelRef.current();
       }
     };
@@ -1217,4 +1223,4 @@ window.AdminImportPage = AdminImportPage;
 // The announcement-broadcast helpers (isSendAnnouncementDisabled /
 // sendAnnouncementLabel) moved to admin_announcement.jsx alongside the
 // AnnouncementComposer component they drive (mp-djc).
-export { deriveCompetitionName, validatePoolSettings, validateSwissSettings, normTheme };
+export { deriveCompetitionName, validatePoolSettings, validateSwissSettings };

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -89,6 +89,22 @@ function validateSwissSettings(format, swissRounds) {
   return { ok: true, error: null };
 }
 
+// Normalize a theme object to the canonical {primaryColor, accentSoftColor,
+// windowTitle} shape BrandingManager emits, or null when no colour/title is
+// configured (an empty {} — e.g. a logo-only config — counts as absent). The
+// defaults mirror BrandingManager so the dirty-tracking snapshot compares equal
+// before and after BrandingManager's mount-time onThemeChange sync (mp-sspn).
+// Exported for vitest at __tests__/admin_setup.test.jsx.
+function normTheme(t) {
+  const has = t && (t.primaryColor || t.accentSoftColor || t.windowTitle);
+  if (!has) return null;
+  return {
+    primaryColor: t.primaryColor || "#1d3557",
+    accentSoftColor: t.accentSoftColor || "#e7eaf3",
+    windowTitle: t.windowTitle || "",
+  };
+}
+
 function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerMode, authConfig, password, showToast }) {
   // In locked mode the on-disk Password is irrelevant — auth comes
   // from TOURNAMENT_PASSWORD_HASH and the backend rejects PUTs that
@@ -165,8 +181,13 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [publicOpen, setPublicOpen] = useStateA(hasPublicInfo);
 
   // mp-sspn: dirty tracking for the unsaved-changes cue + cancel guard.
-  // Snapshot the editable form fields (theme is excluded — BrandingManager's
-  // mount-time onThemeChange sync would otherwise register a false change).
+  // Branding colours/title ride along on "Save changes" (via onThemeChange ->
+  // theme), so they MUST count toward dirty or a branding-only edit is silently
+  // lost on cancel/navigate. The reason theme was tricky: BrandingManager fires
+  // onThemeChange on mount with a *defaults-filled* object, which differs from
+  // the raw tournament.theme and would false-dirty on load. normTheme mirrors
+  // BrandingManager's own normalization (same defaults; empty/logo-only config
+  // -> null) so the pre- and post-sync snapshots compare equal.
   const initialSnapRef = useRefA(null);
   const [dirty, setDirty] = useStateA(false);
   useEffectA(() => {
@@ -175,12 +196,13 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
       publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
       awardsNote, infoNotes, pass,
       contacts: contacts.map(c => ({ label: c.label || "", value: c.value || "" })),
+      theme: normTheme(theme),
     });
     if (initialSnapRef.current === null) { initialSnapRef.current = snap; return; }
     setDirty(snap !== initialSnapRef.current);
   }, [name, venue, date, durationDays, courts, openingBlock, lunchBlock, closingBlock,
     publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
-    awardsNote, infoNotes, pass, contacts]);
+    awardsNote, infoNotes, pass, contacts, theme]);
 
   // Elevated (destructive-ops) password — spec 004 / mp-e21. File mode only;
   // in locked mode it's the TOURNAMENT_ADMIN_PASSWORD_HASH env var (read-only
@@ -1195,4 +1217,4 @@ window.AdminImportPage = AdminImportPage;
 // The announcement-broadcast helpers (isSendAnnouncementDisabled /
 // sendAnnouncementLabel) moved to admin_announcement.jsx alongside the
 // AnnouncementComposer component they drive (mp-djc).
-export { deriveCompetitionName, validatePoolSettings, validateSwissSettings };
+export { deriveCompetitionName, validatePoolSettings, validateSwissSettings, normTheme };

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -215,7 +215,10 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     const ref = fieldRefs[field];
     if (ref && ref.current) {
       try { ref.current.focus({ preventScroll: true }); } catch (_e) { ref.current.focus(); }
-      ref.current.scrollIntoView({ block: "center", behavior: "smooth" });
+      // Respect reduced-motion: smooth scroll is motion the user may have opted out of.
+      const reduce = typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      ref.current.scrollIntoView({ block: "center", behavior: reduce ? "auto" : "smooth" });
     }
     return false;
   };
@@ -420,11 +423,11 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
             aria-expanded={publicOpen}
             onClick={() => setPublicOpen((o) => !o)}
           >
-            <span className="disclosure__chevron" aria-hidden="true">▸</span>
             <span className="disclosure__text">
               <span className="card__title">Public information</span>
               <span className="card__sub">Shown to attendees on the public tournament page.{!publicOpen && hasPublicInfo ? " Configured." : ""}</span>
             </span>
+            <span className="disclosure__toggle" aria-hidden="true">{publicOpen ? "−" : "+"}</span>
           </button>
           {publicOpen && (
           <div style={{ marginTop: 16 }}>
@@ -503,14 +506,14 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           <div className="card__head"><div className="card__title">Access &amp; security</div></div>
           {locked ? (
             <div className="field">
-              <label className="field__label">Admin Password</label>
+              <label className="field__label">Admin password</label>
               <div className="field__hint" style={{ marginTop: 4 }}>
                 This server is in locked mode. The admin password comes from <code>TOURNAMENT_PASSWORD_HASH</code> and can only be rotated by restarting the server with a new hash.
               </div>
             </div>
           ) : (
             <div className="field">
-              <label className="field__label">Admin Password</label>
+              <label className="field__label">Admin password</label>
               <input className="input" type="password" value={pass} onChange={(e) => { setPass(e.target.value); setError(""); }} placeholder="••••••••" autoComplete="new-password" />
               <div className="field__hint">Enter a new password to change it. Leave blank to keep the current one.</div>
             </div>
@@ -575,8 +578,8 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           {/* mp-sspn: make the split persistence model explicit so the single */}
           {/* Save button's scope isn't a guess. */}
           <div className="edit-actions__note">
-            Saves tournament details, ceremony blocks, public info, branding colours and the admin password.
-            The logo, sponsors and destructive-ops password save on their own buttons.
+            Saves the tournament details, schedule blocks, public information, branding colors, and admin password.
+            The logo, sponsors, and destructive-ops password save on their own buttons.
           </div>
           <div className="edit-actions__buttons">
             {dirty && <span className="edit-actions__dirty" aria-live="polite">Unsaved changes</span>}

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -136,7 +136,12 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   // null = no field-scoped error (general errors still use the top banner).
   const [errorField, setErrorField] = useStateA(null);
   // mp-scf: theme colors (updated live by BrandingManager via onThemeChange).
-  const [theme, setTheme] = useStateA(tournament.theme || null);
+  // Initialise through normalizeTheme so the very first render holds the same
+  // shape BrandingManager emits — when the server returns theme:{} for a
+  // logo-only tournament, the raw value is a truthy empty object that would
+  // otherwise reach the dirty snapshot and the save payload as `{}` (the
+  // backend tolerates it but it's cleaner not to rely on that).
+  const [theme, setTheme] = useStateA(normalizeTheme(tournament.theme));
 
   // mp-sspn: in-flight save state — disables the primary button and swaps its
   // label to "Saving…" so the long form's primary action gives feedback

--- a/web-mobile/js/admin_sponsors.jsx
+++ b/web-mobile/js/admin_sponsors.jsx
@@ -71,7 +71,7 @@ function SponsorsManager({ tournament, password, showToast, maxSponsors }) {
   };
 
   return (
-    <div className="card card--pad-lg" style={{ marginTop: 16 }}>
+    <div className="card card--pad-lg">
       <div className="card__title">Sponsors</div>
       <div className="field__hint" style={{ marginBottom: 12 }}>
         Logos shown on the viewer home and on the lobby/TV display surfaces. Up to {cap} sponsors;

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -20,6 +20,22 @@ const THEME = {
   "cardVariant": 1
 };
 
+// Darken a #rrggbb hex toward black by `amount` (0..1). Used to derive the
+// filled-button hover shade (--accent-strong) from a runtime Branding accent
+// so the hover tracks the configured colour instead of a hard-coded navy
+// (mp-nubo). Returns null on malformed input so callers fall back to the CSS
+// default token.
+function darkenHex(hex, amount) {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex || "");
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  const f = 1 - amount;
+  const r = Math.round(((n >> 16) & 255) * f);
+  const g = Math.round(((n >> 8) & 255) * f);
+  const b = Math.round((n & 255) * f);
+  return "#" + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1);
+}
+
 // mp-scf: apply tournament-configured CSS custom properties. Called once
 // after tournament load and again on tournament_updated. Removes overrides
 // when the theme field is absent so the CSS defaults take over.
@@ -27,8 +43,13 @@ function applyTheme(theme) {
   const root = document.documentElement;
   if (theme && theme.primaryColor) {
     root.style.setProperty("--accent", theme.primaryColor);
+    // mp-nubo: keep the button hover shade in sync with the custom accent.
+    const strong = darkenHex(theme.primaryColor, 0.2);
+    if (strong) root.style.setProperty("--accent-strong", strong);
+    else root.style.removeProperty("--accent-strong");
   } else {
     root.style.removeProperty("--accent");
+    root.style.removeProperty("--accent-strong");
   }
   if (theme && theme.accentSoftColor) {
     root.style.setProperty("--accent-soft", theme.accentSoftColor);


### PR DESCRIPTION
## Summary

- **Edit Tournament page restructured** from one undifferentiated mega-card into four concern-grouped cards — Tournament details, Schedule blocks, Public information, Access & security — in a consistent 16px stack. Fixed the awkward 2+1 row grids (date+days, courts, ceremony durations now a proper 3-col). Branding + Sponsors moved above the action bar so **Save changes** is the page's final commit.
- **Save now gives feedback**: the primary button disables and shows `Saving…`, `updateTournament` returns a success result, and `onSave` navigates only on success (stays on the page to retry on failure). Added an "Unsaved changes" cue and confirm-on-cancel.
- **Errors render at their cause**: validation errors now appear inline beside the offending field (focus + scroll-into-view, `role="alert"`) instead of only a top banner that lands off-screen on a long form.
- **Keyboard**: `Cmd/Ctrl+S` saves, `Esc` cancels.
- **Public information is collapsible** (progressive disclosure), matching the existing CourtPacePanel `+`/`−` convention; collapsed by default unless data already exists.
- **Branding card** finalized to the tinted accent-band treatment.
- **Global `.btn` fixes** (from a follow-up critique of the button component): theme-aware hover via a new `--accent-strong` token (a custom Branding accent no longer reverts to navy on hover — a real theming bug), a `2px var(--accent)` focus-visible ring (was the UA default 1px), a 44px touch target on coarse pointers (desktop keeps 34px), an enumerated transition, and a `:active` press state.

## Why

The single mega-card buried the Access/password section and made a long form hard to scan; the save model gave no in-flight feedback and validation errors surfaced far from their cause. Both surfaced via `/impeccable critique` (Edit page scored 27/40). The button hover bug is a genuine defect against the Branding feature: with a custom accent configured, `.btn--primary:hover` hard-coded `#16263f`, so the button reset to navy on hover.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_setup.jsx` | `AdminEditTournament`: 4-card grouping, save feedback + `Saving…` state, inline field errors, dirty cue, `Cmd/Ctrl+S`/`Esc`, collapsible Public information |
| `web-mobile/js/admin.jsx` | `updateTournament` returns a success bool; `onSave` awaits it and navigates only on success |
| `web-mobile/js/admin_branding.jsx` | Branding V3 tinted accent-band, collapsed onto a single `fileRef` |
| `web-mobile/js/admin_sponsors.jsx` | Drop redundant top margin (stack gap owns spacing now) |
| `web-mobile/js/app.jsx` | `darkenHex` helper; `applyTheme` sets `--accent-strong` from a runtime accent |
| `web-mobile/css/styles.css` | `edit-stack`/`edit-actions`/`disclosure`/`branding`/`field__error` styles; `--accent-strong` token; `.btn` focus-visible + `:active` + coarse-pointer 44px; tokenized hover; enumerated transition |

## Screenshots

**Edit Tournament page — before (origin/main):** one undifferentiated card holding every field, an uppercase section eyebrow, all optional public fields always expanded, plain Branding.

![before](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/266/before_desktop.png)

**After — four grouped cards, collapsed Public information, tinted Branding band, Save as the final action:**

![after-desktop](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/266/after_desktop.png)

**After — mobile (rows collapse to one column, no horizontal overflow):**

![after-mobile](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/266/after_mobile.png)

Button-level changes are subtle in static images; verified by measurement (see Test plan): keyboard focus = `2px solid rgb(29,53,87)`; default hover unchanged (`rgb(22,38,63)`); custom accent `#aa0000` → `--accent-strong #880000`; coarse-pointer buttons 44px vs 34px desktop.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages ≥85% coverage; govulncheck clean; eslint clean on all changed files
- [x] New/updated unit tests cover the change — `admin_setup` vitest 35/35 (pure helpers); button/disclosure behavior is CSS/DOM-level, verified in-browser below
- [x] Manual browser verification — exercised in Chromium (Playwright) on the running app: 4-card render; inline error + focus on empty name (top banner suppressed); dirty cue toggles with no false positive; `Ctrl+S` persists to `tournament.md` + navigates; button save navigates; `Esc` clean navigates, `Esc` dirty shows "Discard unsaved changes?"; disclosure `+`/`−` toggles `aria-expanded`; `.btn` focus ring `2px` accent; themed hover (default + custom accent); coarse-pointer 44px / desktop 34px; no horizontal overflow at 390px
- [x] Screenshots added above (before/after desktop + mobile)
- [x] No new console errors or warnings — only the pre-existing benign `/api/branding/logo` HEAD probe (404 = "no logo", handled in code)

Closes mp-sspn
Closes mp-nubo
