### PR TITLE
fix(mp-3m1c): add missing compId to viewer match aggregators

### DIFF
--- a/internal/engine/daihyosen.go
+++ b/internal/engine/daihyosen.go
@@ -295,8 +295,8 @@ func ComputeTeamSummary(subResults []state.SubMatchResult, sideAName, sideBName 
 		if sub.Position < 0 {
 			continue
 		}
-		sideAWin := sub.Winner == sideAName || sub.Winner == sub.SideA
-		sideBWin := sub.Winner == sideBName || sub.Winner == sub.SideB
+		sideAWin := sub.Winner == sideAName || (sub.SideA != "" && sub.Winner == sub.SideA)
+		sideBWin := sub.Winner == sideBName || (sub.SideB != "" && sub.Winner == sub.SideB)
 		switch {
 		case sideAWin:
 			a.IndividualWins++

--- a/internal/engine/daihyosen.go
+++ b/internal/engine/daihyosen.go
@@ -295,8 +295,8 @@ func ComputeTeamSummary(subResults []state.SubMatchResult, sideAName, sideBName 
 		if sub.Position < 0 {
 			continue
 		}
-		sideAWin := sub.Winner == sideAName || (sub.SideA != "" && sub.Winner == sub.SideA)
-		sideBWin := sub.Winner == sideBName || (sub.SideB != "" && sub.Winner == sub.SideB)
+		sideAWin := isWinForSide(sub.Winner, sideAName, sub.SideA)
+		sideBWin := isWinForSide(sub.Winner, sideBName, sub.SideB)
 		switch {
 		case sideAWin:
 			a.IndividualWins++

--- a/internal/engine/pool_daihyosen_test.go
+++ b/internal/engine/pool_daihyosen_test.go
@@ -117,8 +117,9 @@ func TestGeneratePoolDaihyosenMatches_SkipsExistingPairs(t *testing.T) {
 // all matches completed. If tieAll is true all teams share identical statistics
 // (full 3-way 8-criteria tie). If tieAll is false Alpha has a clear lead.
 //
-// SubMatchResult.SideA/SideB are always set to avoid the "" == "" false-positive
-// in computeStandings (sub.Winner == sub.SideA when both are "").
+// SubMatchResult.SideA/SideB are set here to exercise the sub.SideA fallback
+// path in computeStandings. The "" == "" false-positive is now guarded by a
+// sub.SideA != "" check, so empty sub-bout sides (from quick-score) are safe.
 func setupTeamPoolComp(t *testing.T, compID string, tieAll bool) (*Engine, *state.Store) {
 	t.Helper()
 	eng, store, _ := setupTestEngine(t)

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -155,8 +155,8 @@ func deriveDaihyosenWinner(result *state.MatchResult) {
 		if sub.Position != -1 || sub.Winner == "" {
 			continue
 		}
-		sideAWin := sub.Winner == result.SideA || sub.Winner == sub.SideA
-		sideBWin := sub.Winner == result.SideB || sub.Winner == sub.SideB
+		sideAWin := sub.Winner == result.SideA || (sub.SideA != "" && sub.Winner == sub.SideA)
+		sideBWin := sub.Winner == result.SideB || (sub.SideB != "" && sub.Winner == sub.SideB)
 		switch {
 		case sideAWin:
 			result.Winner = result.SideA
@@ -551,8 +551,8 @@ func (e *Engine) computeStandingsFrom(loader poolStandingsLoader, compId string)
 
 			if isTeam && len(m.SubResults) > 0 {
 				for _, sub := range m.SubResults {
-					sideAWin := sub.Winner == m.SideA || sub.Winner == sub.SideA
-					sideBWin := sub.Winner == m.SideB || sub.Winner == sub.SideB
+					sideAWin := sub.Winner == m.SideA || (sub.SideA != "" && sub.Winner == sub.SideA)
+					sideBWin := sub.Winner == m.SideB || (sub.SideB != "" && sub.Winner == sub.SideB)
 					switch {
 					case sideAWin:
 						sA.IndividualWins++

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -139,6 +139,15 @@ func applyHansokuIppons(result *state.MatchResult) {
 	}
 }
 
+// isWinForSide reports whether subWinner indicates a win for the given
+// match-level side. It checks both the canonical match side name and the
+// sub-result-level side name (which may differ when the operator used a
+// player name instead of the team name). The subSide != "" guard prevents
+// "" == "" false-positives when sub-bout sides are unset (quick-score).
+func isWinForSide(subWinner, matchSide, subSide string) bool {
+	return subWinner == matchSide || (subSide != "" && subWinner == subSide)
+}
+
 // deriveDaihyosenWinner fills result.Winner from a completed daihyosen
 // sub-result (Position == -1) when the caller has not set it explicitly.
 // Playoff team matches end in daihyosen when IV and PW are tied; the
@@ -155,8 +164,8 @@ func deriveDaihyosenWinner(result *state.MatchResult) {
 		if sub.Position != -1 || sub.Winner == "" {
 			continue
 		}
-		sideAWin := sub.Winner == result.SideA || (sub.SideA != "" && sub.Winner == sub.SideA)
-		sideBWin := sub.Winner == result.SideB || (sub.SideB != "" && sub.Winner == sub.SideB)
+		sideAWin := isWinForSide(sub.Winner, result.SideA, sub.SideA)
+		sideBWin := isWinForSide(sub.Winner, result.SideB, sub.SideB)
 		switch {
 		case sideAWin:
 			result.Winner = result.SideA
@@ -551,8 +560,8 @@ func (e *Engine) computeStandingsFrom(loader poolStandingsLoader, compId string)
 
 			if isTeam && len(m.SubResults) > 0 {
 				for _, sub := range m.SubResults {
-					sideAWin := sub.Winner == m.SideA || (sub.SideA != "" && sub.Winner == sub.SideA)
-					sideBWin := sub.Winner == m.SideB || (sub.SideB != "" && sub.Winner == sub.SideB)
+					sideAWin := isWinForSide(sub.Winner, m.SideA, sub.SideA)
+					sideBWin := isWinForSide(sub.Winner, m.SideB, sub.SideB)
 					switch {
 					case sideAWin:
 						sA.IndividualWins++

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -215,6 +215,52 @@ func TestScoreSummary_Team(t *testing.T) {
 	assert.Equal(t, "W:0 L:1 D:0 | IV:1 IL:2 IT:0 | PW:0 PL:0", teamB.ScoreSummary)
 }
 
+func TestTeamStandings_EmptySubSidesDrawNotFalseWin(t *testing.T) {
+	dir, err := os.MkdirTemp("", "engine-empty-sub-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := state.NewStore(dir)
+	require.NoError(t, err)
+	eng := New(store)
+
+	compID := "empty-sub-draw"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: compID, Name: "Team", TeamSize: 3,
+		Format: state.CompFormatLeague, Status: state.CompStatusPools,
+	}))
+	require.NoError(t, store.SavePools(compID, []helper.Pool{
+		{PoolName: "PoolA", Players: []helper.Player{{Name: "TeamA"}, {Name: "TeamB"}}},
+	}))
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{
+			ID: "PoolA-1", SideA: "TeamA", SideB: "TeamB",
+			Winner: "", Decision: "hikiwake",
+			Status: state.MatchStatusCompleted,
+			SubResults: []state.SubMatchResult{
+				{Position: 1, Winner: "TeamA"},
+				{Position: 2, Winner: "TeamB"},
+				{Position: 3, Winner: ""},
+			},
+		},
+	}))
+
+	standings, err := eng.CalculatePoolStandings(compID)
+	require.NoError(t, err)
+	pool := standings["PoolA"]
+	require.Len(t, pool, 2)
+
+	teamA := pool[0]
+	assert.Equal(t, 1, teamA.IndividualWins, "sub with Winner=TeamA → IV for A")
+	assert.Equal(t, 1, teamA.IndividualLosses, "sub with Winner=TeamB → IL for A")
+	assert.Equal(t, 1, teamA.IndividualDraws, "sub with empty Winner+empty SideA → draw, not false win")
+
+	teamB := pool[1]
+	assert.Equal(t, 1, teamB.IndividualWins)
+	assert.Equal(t, 1, teamB.IndividualLosses)
+	assert.Equal(t, 1, teamB.IndividualDraws, "sub with empty Winner+empty SideB → draw, not false win")
+}
+
 func TestMaybeAutoCompletePools(t *testing.T) {
 	dir, err := os.MkdirTemp("", "engine-autocomplete-*")
 	require.NoError(t, err)

--- a/internal/engine/scoring_test.go
+++ b/internal/engine/scoring_test.go
@@ -250,12 +250,19 @@ func TestTeamStandings_EmptySubSidesDrawNotFalseWin(t *testing.T) {
 	pool := standings["PoolA"]
 	require.Len(t, pool, 2)
 
-	teamA := pool[0]
+	var teamA, teamB state.PlayerStanding
+	for _, s := range pool {
+		switch s.Player.Name {
+		case "TeamA":
+			teamA = s
+		case "TeamB":
+			teamB = s
+		}
+	}
 	assert.Equal(t, 1, teamA.IndividualWins, "sub with Winner=TeamA → IV for A")
 	assert.Equal(t, 1, teamA.IndividualLosses, "sub with Winner=TeamB → IL for A")
 	assert.Equal(t, 1, teamA.IndividualDraws, "sub with empty Winner+empty SideA → draw, not false win")
 
-	teamB := pool[1]
 	assert.Equal(t, 1, teamB.IndividualWins)
 	assert.Equal(t, 1, teamB.IndividualLosses)
 	assert.Equal(t, 1, teamB.IndividualDraws, "sub with empty Winner+empty SideB → draw, not false win")

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -335,12 +335,17 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		const maxBouts = 100
 		if req.TeamAWins < 0 || req.TeamBWins < 0 || req.Draws < 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "win/draw counts must be non-negative"})
 			return
 		}
-		const maxBouts = 100
-		if req.TeamAWins+req.TeamBWins+req.Draws > maxBouts || req.TeamAWins+req.TeamBWins+req.Draws < 0 {
+		if req.TeamAWins > maxBouts || req.TeamBWins > maxBouts || req.Draws > maxBouts {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "total bout count exceeds maximum"})
+			return
+		}
+		total := req.TeamAWins + req.TeamBWins + req.Draws
+		if total > maxBouts {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "total bout count exceeds maximum"})
 			return
 		}

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -335,6 +335,15 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		if req.TeamAWins < 0 || req.TeamBWins < 0 || req.Draws < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "win/draw counts must be non-negative"})
+			return
+		}
+		const maxBouts = 100
+		if req.TeamAWins+req.TeamBWins+req.Draws > maxBouts || req.TeamAWins+req.TeamBWins+req.Draws < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "total bout count exceeds maximum"})
+			return
+		}
 
 		// Determine team winner per kendo rules: most individual wins wins.
 		// winnerSide records the WINNING SIDE (not just the name) so the

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -341,7 +341,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			return
 		}
 		if req.TeamAWins > maxBouts || req.TeamBWins > maxBouts || req.Draws > maxBouts {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "total bout count exceeds maximum"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "individual bout count exceeds maximum"})
 			return
 		}
 		total := req.TeamAWins + req.TeamBWins + req.Draws
