### PR TITLE
feat(mp-s99q): redesign TvDisplay completed/idle empty state

### DIFF
--- a/web-mobile/js/__tests__/display_completed_state.test.jsx
+++ b/web-mobile/js/__tests__/display_completed_state.test.jsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TvDisplay } from '../display.jsx';
+
+// mp-s99q: TvDisplay empty-state redesign tests.
+// Covers the three empty-state sub-states, the IN PROGRESS wayfinding strip,
+// and the "Scan for results" QR affordance.
+
+// Stub window.renderQR so StreamingQR doesn't throw in the test env.
+beforeEach(() => {
+    if (typeof window !== 'undefined') {
+        window.renderQR = () => {};
+    }
+});
+afterEach(() => {
+    if (typeof window !== 'undefined') {
+        delete window.renderQR;
+    }
+});
+
+// Depth-first vnode walker — same pattern as display_white_board.test.jsx.
+function findAll(node, pred, out = []) {
+    if (!node || typeof node !== 'object') return out;
+    if (Array.isArray(node)) { node.forEach(k => findAll(k, pred, out)); return out; }
+    if (pred(node)) out.push(node);
+    const kids = node.children || node.props?.children || [];
+    [].concat(kids).forEach(k => findAll(k, pred, out));
+    return out;
+}
+
+function findFirst(node, pred) {
+    const all = findAll(node, pred);
+    return all.length > 0 ? all[0] : null;
+}
+
+// Walk the entire rendered tree to a flat JSON string for quick substring checks.
+function treeStr(node) { return JSON.stringify(node); }
+
+// Build a minimal tournament with declared courts.
+function makeTournament(courts = ['A']) {
+    return { name: 'Test Cup', courts };
+}
+
+// Build a competition with pool matches on the given court/status pairs.
+function makeComp(id, matches) {
+    return {
+        id,
+        name: `Comp ${id}`,
+        kind: 'individual',
+        teamSize: 0,
+        poolMatches: matches,
+        bracket: null,
+    };
+}
+
+function makeMatch(id, court, status) {
+    return { id, court, status, sideA: { name: `PlayerA-${id}` }, sideB: { name: `PlayerB-${id}` } };
+}
+
+// ─── allCompleted sub-state ───────────────────────────────────────────────────
+
+describe('TvDisplay empty state — allCompleted', () => {
+    it('shows "All matches completed" headline without "on Shiaijo A" suffix', () => {
+        const comps = [makeComp('c1', [
+            makeMatch('m1', 'A', 'completed'),
+            makeMatch('m2', 'A', 'completed'),
+        ])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).toContain('All matches completed');
+        // Must NOT contain the old "on Shiaijo A" suffix.
+        expect(str).not.toContain('on Shiaijo');
+        // data-testid must be present on the headline container.
+        const el = findFirst(tree, n => n?.props?.['data-testid'] === 'display-all-completed');
+        expect(el).toBeTruthy();
+    });
+
+    it('renders a drawn SVG checkmark (polyline), NOT the raw ✓ Unicode glyph', () => {
+        const comps = [makeComp('c1', [makeMatch('m1', 'A', 'completed')])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        const str = treeStr(tree);
+        // The SVG polyline must be present.
+        expect(str).toContain('polyline');
+        // The raw Unicode check glyph must NOT be present.
+        expect(str).not.toContain('✓');
+    });
+
+    it('uses var(--ink-1) for headline color — not the old #9ca3af', () => {
+        const comps = [makeComp('c1', [makeMatch('m1', 'A', 'completed')])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        const str = treeStr(tree);
+        // Old low-contrast gray must be absent from the headline.
+        expect(str).not.toContain('"color":"#9ca3af"');
+        // The ink-1 token must be used somewhere in the headline area.
+        expect(str).toContain('--ink-1');
+    });
+});
+
+// ─── Active-courts wayfinding strip ──────────────────────────────────────────
+
+describe('TvDisplay empty state — IN PROGRESS wayfinding strip', () => {
+    it('renders tvd-active-courts with chips for B and C when court A is completed and B/C have active matches', () => {
+        const tournament = makeTournament(['A', 'B', 'C']);
+        const comps = [
+            makeComp('c1', [
+                makeMatch('a1', 'A', 'completed'),
+                makeMatch('b1', 'B', 'running'),
+                makeMatch('c1', 'C', 'scheduled'),
+            ]),
+        ];
+        // Need both sides to be real names so bracketSidesReady passes for B and C.
+        const tree = TvDisplay({ court: 'A', tournament, competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).toContain('"data-testid":"tvd-active-courts"');
+        // Chips for B and C must appear.
+        expect(str).toContain('"data-court":"B"');
+        expect(str).toContain('"data-court":"C"');
+        // Current court A must NOT appear as a chip.
+        expect(str).not.toContain('"data-court":"A"');
+    });
+
+    it('omits tvd-active-courts strip when no other courts have active matches', () => {
+        const tournament = makeTournament(['A']);
+        const comps = [makeComp('c1', [makeMatch('a1', 'A', 'completed')])];
+        const tree = TvDisplay({ court: 'A', tournament, competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).not.toContain('"data-testid":"tvd-active-courts"');
+    });
+
+    it('omits tvd-active-courts strip when there are no other competitions', () => {
+        const tournament = makeTournament(['A', 'B']);
+        // Court B matches are all completed too.
+        const comps = [makeComp('c1', [
+            makeMatch('a1', 'A', 'completed'),
+            makeMatch('b1', 'B', 'completed'),
+        ])];
+        const tree = TvDisplay({ court: 'A', tournament, competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).not.toContain('"data-testid":"tvd-active-courts"');
+    });
+
+    it('uses "IN PROGRESS" wording — never "LIVE" or "live"', () => {
+        const tournament = makeTournament(['A', 'B']);
+        const comps = [makeComp('c1', [
+            makeMatch('a1', 'A', 'completed'),
+            makeMatch('b1', 'B', 'running'),
+        ])];
+        const tree = TvDisplay({ court: 'A', tournament, competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).toContain('IN PROGRESS');
+        expect(str).not.toContain('LIVE');
+        expect(str).not.toContain('"live"');
+    });
+});
+
+// ─── QR affordance ────────────────────────────────────────────────────────────
+
+describe('TvDisplay empty state — "Scan for results" QR affordance', () => {
+    it('renders "Scan for results" label in the empty state', () => {
+        const comps = [makeComp('c1', [makeMatch('m1', 'A', 'completed')])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).toContain('Scan for results');
+    });
+
+    it('renders "Scan for results" in the no-matches sub-state too', () => {
+        // No matches at all on court A.
+        const comps = [makeComp('c1', [])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).toContain('Scan for results');
+        const el = findFirst(tree, n => n?.props?.['data-testid'] === 'display-no-matches');
+        expect(el).toBeTruthy();
+    });
+
+    it('renders "Scan for results" in the no-matches-at-all sub-state (empty comp)', () => {
+        // No matches anywhere on court A — cleanest path through the noMatches branch.
+        const comps = [makeComp('c1', [])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        const str = treeStr(tree);
+        expect(str).toContain('Scan for results');
+        expect(str).toContain('No matches scheduled');
+    });
+});
+
+// ─── Headline text verification for all three sub-states ──────────────────────
+
+describe('TvDisplay empty state — headline text per sub-state', () => {
+    it('allCompleted: exact headline text (no court suffix)', () => {
+        const comps = [makeComp('c1', [makeMatch('m1', 'A', 'completed')])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        expect(treeStr(tree)).toContain('All matches completed');
+        expect(treeStr(tree)).not.toContain('on Shiaijo');
+    });
+
+    it('noMatches: exact headline text', () => {
+        const comps = [makeComp('c1', [])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        expect(treeStr(tree)).toContain('No matches scheduled');
+    });
+
+    it('noMatches: headline "No matches scheduled" has no court suffix', () => {
+        const comps = [makeComp('c1', [])];
+        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
+        expect(treeStr(tree)).toContain('No matches scheduled');
+        expect(treeStr(tree)).not.toContain('on Shiaijo');
+    });
+});

--- a/web-mobile/js/__tests__/display_completed_state.test.jsx
+++ b/web-mobile/js/__tests__/display_completed_state.test.jsx
@@ -163,23 +163,14 @@ describe('TvDisplay empty state — "Scan for results" QR affordance', () => {
         expect(str).toContain('Scan for results');
     });
 
-    it('renders "Scan for results" in the no-matches sub-state too', () => {
-        // No matches at all on court A.
-        const comps = [makeComp('c1', [])];
-        const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
-        const str = treeStr(tree);
-        expect(str).toContain('Scan for results');
-        const el = findFirst(tree, n => n?.props?.['data-testid'] === 'display-no-matches');
-        expect(el).toBeTruthy();
-    });
-
-    it('renders "Scan for results" in the no-matches-at-all sub-state (empty comp)', () => {
-        // No matches anywhere on court A — cleanest path through the noMatches branch.
+    it('renders "Scan for results" and "No matches scheduled" headline in the no-matches sub-state', () => {
         const comps = [makeComp('c1', [])];
         const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
         const str = treeStr(tree);
         expect(str).toContain('Scan for results');
         expect(str).toContain('No matches scheduled');
+        const el = findFirst(tree, n => n?.props?.['data-testid'] === 'display-no-matches');
+        expect(el).toBeTruthy();
     });
 });
 

--- a/web-mobile/js/__tests__/display_completed_state.test.jsx
+++ b/web-mobile/js/__tests__/display_completed_state.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TvDisplay } from '../display.jsx';
+import { emptyStateHeadline } from '../display_scoreboard.jsx';
 
 // mp-s99q: TvDisplay empty-state redesign tests.
 // Covers the three empty-state sub-states, the IN PROGRESS wayfinding strip,
@@ -203,5 +204,29 @@ describe('TvDisplay empty state — headline text per sub-state', () => {
         const tree = TvDisplay({ court: 'A', tournament: makeTournament(['A']), competitions: comps, connected: true });
         expect(treeStr(tree)).toContain('No matches scheduled');
         expect(treeStr(tree)).not.toContain('on Shiaijo');
+    });
+});
+
+// ─── emptyStateHeadline pure helper — all three sub-states ─────────────────────
+// The "between-matches" branch is unreachable through TvDisplay's own logic
+// (counts and the promote path share bracketSidesReady), so it is covered here
+// at the pure-function level to guard the headline mapping against regression
+// (PR #274 review request).
+
+describe('emptyStateHeadline — headline-per-state mapping', () => {
+    it('allCompleted → "All matches completed"', () => {
+        expect(emptyStateHeadline(true, false)).toBe('All matches completed');
+    });
+
+    it('noMatches → "No matches scheduled"', () => {
+        expect(emptyStateHeadline(false, true)).toBe('No matches scheduled');
+    });
+
+    it('between-matches (defensive fallback) → "No match in progress"', () => {
+        expect(emptyStateHeadline(false, false)).toBe('No match in progress');
+    });
+
+    it('allCompleted takes precedence over noMatches', () => {
+        expect(emptyStateHeadline(true, true)).toBe('All matches completed');
     });
 });

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -1,8 +1,10 @@
 // display_helpers.jsx — shared data/label layer for display surfaces.
-// Pure functions and the TermD wrapper used by TvDisplay, LobbyDisplay,
-// and StreamingOverlay. No React hooks; safe to import from any module.
+// Pure functions, the TermD wrapper, and StreamingQR used by TvDisplay,
+// LobbyDisplay, and StreamingOverlay. No module-level side-effects.
 
 import { withNumber } from './match_scoreboard.jsx';
+
+const { useMemo: useMD, useEffect: useED } = React;
 
 // TermD — kendo-glossary tooltip wrapper. Lazy lookup so the script
 // load order between glossary.jsx and display.jsx doesn't matter.
@@ -240,6 +242,40 @@ function poolNameOf(id) {
     return (cut > 0 && /^\d+$/.test(id.slice(cut + 1))) ? id.slice(0, cut) : "";
 }
 
+// StreamingQR — minimal canvas QR code for the streaming overlay and TV
+// empty-state. Renders using renderQR from qr.jsx when available via
+// window.renderQR. Falls back gracefully (blank canvas) if QR rendering
+// is unavailable. Moved here from streaming_overlay.jsx (mp-s99q) so both
+// StreamingOverlay and TvDisplay can share the same component.
+function StreamingQR({ url, label }) {
+    // Use a stable object as the ref container so the useEffect dependency
+    // doesn't change on every render. The canvas element is stored in
+    // canvasHolder.el after the JSX ref callback fires.
+    const canvasHolder = useMD(() => ({ el: null }), []);
+
+    useED(() => {
+        const canvas = canvasHolder.el;
+        if (!canvas || !url) return undefined;
+        // renderQR may be available on window if qr.jsx has been imported
+        // by another module (e.g. admin_shell.jsx exposes it). If not, skip.
+        const fn = window.renderQR || null;
+        if (!fn) return undefined;
+        try { fn(canvas, url, { moduleSize: 2, quietZone: 2 }); } catch (_e) { /* skip */ }
+        return undefined;
+    }, [url]);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.4vh' }}>
+            <canvas
+                data-testid="overlay-qr"
+                ref={(el) => { canvasHolder.el = el; }}
+                style={{ display: 'block', imageRendering: 'pixelated', borderRadius: 4 }}
+            />
+            {label && <div style={{ fontSize: '1.2vh', opacity: 0.75, textAlign: 'center' }}>{label}</div>}
+        </div>
+    );
+}
+
 export {
     DISPLAY_PLACEHOLDER_RE,
     bracketSidesReady,
@@ -253,4 +289,5 @@ export {
     poolNameOf,
     sideLabel,
     TermD,
+    StreamingQR,
 };

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -271,7 +271,7 @@ function StreamingQR({ url, label }) {
     return (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.4vh' }}>
             <canvas
-                data-testid="overlay-qr"
+                data-testid="qr-canvas"
                 ref={(el) => { canvasHolder.el = el; }}
                 style={{ display: 'block', imageRendering: 'pixelated', borderRadius: 4 }}
             />

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -4,7 +4,11 @@
 
 import { withNumber } from './match_scoreboard.jsx';
 
-const { useMemo: useMD, useEffect: useED } = React;
+// NOTE: this module is the shared *leaf* — other modules import its pure
+// functions (findRunningOnCourt, sideLabel, …). Do NOT destructure hooks off
+// `React` at module-evaluation time: that would throw if the leaf is imported
+// before React loads or in a non-React context, taking the pure helpers down
+// with it. StreamingQR/TermD reference `React.*` lazily, at call time instead.
 
 // TermD — kendo-glossary tooltip wrapper. Lazy lookup so the script
 // load order between glossary.jsx and display.jsx doesn't matter.
@@ -251,9 +255,9 @@ function StreamingQR({ url, label }) {
     // Use a stable object as the ref container so the useEffect dependency
     // doesn't change on every render. The canvas element is stored in
     // canvasHolder.el after the JSX ref callback fires.
-    const canvasHolder = useMD(() => ({ el: null }), []);
+    const canvasHolder = React.useMemo(() => ({ el: null }), []);
 
-    useED(() => {
+    React.useEffect(() => {
         const canvas = canvasHolder.el;
         if (!canvas || !url) return undefined;
         // renderQR may be available on window if qr.jsx has been imported

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -4,11 +4,13 @@
 
 import { withNumber } from './match_scoreboard.jsx';
 
-// NOTE: this module is the shared *leaf* — other modules import its pure
-// functions (findRunningOnCourt, sideLabel, …). Do NOT destructure hooks off
-// `React` at module-evaluation time: that would throw if the leaf is imported
-// before React loads or in a non-React context, taking the pure helpers down
-// with it. StreamingQR/TermD reference `React.*` lazily, at call time instead.
+// NOTE: this module is the shared *leaf* in the display graph — presentation
+// modules (scoreboard, lobby, streaming) import from here, not vice versa.
+// Within this file, hooks are NOT destructured off `React` at module-eval time;
+// StreamingQR and TermD call React.* lazily at render time instead.
+// The import of `withNumber` from `match_scoreboard.jsx` is a transitive
+// dependency on `React` being global, which every display surface already
+// requires before mounting — this is not a new constraint introduced here.
 
 // TermD — kendo-glossary tooltip wrapper. Lazy lookup so the script
 // load order between glossary.jsx and display.jsx doesn't matter.

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -262,7 +262,7 @@ function StreamingQR({ url, label }) {
         if (!canvas || !url) return undefined;
         // renderQR may be available on window if qr.jsx has been imported
         // by another module (e.g. admin_shell.jsx exposes it). If not, skip.
-        const fn = window.renderQR || null;
+        const fn = (typeof window !== 'undefined' && window.renderQR) || null;
         if (!fn) return undefined;
         try { fn(canvas, url, { moduleSize: 2, quietZone: 2 }); } catch (_e) { /* skip */ }
         return undefined;

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -2,7 +2,7 @@
 // Fullscreen white board shown on Shiaijo-dedicated screens.
 // T061, T062, T063, mp-13y.
 
-import { findRunningOnCourt, findUpcomingOnCourt, countCourtMatches, findActiveCourts, sideLabel, phaseLabel, TermD, poolNameOf, StreamingQR } from './display_helpers.jsx';
+import { findRunningOnCourt, findUpcomingOnCourt, countCourtMatches, sideLabel, phaseLabel, TermD, poolNameOf, StreamingQR } from './display_helpers.jsx';
 import { TeamScoreboard, IndividualScore, useTeamLineups, teamIVPW } from './match_scoreboard.jsx';
 
 const { useMemo: useMD } = React;
@@ -403,7 +403,11 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
     // ─────────────────────────────────────────────────────────────────────────
     const qrUrl = typeof window !== 'undefined' ? window.location.origin + '/viewer' : '';
     const otherCourts = useMD(
-        () => findActiveCourts(tournament, competitions).filter(c => c !== court),
+        () => (tournament?.courts || []).filter(c => {
+            if (c === court) return false;
+            const cts = countCourtMatches(competitions, c);
+            return cts.running + cts.scheduled > 0;
+        }),
         [tournament, competitions, court]
     );
 

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -2,7 +2,7 @@
 // Fullscreen white board shown on Shiaijo-dedicated screens.
 // T061, T062, T063, mp-13y.
 
-import { findRunningOnCourt, findUpcomingOnCourt, countCourtMatches, sideLabel, phaseLabel, TermD, poolNameOf } from './display_helpers.jsx';
+import { findRunningOnCourt, findUpcomingOnCourt, countCourtMatches, findActiveCourts, sideLabel, phaseLabel, TermD, poolNameOf, StreamingQR } from './display_helpers.jsx';
 import { TeamScoreboard, IndividualScore, useTeamLineups, teamIVPW } from './match_scoreboard.jsx';
 
 const { useMemo: useMD } = React;
@@ -375,12 +375,29 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
         />;
     }
 
-    // No promoted match → white empty state (matches the white board chrome).
+    // ─── Empty-state redesign (mp-s99q) ──────────────────────────────────────
+    // No promoted match → white board with high-contrast empty state.
+    // Three sub-states: allCompleted / noMatches / between-matches.
+    // Headline uses var(--ink-1) (~10:1 on white) instead of the prior
+    // #9ca3af (2.5:1) which failed WCAG AA — critical for wall screens in
+    // bright halls.
+    // The completed check-badge colours mirror the playoffs/completed status
+    // palette used across the app: #ecfdf5 bg / #065f46 ink / #a7f3d0 border.
+    // Active-courts wayfinding strip shows sibling courts with running or
+    // scheduled matches so operators can redirect spectators.
+    // ─────────────────────────────────────────────────────────────────────────
+    const qrUrl = typeof window !== 'undefined' ? window.location.origin + '/viewer' : '';
+    const otherCourts = useMD(
+        () => findActiveCourts(tournament, competitions).filter(c => c !== court),
+        [tournament, competitions, court]
+    );
+
     return (
         <div className="tvd tvd--white" data-testid="tv-display-root" style={{
             position: "fixed", inset: 0, background: "#ffffff", color: "#111",
             display: "flex", flexDirection: "column", padding: "4vh 5vw",
         }}>
+            {/* Court header + black rule */}
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "3px solid #111", paddingBottom: "1.4vh", marginBottom: "2.4vh", fontSize: "2.6vh", fontWeight: 700, letterSpacing: "0.08em" }}>
                 <div>{tournament?.name ? tournament.name + " · " : ""}SHIAIJO {court}</div>
                 {!connected && (
@@ -391,19 +408,72 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
                     </span>
                 )}
             </div>
-            <div data-testid={allCompleted ? "display-all-completed" : "display-no-matches"}
-                style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: "2vh", fontSize: "5vh", color: "#9ca3af", textAlign: "center", padding: "0 5vw" }}>
-                {allCompleted ? (
-                    <>
-                        <span style={{ fontSize: "6vh", color: "#16a34a" }}>✓</span>
-                        <span>All matches completed on <TermD name="shiaijo">Shiaijo</TermD> {court}</span>
-                    </>
-                ) : noMatches ? (
-                    <span>No matches scheduled</span>
-                ) : (
-                    <span>No match in progress on <TermD name="shiaijo">Shiaijo</TermD> {court}</span>
+
+            {/* Centre block — anchored slightly above dead-centre */}
+            <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", paddingBottom: "8vh", gap: "3vh" }}>
+
+                {/* a) Status icon + headline */}
+                <div data-testid={allCompleted ? "display-all-completed" : "display-no-matches"}
+                    style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "2vh", textAlign: "center", maxWidth: "60vw" }}>
+                    {allCompleted ? (
+                        <>
+                            {/* Drawn SVG checkmark — NOT the raw ✓ Unicode glyph */}
+                            <div style={{
+                                width: "8vh", height: "8vh", borderRadius: "50%",
+                                /* completed-status palette: mirrors playoffs/completed used across the app */
+                                background: "#ecfdf5", border: "2px solid #a7f3d0",
+                                display: "flex", alignItems: "center", justifyContent: "center",
+                                flexShrink: 0,
+                            }}>
+                                <svg viewBox="0 0 24 24" width="4.5vh" height="4.5vh" fill="none"
+                                    stroke="#065f46" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                                    aria-hidden="true">
+                                    <polyline points="20 6 9 17 4 12" />
+                                </svg>
+                            </div>
+                            <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
+                                All matches completed
+                            </div>
+                        </>
+                    ) : noMatches ? (
+                        <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
+                            No matches scheduled
+                        </div>
+                    ) : (
+                        <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
+                            No match in progress
+                        </div>
+                    )}
+                </div>
+
+                {/* b) QR affordance — "Scan for results" */}
+                {qrUrl && (
+                    <div style={{ display: "inline-flex", alignItems: "center", gap: "1.5vw", marginTop: "1vh" }}>
+                        <StreamingQR url={qrUrl} />
+                        <span style={{ fontSize: "2vh", color: "var(--ink-2)", fontWeight: 500 }}>Scan for results</span>
+                    </div>
+                )}
+
+                {/* c) IN PROGRESS wayfinding strip — other active courts */}
+                {otherCourts.length > 0 && (
+                    <div data-testid="tvd-active-courts" style={{ display: "inline-flex", alignItems: "center", gap: "1.2vw", flexWrap: "wrap", justifyContent: "center", marginTop: "1vh" }}>
+                        <span style={{ fontSize: "1.6vh", letterSpacing: "0.12em", color: "var(--ink-3)", fontWeight: 700 }}>IN PROGRESS</span>
+                        {otherCourts.map(c => (
+                            <span key={c} data-court={c} style={{
+                                display: "inline-flex", alignItems: "center", gap: "0.5vw",
+                                background: "var(--accent-soft)", color: "var(--accent)",
+                                borderRadius: "0.6vw", padding: "0.5vh 1.2vw",
+                                fontWeight: 700, fontSize: "1.8vh",
+                            }}>
+                                {/* Static navy dot — wayfinding only, NOT pulsing */}
+                                <span style={{ width: "0.9vh", height: "0.9vh", borderRadius: "50%", background: "var(--accent)", display: "inline-block", flexShrink: 0 }} />
+                                Shiaijo {c}
+                            </span>
+                        ))}
+                    </div>
                 )}
             </div>
+
             {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="tv" />}
         </div>
     );

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -7,6 +7,21 @@ import { TeamScoreboard, IndividualScore, useTeamLineups, teamIVPW } from './mat
 
 const { useMemo: useMD } = React;
 
+// emptyStateHeadline — headline text for the TvDisplay empty state, by sub-state.
+// The third case ("No match in progress") is a defensive fallback that is
+// UNREACHABLE under the current promote logic: countCourtMatches and
+// findUpcomingOnCourt/findRunningOnCourt share the same bracketSidesReady
+// predicate, so any running/scheduled match the counts see is also
+// auto-promoted — and the empty state only renders when nothing is promoted
+// (so counts.running and counts.scheduled are both 0 here). It is kept so that
+// if that invariant is ever broken the screen degrades to a correct message
+// rather than a wrong one. Exported + unit-tested per the PR #274 review (mp-s99q).
+function emptyStateHeadline(allCompleted, noMatches) {
+    if (allCompleted) return "All matches completed";
+    if (noMatches) return "No matches scheduled";
+    return "No match in progress";
+}
+
 // TvWhiteTeamBoard — mp-13y: white scoreboard for a running TEAM match
 // (per the agreed mockup). Replaces the dark aka/shiro half-panels for the
 // team case with a light board: court header + black rule, team name row
@@ -415,35 +430,25 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
                 {/* a) Status icon + headline */}
                 <div data-testid={allCompleted ? "display-all-completed" : "display-no-matches"}
                     style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "2vh", textAlign: "center", maxWidth: "60vw" }}>
-                    {allCompleted ? (
-                        <>
-                            {/* Drawn SVG checkmark — NOT the raw ✓ Unicode glyph */}
-                            <div style={{
-                                width: "8vh", height: "8vh", borderRadius: "50%",
-                                /* completed-status palette: mirrors playoffs/completed used across the app */
-                                background: "#ecfdf5", border: "2px solid #a7f3d0",
-                                display: "flex", alignItems: "center", justifyContent: "center",
-                                flexShrink: 0,
-                            }}>
-                                <svg viewBox="0 0 24 24" width="4.5vh" height="4.5vh" fill="none"
-                                    stroke="#065f46" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
-                                    aria-hidden="true">
-                                    <polyline points="20 6 9 17 4 12" />
-                                </svg>
-                            </div>
-                            <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
-                                All matches completed
-                            </div>
-                        </>
-                    ) : noMatches ? (
-                        <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
-                            No matches scheduled
-                        </div>
-                    ) : (
-                        <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
-                            No match in progress
+                    {allCompleted && (
+                        /* Drawn SVG checkmark — NOT the raw ✓ Unicode glyph */
+                        <div style={{
+                            width: "8vh", height: "8vh", borderRadius: "50%",
+                            /* completed-status palette: mirrors playoffs/completed used across the app */
+                            background: "#ecfdf5", border: "2px solid #a7f3d0",
+                            display: "flex", alignItems: "center", justifyContent: "center",
+                            flexShrink: 0,
+                        }}>
+                            <svg viewBox="0 0 24 24" width="4.5vh" height="4.5vh" fill="none"
+                                stroke="#065f46" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+                                aria-hidden="true">
+                                <polyline points="20 6 9 17 4 12" />
+                            </svg>
                         </div>
                     )}
+                    <div style={{ fontSize: "5vh", fontWeight: 700, color: "var(--ink-1)", textWrap: "balance", lineHeight: 1.15 }}>
+                        {emptyStateHeadline(allCompleted, noMatches)}
+                    </div>
                 </div>
 
                 {/* b) QR affordance — "Scan for results" */}
@@ -479,4 +484,4 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
     );
 }
 
-export { TvDisplay, TvWhiteBoard, TvIndividualBoard, gatherIndividualGroup };
+export { TvDisplay, TvWhiteBoard, TvIndividualBoard, gatherIndividualGroup, emptyStateHeadline };

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -432,7 +432,7 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
             <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", paddingBottom: "8vh", gap: "3vh" }}>
 
                 {/* a) Status icon + headline */}
-                <div data-testid={allCompleted ? "display-all-completed" : "display-no-matches"}
+                <div data-testid={allCompleted ? "display-all-completed" : (noMatches ? "display-no-matches" : "display-between-matches")}
                     style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "2vh", textAlign: "center", maxWidth: "60vw" }}>
                     {allCompleted && (
                         /* Drawn SVG checkmark — NOT the raw ✓ Unicode glyph */

--- a/web-mobile/js/streaming_overlay.jsx
+++ b/web-mobile/js/streaming_overlay.jsx
@@ -1,7 +1,7 @@
 // streaming_overlay.jsx — OBS/vMix streaming overlay (StreamingOverlay).
 // Transparent-background lower-third for broadcast integrations. T066, T067, mp-13y.
 
-import { findRunningOnCourt, sideLabel, TermD } from './display_helpers.jsx';
+import { findRunningOnCourt, sideLabel, TermD, StreamingQR } from './display_helpers.jsx';
 import { useTeamLineups, teamIVPW } from './match_scoreboard.jsx';
 import { pickFromLineup } from './lineup_resolver.jsx';
 
@@ -50,38 +50,6 @@ function findCurrentBoutIndex(subResults) {
         if (!hasIppon && !hasFoul && !hasHantei && !hasOutcome && !isDraw) return i;
     }
     return regular.length;
-}
-
-// StreamingQR — minimal canvas QR code for the streaming overlay.
-// Renders using renderQR from qr.jsx when available via window.renderQR.
-// Falls back gracefully (blank canvas) if QR rendering is unavailable.
-function StreamingQR({ url, label }) {
-    // Use a stable object as the ref container so the useEffect dependency
-    // doesn't change on every render. The canvas element is stored in
-    // canvasHolder.el after the JSX ref callback fires.
-    const canvasHolder = useMD(() => ({ el: null }), []);
-
-    useED(() => {
-        const canvas = canvasHolder.el;
-        if (!canvas || !url) return undefined;
-        // renderQR may be available on window if qr.jsx has been imported
-        // by another module (e.g. admin_shell.jsx exposes it). If not, skip.
-        const fn = window.renderQR || null;
-        if (!fn) return undefined;
-        try { fn(canvas, url, { moduleSize: 2, quietZone: 2 }); } catch (_e) { /* skip */ }
-        return undefined;
-    }, [url]);
-
-    return (
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.4vh' }}>
-            <canvas
-                data-testid="overlay-qr"
-                ref={(el) => { canvasHolder.el = el; }}
-                style={{ display: 'block', imageRendering: 'pixelated', borderRadius: 4 }}
-            />
-            {label && <div style={{ fontSize: '1.2vh', opacity: 0.75, textAlign: 'center' }}>{label}</div>}
-        </div>
-    );
 }
 
 // <StreamingOverlay court="A" position="bottom"> — transparent-background


### PR DESCRIPTION
## Summary

Redesign of the per-court TV board's empty/idle states, from the `/impeccable critique` of the "all matches completed" screen. The headline rendered in `#9ca3af` gray on white = **2.5:1 contrast**, failing WCAG AA on a product whose entire purpose (PRODUCT.md) is high-contrast legibility on wall screens in bright halls. This raises it to ~10:1 and turns an idle-court dead end into useful wayfinding.

- **Contrast fix:** headline → `var(--ink-1)` (`#111827`, ~10:1), applied to all three sub-states (completed / no-matches / between-matches). The most important text on the board is now the strongest, not the weakest.
- **Confident completion:** drawn SVG check in a success-tinted circle (the existing completed-status palette `#ecfdf5`/`#065f46`/`#a7f3d0`) replacing the raw `✓` Unicode glyph; headline drops the redundant "on Shiaijo {court}" (the header already names the court) and gets `text-wrap: balance`.
- **"Scan for results" QR** → `/viewer`, reusing the existing `StreamingQR`.
- **"IN PROGRESS" wayfinding strip:** navy chips (`var(--accent)` / `var(--accent-soft)`) for sibling courts with running or scheduled matches, current court excluded, strip omitted when none. (Wording is "in progress", not "live" — this project has purged that term.)

## Why

A finished court is a peak moment shown to a captive room, but the old screen said "nothing here" in low-contrast gray. The redesign makes the completion confident and points spectators at the courts still going.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/display_scoreboard.jsx` | Redesigned the `TvDisplay` empty-state block: tokenized high-contrast headline, SVG check badge, QR affordance, `findActiveCourts`-driven `IN PROGRESS` strip |
| `web-mobile/js/display_helpers.jsx` | `StreamingQR` relocated here (shared leaf) so both the overlay and TV board consume it without coupling the two presentation modules |
| `web-mobile/js/streaming_overlay.jsx` | Imports `StreamingQR` from the shared leaf instead of defining it |
| `web-mobile/js/__tests__/display_completed_state.test.jsx` | New — 13 tests for the redesigned states |

Dependency graph stays acyclic: `display.jsx → {scoreboard, lobby, streaming} → display_helpers`; `display_helpers` imports nothing from a presentation module.

> **Stacked on #272** (base branch `claude/keen-yalow-d8e0ec`). This change edits `display_scoreboard.jsx`, which only exists after the split in #272. Merge #272 first; this PR's base will retarget to `main`.

## Screenshots

Captured live from the running mobile-app on seeded "London Cup Demo" data (court A completed, a match flipped to running on court B to populate the strip). The board renders: header + rule, green check in the success circle, **"All matches completed"** in full ink, a working QR with "Scan for results", and an `IN PROGRESS · ● Shiaijo B` navy chip.

Browser-measured proof of the fix (`getComputedStyle`), which is stronger than a JPEG for the contrast claim:

| Element | Computed value | Means |
|---|---|---|
| Headline color | `rgb(17, 24, 39)` | `--ink-1`, **~10:1** (was `rgb(156, 163, 175)` = 2.5:1) |
| Chip background | `rgb(231, 234, 243)` | `--accent-soft` resolves |
| Chip text | `rgb(29, 53, 87)` | `--accent` resolves |
| SVG check | rendered 46×46px | drawn, not the Unicode glyph |
| QR canvas | present | `StreamingQR` → `/viewer` |
| Current court in strip | excluded | court A absent from its own `IN PROGRESS` chips |

**"All matches completed" — with IN PROGRESS wayfinding strip (court B active):**

![TvDisplay — all completed with IN PROGRESS strip](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/274/display-with-strip.png)

**"All matches completed" — strip omitted when no sibling courts are active:**

![TvDisplay — all completed, no strip](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/274/display-all-completed.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all Go packages green, coverage ≥ 85%
- [x] New/updated unit tests cover the change — 13 new tests in `display_completed_state.test.jsx` (headline text per state, `--ink-1` usage, active-court chips incl. current-court exclusion and absent-when-none, "Scan for results", "IN PROGRESS" not "LIVE"); full suite **1518/1518**
- [x] Manual browser verification — loaded `/display?court=A` on seeded data; confirmed computed colors above, SVG check + QR render, populated `IN PROGRESS` strip
- [x] Screenshots added above — live capture + computed-style attestation
- [x] No new console errors or warnings — clean across the empty-state render

Closes mp-s99q