@@ -371,7 +371,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 		// computeStandings uses `sub.Winner == m.SideA` (the match-level
 		// name); the `sub.Winner == sub.SideA` fallback is guarded against
 		// the "" == "" false-positive.
-		subResults := make([]state.SubMatchResult, 0, req.TeamAWins+req.TeamBWins+req.Draws)
+		subResults := make([]state.SubMatchResult, 0, total)
 		pos := 1
 		for range req.TeamAWins {
 			subResults = append(subResults, state.SubMatchResult{Position: pos, Winner: req.SideA})

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -352,20 +352,23 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 		}
 
 		// Synthesise SubResults so standings IV/IL/IT counts are correct.
-		// SideA/SideB must be set so the empty-Winner draw case doesn't
-		// accidentally match `sub.Winner == sub.SideA` in computeStandings.
+		// Sub-bout SideA/SideB are left empty — individual bout sides are
+		// unknown in quick-score mode (no lineup). Winner attribution in
+		// computeStandings uses `sub.Winner == m.SideA` (the match-level
+		// name); the `sub.Winner == sub.SideA` fallback is guarded against
+		// the "" == "" false-positive.
 		subResults := make([]state.SubMatchResult, 0, req.TeamAWins+req.TeamBWins+req.Draws)
 		pos := 1
 		for range req.TeamAWins {
-			subResults = append(subResults, state.SubMatchResult{Position: pos, SideA: req.SideA, SideB: req.SideB, Winner: req.SideA})
+			subResults = append(subResults, state.SubMatchResult{Position: pos, Winner: req.SideA})
 			pos++
 		}
 		for range req.TeamBWins {
-			subResults = append(subResults, state.SubMatchResult{Position: pos, SideA: req.SideA, SideB: req.SideB, Winner: req.SideB})
+			subResults = append(subResults, state.SubMatchResult{Position: pos, Winner: req.SideB})
 			pos++
 		}
 		for range req.Draws {
-			subResults = append(subResults, state.SubMatchResult{Position: pos, SideA: req.SideA, SideB: req.SideB, Winner: ""})
+			subResults = append(subResults, state.SubMatchResult{Position: pos})
 			pos++
 		}
 

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -112,6 +112,13 @@ func TestQuickScoreHandler(t *testing.T) {
 		assert.Equal(t, "TeamA", result.Winner)
 		assert.Len(t, result.SubResults, 5) // 3+1+1
 
+		// Sub-bouts must NOT carry team names — they're individual bout
+		// slots without known competitors in quick-score mode.
+		for _, sub := range result.SubResults {
+			assert.Empty(t, sub.SideA, "sub-bout SideA must be empty, not team name")
+			assert.Empty(t, sub.SideB, "sub-bout SideB must be empty, not team name")
+		}
+
 		standings, err := eng.CalculatePoolStandings("c1")
 		assert.NoError(t, err)
 		pool := standings["PoolA"]

--- a/internal/mobileapp/handlers_match_test.go
+++ b/internal/mobileapp/handlers_match_test.go
@@ -169,6 +169,30 @@ func TestQuickScoreHandler(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
+
+	t.Run("negative bout counts rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"sideA": "TeamA", "sideB": "TeamB", "teamAWins": -1, "teamBWins": 1,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/c1/matches/PoolA-1/quick-score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "non-negative")
+	})
+
+	t.Run("excessive bout count rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"sideA": "TeamA", "sideB": "TeamB", "teamAWins": 50, "teamBWins": 51,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/c1/matches/PoolA-1/quick-score", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "exceeds maximum")
+	})
 }
 
 // TestScoreHandlers_RejectSideMismatch pins the HTTP 409 mapping for the

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5104,6 +5104,10 @@ button.pool-match-row {
   letter-spacing: 0.04em;
 }
 
+.match-detail-card__comp {
+  color: var(--ink-2, #374151);
+}
+
 .match-detail-card__close {
   background: none;
   border: none;
@@ -5253,7 +5257,8 @@ button.pool-match-row {
 .msb-row--summary { border-top: 2px solid #111; }
 .msb-row--summary .msb-slot { border: none; flex-direction: column; min-width: 26px;
   font-size: 16px; font-weight: 800; height: auto; }
-.msb-lab { display: block; font-size: 8px; font-weight: 600; color: #6b7280; letter-spacing: .04em; }
+.msb-lab { display: block; font-size: 10px; font-weight: 600; color: #6b7280; letter-spacing: .04em; }
+abbr.msb-lab { text-decoration: none; cursor: help; }
 /* live highlight */
 .msb-row--now { background: #fef3c7; }
 .msb-row--queued .msb-name { color: #9ca3af; }
@@ -5275,6 +5280,9 @@ button.pool-match-row {
 .msb--tv .msb-lab { font-size: 1.2vh; }
 .msb--tv .msb-hansoku { font-size: 2.6vh; }
 .msb--tv .msb-dh-tag { font-size: 1.8vh; padding: 0.4vh 1.2vh; letter-spacing: .12em; }
+/* TV bout decisiveness: winning side's filled slots are slightly bolder
+   so spectators can read the match result at a glance from distance. */
+.msb--tv .msb-slots--win .msb-slot { font-size: 3.2vh; }
 
 /* ---------- League Round-Robin Matrix (Viewer) ---------- */
 .league-matrix-wrap {

--- a/web-mobile/js/__tests__/match_scoreboard.test.jsx
+++ b/web-mobile/js/__tests__/match_scoreboard.test.jsx
@@ -83,6 +83,23 @@ describe('match_scoreboard: teamIVPW', () => {
     expect(teamIVPW(subs)).toEqual({ ivShiro: 1, ivAka: 1, pwShiro: 0, pwAka: 0 });
   });
 
+  it('counts IV via match-level side names when sub-bout sides are empty (quick-score)', () => {
+    const subs = [
+      { position: 1, sideA: '', sideB: '', winner: 'Team Alpha', ipponsA: [], ipponsB: [] },
+      { position: 2, sideA: '', sideB: '', winner: 'Team Alpha', ipponsA: [], ipponsB: [] },
+      { position: 3, sideA: '', sideB: '', winner: 'Team Beta', ipponsA: [], ipponsB: [] },
+    ];
+    // matchSideA=aka(right)=Team Alpha, matchSideB=shiro(left)=Team Beta
+    expect(teamIVPW(subs, 'Team Alpha', 'Team Beta')).toEqual({ ivShiro: 1, ivAka: 2, pwShiro: 0, pwAka: 0 });
+  });
+
+  it('does not false-positive on empty winner with empty sub-sides (draw)', () => {
+    const subs = [
+      { position: 1, sideA: '', sideB: '', winner: '', ipponsA: [], ipponsB: [] },
+    ];
+    expect(teamIVPW(subs, 'Team A', 'Team B')).toEqual({ ivShiro: 0, ivAka: 0, pwShiro: 0, pwAka: 0 });
+  });
+
   it('falls back to ippon comparison when winner matches neither side', () => {
     const subs = [
       { position: 1, sideA: 'Aka P', sideB: 'Shiro P', winner: '', ipponsB: ['M', 'K'], ipponsA: [] },

--- a/web-mobile/js/__tests__/match_scoreboard.test.jsx
+++ b/web-mobile/js/__tests__/match_scoreboard.test.jsx
@@ -160,6 +160,35 @@ describe('match_scoreboard components', () => {
     expect(collectText(aka)).toBe('Aka Player');
   });
 
+  it('BoutSubRow filters out match-level team names from sub-bout sides (quick-score path)', () => {
+    // mp-3m1c: when scored via quick-score, the backend stores the TEAM name in
+    // every sub-bout's sideA/sideB. Without the matchSideA/matchSideB filter,
+    // the row would show "Team Alpha" on every row instead of the bout number.
+    const sub = { position: 2, sideA: 'Team Alpha', sideB: 'Team Beta', ipponsA: [], ipponsB: [], winner: 'Team Beta' };
+    const tree = runtime.mount(BoutSubRow, {
+      sub, index: 1, lineupA: null, lineupB: null, teamSize: 5,
+      matchSideA: 'Team Alpha', matchSideB: 'Team Beta',
+    });
+    const shiro = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-shiro-name');
+    const aka = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-aka-name');
+    // Should show bout number "2", not team names
+    expect(collectText(shiro)).toBe('2');
+    expect(collectText(aka)).toBe('2');
+  });
+
+  it('BoutSubRow still shows real competitor names when they differ from match-level teams', () => {
+    // Kachinuki: sub-bout sideA/sideB are individual competitor names, not team names.
+    const sub = { position: 3, sideA: 'Tanaka', sideB: 'Suzuki', ipponsB: ['M'], ipponsA: [] };
+    const tree = runtime.mount(BoutSubRow, {
+      sub, index: 2, lineupA: null, lineupB: null, teamSize: 5,
+      matchSideA: 'Team Alpha', matchSideB: 'Team Beta',
+    });
+    const shiro = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-shiro-name');
+    const aka = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-aka-name');
+    expect(collectText(shiro)).toBe('Suzuki');
+    expect(collectText(aka)).toBe('Tanaka');
+  });
+
   it('IndividualScore: same-name head-to-head does NOT mark BOTH sides as winners on an ippon-less decision', () => {
     // mp-13y: when both sides share a NAME and no ids disambiguate them, a
     // hantei/fusensho decision must not flag a win on both sides (the

--- a/web-mobile/js/__tests__/match_scoreboard.test.jsx
+++ b/web-mobile/js/__tests__/match_scoreboard.test.jsx
@@ -188,9 +188,9 @@ describe('match_scoreboard components', () => {
     });
     const shiro = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-shiro-name');
     const aka = findInTree(tree, n => n?.props?.['data-testid'] === 'sub-aka-name');
-    // Should show bout number "2", not team names
-    expect(collectText(shiro)).toBe('2');
-    expect(collectText(aka)).toBe('2');
+    // Should show bout number "#2", not team names
+    expect(collectText(shiro)).toBe('#2');
+    expect(collectText(aka)).toBe('#2');
   });
 
   it('BoutSubRow still shows real competitor names when they differ from match-level teams', () => {

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -365,7 +365,9 @@ function TvWhiteBoard({ tournament, court, connected, promoted, isTeamMatch, sub
                         MatchDetailCard). */}
                     <TeamScoreboard subResults={subResults} lineupA={lineupA} lineupB={lineupB}
                         teamSize={teamSize} showDH={showDH} variant="tv"
-                        shiroName={shiroTeam} akaName={akaTeam} />
+                        shiroName={shiroTeam} akaName={akaTeam}
+                        matchSideA={promoted.match.sideA?.name || (typeof promoted.match.sideA === "string" ? promoted.match.sideA : "")}
+                        matchSideB={promoted.match.sideB?.name || (typeof promoted.match.sideB === "string" ? promoted.match.sideB : "")} />
                 </div>
             ) : (
                 <div style={{ flex: 1, display: "flex", alignItems: "flex-start", justifyContent: "center", paddingTop: "2vh" }}>

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -622,6 +622,11 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
     const subResults = (promoted && promoted.match && promoted.match.subResults) || [];
     const isKnockoutPhase = !!(promoted && promoted.isBracket) ||
         !!(promoted && promoted.match && promoted.match.phase === "bracket");
+    // Extract stable string primitives from promoted.match.sideA/B so the
+    // useMemo below can dep on values rather than the promoted object literal
+    // (which is recreated on every render, defeating memoisation).
+    const promotedSideA = promoted?.match?.sideA?.name || (typeof promoted?.match?.sideA === "string" ? promoted.match.sideA : "");
+    const promotedSideB = promoted?.match?.sideB?.name || (typeof promoted?.match?.sideB === "string" ? promoted.match.sideB : "");
     const showDH = useMD(() => {
         if (!isTeamMatch || !isKnockoutPhase) return false;
         const regularSubs = subResults.filter(s => s.position !== -1);
@@ -645,11 +650,9 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
         // teamIVPW already prefers an explicit `sub.winner` (which the server
         // guarantees equals sideA/sideB), so a hantei-decided 0-0 bout is
         // counted as an IV for its winner there — no extra hantei loop needed.
-        const mA = promoted.match.sideA?.name || (typeof promoted.match.sideA === "string" ? promoted.match.sideA : "");
-        const mB = promoted.match.sideB?.name || (typeof promoted.match.sideB === "string" ? promoted.match.sideB : "");
-        const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults, mA, mB);
+        const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults, promotedSideA, promotedSideB);
         return ivShiro === ivAka && pwShiro === pwAka;
-    }, [subResults, isTeamMatch, isKnockoutPhase, promoted]);
+    }, [subResults, isTeamMatch, isKnockoutPhase, promotedSideA, promotedSideB]);
 
     // White scoreboard for any promoted match.
     // Team → TvWhiteBoard (IV/PW summary + bout grid). Individual → grouped

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -485,13 +485,14 @@ function TvIndividualBoard({ tournament, court, connected, promoted, queueMatche
             <div data-testid="tvd-indiv-group" data-dropped={dropped} style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-start", gap: "1vh", overflow: "hidden" }}>
                 {rows.map(m => {
                     const isNow = m.id === promoted.match.id || m.status === "running";
+                    const isDone = !isNow && m.status === "completed";
                     return (
                         <div key={m.id} data-testid={isNow ? "tvd-indiv-row-now" : "tvd-indiv-row"}
-                            className={"tvd-indiv-row" + (isNow ? " tvd-indiv-row--now" : "")}
+                            className={"tvd-indiv-row" + (isNow ? " tvd-indiv-row--now" : "") + (isDone ? " tvd-indiv-row--done" : "")}
                             style={{
                                 padding: "1vh 1.5vw", borderRadius: "0.6vw",
-                                background: isNow ? "#fef3c7" : "transparent",
-                                opacity: isNow ? 1 : 0.78,
+                                background: isNow ? "#fef3c7" : isDone ? "#f9fafb" : "transparent",
+                                opacity: isNow ? 1 : isDone ? 0.88 : 0.78,
                             }}>
                             <IndividualScore match={m} variant="tv" showNames withZekkenName={zekken} />
                         </div>

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -644,9 +644,11 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
         // teamIVPW already prefers an explicit `sub.winner` (which the server
         // guarantees equals sideA/sideB), so a hantei-decided 0-0 bout is
         // counted as an IV for its winner there — no extra hantei loop needed.
-        const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults);
+        const mA = promoted.match.sideA?.name || (typeof promoted.match.sideA === "string" ? promoted.match.sideA : "");
+        const mB = promoted.match.sideB?.name || (typeof promoted.match.sideB === "string" ? promoted.match.sideB : "");
+        const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults, mA, mB);
         return ivShiro === ivAka && pwShiro === pwAka;
-    }, [subResults, isTeamMatch, isKnockoutPhase]);
+    }, [subResults, isTeamMatch, isKnockoutPhase, promoted]);
 
     // White scoreboard for any promoted match.
     // Team → TvWhiteBoard (IV/PW summary + bout grid). Individual → grouped
@@ -1225,7 +1227,9 @@ function StreamingOverlay({ court, position, competitions }) {
 
     // mp-13y #10: running IV/PW aggregate per side. teamIVPW excludes the
     // Daihyosen (position -1) row. sideB = shiro, sideA = aka.
-    const ovlIV = isTeamMatch ? teamIVPW(ovlSubResults) : { ivShiro: 0, ivAka: 0, pwShiro: 0, pwAka: 0 };
+    const ovlSideA = hasLive ? (live.match.sideA?.name || (typeof live.match.sideA === "string" ? live.match.sideA : "")) : "";
+    const ovlSideB = hasLive ? (live.match.sideB?.name || (typeof live.match.sideB === "string" ? live.match.sideB : "")) : "";
+    const ovlIV = isTeamMatch ? teamIVPW(ovlSubResults, ovlSideA, ovlSideB) : { ivShiro: 0, ivAka: 0, pwShiro: 0, pwAka: 0 };
 
     // DH-pending: all regular bouts are scored, the match is tied (equal IV
     // and PW), but no DH sub-result has been created yet. In that case

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -210,19 +210,19 @@ export function BoutSubRow({ sub, index, lineupA, lineupB, teamSize, isDH, state
 
 // Aggregate IV (individual victories) + PW (points won) per side from the
 // regular (non-DH) bouts. sideB = shiro/left, sideA = aka/right.
-export function teamIVPW(subResults) {
+export function teamIVPW(subResults, matchSideA, matchSideB) {
   let ivShiro = 0, ivAka = 0, pwShiro = 0, pwAka = 0;
   for (const s of (subResults || []).filter(x => x.position !== -1)) {
     const a = ipponLetters(s.ipponsA).filter(Boolean).length;
     const b = ipponLetters(s.ipponsB).filter(Boolean).length;
     pwShiro += b; pwAka += a;
-    // IV (individual victory): prefer the explicit winner — quick-score and
-    // decision-based outcomes (fusensho, kiken, hantei) set `winner` without
-    // ippon letters, so an ippon-count comparison alone would miss the
-    // victory. Fall back to ippon counts only when no winner is recorded or
-    // it matches neither side. sideA = aka (right), sideB = shiro (left).
-    if (s.winner && s.winner === s.sideA) ivAka++;
-    else if (s.winner && s.winner === s.sideB) ivShiro++;
+    // Mirror Go backend pattern (scoring.go): check match-level side name
+    // first, then sub-level side name (guarded against "" == "" false
+    // positive). Quick-scored bouts have empty sub-level sides.
+    const isAkaWin = s.winner && (s.winner === matchSideA || (s.sideA && s.winner === s.sideA));
+    const isShiroWin = s.winner && (s.winner === matchSideB || (s.sideB && s.winner === s.sideB));
+    if (isAkaWin) ivAka++;
+    else if (isShiroWin) ivShiro++;
     else if (b > a) ivShiro++;
     else if (a > b) ivAka++;
   }
@@ -291,7 +291,7 @@ export function IndividualScore({ match, variant, showNames, withZekkenName }) {
 // `showDH`. Shiro left/dark, Aka right/red.
 export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH, variant, shiroName, akaName, matchSideA, matchSideB }) {
   const regular = (subResults || []).filter(s => s.position !== -1);
-  const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults);
+  const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults, matchSideA, matchSideB);
   // FIK: a Daihyosen (representative bout) only happens when the team match is
   // TIED after the regular bouts — equal individual victories AND equal points.
   // Guard the render on the tie so a stale/invalid position:-1 sub never shows a

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -117,11 +117,17 @@ function ipponLetters(arr) {
 // outer edge is the left), aka fills right→left (its outer edge is the right),
 // so for aka we reverse the visual cell order. The testid stays on the logical
 // outer cell (letters[0]) regardless of which side renders it.
+const WAZA_NAMES = { M: "Men (head)", K: "Kote (wrist)", D: "Do (body)", T: "Tsuki (throat)", H: "Hansoku (penalty)", S: "Sune (shin)" };
+
 function slotCells(letters, side, testid) {
-  const cells = [0, 1].map(i => (
-    <span key={i} className={"msb-slot" + (side === "aka" ? " msb-slot--aka" : "")}
-      data-testid={i === 0 ? testid : undefined}>{letters[i] || ""}</span>
-  ));
+  const cells = [0, 1].map(i => {
+    const ch = letters[i] || "";
+    return (
+      <span key={i} className={"msb-slot" + (side === "aka" ? " msb-slot--aka" : "")}
+        title={WAZA_NAMES[ch] || undefined}
+        data-testid={i === 0 ? testid : undefined}>{ch}</span>
+    );
+  });
   return side === "aka" ? cells.reverse() : cells;
 }
 
@@ -190,7 +196,7 @@ export function BoutSubRow({ sub, index, lineupA, lineupB, teamSize, isDH, state
     if (n === matchSideA || n === matchSideB) return "";
     return n;
   };
-  const boutNum = isDH ? "DH" : String(sub && sub.position > 0 ? sub.position : index + 1);
+  const boutNum = isDH ? "DH" : "#" + (sub && sub.position > 0 ? sub.position : index + 1);
   const shiroName = (lineupB ? pickFromLineup(lineupB, index, teamSize) : "") || subSideName(sub && sub.sideB) || boutNum;
   const akaName = (lineupA ? pickFromLineup(lineupA, index, teamSize) : "") || subSideName(sub && sub.sideA) || boutNum;
   // TV sizing comes from the parent `.msb--tv .msb-row` selector, so no
@@ -323,13 +329,13 @@ export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH,
         <span className="msb-name" data-testid="summary-shiro-name">{shiroName || ""}</span>
         <span className="msb-marks">
           <span className="msb-slots">
-            <span className="msb-slot msb-sum"><span className="msb-lab">IV</span>{ivShiro}</span>
-            <span className="msb-slot msb-sum"><span className="msb-lab">PW</span>{pwShiro}</span>
+            <span className="msb-slot msb-sum"><abbr className="msb-lab" title="Individual Victories">IV</abbr>{ivShiro}</span>
+            <span className="msb-slot msb-sum"><abbr className="msb-lab" title="Points Won">PW</abbr>{pwShiro}</span>
           </span>
           <span className="msb-vs" />
           <span className="msb-slots msb-slots--aka">
-            <span className="msb-slot msb-slot--aka msb-sum"><span className="msb-lab">PW</span>{pwAka}</span>
-            <span className="msb-slot msb-slot--aka msb-sum"><span className="msb-lab">IV</span>{ivAka}</span>
+            <span className="msb-slot msb-slot--aka msb-sum"><abbr className="msb-lab" title="Points Won">PW</abbr>{pwAka}</span>
+            <span className="msb-slot msb-slot--aka msb-sum"><abbr className="msb-lab" title="Individual Victories">IV</abbr>{ivAka}</span>
           </span>
         </span>
         <span className="msb-name msb-name--aka" data-testid="summary-aka-name">{akaName || ""}</span>

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -180,8 +180,16 @@ function centreMarks(sub) {
 // pinned lineup, else the per-bout competitor stored on the sub (kachinuki
 // matches carry sub.sideA/sub.sideB), else the bout number — never the team
 // name (it would repeat on every row).
-export function BoutSubRow({ sub, index, lineupA, lineupB, teamSize, isDH, state }) {
-  const subSideName = (v) => (v && v.name) || (typeof v === "string" ? v : "");
+export function BoutSubRow({ sub, index, lineupA, lineupB, teamSize, isDH, state, matchSideA, matchSideB }) {
+  const subSideName = (v) => {
+    const n = (v && v.name) || (typeof v === "string" ? v : "");
+    if (!n) return "";
+    // Filter out match-level team names — when the backend stores the team
+    // name in every sub-bout (quick-score path), we must fall through to the
+    // bout number rather than repeating the team name on every row.
+    if (n === matchSideA || n === matchSideB) return "";
+    return n;
+  };
   const boutNum = isDH ? "DH" : String(sub && sub.position > 0 ? sub.position : index + 1);
   const shiroName = (lineupB ? pickFromLineup(lineupB, index, teamSize) : "") || subSideName(sub && sub.sideB) || boutNum;
   const akaName = (lineupA ? pickFromLineup(lineupA, index, teamSize) : "") || subSideName(sub && sub.sideA) || boutNum;
@@ -281,7 +289,7 @@ export function IndividualScore({ match, variant, showNames, withZekkenName }) {
 // TeamScoreboard — §277 team table: an IV/PW summary row (labeled, per side) +
 // one BoutSubRow per regular bout + the Daihyosen banner + rep-bout row when
 // `showDH`. Shiro left/dark, Aka right/red.
-export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH, variant, shiroName, akaName }) {
+export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH, variant, shiroName, akaName, matchSideA, matchSideB }) {
   const regular = (subResults || []).filter(s => s.position !== -1);
   const { ivShiro, ivAka, pwShiro, pwAka } = teamIVPW(subResults);
   // FIK: a Daihyosen (representative bout) only happens when the team match is
@@ -330,7 +338,7 @@ export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH,
       {/* per-bout rows */}
       {regular.map((sub, i) => (
         <BoutSubRow key={i} sub={sub} index={i} lineupA={lineupA} lineupB={lineupB}
-          teamSize={teamSize} isDH={false} state={rowState(i)} />
+          teamSize={teamSize} isDH={false} state={rowState(i)} matchSideA={matchSideA} matchSideB={matchSideB} />
       ))}
 
       {/* No bouts recorded yet (lineups not submitted / up-next): show the
@@ -339,7 +347,7 @@ export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH,
           pinned player name when a lineup exists, else the bout number. */}
       {regular.length === 0 && teamSize > 0 && Array.from({ length: teamSize }, (_, i) => (
         <BoutSubRow key={"ph" + i} sub={{}} index={i} lineupA={lineupA} lineupB={lineupB}
-          teamSize={teamSize} isDH={false} state="queued" />
+          teamSize={teamSize} isDH={false} state="queued" matchSideA={matchSideA} matchSideB={matchSideB} />
       ))}
 
       {/* Daihyosen banner + rep bout (knockout tie only). The DH sub is
@@ -354,7 +362,7 @@ export function TeamScoreboard({ subResults, lineupA, lineupB, teamSize, showDH,
           {dhSub
             ? <BoutSubRow sub={{ ...dhSub, teamB: shiroName, teamA: akaName }}
                 index={regular.length} lineupA={lineupA} lineupB={lineupB}
-                teamSize={teamSize} isDH={true} state="now" />
+                teamSize={teamSize} isDH={true} state="now" matchSideA={matchSideA} matchSideB={matchSideB} />
             : <div className="msb-dh-pending" data-testid="tvd-dh-pending">Daihyosen pending</div>}
         </>
       )}

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -137,7 +137,7 @@ function slotCells(letters, side, testid) {
 // decision (hantei, fusensho, kiken) the winning side is otherwise invisible,
 // so we mark it with ○ (FIK hantei-win symbol) in the winner's first slot.
 // A plain helper (not a component) so it renders inline into the parent's tree.
-function centreMarks(sub) {
+function centreMarks(sub, matchSideA, matchSideB) {
   const lettersB = ipponLetters(sub.ipponsB); // shiro / left
   const lettersA = ipponLetters(sub.ipponsA); // aka / right
   const foulB = boutHansokuMark(sub.hansokuB);
@@ -147,16 +147,13 @@ function centreMarks(sub) {
     (window.isHikiwake(sub.score?.type) || window.isHikiwake(sub.decision));
   // Win mark only when there are no ippon letters (otherwise the letters
   // already show who won). sideB = shiro/left, sideA = aka/right.
-  // The backend may persist a daihyosen winner as the TEAM name rather than
-  // the rep competitor's name — accept sub.teamB/sub.teamA as fallback keys
-  // (TeamScoreboard threads shiroName/akaName into the DH sub as teamB/teamA)
-  // so the win mark still lands on the winning side instead of falling back
-  // to the centre Ht.
+  // Fallback chain: sub-level side → daihyosen team alias → match-level side
+  // (quick-score sub-bouts have empty sub.sideA/sideB).
   const noIppons = !lettersB.some(Boolean) && !lettersA.some(Boolean);
   const winShiro = !!(noIppons && sub.winner &&
-    (sub.winner === sub.sideB || sub.winner === sub.teamB));
+    (sub.winner === sub.sideB || sub.winner === sub.teamB || (matchSideB && sub.winner === matchSideB)));
   const winAka = !!(noIppons && sub.winner &&
-    (sub.winner === sub.sideA || sub.winner === sub.teamA));
+    (sub.winner === sub.sideA || sub.winner === sub.teamA || (matchSideA && sub.winner === matchSideA)));
   // The mark sits on the WINNING side, not in the centre: "Ht" for a hantei
   // decision, else ○ (fusensho/kiken/other ippon-less win). Only when the
   // hantei winner is unknown does "Ht" fall back to the centre cell.
@@ -208,7 +205,7 @@ export function BoutSubRow({ sub, index, lineupA, lineupB, teamSize, isDH, state
   return (
     <div className={cls} data-testid={isDH ? "sub-row-dh" : `sub-row-${index}`}>
       <span className="msb-name" data-testid="sub-shiro-name">{shiroName}</span>
-      {centreMarks(sub)}
+      {centreMarks(sub, matchSideA, matchSideB)}
       <span className="msb-name msb-name--aka" data-testid="sub-aka-name">{akaName}</span>
     </div>
   );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1631,7 +1631,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
         });
     }
     return out;
-  }, [pools, poolMatches, bracket, c.id, c.name, c.kind, c.teamSize]);
+  }, [pools, poolMatches, bracket, c.id, c.name, c.kind, c.teamSize, c.format]);
 
   const [followedPlayer] = useFollowedPlayer();
   const [watchlist] = useWatchlist();
@@ -1800,7 +1800,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightPlayer={followedPlayer}
                     onMatchClick={(m, ri) => {
                       const label = window.roundLabel(ri, derivedBracket.rounds.length);
-                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize });
+                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize });
                     }}
                   />
                 </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1832,6 +1832,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
 
 // Inline match detail card — shown directly on the page (no modal needed).
 function MatchDetailCard({ match, onClose }) {
+  window.useEscapeToClose(onClose);
   if (!match) return null;
   const isTeam = match.compKind === "team" || match.teamSize > 0;
   const teamSize = match.teamSize || 0;
@@ -1856,6 +1857,7 @@ function MatchDetailCard({ match, onClose }) {
     <div className="match-detail-card">
       <div className="match-detail-card__head">
         <div className="match-detail-card__meta">
+          {match.compName && <><span className="match-detail-card__comp">{match.compName}</span><span>·</span></>}
           <span><TermV name="shiaijo">Shiaijo</TermV> {match.court}</span>
           <span>·</span>
           <span>{match.phase === "pool" ? poolLabel(match) : (match.round || "")}</span>
@@ -3510,10 +3512,46 @@ function ViewerSchedule({ tournament, onBack, tweaks }) {
 function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId }) {
   window.useEscapeToClose(onClose);
   const [scoringMatch, setScoringMatch] = useState(null);
+  const triggerRef = useRefV(null);
+  const trapRef = useRefV(null);
+  const modalRefCb = React.useCallback((node) => {
+    if (node) {
+      triggerRef.current = document.activeElement;
+      const prevOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      const onKeyDown = (e) => {
+        if (e.key !== "Tab") return;
+        const f = [...node.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')]
+          .filter((el) => !el.disabled && el.offsetParent !== null);
+        if (f.length === 0) { e.preventDefault(); return; }
+        const first = f[0], last = f[f.length - 1], active = document.activeElement;
+        if (e.shiftKey && (active === first || active === node)) { e.preventDefault(); last.focus(); }
+        else if (!e.shiftKey && active === last) { e.preventDefault(); first.focus(); }
+      };
+      document.addEventListener("keydown", onKeyDown, true);
+      const focusTimer = setTimeout(() => {
+        (node.querySelector("button") || node).focus();
+      }, 0);
+      trapRef.current = { onKeyDown, focusTimer, prevOverflow };
+    } else {
+      const t = trapRef.current;
+      if (t) {
+        clearTimeout(t.focusTimer);
+        document.removeEventListener("keydown", t.onKeyDown, true);
+        document.body.style.overflow = t.prevOverflow;
+        trapRef.current = null;
+      }
+      const trig = triggerRef.current;
+      if (trig && typeof trig.focus === "function" && document.contains(trig)) trig.focus();
+    }
+  }, []);
   if (!match) return null;
   const isSelfRun = tournament && tournament.mode === "self-run";
   const bothSidesReady = window.hasBothSides ? window.hasBothSides(match) : false;
   const isFinalized = match.status === "completed";
+  const sideAName = match.sideA?.name || (typeof match.sideA === "string" ? match.sideA : "");
+  const sideBName = match.sideB?.name || (typeof match.sideB === "string" ? match.sideB : "");
+  const dialogLabel = sideAName && sideBName ? `Match: ${sideBName} vs ${sideAName}` : "Match details";
 
   if (scoringMatch && window.ScoreEditorModal) {
     return React.createElement(window.ScoreEditorModal, {
@@ -3535,7 +3573,7 @@ function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId })
 
   return (
     <div className="modal-backdrop" onClick={onClose} style={{ zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <div onClick={e => e.stopPropagation()} style={{ width: "100%", maxWidth: 500, margin: 16 }}>
+      <div ref={modalRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={dialogLabel} onClick={e => e.stopPropagation()} style={{ width: "100%", maxWidth: 500, margin: 16 }}>
         {/* Reuse the canonical MatchDetailCard so the modal and the inline
             card render identically (DRY): same header, colour badges and
             BoutSubRow team grid. The modal adds only the self-run scoring. */}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -2632,7 +2632,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                     if (isTeam) {
                       // Team: enrich match the same way as the legacy PoolMatchRow path
                       const isDH = isPoolDaihyosenID(m.id || "");
-                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compName: competition.name, compKind: isDH ? "" : competition.kind, teamSize: isDH ? 0 : competition.teamSize };
+                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isDH ? "" : competition.kind, teamSize: isDH ? 0 : competition.teamSize };
                       return (
                         <PoolNumberedMatchRow
                           key={m.id}
@@ -2643,7 +2643,7 @@ function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMat
                       );
                     } else {
                       // Individual: ippon notation score
-                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compName: competition.name, compKind: "", teamSize: 0 };
+                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0 };
                       return (
                         <PoolNumberedMatchRow
                           key={m.id}

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1890,7 +1890,9 @@ function MatchDetailCard({ match, onClose }) {
           individual → ippon-letter slots. */}
       {isTeam
         ? <TeamScoreboard subResults={match.subResults || []} lineupA={lineupA} lineupB={lineupB}
-            teamSize={teamSize} showDH={showDH} variant="card" shiroName={bName} akaName={aName} />
+            teamSize={teamSize} showDH={showDH} variant="card" shiroName={bName} akaName={aName}
+            matchSideA={match.sideA?.name || (typeof match.sideA === "string" ? match.sideA : "")}
+            matchSideB={match.sideB?.name || (typeof match.sideB === "string" ? match.sideB : "")} />
         : (isDone || isLive) && <IndividualScore match={match} variant="card" />}
     </div>
   );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1615,7 +1615,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             const matches = poolMatches ? poolMatches.filter(m => m.id.startsWith(p.poolName + "-")) : [];
             matches.forEach((m) => {
                 const isDH = isPoolDaihyosenID(m.id || "");
-                out.push({ ...m, phase: "pool", phaseName: p.poolName, poolName: p.poolName, compFormat: c.format, compName: c.name, compKind: isDH ? "" : c.kind, teamSize: isDH ? 0 : c.teamSize });
+                out.push({ ...m, phase: "pool", phaseName: p.poolName, poolName: p.poolName, compFormat: c.format, compId: c.id, compName: c.name, compKind: isDH ? "" : c.kind, teamSize: isDH ? 0 : c.teamSize });
             });
         });
     }
@@ -1627,11 +1627,11 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
     // renders `bracket`/`derivedBracket` directly and is NOT affected.
     if (bracket && bracket.rounds && !bracket.preview) {
         bracket.rounds.forEach((round, ri) => {
-            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length), roundIndex: ri, compKind: c.kind, teamSize: c.teamSize }));
+            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length), roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize }));
         });
     }
     return out;
-  }, [pools, poolMatches, bracket, c.kind, c.teamSize]);
+  }, [pools, poolMatches, bracket, c.id, c.name, c.kind, c.teamSize]);
 
   const [followedPlayer] = useFollowedPlayer();
   const [watchlist] = useWatchlist();
@@ -1800,7 +1800,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightPlayer={followedPlayer}
                     onMatchClick={(m, ri) => {
                       const label = window.roundLabel(ri, derivedBracket.rounds.length);
-                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, compKind: c.kind, teamSize: c.teamSize });
+                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize });
                     }}
                   />
                 </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1831,8 +1831,8 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
 }
 
 // Inline match detail card — shown directly on the page (no modal needed).
-function MatchDetailCard({ match, onClose }) {
-  window.useEscapeToClose(onClose);
+function MatchDetailCard({ match, onClose, escapeToClose = true }) {
+  window.useEscapeToClose(escapeToClose ? onClose : undefined);
   if (!match) return null;
   const isTeam = match.compKind === "team" || match.teamSize > 0;
   const teamSize = match.teamSize || 0;
@@ -3577,7 +3577,7 @@ function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId })
         {/* Reuse the canonical MatchDetailCard so the modal and the inline
             card render identically (DRY): same header, colour badges and
             BoutSubRow team grid. The modal adds only the self-run scoring. */}
-        <MatchDetailCard match={match} onClose={onClose} />
+        <MatchDetailCard match={match} onClose={onClose} escapeToClose={false} />
         {isSelfRun && bothSidesReady && (
           <div className="card" style={{ marginTop: 12, padding: 16 }}>
             {isFinalized ? (


### PR DESCRIPTION
## Summary

- Fix viewer match aggregators missing `compId`, which caused `useTeamLineups` to never fetch team lineups for bracket/pool matches in the public viewer
- Fix bout rows displaying team names instead of position numbers when scored via quick-score (frontend filter + backend root cause)
- Fix `c.format` missing from `allMatches` useMemo dependency array (stale `compFormat` on SSE-driven format changes)
- Fix bracket-tab `onMatchClick` omitting `roundIndex`, which forced `useTeamLineups` to parse the round label string instead of using the 0-based index
- **Backend root cause:** quick-score handler copied team names into every synthesised sub-bout's `SideA`/`SideB` — these fields should be empty since individual bout sides are unknown in quick-score mode. Also harden the `sub.Winner == sub.SideA` fallback in `computeStandings`, `ComputeTeamSummary`, and `deriveDaihyosenWinner` against the `"" == ""` false-positive.
- **UX polish (critique P2/P3):** Focus trap + `aria-modal` on MatchViewerModal; Escape-to-close on inline MatchDetailCard; competition name in card header; waza tooltips on ippon slots; `<abbr>` with title on IV/PW summary labels; bout labels prefixed with `#` for clarity; `msb-lab` font bump 8px to 10px; TV completed-row tint; TV bout winner slot emphasis.

## Why

**compId bug:** `useTeamLineups` derives `compId` from `competition?.id || match?.compId`. `MatchDetailCard` passes `undefined` for `competition`, so it relies entirely on `match.compId`. Three match enrichment sites in `ViewerCompetition` omitted `compId`, causing `useTeamLineups` to early-return without fetching.

**Bout-row bug (frontend):** `subSideName` in `BoutSubRow` returned the team name from `sub.sideA`/`sub.sideB` (stored by the quick-score backend path), so the `boutNum` fallback never triggered. Fix: filter out match-level team names so the fallback chain reaches the position number.

**Bout-row bug (backend root cause):** The quick-score handler (`PUT /competitions/:id/matches/:mid/quick-score`) set `SideA: req.SideA, SideB: req.SideB` on every synthesised `SubMatchResult`, propagating team names where individual competitor names or empty strings belong. The standings code (`computeStandings`, `ComputeTeamSummary`) had a `sub.Winner == sub.SideA` fallback that only worked correctly when sub.SideA was non-empty — an empty-Winner draw with empty sub.SideA would false-positive as a sideA win via `"" == ""`. Fixed by: (1) leaving sub-bout SideA/SideB empty in quick-score, (2) guarding all 3 fallback sites with `sub.SideA != ""`.

**useMemo dep:** `c.format` was used in pool enrichment (`compFormat: c.format`) but omitted from the dependency array — if competition format changes via SSE without other deps changing, `compFormat` would be stale.

**roundIndex:** bracket-tab `onMatchClick` built `selectedMatch` without `roundIndex`, so `useTeamLineups` fell back to parsing `match.round` (now a bracket-size label like "Round 16" that a "Round N"→N-1 parse would misread as round 15).

**UX polish:** Nielsen heuristic critique (27/40) identified P2 accessibility gaps (no focus trap, no keyboard dismiss) and P3 discoverability issues (cryptic IV/PW labels, no competition context, low contrast on completed rows). All addressed.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | Add `compId: c.id` to pool/bracket aggregators + `onMatchClick`; add `c.format` to useMemo deps; add `roundIndex: ri` to bracket click handler; focus trap + aria-modal on MatchViewerModal; Escape-to-close + comp name on MatchDetailCard |
| `web-mobile/js/match_scoreboard.jsx` | Add `matchSideA`/`matchSideB` props to `BoutSubRow`; filter team names from sub-bout side names to fall through to position numbers; `#`-prefixed bout labels; waza tooltips on ippon slots; `<abbr>` with title on IV/PW summary labels |
| `web-mobile/js/display.jsx` | Thread `matchSideA`/`matchSideB` to TV display `TeamScoreboard` call; completed-row tint on TvIndividualBoard |
| `web-mobile/css/styles.css` | `.match-detail-card__comp` styling; `msb-lab` font bump 8px to 10px; `abbr.msb-lab` decoration reset; TV bout winner slot emphasis (3.2vh) |
| `web-mobile/js/__tests__/match_scoreboard.test.jsx` | Add 2 tests: team-name filtering falls through to bout number; real competitor names still render; updated bout label assertions for `#` prefix |
| `internal/mobileapp/handlers_match.go` | Quick-score: stop copying team names into sub-bout SideA/SideB |
| `internal/mobileapp/handlers_match_test.go` | Assert quick-score sub-bouts have empty SideA/SideB |
| `internal/engine/scoring.go` | Guard `sub.Winner == sub.SideA` with `sub.SideA != ""` in computeStandings + deriveDaihyosenWinner |
| `internal/engine/daihyosen.go` | Guard `sub.Winner == sub.SideA` with `sub.SideA != ""` in ComputeTeamSummary |
| `internal/engine/scoring_test.go` | New test: empty sub-bout sides with empty Winner count as draws, not false sideA wins |
| `internal/engine/pool_daihyosen_test.go` | Update comment to reflect new guard |

## Screenshots

Viewer MatchDetailCard for a completed team match (Team Beta 2-1 Team Alpha) at mobile viewport (390x844). Bout rows show position numbers (#1, #2, #3), ippon letters (K, M, H) render correctly, IV/PW summary header present.

![Viewer MatchDetailCard with team match detail](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/267/match-detail.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages above 85% coverage gate
- [x] New/updated unit tests cover the change — 2 vitest cases + 2 Go tests (quick-score empty sides, empty-sides-draw-not-false-win)
- [x] `npx vitest run` — 60 test files, 1441 tests pass (includes updated bout label `#` prefix assertions)
- [x] Manual browser verification (for `web-mobile/` changes) — created team tournament (4 teams, 3-person, playoffs), scored match m-r1-0 (Team Beta 2-1 Team Alpha) via detailed score API, clicked completed match in viewer → MatchDetailCard rendered with bout position numbers (not team names), ippon letters (K, M, H), and IV/PW summary
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors or warnings

Closes mp-3m1c
