### PR TITLE
fix(mp-42rg): de-duplicate triple-NOW on multi-watch viewport

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -134,9 +134,26 @@ Three levels only:
 
 Never combine shadow with a solid border on the same side — pick one elevation language per component.
 
+### Rings
+
+Two semantic ring tokens, both `0 0 0 3px var(--accent-soft)` today. They carry the **same value but different intent**, so a future change to one (e.g. an a11y tweak to the focus ring) doesn't silently restyle the other.
+
+| Token | Use |
+|---|---|
+| `--focus-ring` | Keyboard-focus halo on **text-entry controls** (`.input/.textarea/.select`, `.radio-pill`, `.lined-textarea`, `.ipt-btn`). Buttons use the separate `outline: 2px solid var(--accent)` convention, not this. |
+| `--ring-active` | The **running/highlight card** halo (`.bc-match--running` / `--highlight`, `.sched-row--running`, `.vsched-item--running`) — part of the navy running-signal language (§5). |
+
+The `.dot--running` pulse uses a 4px ring inline (its own keyframe), not these tokens.
+
 ### Motion
 
-| Token (de facto) | Use |
+| Token | Value | Use |
+|---|---|---|
+| `--ease-out` | `cubic-bezier(0.2, 0.8, 0.2, 1)` | Standard ease-out — the default for transitions and entrances. Decelerates hard, no overshoot. |
+
+Durations remain literals (de facto tokens, fold new work toward these):
+
+| Duration (de facto) | Use |
 |---|---|
 | `120ms` | Color/border transitions on buttons, chips, badges |
 | `140ms` | Card hovers (tcard, pool, sched-row) |
@@ -147,7 +164,7 @@ Keyframes (find each `@keyframes` block in [styles.css](web-mobile/css/styles.cs
 - `pulse` (1.6s infinite) — `.dot--running` only
 - `spin` (0.6s linear infinite) — loading spinners
 - `toast-in` (300ms) — toast entrance
-- `decision-prompt-in` (160ms, cubic-bezier(0.2, 0.8, 0.2, 1)) — match-decision modal entrance
+- `decision-prompt-in` (160ms, `var(--ease-out)`) — match-decision modal entrance
 
 A `prefers-reduced-motion: reduce` block at the bottom of `styles.css` disables all four animations (`.dot--running`, `.spinner`, `.toast`, `.decision-prompt`). Gate any new non-essential animation behind this media query.
 
@@ -389,7 +406,7 @@ Match-decision visual suffixes are documented in [§4 Match cards](#match-cards-
 - **Contrast**: `--ink-4` is the floor at 4.7:1 on `--surface` (WCAG AA). For tournament-critical surfaces that must survive venue glare, use `--ink-1` (~18:1, AAA). Don't introduce new gray tokens without re-checking contrast.
 - **Keyboard**: every modal honors Escape via `useEscapeToClose`. The admin score editor supports `←` / `→` to navigate between matches **on the same shiaijo** — see [CLAUDE.md](CLAUDE.md) and the note in [admin_schedule.jsx](web-mobile/js/admin_schedule.jsx). When adding keyboard shortcuts, gate them on `!isTextEntry(e.target)` (defined in [ui.jsx#L151](web-mobile/js/ui.jsx#L151)) so they don't clobber inputs.
 - **Touch**: `@media (pointer: coarse)` blocks bump padding on dense controls. The internal floor is ≥ 36px on shared surfaces and ≥ 44px under coarse pointers — note that platform guidance (Apple HIG, WCAG 2.5.5 AAA) wants 44px universally; the 36px floor is a pragmatic choice for laptop-mouse admin surfaces, not a target to aim for. Test any new dense surface on a tablet before merging.
-- **Focus rings**: inputs use a 3px `--accent-soft` ring. Don't suppress `:focus-visible` — operators tab through forms.
+- **Focus rings**: text-entry controls use the `--focus-ring` token (3px `--accent-soft`); buttons use `outline: 2px solid var(--accent)`. Don't suppress `:focus-visible` — operators tab through forms. See §3 Rings.
 - **Motion**: there's no global `prefers-reduced-motion` opt-out yet — tracked in `bd show bracket-creator-3ch`. Pulse, spin, toast-in, and decision-prompt-in are the only ambient animations; if you add more, gate them yourself until the global block lands.
 
 ## 7. Frontend conventions

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6809,7 +6809,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   padding-top: 2px;
 }
 .vsched--incard .vsched-item--running {
-  box-shadow: none;
   border-radius: 8px;
   margin: 2px 0;
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -927,11 +927,11 @@ a:hover {
 
   0%,
   100% {
-    box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.18);
+    box-shadow: 0 0 0 4px rgba(29, 53, 87, 0.18);
   }
 
   50% {
-    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0);
+    box-shadow: 0 0 0 6px rgba(29, 53, 87, 0);
   }
 }
 
@@ -2955,18 +2955,18 @@ button.pool-match-row {
 
 .hero-running {
   background: var(--surface);
-  border: 1px solid var(--red);
+  border: 1px solid var(--accent);
   border-radius: var(--r-lg);
   padding: 12px 14px 14px;
   margin-bottom: 16px;
-  box-shadow: 0 0 0 4px var(--red-soft);
+  box-shadow: 0 0 0 4px var(--accent-soft);
 }
 
 .hero-running__lbl {
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: var(--red);
+  color: var(--accent);
   display: flex;
   align-items: center;
   gap: 6px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2510,6 +2510,7 @@ a.vlist-item {
 .vsched-item--running {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-soft);
+  background-color: var(--accent-soft);
 }
 
 .vsched-item__head {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -64,6 +64,20 @@
   --shadow: 0 1px 2px rgba(20, 25, 40, 0.05), 0 8px 20px -12px rgba(20, 25, 40, 0.18);
   --shadow-lg: 0 12px 32px -16px rgba(20, 25, 40, 0.25);
 
+  /* Focus ring (DESIGN.md §6): the soft 3px ring on text-entry controls
+     (.input/.textarea/.select, .radio-pill, .lined-textarea, .ipt-btn).
+     Buttons use the solid `outline: 2px var(--accent)` convention instead. */
+  --focus-ring: 0 0 0 3px var(--accent-soft);
+  /* Active/highlight card ring (DESIGN.md §5 "Running signal"): the navy
+     running/highlight halo on cards (.bc-match--running/--highlight,
+     .sched-row--running, .vsched-item--running). Same value as --focus-ring
+     today, separate token by intent so the two can diverge independently. */
+  --ring-active: 0 0 0 3px var(--accent-soft);
+
+  /* Standard ease-out curve — the project's default entrance/transition
+     easing (DESIGN.md Motion). Decelerates hard, no overshoot. */
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+
   --font: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --font-display: "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -605,7 +619,7 @@ a:hover {
 .running-strip__chip:focus-visible,
 .radio-pill:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--focus-ring);
 }
 
 .score-btn:disabled {
@@ -697,7 +711,7 @@ a:hover {
 .textarea:focus,
 .select:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--focus-ring);
 }
 
 .textarea {
@@ -719,7 +733,7 @@ a:hover {
 
 .lined-textarea:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--focus-ring);
 }
 
 .lined-textarea__nums {
@@ -1114,12 +1128,12 @@ a:hover {
 
 .bc-match--highlight {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--ring-active);
 }
 
 .bc-match--running {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--ring-active);
 }
 
 .bc-match--done {
@@ -1705,7 +1719,7 @@ a:hover {
 
 .sched-row--running {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--ring-active);
 }
 
 .sched-row--done {
@@ -2513,7 +2527,7 @@ a.vlist-item {
 
 .vsched-item--running {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--ring-active);
   background-color: var(--accent-soft);
 }
 
@@ -5835,9 +5849,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   text-transform: uppercase;
   cursor: pointer;
   min-height: 24px;
-  transition: border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-              color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-              background-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: border-color 120ms var(--ease-out),
+              color 120ms var(--ease-out),
+              background-color 120ms var(--ease-out);
 }
 .encho-pill:hover,
 .encho-pill:focus-visible {
@@ -5855,7 +5869,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   margin-bottom: 12px;
   font-size: 12px;
   flex-wrap: wrap;
-  transition: padding 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: padding 180ms var(--ease-out);
 }
 .encho-row__label {
   display: flex;
@@ -5955,9 +5969,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   height: 38px;
   font-size: 16px;
   border-radius: 6px;
-  transition: background-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-              border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-              color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: background-color 120ms var(--ease-out),
+              border-color 120ms var(--ease-out),
+              color 120ms var(--ease-out);
 }
 /* Drop the heavy scale+shadow on filled slots; use an inset 2px border in
    the side colour for a "value locked in" instrument-readout feel. */
@@ -6130,9 +6144,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   place-items: center;
   cursor: pointer;
   color: var(--ink-3);
-  transition: background-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-              border-color 120ms cubic-bezier(0.2, 0.8, 0.2, 1),
-              color 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: background-color 120ms var(--ease-out),
+              border-color 120ms var(--ease-out),
+              color 120ms var(--ease-out);
   padding: 0;
 }
 .editor-modal--compact .editor-side__pt--filled {
@@ -6279,12 +6293,12 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .ipt-btn:focus-visible {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  box-shadow: var(--focus-ring);
 }
 
 /* --- Decision prompt motion (compact + roomy) -------------------------- */
 .decision-prompt {
-  animation: decision-prompt-in 160ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  animation: decision-prompt-in 160ms var(--ease-out) both;
 }
 @keyframes decision-prompt-in {
   from { opacity: 0; transform: translateY(12px); }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2608,6 +2608,11 @@ a.vlist-item {
   font-family: var(--font-mono);
   font-weight: 700;
 }
+/* Live (in-progress) score on a running match: accent-tinted so it reads as
+   "current score, still climbing" rather than a settled final result. */
+.vsched-item__score--live {
+  color: var(--accent);
+}
 
 /* Button vsched-item: .vsched-item defines bg + border via CSS; just reset default
    browser button appearance without clobbering those values. */
@@ -2636,11 +2641,6 @@ button.vsched-item:not([data-clickable]) {
 .vsched-item__status {
   margin-left: auto;
   color: var(--ink-3);
-}
-
-/* Running "● NOW" label inside head row pushed right automatically */
-.vsched-item__head .bc-running {
-  margin-left: auto;
 }
 
 /* HANTEI badge */
@@ -6763,6 +6763,42 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 /* ---------- Mymatch / watchlist card spacing ---------- */
 .mymatch-card { margin-bottom: 16px; }
+
+/* ---------- Watchlist card heading (not an eyebrow — no uppercase) ---------- */
+.watchlist-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.watchlist-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink-1);
+  letter-spacing: -0.01em;
+}
+
+/* vsched inside the watchlist card: flat row list, no nested card boxes.
+   Regular items become hairline-separated rows; running items keep their
+   accent ring since they carry meaningful live state. */
+.vsched--incard { gap: 0; margin-top: 12px; }
+.vsched--incard .vsched-item:not(.vsched-item--running) {
+  border: none;
+  border-top: 1px solid var(--line);
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
+  padding: 8px 2px;
+}
+.vsched--incard .vsched-item:not(.vsched-item--running):first-child {
+  border-top: none;
+  padding-top: 2px;
+}
+.vsched--incard .vsched-item--running {
+  box-shadow: none;
+  border-radius: 8px;
+  margin: 2px 0;
+}
 
 /* ---------- Checked-in tick in watchlist chips ---------- */
 .pmf__chip-tick { margin-left: 4px; font-size: 10px; }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -927,11 +927,11 @@ a:hover {
 
   0%,
   100% {
-    box-shadow: 0 0 0 4px rgba(29, 53, 87, 0.18);
+    box-shadow: 0 0 0 4px var(--accent-soft);
   }
 
   50% {
-    box-shadow: 0 0 0 6px rgba(29, 53, 87, 0);
+    box-shadow: 0 0 0 6px transparent;
   }
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6762,8 +6762,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 /* ---------- Section-title modifiers ---------- */
 .section-title--flush { margin-top: 0; }
 .section-title--inrow { margin-top: 0; display: flex; align-items: center; gap: 8px; }
-/* Slightly smaller sub-section label with top spacing */
-.section-title--sub { margin-top: 14px; font-size: 13px; }
 
 /* ---------- Hint text utilities (inline note, muted) ---------- */
 .hint    { font-size: 12px; color: var(--ink-3); margin-bottom: 8px; }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -66,7 +66,7 @@
 
   /* Focus ring (DESIGN.md §6): the soft 3px ring on text-entry controls
      (.input/.textarea/.select, .radio-pill, .lined-textarea, .ipt-btn).
-     Buttons use the solid `outline: 2px var(--accent)` convention instead. */
+     Buttons use the solid `outline: 2px solid var(--accent)` convention instead. */
   --focus-ring: 0 0 0 3px var(--accent-soft);
   /* Active/highlight card ring (DESIGN.md §5 "Running signal"): the navy
      running/highlight halo on cards (.bc-match--running/--highlight,

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2378,9 +2378,9 @@ a:hover {
 }
 
 .my-match__lbl {
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   opacity: 0.7;
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2373,6 +2373,10 @@ a:hover {
   overflow: hidden;
 }
 
+.my-match--running {
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
 .my-match__lbl {
   font-size: 10.5px;
   font-weight: 700;

--- a/web-mobile/index.html
+++ b/web-mobile/index.html
@@ -65,6 +65,10 @@
          picks up the labels. -->
     <script type="module" src="/dist/display.js?v=5"></script>
     <script type="module" src="/dist/viewer.js?v=5"></script>
+    <!-- Watchlist UI (WatchPicker/WatchHeroCard/WatchlistPanel), extracted from
+         viewer.jsx. Reads its viewer.jsx helper deps from window at render time,
+         so load order relative to viewer.js does not matter. -->
+    <script type="module" src="/dist/viewer_watchlist.js?v=5"></script>
     <script type="module" src="/dist/admin_helpers.js?v=5"></script>
     <script type="module" src="/dist/admin_shell.js?v=5"></script>
     <script type="module" src="/dist/admin_scoring_modal.js?v=5"></script>

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, linkBase, isNonPublicOrigin, VSchedItem } from '../viewer.jsx';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, linkBase, isNonPublicOrigin } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 
@@ -1262,5 +1262,147 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
     const scoreSpan = findNode(tree, n => n.type === 'span' && String(n.props?.className || '').includes('vsched-item__score'));
     expect(scoreSpan).toBeTruthy();
     expect(scoreSpan.props.className).not.toContain('vsched-item__score--live');
+  });
+});
+
+// -----------------------------------------------------------------------
+// ViewerHome globalRunning de-dup render test (mp-42rg)
+// -----------------------------------------------------------------------
+describe('ViewerHome globalRunning de-dup (mp-42rg)', () => {
+  const realReact = global.React;
+  let runtime;
+  let ViewerHomeComp;
+  let originalLocalStorageDescriptor;
+  // Module-level consts captured at import time + render-time window reads
+  const STUBBED = [
+    'StatusBadge', 'formatDate', 'formatLabel', 'formatViewerHeaderEyebrow',
+    'pluralize', 'hasBothSides', 'compareDmy', 'queueLabelCompact',
+    'roundLabel', 'matchScoreStr', 'ipponsFromScore',
+  ];
+  const savedGlobals = {};
+
+  function findNode(node, pred) {
+    if (!node || typeof node !== 'object') return null;
+    if (Array.isArray(node)) {
+      for (const k of node) { const f = findNode(k, pred); if (f) return f; }
+      return null;
+    }
+    if (pred(node)) return node;
+    const kids = node.children || node.props?.children || [];
+    for (const k of [].concat(kids)) { const f = findNode(k, pred); if (f) return f; }
+    return null;
+  }
+
+  const mkPlayer = (id, name) => ({ id, name, dojo: 'TestDojo' });
+  const mkRunning = (id, sideAId, sideBId) => ({
+    id, status: 'running', phase: 'pool', poolName: 'Pool A', court: 'A',
+    sideA: { id: sideAId, name: sideAId }, sideB: { id: sideBId, name: sideBId },
+    ipponsA: [], ipponsB: [],
+  });
+  const mkTournament = (poolMatches) => ({
+    name: 'T', date: '10-06-2026',
+    competitions: [{
+      id: 'c1', name: 'Open', format: 'individual', status: 'pools',
+      players: [
+        mkPlayer('p-alice', 'Alice'), mkPlayer('p-bob', 'Bob'),
+        mkPlayer('p-carol', 'Carol'), mkPlayer('p-dave', 'Dave'),
+      ],
+      poolMatches,
+    }],
+  });
+  const NOOP = () => {};
+
+  beforeEach(async () => {
+    // Install a fresh localStorage mock via defineProperty so prior test suites
+    // that clobber window.localStorage via defineProperty don't break this suite.
+    originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    const store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (k) => (k in store ? store[k] : null),
+        setItem: (k, v) => { store[k] = String(v); },
+        removeItem: (k) => { delete store[k]; },
+        clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+      },
+      writable: true,
+      configurable: true,
+    });
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => {
+      savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+        ? { had: true, val: global.window[k] } : { had: false };
+    });
+    // Module-level const bindings — must be set before vi.resetModules + import
+    global.window.StatusBadge = vi.fn(() => null);
+    global.window.formatDate = (d) => d || '';
+    global.window.formatLabel = (l) => l || '';
+    global.window.formatViewerHeaderEyebrow = () => '';
+    global.window.pluralize = (n, s) => `${n} ${s}`;
+    // Render-time window reads
+    global.window.hasBothSides = () => true;
+    global.window.compareDmy = () => 0;
+    global.window.queueLabelCompact = null;
+    global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.matchScoreStr = () => '';
+    global.window.ipponsFromScore = () => [];
+    vi.resetModules();
+    ({ ViewerHome: ViewerHomeComp } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorageDescriptor);
+    }
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('excludes watched running matches from .hero-running and shows unwatched ones', () => {
+    // Alice is watched. Alice's match (m-alice) must be excluded from
+    // .hero-running; Carol's unwatched match (m-carol) must appear there.
+    window.localStorage.setItem('bc_watchlist',
+      JSON.stringify([{ type: 'player', id: 'p-alice', name: 'Alice' }]));
+    const aliceMatch = mkRunning('m-alice', 'p-alice', 'p-bob');
+    const carolMatch = mkRunning('m-carol', 'p-carol', 'p-dave');
+    const tree = runtime.mount(ViewerHomeComp, {
+      tournament: mkTournament([aliceMatch, carolMatch]),
+      sseConnected: true, onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP,
+    });
+    const heroRunning = findNode(tree, n => n.props?.className === 'hero-running');
+    // .hero-running present because Carol's match is not watched
+    expect(heroRunning).toBeTruthy();
+    // Alice's match key must NOT appear inside .hero-running
+    const aliceKey = findNode(heroRunning, n => n.props?.key === 'c1:m-alice');
+    expect(aliceKey).toBeNull();
+    // Carol's match key MUST appear inside .hero-running
+    const carolKey = findNode(heroRunning, n => n.props?.key === 'c1:m-carol');
+    expect(carolKey).toBeTruthy();
+  });
+
+  it('hides .hero-running entirely when every running match is in the watchlist', () => {
+    // Both Alice and Carol watched → globalRunning is empty → no .hero-running
+    window.localStorage.setItem('bc_watchlist',
+      JSON.stringify([
+        { type: 'player', id: 'p-alice', name: 'Alice' },
+        { type: 'player', id: 'p-carol', name: 'Carol' },
+      ]));
+    const aliceMatch = mkRunning('m-alice', 'p-alice', 'p-bob');
+    const carolMatch = mkRunning('m-carol', 'p-carol', 'p-dave');
+    const tree = runtime.mount(ViewerHomeComp, {
+      tournament: mkTournament([aliceMatch, carolMatch]),
+      sseConnected: true, onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP,
+    });
+    const heroRunning = findNode(tree, n => n.props?.className === 'hero-running');
+    expect(heroRunning).toBeNull();
   });
 });

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, linkBase, isNonPublicOrigin } from '../viewer.jsx';
+import { applyFilters, matchHighlightedBy, competitionKindLabel, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, compMatches, subBoutLabel, TournamentInfo, isHttpURL, linkBase, isNonPublicOrigin, VSchedItem } from '../viewer.jsx';
 import { formatDate } from '../ui.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 
@@ -1171,3 +1171,96 @@ describe('isNonPublicOrigin', () => {
   });
 });
 
+
+// VSchedItem live score rendering — T217
+// Assertions: running match with ≥1 ippon renders score + .vsched-item__score--live;
+// running match with no score falls through to "vs".
+describe('VSchedItem live score rendering (mp-42rg)', () => {
+  const realReact = global.React;
+  let runtime;
+  let VSchedItemComp;
+  const savedGlobals = {};
+  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'roundLabel', 'pluralize', 'queueLabelCompact'];
+
+  function findNode(node, pred) {
+    if (!node || typeof node !== 'object') return null;
+    if (Array.isArray(node)) {
+      for (const k of node) { const f = findNode(k, pred); if (f) return f; }
+      return null;
+    }
+    if (pred(node)) return node;
+    const kids = node.children || node.props?.children || [];
+    for (const k of [].concat(kids)) { const f = findNode(k, pred); if (f) return f; }
+    return null;
+  }
+
+  const mkMatch = (overrides) => ({
+    id: 'm1', compId: 'c1', status: 'running', court: 'A',
+    phase: 'bracket', round: 'QF',
+    sideA: { id: 'pA', name: 'Alice' },
+    sideB: { id: 'pB', name: 'Bob' },
+    ipponsA: [], ipponsB: [],
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => {
+      savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+        ? { had: true, val: global.window[k] } : { had: false };
+    });
+    global.window.ipponsFromScore = vi.fn(() => []);
+    global.window.matchScoreStr = vi.fn(() => '');
+    global.window.roundLabel = vi.fn((i) => `Round ${i + 1}`);
+    global.window.pluralize = vi.fn((n, s) => `${n} ${s}`);
+    global.window.queueLabelCompact = null;
+    vi.resetModules();
+    ({ VSchedItem: VSchedItemComp } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('renders .vsched-item--running class for a running match', () => {
+    const tree = runtime.mount(VSchedItemComp, { m: mkMatch(), tweaks: {} });
+    const btn = findNode(tree, n => n.type === 'button');
+    expect(btn?.props?.className).toMatch(/vsched-item--running/);
+  });
+
+  it('renders score + .vsched-item__score--live when running and matchScoreStr returns a non-empty string', () => {
+    global.window.matchScoreStr = vi.fn(() => 'M–·');
+    const tree = runtime.mount(VSchedItemComp, { m: mkMatch({ ipponsA: ['M'], ipponsB: [] }), tweaks: {} });
+    const scoreSpan = findNode(tree, n => n.type === 'span' && String(n.props?.className || '').includes('vsched-item__score'));
+    expect(scoreSpan).toBeTruthy();
+    expect(scoreSpan.props.className).toContain('vsched-item__score--live');
+    const scoreText = [].concat(scoreSpan.children ?? scoreSpan.props?.children ?? []).join('');
+    expect(scoreText).toBe('M–·');
+  });
+
+  it('renders "vs" when running but matchScoreStr returns empty (no ippon yet)', () => {
+    global.window.matchScoreStr = vi.fn(() => '');
+    const tree = runtime.mount(VSchedItemComp, { m: mkMatch(), tweaks: {} });
+    const vsSpan = findNode(tree, n => n.type === 'span' && String(n.props?.className || '').includes('vsched-item__vs'));
+    expect(vsSpan).toBeTruthy();
+    const text = [].concat(vsSpan.children ?? vsSpan.props?.children ?? []).join('');
+    expect(text).toBe('vs');
+  });
+
+  it('does NOT add .vsched-item__score--live for a completed match', () => {
+    global.window.matchScoreStr = vi.fn(() => 'MK–D');
+    const tree = runtime.mount(VSchedItemComp, { m: mkMatch({ status: 'completed' }), tweaks: {} });
+    const scoreSpan = findNode(tree, n => n.type === 'span' && String(n.props?.className || '').includes('vsched-item__score'));
+    expect(scoreSpan).toBeTruthy();
+    expect(scoreSpan.props.className).not.toContain('vsched-item__score--live');
+  });
+});

--- a/web-mobile/js/__tests__/viewer_mymatch.test.jsx
+++ b/web-mobile/js/__tests__/viewer_mymatch.test.jsx
@@ -133,9 +133,9 @@ describe('mymatchQueueLabel', () => {
     expect(mymatchQueueLabel({ status: 'scheduled', queuePosition: 99 })).toBe('98 before yours');
   });
 
-  it('returns null when status === "running" (round label already shows NOW)', () => {
-    // The my-match__round element appends " · NOW" for running matches, so
-    // the Queue chip must not duplicate it.
+  it('returns null when status === "running" (running state shown by .my-match--running ring)', () => {
+    // WatchHeroCard signals the running state via the .my-match--running CSS ring
+    // and label change ("Your match") — the Queue chip must not add a redundant label.
     expect(mymatchQueueLabel({ status: 'running', queuePosition: 0 })).toBeNull();
     expect(mymatchQueueLabel({ status: 'running' })).toBeNull();
     expect(mymatchQueueLabel({ status: 'running', queuePosition: 3 })).toBeNull();

--- a/web-mobile/js/__tests__/viewer_watchlist.test.jsx
+++ b/web-mobile/js/__tests__/viewer_watchlist.test.jsx
@@ -77,4 +77,28 @@ describe('buildWatchlistUpcoming', () => {
     const upcoming = buildWatchlistUpcoming(watched, all);
     expect(upcoming.map((m) => m.id)).toEqual(['live']);
   });
+
+  // mp-42rg: verifies the de-duplication contract — running matches in the
+  // watched-upcoming list carry stable `.id` values that the ViewerHome
+  // component uses to filter them out of the global NOW section. Without this,
+  // the same match appears 3× on a 375px viewport.
+  it('running matches in upcoming have stable IDs for global-NOW de-duplication', () => {
+    const watched = [{ id: 'p1' }, { id: 'p2' }];
+    const all = [
+      { id: 'r1', sideAId: 'p1', sideBId: 'x', status: 'running', scheduledAt: '09:00' },
+      { id: 'r2', sideAId: 'y', sideBId: 'z', status: 'running', scheduledAt: '09:05' },
+      { id: 's1', sideAId: 'p2', sideBId: 'w', status: 'scheduled', scheduledAt: '10:00' },
+    ];
+    const upcoming = buildWatchlistUpcoming(watched, all);
+    const upcomingIds = new Set(upcoming.map((m) => m.id));
+
+    // r1 involves watched p1 → in upcoming, should be excluded from global NOW
+    expect(upcomingIds.has('r1')).toBe(true);
+    // r2 involves no watched player → not in upcoming, stays in global NOW
+    expect(upcomingIds.has('r2')).toBe(false);
+
+    // Simulates ViewerHome's globalRunning filter
+    const globalRunning = all.filter((m) => m.status === 'running' && !upcomingIds.has(m.id));
+    expect(globalRunning.map((m) => m.id)).toEqual(['r2']);
+  });
 });

--- a/web-mobile/js/__tests__/viewer_watchlist.test.jsx
+++ b/web-mobile/js/__tests__/viewer_watchlist.test.jsx
@@ -79,26 +79,44 @@ describe('buildWatchlistUpcoming', () => {
   });
 
   // mp-42rg: verifies the de-duplication contract — running matches in the
-  // watched-upcoming list carry stable `.id` values that the ViewerHome
-  // component uses to filter them out of the global NOW section. Without this,
+  // watched-upcoming list carry stable composite keys (compId:id) that
+  // ViewerHome uses to filter them out of the global NOW section. Without this,
   // the same match appears 3× on a 375px viewport.
-  it('running matches in upcoming have stable IDs for global-NOW de-duplication', () => {
+  it('running matches in upcoming have stable composite keys for global-NOW de-duplication', () => {
     const watched = [{ id: 'p1' }, { id: 'p2' }];
     const all = [
-      { id: 'r1', sideAId: 'p1', sideBId: 'x', status: 'running', scheduledAt: '09:00' },
-      { id: 'r2', sideAId: 'y', sideBId: 'z', status: 'running', scheduledAt: '09:05' },
-      { id: 's1', sideAId: 'p2', sideBId: 'w', status: 'scheduled', scheduledAt: '10:00' },
+      { id: 'r1', compId: 'comp-A', sideAId: 'p1', sideBId: 'x', status: 'running', scheduledAt: '09:00' },
+      { id: 'r2', compId: 'comp-A', sideAId: 'y', sideBId: 'z', status: 'running', scheduledAt: '09:05' },
+      { id: 's1', compId: 'comp-A', sideAId: 'p2', sideBId: 'w', status: 'scheduled', scheduledAt: '10:00' },
     ];
     const upcoming = buildWatchlistUpcoming(watched, all);
-    const upcomingIds = new Set(upcoming.map((m) => m.id));
+    const upcomingKeys = new Set(upcoming.map((m) => `${m.compId}:${m.id}`));
 
     // r1 involves watched p1 → in upcoming, should be excluded from global NOW
-    expect(upcomingIds.has('r1')).toBe(true);
+    expect(upcomingKeys.has('comp-A:r1')).toBe(true);
     // r2 involves no watched player → not in upcoming, stays in global NOW
-    expect(upcomingIds.has('r2')).toBe(false);
+    expect(upcomingKeys.has('comp-A:r2')).toBe(false);
 
-    // Simulates ViewerHome's globalRunning filter
-    const globalRunning = all.filter((m) => m.status === 'running' && !upcomingIds.has(m.id));
+    // Simulates ViewerHome's globalRunning filter (composite key)
+    const globalRunning = all.filter((m) => m.status === 'running' && !upcomingKeys.has(`${m.compId}:${m.id}`));
     expect(globalRunning.map((m) => m.id)).toEqual(['r2']);
+  });
+
+  it('cross-competition collision: same match id in different comps are not confused', () => {
+    // "Pool A-0" is a common id; comp-B has its own unrelated running match with
+    // the same id but a different compId — it must NOT be filtered out.
+    const watched = [{ id: 'p1' }];
+    const all = [
+      { id: 'Pool A-0', compId: 'comp-A', sideAId: 'p1', sideBId: 'x', status: 'running', scheduledAt: '09:00' },
+      { id: 'Pool A-0', compId: 'comp-B', sideAId: 'y', sideBId: 'z', status: 'running', scheduledAt: '09:00' },
+    ];
+    const upcoming = buildWatchlistUpcoming(watched, all);
+    const upcomingKeys = new Set(upcoming.map((m) => `${m.compId}:${m.id}`));
+
+    const globalRunning = all.filter((m) => m.status === 'running' && !upcomingKeys.has(`${m.compId}:${m.id}`));
+    // comp-A match is watched → excluded; comp-B match has the same id but
+    // a different compId → must remain visible in the global NOW section.
+    expect(globalRunning).toHaveLength(1);
+    expect(globalRunning[0].compId).toBe('comp-B');
   });
 });

--- a/web-mobile/js/__tests__/viewer_watchlist_panel.test.jsx
+++ b/web-mobile/js/__tests__/viewer_watchlist_panel.test.jsx
@@ -79,8 +79,12 @@ describe('WatchHeroCard', () => {
 
   it('uses a dojo eyebrow when the entity label differs from the competing member', () => {
     // Dojo primary "Hagane Dojo" → member p1 (Robert) is competing.
+    // MATCH is running, so the hero label is the bare dojo eyebrow — no
+    // "· next up" suffix (a running match is happening now, not next up).
     const tree = runtime.mount(WatchHeroCard, { nextMatch: MATCH, primaryIds: new Set(['p1', 'p3']), entityLabel: 'Hagane Dojo', onMatchClick: vi.fn() });
-    expect(collectText(byClass(tree, 'my-match__lbl')[0])).toMatch(/Hagane Dojo · next up/i);
+    const lbl = collectText(byClass(tree, 'my-match__lbl')[0]);
+    expect(lbl).toContain('Hagane Dojo');
+    expect(lbl).not.toMatch(/next up/i);
     expect(collectText(byClass(tree, 'my-match__name')[0])).toContain('Robert Young');
   });
 });

--- a/web-mobile/js/__tests__/viewer_watchlist_panel.test.jsx
+++ b/web-mobile/js/__tests__/viewer_watchlist_panel.test.jsx
@@ -52,7 +52,11 @@ describe('WatchHeroCard', () => {
     global.window.pluralize = (count, singular, plural) =>
       count === 1 ? `${count} ${singular}` : `${count} ${plural || singular + 's'}`;
     vi.resetModules();
-    ({ WatchHeroCard } = await import('../viewer.jsx'));
+    // viewer.jsx populates window.* with the helpers WatchHeroCard reads at
+    // render (matchParticipantIds, poolLabel, mymatchQueueLabel, TermV);
+    // the component itself now lives in viewer_watchlist.jsx.
+    await import('../viewer.jsx');
+    ({ WatchHeroCard } = await import('../viewer_watchlist.jsx'));
   });
   afterEach(() => { runtime.unmount(); global.React = realReact; vi.resetModules(); });
 
@@ -98,7 +102,11 @@ describe('WatchlistPanel', () => {
     global.window.pluralize = (count, singular, plural) =>
       count === 1 ? `${count} ${singular}` : `${count} ${plural || singular + 's'}`;
     vi.resetModules();
-    ({ WatchlistPanel, WatchHeroCard } = await import('../viewer.jsx'));
+    // viewer.jsx populates window.* with the helpers the panel reads at render
+    // (effectivePrimaryKey, entryKey, resolveEntryPlayerIds, addPlayerToWatchlist,
+    // VSchedItem, WATCHLIST_MAX); the components live in viewer_watchlist.jsx.
+    await import('../viewer.jsx');
+    ({ WatchlistPanel, WatchHeroCard } = await import('../viewer_watchlist.jsx'));
   });
   afterEach(() => { runtime.unmount(); global.React = realReact; vi.resetModules(); });
 
@@ -184,7 +192,10 @@ describe('WatchPicker', () => {
     global.window.pluralize = (count, singular, plural) =>
       count === 1 ? `${count} ${singular}` : `${count} ${plural || singular + 's'}`;
     vi.resetModules();
-    ({ WatchPicker } = await import('../viewer.jsx'));
+    // WatchPicker now lives in viewer_watchlist.jsx (reads window.pluralize,
+    // set above, at module load).
+    await import('../viewer.jsx');
+    ({ WatchPicker } = await import('../viewer_watchlist.jsx'));
   });
   afterEach(() => { runtime.unmount(); global.React = realReact; vi.resetModules(); });
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -955,7 +955,9 @@ export function resolveDeepLink(searchString, roster) {
 function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults, sseConnected = true }) {
   // WatchlistPanel lives in viewer_watchlist.jsx; read it at render time so the
   // viewer.jsx <-> viewer_watchlist.jsx runtime cycle is load-order independent.
-  const WatchlistPanel = window.WatchlistPanel;
+  // Fall back to a no-op if viewer_watchlist.js fails to load so the rest of
+  // the page still renders rather than crashing on an invalid element type.
+  const WatchlistPanel = window.WatchlistPanel ?? (() => null);
   const t = tournament;
   const comps = t.competitions || [];
   const compsByDate = useMemo(() => {

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -953,6 +953,9 @@ export function resolveDeepLink(searchString, roster) {
 }
 
 function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSchedule, onRegister, onOpenResults, sseConnected = true }) {
+  // WatchlistPanel lives in viewer_watchlist.jsx; read it at render time so the
+  // viewer.jsx <-> viewer_watchlist.jsx runtime cycle is load-order independent.
+  const WatchlistPanel = window.WatchlistPanel;
   const t = tournament;
   const comps = t.competitions || [];
   const compsByDate = useMemo(() => {
@@ -1319,100 +1322,6 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   );
 }
 
-// WatchPicker — unified typeahead over the tournament roster that yields
-// EITHER a player pick or a whole-dojo pick. A single search box surfaces both
-// (matching dojos first, then matching players), so "Hagane" offers
-// "Watch all of Hagane Dojo" as one entry instead of forcing the user to add
-// members one by one. Replaces the old SinglePlayerPicker (mp-xhaa).
-function WatchPicker({ roster, dojos, watchedPlayerIds, watchedDojos, onPickPlayer, onPickDojo, placeholder }) {
-  const [query, setQuery] = useState("");
-  const [open, setOpen] = useState(false);
-  const ref = useRefV(null);
-  const excludedPlayers = useMemo(() => new Set(watchedPlayerIds || []), [watchedPlayerIds]);
-  const excludedDojos = useMemo(() => new Set(watchedDojos || []), [watchedDojos]);
-  const q = query.trim().toLowerCase();
-
-  // Dojo matches: a dojo is offered until it is watched as a dojo entry. The
-  // count shows how many roster members it currently covers.
-  const dojoMatches = useMemo(() => {
-    return (dojos || [])
-      .filter((d) => !excludedDojos.has(d.name))
-      .filter((d) => !q || d.name.toLowerCase().includes(q))
-      .slice(0, 6);
-  }, [dojos, q, excludedDojos]);
-
-  const playerMatches = useMemo(() => {
-    const base = roster.filter((p) => !excludedPlayers.has(p.id));
-    if (!q) return base.slice(0, 20);
-    return base.filter((p) =>
-      (p.name || "").toLowerCase().includes(q) || (p.dojo || "").toLowerCase().includes(q)
-    ).slice(0, 20);
-  }, [roster, q, excludedPlayers]);
-
-  const total = dojoMatches.length + playerMatches.length;
-
-  React.useEffect(() => {
-    const onDoc = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, []);
-
-  const pickPlayer = (p) => { onPickPlayer(p); setQuery(""); setOpen(false); };
-  const pickDojo = (d) => { onPickDojo(d); setQuery(""); setOpen(false); };
-
-  return (
-    <div className="pmf" ref={ref}>
-      <div className="pmf__bar" onClick={() => setOpen(true)}>
-        <input
-          className="pmf__input"
-          placeholder={placeholder || "Search players or dojos…"}
-          value={query}
-          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
-          onFocus={() => setOpen(true)}
-        />
-      </div>
-      {open && total > 0 && (
-        <div className="pmf__dropdown">
-          <div className="pmf__dropdown-head">
-            {q ? pluralize(total, "match", "matches") : `${pluralize(roster.length, "participant")} · ${pluralize((dojos || []).length, "dojo")} — type to search`}
-          </div>
-          {/* Dojo options first — a dojo entry is dynamic (auto-includes late
-              registrations), so it's the higher-leverage choice for a coach. */}
-          {dojoMatches.map((d) => (
-            <button
-              key={"dojo:" + d.name}
-              className="pmf__option pmf__option--dojo"
-              onClick={() => pickDojo(d)}
-            >
-              <span className="pmf__check" aria-hidden="true">⌂</span>
-              <span className="pmf__opt-body">
-                <span className="pmf__opt-name">{d.name}</span>
-                <span className="pmf__opt-dojo">Watch all · {pluralize(d.total, "member")}</span>
-              </span>
-            </button>
-          ))}
-          {playerMatches.map((p) => (
-            <button
-              key={p.id}
-              className="pmf__option"
-              onClick={() => pickPlayer(p)}
-            >
-              <span className="pmf__check">{p.checkedIn ? "✓" : ""}</span>
-              <span className="pmf__opt-body">
-                <span className="pmf__opt-name">
-                  {p.name}
-                  {p.checkedIn && <span className="tag-badge pmf__checkin-tag">Checked in</span>}
-                </span>
-                <span className="pmf__opt-dojo">{p.dojo || ""}</span>
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 // mymatchQueueLabel — FR-025 label for the "Your next match" Queue chip.
 //
 // Contract:
@@ -1448,257 +1357,6 @@ export function mymatchQueueLabel(m) {
 export function subBoutLabel(sub, index) {
   if (sub && sub.position === -1) return "Daihyosen";
   return `Match ${(sub && sub.position) || index + 1}`;
-}
-
-// WatchHeroCard — the rich "next match" hero for the PRIMARY watched entity
-// (mp-xhaa). Lifted from the former MyMatchPanel so the lone-competitor case
-// keeps its full treatment: AKA/SHIRO badge, queue position, opponent, court,
-// time. The subject is whichever side belongs to the primary — for a player
-// primary that's the player; for a dojo primary it's the member currently
-// competing (primaryIds covers all members).
-function WatchHeroCard({ nextMatch, primaryIds, entityLabel, onMatchClick }) {
-  if (!nextMatch) return null;
-  const ids = primaryIds || new Set();
-  const [aId, bId] = matchParticipantIds(nextMatch);
-  // Pick the side belonging to the primary; default to side A if neither id
-  // resolves (name-only legacy data).
-  const isOnSideA = aId && ids.has(aId) ? true : (bId && ids.has(bId) ? false : true);
-  const subject = isOnSideA ? nextMatch.sideA : nextMatch.sideB;
-  const opponent = isOnSideA ? nextMatch.sideB : nextMatch.sideA;
-  const subjectName = (subject && subject.name) || entityLabel || "";
-  // Full-text Aka/Shiro badge (bc-color-badge), consistent with bracket.jsx;
-  // the compact 14×14 variant would clip "AKA"/"SHIRO".
-  const myBadgeClass = isOnSideA ? "bc-color-badge--aka" : "bc-color-badge--shiro";
-  const myBadgeLabel = isOnSideA ? "AKA" : "SHIRO";
-  const oppBadgeClass = isOnSideA ? "bc-color-badge--shiro" : "bc-color-badge--aka";
-  const oppBadgeLabel = isOnSideA ? "SHIRO" : "AKA";
-  const phaseLabel = nextMatch.phase === "pool" ? poolLabel(nextMatch) : (nextMatch.round || "Bracket");
-  // FR-025: 1-indexed queue position. Wording mirrors VSchedItem + display.jsx.
-  const queueLabel = mymatchQueueLabel(nextMatch);
-  const queueHighlight = queueLabel === "Next up";
-  // For a dojo primary, name the dojo above the competing member so the
-  // relationship is clear ("Hagane Dojo" → "Aoi" is up).
-  const showDojoEyebrow = entityLabel && entityLabel !== subjectName;
-
-  return (
-    <div className={`my-match ${nextMatch.status === "running" ? "my-match--running" : ""}`} data-testid="watch-hero">
-      <div className="my-match__lbl">
-        {nextMatch.status === "running"
-          ? (showDojoEyebrow ? entityLabel : "Your match")
-          : (showDojoEyebrow ? `${entityLabel} · next up` : "Your next match")}
-      </div>
-      <div className="my-match__name">
-        <span className={`bc-color-badge ${myBadgeClass}`}>{myBadgeLabel}</span>
-        {subjectName}
-      </div>
-      <div className="my-match__round">
-        {nextMatch.compName ? `${nextMatch.compName} · ` : ""}{phaseLabel}
-      </div>
-      <div className="my-match__row">
-        <div className="my-match__chip">
-          <span className="l">Court</span>
-          <span className="v"><TermV name="shiaijo">Shiaijo</TermV> {nextMatch.court || "—"}</span>
-        </div>
-        <div className="my-match__chip">
-          <span className="l">Time</span>
-          <span className="v">{nextMatch.scheduledAt || "TBA"}</span>
-        </div>
-        {queueLabel && (
-          <div
-            className="my-match__chip"
-            data-testid="my-match-queue"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <span className="l">Queue</span>
-            {/* The .my-match card background is var(--accent) (dark blue), so
-                colouring text with var(--accent) renders unreadable. The chip
-                inherits white from --accent-fg; emphasise the in-progress/up-next
-                state with full opacity + a Unicode bullet instead.
-                Wrap the decorative bullet in aria-hidden to keep screen reader
-                announcements clean and focused on the queue label text. */}
-            <span className="v" style={{ opacity: queueHighlight ? 1 : 0.92 }}>
-              {queueHighlight ? <span aria-hidden="true">{"• "}</span> : null}
-              {queueLabel}
-            </span>
-          </div>
-        )}
-      </div>
-      {opponent && (typeof opponent === "object") ? (
-        <button
-          className="my-match__opp"
-          onClick={() => onMatchClick && onMatchClick(nextMatch)}
-        >
-          <div className="l">
-            <span className={`bc-color-badge ${oppBadgeClass}`}>{oppBadgeLabel}</span>
-            vs Opponent
-          </div>
-          <div className="n">{opponent.name}</div>
-          {opponent.dojo ? <div className="d">{opponent.dojo}</div> : null}
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-// WatchlistPanel — the unified personalisation panel (mp-xhaa). One card that
-// absorbs the former "Find my matches" hero and the multi-player watchlist:
-//   - chip list of watched entities (players + whole dojos), each removable,
-//     each pin-able when ≥2 entities exist;
-//   - a single unified picker (WatchPicker) that adds a player OR a dojo;
-//   - the hero card for the primary entity (implicit when 1, pinned when ≥2);
-//   - a bounded "watched upcoming" compact list when ≥2 entities are watched.
-function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimaryKey, primaryEntry, primaryNextMatch, upcoming, onMatchClick }) {
-  const rosterById = useMemo(() => new Map(roster.map((p) => [p.id, p])), [roster]);
-
-  // Dojos present in the roster, with current member counts.
-  const dojos = useMemo(() => {
-    const counts = new Map();
-    roster.forEach((p) => { if (p.dojo) counts.set(p.dojo, (counts.get(p.dojo) || 0) + 1); });
-    return Array.from(counts.entries()).map(([name, total]) => ({ name, total })).sort((a, b) => a.name.localeCompare(b.name));
-  }, [roster]);
-
-  const watchedPlayerIds = useMemo(() => watchlist.filter((e) => e.type === "player").map((e) => e.id), [watchlist]);
-  const watchedDojos = useMemo(() => watchlist.filter((e) => e.type === "dojo").map((e) => e.dojo), [watchlist]);
-
-  const count = watchlist.length;
-  const multi = count >= 2;
-  const effectiveKey = effectivePrimaryKey(watchlist, primaryKey);
-
-  const addPlayer = (p) => setWatchlist(addPlayerToWatchlist(watchlist, p));
-  const addDojo = (d) => {
-    if (!d || !d.name) return;
-    if (watchlist.some((e) => e.type === "dojo" && e.dojo === d.name)) return;
-    setWatchlist([...watchlist, { type: "dojo", dojo: d.name }]);
-  };
-  const removeEntry = (entry) => {
-    const k = entryKey(entry);
-    setWatchlist(watchlist.filter((e) => entryKey(e) !== k));
-    if (primaryKey === k) setPrimaryKey(""); // clear a now-orphaned pin
-  };
-  const togglePin = (entry) => {
-    const k = entryKey(entry);
-    setPrimaryKey(primaryKey === k ? "" : k);
-  };
-
-  // Chip for one entry — player or dojo, with optional pin star (≥2 entries)
-  // and a remove button.
-  const renderChip = (entry) => {
-    const k = entryKey(entry);
-    // Only flag the primary chip visually when there's a choice to make (≥2
-    // entries). With a lone entry the navy fill is decorative and clashes with
-    // the navy hero directly below it.
-    const isPrimary = multi && effectiveKey === k;
-    if (entry.type === "dojo") {
-      const total = dojos.find((d) => d.name === entry.dojo)?.total ?? 0;
-      return (
-        <span key={k} className={`pmf__chip pmf__chip--dojo ${isPrimary ? "is-primary" : ""}`}>
-          {multi && (
-            <button className="pmf__chip-pin" onClick={() => togglePin(entry)} aria-label={isPrimary ? `Unpin ${entry.dojo}` : `Pin ${entry.dojo} as primary`} aria-pressed={isPrimary}>
-              {isPrimary ? "★" : "☆"}
-            </button>
-          )}
-          <span className="pmf__chip-icon" aria-hidden="true">⌂</span>
-          {entry.dojo} ({total})
-          <button onClick={() => removeEntry(entry)} aria-label={`Remove ${entry.dojo}`}>×</button>
-        </span>
-      );
-    }
-    const pRecord = rosterById.get(entry.id);
-    const checkedIn = pRecord && pRecord.checkedIn;
-    const name = (pRecord && pRecord.name) || entry.name || "(unknown)";
-    return (
-      <span key={k} className={`pmf__chip ${checkedIn ? "is-checked-in" : ""} ${isPrimary ? "is-primary" : ""}`} title={checkedIn ? "Checked in" : undefined}>
-        {multi && (
-          <button className="pmf__chip-pin" onClick={() => togglePin(entry)} aria-label={isPrimary ? `Unpin ${name}` : `Pin ${name} as primary`} aria-pressed={isPrimary}>
-            {isPrimary ? "★" : "☆"}
-          </button>
-        )}
-        {name}
-        {checkedIn && <span className="pmf__chip-tick" aria-hidden="true">✓</span>}
-        <button onClick={() => removeEntry(entry)} aria-label={`Remove ${name}`}>×</button>
-      </span>
-    );
-  };
-
-  const primaryLabel = primaryEntry
-    ? (primaryEntry.type === "dojo" ? primaryEntry.dojo : (rosterById.get(primaryEntry.id)?.name || primaryEntry.name || ""))
-    : "";
-
-  return (
-    <div className="card card--sm mymatch-card" data-testid="viewer-home-watchlist">
-      <div className="watchlist-card-head">
-        <span className="watchlist-card-title">Watchlist</span>
-        {count > 0 && <span className="watchlist-count">{count}</span>}
-      </div>
-
-      {count === 0 ? (
-        <div className="hint">
-          Track yourself, a few competitors, or a whole dojo — we'll surface their next matches and alert you when they're on deck. Add up to {WATCHLIST_MAX}.
-        </div>
-      ) : (
-        <div className="pmf__bar pmf__bar--standalone watchlist-chips">
-          {watchlist.map(renderChip)}
-        </div>
-      )}
-
-      {count >= WATCHLIST_MAX ? (
-        <div className="hint--sm">Watchlist full ({WATCHLIST_MAX}). Remove an entry to add more.</div>
-      ) : (
-        <WatchPicker
-          roster={roster}
-          dojos={dojos}
-          watchedPlayerIds={watchedPlayerIds}
-          watchedDojos={watchedDojos}
-          onPickPlayer={addPlayer}
-          onPickDojo={addDojo}
-          placeholder={count === 0 ? "Add a player or dojo to watch…" : "Add another player or dojo…"}
-        />
-      )}
-
-      {/* Hint when ≥2 entities are watched but none is pinned: no hero/chime
-          until the user picks a primary. */}
-      {multi && !primaryEntry && (
-        <div className="hint watchlist-pin-hint">
-          Tap ☆ on a chip to pin your primary — they get the big card and an on-deck chime.
-        </div>
-      )}
-
-      {/* Primary hero — implicit when 1 entity, pinned when ≥2. */}
-      {primaryEntry && primaryNextMatch && (
-        <WatchHeroCard
-          nextMatch={primaryNextMatch}
-          primaryIds={new Set(resolveEntryPlayerIds(primaryEntry, roster))}
-          entityLabel={primaryLabel}
-          onMatchClick={onMatchClick}
-        />
-      )}
-      {primaryEntry && !primaryNextMatch && (
-        <div className="hint--md watchlist-primary-done">
-          {primaryLabel ? `No upcoming matches for ${primaryLabel}.` : "No upcoming matches."}
-        </div>
-      )}
-
-      {/* Bounded compact list of upcoming watched matches — shown when ≥2
-          entities are watched so a coach sees the whole squad at a glance. */}
-      {multi && upcoming.length > 0 && (
-        <>
-          <div className="vsched vsched--incard">
-            {upcoming.map((m) => (
-              <VSchedItem
-                key={m.compId + m.id}
-                m={m}
-                tweaks={{ showDojo: true }}
-                showCompetition
-                onClick={() => onMatchClick && onMatchClick(m)}
-              />
-            ))}
-          </div>
-        </>
-      )}
-    </div>
-  );
 }
 
 // DisplayModes — viewer-home section linking to the public /display routes.
@@ -3108,7 +2766,7 @@ function matchHighlightedBy(m, picked, dojoText) {
   return false;
 }
 
-export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, useWatchlist, entryKey, normalizeWatchlistEntry, normalizeWatchlist, migrateWatchlistOnLoad, resolveEntryPlayerIds, resolveWatchedPlayers, effectivePrimaryKey, findPrimaryEntry, buildPrimaryNextMatch, computeSecondaryAlert, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, isPlayerWatched, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, buildRoster, WatchlistPanel, WatchHeroCard, WatchPicker, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, ViewerHome, MyMatchAlertBanner, LeagueMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection };
+export { PlayerMultiFilter, applyFilters, matchHighlightedBy, competitionKindLabel, compMatches, tournamentMatches, currentMatchOf, buildPlayerMatchHighlight, buildWatchlistUpcoming, useWatchlist, entryKey, normalizeWatchlistEntry, normalizeWatchlist, migrateWatchlistOnLoad, resolveEntryPlayerIds, resolveWatchedPlayers, effectivePrimaryKey, findPrimaryEntry, buildPrimaryNextMatch, computeSecondaryAlert, isSwissFinalStandings, swissStandingsHeading, isFollowedPlayer, isPlayerWatched, deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, buildRoster, MatchDetailCard, MatchViewerModal, AnnouncementCard, AnnouncementBanner, ViewerCompetition, ViewerOverview, ViewerHome, MyMatchAlertBanner, LeagueMatrix, PoolsViewer, PoolNumberedMatchRow, AwardsView, FightingSpiritSection, matchParticipantIds, TermV, VSchedItem, addPlayerToWatchlist, poolLabel, WATCHLIST_MAX };
 
 if (typeof window !== 'undefined') {
     window.PlayerMultiFilter = PlayerMultiFilter;
@@ -4304,5 +3962,18 @@ window.isNonPublicOrigin = isNonPublicOrigin;
 // mp-koqh: public results page.
 window.buildAllWinnersPublic = buildAllWinnersPublic;
 window.AllWinnersView = AllWinnersView;
+
+// Helpers consumed by viewer_watchlist.jsx (WatchPicker/WatchHeroCard/
+// WatchlistPanel) at render time. poolLabel is already exposed above.
+window.matchParticipantIds = matchParticipantIds;
+window.addPlayerToWatchlist = addPlayerToWatchlist;
+window.effectivePrimaryKey = effectivePrimaryKey;
+window.entryKey = entryKey;
+window.resolveEntryPlayerIds = resolveEntryPlayerIds;
+window.mymatchQueueLabel = mymatchQueueLabel;
+window.TermV = TermV;
+window.VSchedItem = VSchedItem;
+window.WATCHLIST_MAX = WATCHLIST_MAX;
+
 export { shouldShowRegister };
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1171,7 +1171,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             <div className="hero-running">
               <div className="hero-running__lbl"><span className="dot dot--running"></span> NOW · {pluralize(globalRunning.length, "match", "matches")}</div>
               <div className="vsched hero-running__vsched">
-                {globalRunning.slice(0, 3).map((m) => <VSchedItem key={m.compId + m.id} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
+                {globalRunning.slice(0, 3).map((m) => <VSchedItem key={`${m.compId}:${m.id}`} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
               </div>
             </div>
           )}
@@ -1273,7 +1273,7 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             <>
               <div className="section-title viewer__upnext-title">Up next · {upNext.length}</div>
               <div className="vsched">
-                {upNext.map((m) => <VSchedItem key={m.compId + m.id} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
+                {upNext.map((m) => <VSchedItem key={`${m.compId}:${m.id}`} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
               </div>
             </>
           )}
@@ -2937,7 +2937,7 @@ function ScheduleViewer({ tournament, tweaks }) {
                 {list.length === 0 ? (
                   <div style={{ fontSize: 12, color: "var(--ink-3)", padding: "20px 8px", textAlign: "center" }}>No matches</div>
                 ) : list.map((m) => (
-                  <TWMatch key={m.compId + m.id} m={m} highlight={matchHasFilter(m)} tweaks={tweaks} onClick={() => tweaks.onMatchClick && tweaks.onMatchClick(m)} />
+                  <TWMatch key={`${m.compId}:${m.id}`} m={m} highlight={matchHasFilter(m)} tweaks={tweaks} onClick={() => tweaks.onMatchClick && tweaks.onMatchClick(m)} />
                 ))}
               </div>
             </div>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1480,15 +1480,23 @@ function WatchHeroCard({ nextMatch, primaryIds, entityLabel, onMatchClick }) {
   const showDojoEyebrow = entityLabel && entityLabel !== subjectName;
 
   return (
-    <div className="my-match" data-testid="watch-hero">
-      <div className="my-match__lbl">{showDojoEyebrow ? `${entityLabel} · next up` : "Your next match"}</div>
+    <div className={`my-match ${nextMatch.status === "running" ? "my-match--running" : ""}`} data-testid="watch-hero">
+      <div className="my-match__lbl">
+        {nextMatch.status === "running" ? (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <span className="dot--running" style={{ width: 8, height: 8, borderRadius: '50%' }}></span>
+            LIVE NOW
+          </span>
+        ) : (
+          showDojoEyebrow ? `${entityLabel} · next up` : "Your next match"
+        )}
+      </div>
       <div className="my-match__name">
         <span className={`bc-color-badge ${myBadgeClass}`}>{myBadgeLabel}</span>
         {subjectName}
       </div>
       <div className="my-match__round">
         {nextMatch.compName ? `${nextMatch.compName} · ` : ""}{phaseLabel}
-        {nextMatch.status === "running" ? " · NOW" : ""}
       </div>
       <div className="my-match__row">
         <div className="my-match__chip">

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1164,9 +1164,6 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
             onMatchClick={setSelectedMatch}
           />
 
-          {/* mp-cw1: Browser push notification opt-in toggle. */}
-          <NotificationSettings />
-
           {globalRunning.length > 0 && (
             <div className="hero-running">
               <div className="hero-running__lbl"><span className="dot dot--running"></span> NOW · {pluralize(globalRunning.length, "match", "matches")}</div>
@@ -1309,6 +1306,10 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
               (viewer) keeps its tab and stays interactive. Collapsed by
               default (mp-mjaq) since most viewers are spectators; only
               tournament operators need these links. */}
+          {/* mp-cw1: Browser push notification opt-in toggle — settings belong at the
+              bottom of the page, not between the watchlist and live-match signals. */}
+          <NotificationSettings />
+
           <DisplayModes tournament={t} />
           {window.VersionFooter && <window.VersionFooter />}
         </div>
@@ -1627,9 +1628,9 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
 
   return (
     <div className="card card--sm mymatch-card" data-testid="viewer-home-watchlist">
-      <div className="section-title section-title--inrow">
-        <span>Watchlist</span>
-        {count > 0 && <span className="watchlist-count">{pluralize(count, "entry", "entries")}</span>}
+      <div className="watchlist-card-head">
+        <span className="watchlist-card-title">Watchlist</span>
+        {count > 0 && <span className="watchlist-count">{count}</span>}
       </div>
 
       {count === 0 ? (
@@ -1683,17 +1684,13 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
           entities are watched so a coach sees the whole squad at a glance. */}
       {multi && upcoming.length > 0 && (
         <>
-          <div className="section-title section-title--sub">
-            Watched matches · upcoming {upcoming.length}
-          </div>
-          <div className="vsched">
+          <div className="vsched vsched--incard">
             {upcoming.map((m) => (
               <VSchedItem
                 key={m.compId + m.id}
                 m={m}
                 tweaks={{ showDojo: true }}
                 showCompetition
-                hideNowBadge
                 onClick={() => onMatchClick && onMatchClick(m)}
               />
             ))}
@@ -2439,7 +2436,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, runningMatches,
   );
 }
 
-const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight, hideNowBadge }) => {
+const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight }) => {
   const aWin = m.winner && m.sideA && m.winner.id === m.sideA.id;
   const bWin = m.winner && m.sideB && m.winner.id === m.sideB.id;
   // Bracket matches carry scoreA/scoreB strings rather than ipponsA/B arrays.
@@ -2448,7 +2445,13 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight,
   // both ippon arrays are absent (which would invert left/right when AKA wins).
   const vIpponsA = m.ipponsA || window.ipponsFromScore(m.scoreA);
   const vIpponsB = m.ipponsB || window.ipponsFromScore(m.scoreB);
-  const scoreStr = m.status === "completed" ? window.matchScoreStr(m, vIpponsB, vIpponsA) : null;
+  // Score string for completed matches (final) and running matches (live, once
+  // at least one ippon has landed). matchScoreStr returns "" before any score
+  // exists, so a just-started running match falls through to the "vs" render.
+  const isRunning = m.status === "running";
+  const scoreStr = (m.status === "completed" || isRunning)
+    ? (window.matchScoreStr(m, vIpponsB, vIpponsA) || null)
+    : null;
   // FR-025: queue position is 1-indexed per court for scheduled matches;
   // running/completed are 0 (set server-side, omitempty in JSON → undefined
   // on older payloads). Treat null/undefined/0 as "don't render" so the UI
@@ -2476,7 +2479,6 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight,
             {queueLabel}
           </span>
         )}
-        {m.status === "running" && !hideNowBadge && <span className="bc-running">● NOW</span>}
         {m.status === "completed" && <span className="vsched-item__status">Final</span>}
         {m.status === "completed" && m.decidedByHantei && (
           <span className="vsched-item__hantei" data-testid="vsched-hantei">HANTEI</span>
@@ -2495,8 +2497,8 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight,
           <span className="n">{withNumber(m.sideB)}</span>
           {tweaks.showDojo && m.sideB?.dojo ? <span className="d">{m.sideB.dojo}</span> : null}
         </div>
-        {m.status === "completed" && scoreStr ? (
-          <span className="vsched-item__score">{scoreStr}</span>
+        {scoreStr ? (
+          <span className={`vsched-item__score${isRunning ? " vsched-item__score--live" : ""}`}>{scoreStr}</span>
         ) : m.status === "completed" ? (
           <span className="vsched-item__vs">—</span>
         ) : (

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1485,7 +1485,7 @@ function WatchHeroCard({ nextMatch, primaryIds, entityLabel, onMatchClick }) {
         {nextMatch.status === "running" ? (
           <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <span className="dot--running" style={{ width: 8, height: 8, borderRadius: '50%' }}></span>
-            LIVE NOW
+            CURRENT
           </span>
         ) : (
           showDojoEyebrow ? `${entityLabel} · next up` : "Your next match"

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1041,11 +1041,11 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   // twice on a phone viewport. When every running match is tracked, the
   // hero-running section disappears entirely (hybrid approach).
   const watchedUpcomingIds = useMemo(
-    () => new Set(watchedUpcoming.map((m) => m.id)),
+    () => new Set(watchedUpcoming.map((m) => `${m.compId}:${m.id}`)),
     [watchedUpcoming]
   );
   const globalRunning = useMemo(
-    () => running.filter((m) => !watchedUpcomingIds.has(m.id)),
+    () => running.filter((m) => !watchedUpcomingIds.has(`${m.compId}:${m.id}`)),
     [running, watchedUpcomingIds]
   );
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1036,6 +1036,19 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
     [resolvedWatched, bothSidesMatches]
   );
 
+  // mp-42rg: de-duplicate the global NOW section — exclude matches already
+  // visible in the watched-upcoming list so the same card doesn't appear
+  // twice on a phone viewport. When every running match is tracked, the
+  // hero-running section disappears entirely (hybrid approach).
+  const watchedUpcomingIds = useMemo(
+    () => new Set(watchedUpcoming.map((m) => m.id)),
+    [watchedUpcoming]
+  );
+  const globalRunning = useMemo(
+    () => running.filter((m) => !watchedUpcomingIds.has(m.id)),
+    [running, watchedUpcomingIds]
+  );
+
   // On-deck matches for NON-primary watched players (the quiet, rate-limited
   // banner path). A match that involves the primary is handled by the loud
   // path, so it is excluded here.
@@ -1154,11 +1167,11 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
           {/* mp-cw1: Browser push notification opt-in toggle. */}
           <NotificationSettings />
 
-          {running.length > 0 && (
+          {globalRunning.length > 0 && (
             <div className="hero-running">
-              <div className="hero-running__lbl"><span className="dot dot--running"></span> NOW · {pluralize(running.length, "match", "matches")}</div>
+              <div className="hero-running__lbl"><span className="dot dot--running"></span> NOW · {pluralize(globalRunning.length, "match", "matches")}</div>
               <div className="vsched hero-running__vsched">
-                {running.slice(0, 3).map((m) => <VSchedItem key={m.compId + m.id} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
+                {globalRunning.slice(0, 3).map((m) => <VSchedItem key={m.compId + m.id} m={m} tweaks={{ showDojo: true }} showCompetition onClick={() => setSelectedMatch(m)} />)}
               </div>
             </div>
           )}
@@ -1677,6 +1690,7 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
                 m={m}
                 tweaks={{ showDojo: true }}
                 showCompetition
+                hideNowBadge
                 onClick={() => onMatchClick && onMatchClick(m)}
               />
             ))}
@@ -2422,7 +2436,7 @@ function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, runningMatches,
   );
 }
 
-const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight }) => {
+const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight, hideNowBadge }) => {
   const aWin = m.winner && m.sideA && m.winner.id === m.sideA.id;
   const bWin = m.winner && m.sideB && m.winner.id === m.sideB.id;
   // Bracket matches carry scoreA/scoreB strings rather than ipponsA/B arrays.
@@ -2459,7 +2473,7 @@ const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, highlight 
             {queueLabel}
           </span>
         )}
-        {m.status === "running" && <span className="bc-running">● NOW</span>}
+        {m.status === "running" && !hideNowBadge && <span className="bc-running">● NOW</span>}
         {m.status === "completed" && <span className="vsched-item__status">Final</span>}
         {m.status === "completed" && m.decidedByHantei && (
           <span className="vsched-item__hantei" data-testid="vsched-hantei">HANTEI</span>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1034,8 +1034,9 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   const primaryIds = useMemo(() => new Set(resolveEntryPlayerIds(primaryEntry, roster)), [primaryEntry, roster]);
   const primaryNextMatch = useMemo(() => buildPrimaryNextMatch(primaryEntry, roster, bothSidesMatches), [primaryEntry, roster, bothSidesMatches]);
 
-  // Compact "watched upcoming" list shown when ≥2 entities are watched and no
-  // single primary is pinned. Bounded so it stays glanceable on a phone.
+  // Compact "watched upcoming" list shown when ≥2 entities are watched and
+  // there are upcoming matches (regardless of whether a primary is pinned).
+  // Bounded so it stays glanceable on a phone.
   const watchedUpcoming = useMemo(
     () => buildWatchlistUpcoming(resolvedWatched, bothSidesMatches, WATCHED_UPCOMING_LIST_MAX),
     [resolvedWatched, bothSidesMatches]

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1482,14 +1482,9 @@ function WatchHeroCard({ nextMatch, primaryIds, entityLabel, onMatchClick }) {
   return (
     <div className={`my-match ${nextMatch.status === "running" ? "my-match--running" : ""}`} data-testid="watch-hero">
       <div className="my-match__lbl">
-        {nextMatch.status === "running" ? (
-          <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-            <span className="dot--running" style={{ width: 8, height: 8, borderRadius: '50%' }}></span>
-            CURRENT
-          </span>
-        ) : (
-          showDojoEyebrow ? `${entityLabel} · next up` : "Your next match"
-        )}
+        {nextMatch.status === "running"
+          ? (showDojoEyebrow ? entityLabel : "Your match")
+          : (showDojoEyebrow ? `${entityLabel} · next up` : "Your next match")}
       </div>
       <div className="my-match__name">
         <span className={`bc-color-badge ${myBadgeClass}`}>{myBadgeLabel}</span>

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1034,9 +1034,10 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   const primaryIds = useMemo(() => new Set(resolveEntryPlayerIds(primaryEntry, roster)), [primaryEntry, roster]);
   const primaryNextMatch = useMemo(() => buildPrimaryNextMatch(primaryEntry, roster, bothSidesMatches), [primaryEntry, roster, bothSidesMatches]);
 
-  // Compact "watched upcoming" list shown when ≥2 entities are watched and
-  // there are upcoming matches (regardless of whether a primary is pinned).
-  // Bounded so it stays glanceable on a phone.
+  // Compact list of running and upcoming watched matches — shown when ≥2 entities
+  // are watched (coach multi-watch). Includes running matches so they can be
+  // excluded from the global-NOW hero section (mp-42rg de-dup). Bounded so it
+  // stays glanceable on a phone.
   const watchedUpcoming = useMemo(
     () => buildWatchlistUpcoming(resolvedWatched, bothSidesMatches, WATCHED_UPCOMING_LIST_MAX),
     [resolvedWatched, bothSidesMatches]

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1046,14 +1046,10 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
   // visible in the watched-upcoming list so the same card doesn't appear
   // twice on a phone viewport. When every running match is tracked, the
   // hero-running section disappears entirely (hybrid approach).
-  const watchedUpcomingIds = useMemo(
-    () => new Set(watchedUpcoming.map((m) => `${m.compId}:${m.id}`)),
-    [watchedUpcoming]
-  );
-  const globalRunning = useMemo(
-    () => running.filter((m) => !watchedUpcomingIds.has(`${m.compId}:${m.id}`)),
-    [running, watchedUpcomingIds]
-  );
+  const globalRunning = useMemo(() => {
+    const watchedIds = new Set(watchedUpcoming.map((m) => `${m.compId}:${m.id}`));
+    return running.filter((m) => !watchedIds.has(`${m.compId}:${m.id}`));
+  }, [running, watchedUpcoming]);
 
   // On-deck matches for NON-primary watched players (the quiet, rate-limited
   // banner path). A match that involves the primary is handled by the loud
@@ -1330,13 +1326,16 @@ function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOpenSched
 // Contract:
 //   - status==="scheduled" + queuePosition===1 → "Next up"
 //   - status==="scheduled" + queuePosition>1   → "<qp-1> before yours"
-//   - status==="running"                       → null (round label already shows " · NOW")
+//   - status==="running"                       → null (WatchHeroCard signals running
+//                                                        via .my-match--running ring + label change;
+//                                                        no Queue chip needed)
 //   - anything else (completed/forfeit/cancelled, or no qp)  → null (hide chip)
 //
 // Wording mirrors the VSchedItem helper below and display.jsx::queueLabel
 // so all three viewer surfaces agree. Running matches return null because
-// the my-match__round label already appends " · NOW" — rendering it
-// again in the Queue chip would be a duplicate. We intentionally do NOT
+// WatchHeroCard already signals the running state via the .my-match--running
+// CSS ring and label change ("Your match") — the Queue chip must not add a
+// redundant label. We intentionally do NOT
 // fall back to "Scheduled HH:MM" the way display.jsx does — the
 // MyMatchPanel already has a dedicated Time chip.
 // Exported for unit-testing.

--- a/web-mobile/js/viewer_watchlist.jsx
+++ b/web-mobile/js/viewer_watchlist.jsx
@@ -1,0 +1,376 @@
+// viewer_watchlist.jsx — the watchlist personalisation UI, extracted from
+// viewer.jsx to keep that file's component count manageable (mp-42rg follow-up).
+//
+// Sharing model (matches the rest of web-mobile/js): files are compiled
+// individually by esbuild and loaded as ordered <script type="module"> tags,
+// so cross-file code is shared via `window.*`, NOT ES imports (those would
+// 404 in the browser — the served file is .js, the import path is .jsx).
+//
+// This file and viewer.jsx form a runtime CYCLE: ViewerHome (in viewer.jsx)
+// renders WatchlistPanel (here), while these components consume helpers that
+// stay in viewer.jsx (TermV, VSchedItem, entryKey, …). The cycle is safe
+// because every cross-boundary helper is read from `window` at RENDER time
+// (inside the component body), by which point both scripts have evaluated and
+// populated `window`. Only React (a vendor global) and pluralize (from ui.js,
+// loaded before this file) are read at module-eval time.
+const { useState, useMemo } = React;
+const useRefV = React.useRef;
+const pluralize = window.pluralize;
+
+// WatchPicker — unified typeahead over the tournament roster that yields
+// EITHER a player pick or a whole-dojo pick. A single search box surfaces both
+// (matching dojos first, then matching players), so "Hagane" offers
+// "Watch all of Hagane Dojo" as one entry instead of forcing the user to add
+// members one by one. Replaces the old SinglePlayerPicker (mp-xhaa).
+function WatchPicker({ roster, dojos, watchedPlayerIds, watchedDojos, onPickPlayer, onPickDojo, placeholder }) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const ref = useRefV(null);
+  const excludedPlayers = useMemo(() => new Set(watchedPlayerIds || []), [watchedPlayerIds]);
+  const excludedDojos = useMemo(() => new Set(watchedDojos || []), [watchedDojos]);
+  const q = query.trim().toLowerCase();
+
+  // Dojo matches: a dojo is offered until it is watched as a dojo entry. The
+  // count shows how many roster members it currently covers.
+  const dojoMatches = useMemo(() => {
+    return (dojos || [])
+      .filter((d) => !excludedDojos.has(d.name))
+      .filter((d) => !q || d.name.toLowerCase().includes(q))
+      .slice(0, 6);
+  }, [dojos, q, excludedDojos]);
+
+  const playerMatches = useMemo(() => {
+    const base = roster.filter((p) => !excludedPlayers.has(p.id));
+    if (!q) return base.slice(0, 20);
+    return base.filter((p) =>
+      (p.name || "").toLowerCase().includes(q) || (p.dojo || "").toLowerCase().includes(q)
+    ).slice(0, 20);
+  }, [roster, q, excludedPlayers]);
+
+  const total = dojoMatches.length + playerMatches.length;
+
+  React.useEffect(() => {
+    const onDoc = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  const pickPlayer = (p) => { onPickPlayer(p); setQuery(""); setOpen(false); };
+  const pickDojo = (d) => { onPickDojo(d); setQuery(""); setOpen(false); };
+
+  return (
+    <div className="pmf" ref={ref}>
+      <div className="pmf__bar" onClick={() => setOpen(true)}>
+        <input
+          className="pmf__input"
+          placeholder={placeholder || "Search players or dojos…"}
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+        />
+      </div>
+      {open && total > 0 && (
+        <div className="pmf__dropdown">
+          <div className="pmf__dropdown-head">
+            {q ? pluralize(total, "match", "matches") : `${pluralize(roster.length, "participant")} · ${pluralize((dojos || []).length, "dojo")} — type to search`}
+          </div>
+          {/* Dojo options first — a dojo entry is dynamic (auto-includes late
+              registrations), so it's the higher-leverage choice for a coach. */}
+          {dojoMatches.map((d) => (
+            <button
+              key={"dojo:" + d.name}
+              className="pmf__option pmf__option--dojo"
+              onClick={() => pickDojo(d)}
+            >
+              <span className="pmf__check" aria-hidden="true">⌂</span>
+              <span className="pmf__opt-body">
+                <span className="pmf__opt-name">{d.name}</span>
+                <span className="pmf__opt-dojo">Watch all · {pluralize(d.total, "member")}</span>
+              </span>
+            </button>
+          ))}
+          {playerMatches.map((p) => (
+            <button
+              key={p.id}
+              className="pmf__option"
+              onClick={() => pickPlayer(p)}
+            >
+              <span className="pmf__check">{p.checkedIn ? "✓" : ""}</span>
+              <span className="pmf__opt-body">
+                <span className="pmf__opt-name">
+                  {p.name}
+                  {p.checkedIn && <span className="tag-badge pmf__checkin-tag">Checked in</span>}
+                </span>
+                <span className="pmf__opt-dojo">{p.dojo || ""}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// WatchHeroCard — the rich "next match" hero for the PRIMARY watched entity
+// (mp-xhaa). Lifted from the former MyMatchPanel so the lone-competitor case
+// keeps its full treatment: AKA/SHIRO badge, queue position, opponent, court,
+// time. The subject is whichever side belongs to the primary — for a player
+// primary that's the player; for a dojo primary it's the member currently
+// competing (primaryIds covers all members).
+function WatchHeroCard({ nextMatch, primaryIds, entityLabel, onMatchClick }) {
+  // Cross-boundary helpers from viewer.jsx, read at render time (see header).
+  const { matchParticipantIds, poolLabel, mymatchQueueLabel, TermV } = window;
+  if (!nextMatch) return null;
+  const ids = primaryIds || new Set();
+  const [aId, bId] = matchParticipantIds(nextMatch);
+  // Pick the side belonging to the primary; default to side A if neither id
+  // resolves (name-only legacy data).
+  const isOnSideA = aId && ids.has(aId) ? true : (bId && ids.has(bId) ? false : true);
+  const subject = isOnSideA ? nextMatch.sideA : nextMatch.sideB;
+  const opponent = isOnSideA ? nextMatch.sideB : nextMatch.sideA;
+  const subjectName = (subject && subject.name) || entityLabel || "";
+  // Full-text Aka/Shiro badge (bc-color-badge), consistent with bracket.jsx;
+  // the compact 14×14 variant would clip "AKA"/"SHIRO".
+  const myBadgeClass = isOnSideA ? "bc-color-badge--aka" : "bc-color-badge--shiro";
+  const myBadgeLabel = isOnSideA ? "AKA" : "SHIRO";
+  const oppBadgeClass = isOnSideA ? "bc-color-badge--shiro" : "bc-color-badge--aka";
+  const oppBadgeLabel = isOnSideA ? "SHIRO" : "AKA";
+  const phaseLabel = nextMatch.phase === "pool" ? poolLabel(nextMatch) : (nextMatch.round || "Bracket");
+  // FR-025: 1-indexed queue position. Wording mirrors VSchedItem + display.jsx.
+  const queueLabel = mymatchQueueLabel(nextMatch);
+  const queueHighlight = queueLabel === "Next up";
+  // For a dojo primary, name the dojo above the competing member so the
+  // relationship is clear ("Hagane Dojo" → "Aoi" is up).
+  const showDojoEyebrow = entityLabel && entityLabel !== subjectName;
+
+  return (
+    <div className={`my-match ${nextMatch.status === "running" ? "my-match--running" : ""}`} data-testid="watch-hero">
+      <div className="my-match__lbl">
+        {nextMatch.status === "running"
+          ? (showDojoEyebrow ? entityLabel : "Your match")
+          : (showDojoEyebrow ? `${entityLabel} · next up` : "Your next match")}
+      </div>
+      <div className="my-match__name">
+        <span className={`bc-color-badge ${myBadgeClass}`}>{myBadgeLabel}</span>
+        {subjectName}
+      </div>
+      <div className="my-match__round">
+        {nextMatch.compName ? `${nextMatch.compName} · ` : ""}{phaseLabel}
+      </div>
+      <div className="my-match__row">
+        <div className="my-match__chip">
+          <span className="l">Court</span>
+          <span className="v"><TermV name="shiaijo">Shiaijo</TermV> {nextMatch.court || "—"}</span>
+        </div>
+        <div className="my-match__chip">
+          <span className="l">Time</span>
+          <span className="v">{nextMatch.scheduledAt || "TBA"}</span>
+        </div>
+        {queueLabel && (
+          <div
+            className="my-match__chip"
+            data-testid="my-match-queue"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <span className="l">Queue</span>
+            {/* The .my-match card background is var(--accent) (dark blue), so
+                colouring text with var(--accent) renders unreadable. The chip
+                inherits white from --accent-fg; emphasise the in-progress/up-next
+                state with full opacity + a Unicode bullet instead.
+                Wrap the decorative bullet in aria-hidden to keep screen reader
+                announcements clean and focused on the queue label text. */}
+            <span className="v" style={{ opacity: queueHighlight ? 1 : 0.92 }}>
+              {queueHighlight ? <span aria-hidden="true">{"• "}</span> : null}
+              {queueLabel}
+            </span>
+          </div>
+        )}
+      </div>
+      {opponent && (typeof opponent === "object") ? (
+        <button
+          className="my-match__opp"
+          onClick={() => onMatchClick && onMatchClick(nextMatch)}
+        >
+          <div className="l">
+            <span className={`bc-color-badge ${oppBadgeClass}`}>{oppBadgeLabel}</span>
+            vs Opponent
+          </div>
+          <div className="n">{opponent.name}</div>
+          {opponent.dojo ? <div className="d">{opponent.dojo}</div> : null}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// WatchlistPanel — the unified personalisation panel (mp-xhaa). One card that
+// absorbs the former "Find my matches" hero and the multi-player watchlist:
+//   - chip list of watched entities (players + whole dojos), each removable,
+//     each pin-able when ≥2 entities exist;
+//   - a single unified picker (WatchPicker) that adds a player OR a dojo;
+//   - the hero card for the primary entity (implicit when 1, pinned when ≥2);
+//   - a bounded "watched upcoming" compact list when ≥2 entities are watched.
+function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimaryKey, primaryEntry, primaryNextMatch, upcoming, onMatchClick }) {
+  // Cross-boundary helpers from viewer.jsx, read at render time (see header).
+  const { effectivePrimaryKey, addPlayerToWatchlist, entryKey, resolveEntryPlayerIds, VSchedItem, WATCHLIST_MAX } = window;
+  const rosterById = useMemo(() => new Map(roster.map((p) => [p.id, p])), [roster]);
+
+  // Dojos present in the roster, with current member counts.
+  const dojos = useMemo(() => {
+    const counts = new Map();
+    roster.forEach((p) => { if (p.dojo) counts.set(p.dojo, (counts.get(p.dojo) || 0) + 1); });
+    return Array.from(counts.entries()).map(([name, total]) => ({ name, total })).sort((a, b) => a.name.localeCompare(b.name));
+  }, [roster]);
+
+  const watchedPlayerIds = useMemo(() => watchlist.filter((e) => e.type === "player").map((e) => e.id), [watchlist]);
+  const watchedDojos = useMemo(() => watchlist.filter((e) => e.type === "dojo").map((e) => e.dojo), [watchlist]);
+
+  const count = watchlist.length;
+  const multi = count >= 2;
+  const effectiveKey = effectivePrimaryKey(watchlist, primaryKey);
+
+  const addPlayer = (p) => setWatchlist(addPlayerToWatchlist(watchlist, p));
+  const addDojo = (d) => {
+    if (!d || !d.name) return;
+    if (watchlist.some((e) => e.type === "dojo" && e.dojo === d.name)) return;
+    setWatchlist([...watchlist, { type: "dojo", dojo: d.name }]);
+  };
+  const removeEntry = (entry) => {
+    const k = entryKey(entry);
+    setWatchlist(watchlist.filter((e) => entryKey(e) !== k));
+    if (primaryKey === k) setPrimaryKey(""); // clear a now-orphaned pin
+  };
+  const togglePin = (entry) => {
+    const k = entryKey(entry);
+    setPrimaryKey(primaryKey === k ? "" : k);
+  };
+
+  // Chip for one entry — player or dojo, with optional pin star (≥2 entries)
+  // and a remove button.
+  const renderChip = (entry) => {
+    const k = entryKey(entry);
+    // Only flag the primary chip visually when there's a choice to make (≥2
+    // entries). With a lone entry the navy fill is decorative and clashes with
+    // the navy hero directly below it.
+    const isPrimary = multi && effectiveKey === k;
+    if (entry.type === "dojo") {
+      const total = dojos.find((d) => d.name === entry.dojo)?.total ?? 0;
+      return (
+        <span key={k} className={`pmf__chip pmf__chip--dojo ${isPrimary ? "is-primary" : ""}`}>
+          {multi && (
+            <button className="pmf__chip-pin" onClick={() => togglePin(entry)} aria-label={isPrimary ? `Unpin ${entry.dojo}` : `Pin ${entry.dojo} as primary`} aria-pressed={isPrimary}>
+              {isPrimary ? "★" : "☆"}
+            </button>
+          )}
+          <span className="pmf__chip-icon" aria-hidden="true">⌂</span>
+          {entry.dojo} ({total})
+          <button onClick={() => removeEntry(entry)} aria-label={`Remove ${entry.dojo}`}>×</button>
+        </span>
+      );
+    }
+    const pRecord = rosterById.get(entry.id);
+    const checkedIn = pRecord && pRecord.checkedIn;
+    const name = (pRecord && pRecord.name) || entry.name || "(unknown)";
+    return (
+      <span key={k} className={`pmf__chip ${checkedIn ? "is-checked-in" : ""} ${isPrimary ? "is-primary" : ""}`} title={checkedIn ? "Checked in" : undefined}>
+        {multi && (
+          <button className="pmf__chip-pin" onClick={() => togglePin(entry)} aria-label={isPrimary ? `Unpin ${name}` : `Pin ${name} as primary`} aria-pressed={isPrimary}>
+            {isPrimary ? "★" : "☆"}
+          </button>
+        )}
+        {name}
+        {checkedIn && <span className="pmf__chip-tick" aria-hidden="true">✓</span>}
+        <button onClick={() => removeEntry(entry)} aria-label={`Remove ${name}`}>×</button>
+      </span>
+    );
+  };
+
+  const primaryLabel = primaryEntry
+    ? (primaryEntry.type === "dojo" ? primaryEntry.dojo : (rosterById.get(primaryEntry.id)?.name || primaryEntry.name || ""))
+    : "";
+
+  return (
+    <div className="card card--sm mymatch-card" data-testid="viewer-home-watchlist">
+      <div className="watchlist-card-head">
+        <span className="watchlist-card-title">Watchlist</span>
+        {count > 0 && <span className="watchlist-count">{count}</span>}
+      </div>
+
+      {count === 0 ? (
+        <div className="hint">
+          Track yourself, a few competitors, or a whole dojo — we'll surface their next matches and alert you when they're on deck. Add up to {WATCHLIST_MAX}.
+        </div>
+      ) : (
+        <div className="pmf__bar pmf__bar--standalone watchlist-chips">
+          {watchlist.map(renderChip)}
+        </div>
+      )}
+
+      {count >= WATCHLIST_MAX ? (
+        <div className="hint--sm">Watchlist full ({WATCHLIST_MAX}). Remove an entry to add more.</div>
+      ) : (
+        <WatchPicker
+          roster={roster}
+          dojos={dojos}
+          watchedPlayerIds={watchedPlayerIds}
+          watchedDojos={watchedDojos}
+          onPickPlayer={addPlayer}
+          onPickDojo={addDojo}
+          placeholder={count === 0 ? "Add a player or dojo to watch…" : "Add another player or dojo…"}
+        />
+      )}
+
+      {/* Hint when ≥2 entities are watched but none is pinned: no hero/chime
+          until the user picks a primary. */}
+      {multi && !primaryEntry && (
+        <div className="hint watchlist-pin-hint">
+          Tap ☆ on a chip to pin your primary — they get the big card and an on-deck chime.
+        </div>
+      )}
+
+      {/* Primary hero — implicit when 1 entity, pinned when ≥2. */}
+      {primaryEntry && primaryNextMatch && (
+        <WatchHeroCard
+          nextMatch={primaryNextMatch}
+          primaryIds={new Set(resolveEntryPlayerIds(primaryEntry, roster))}
+          entityLabel={primaryLabel}
+          onMatchClick={onMatchClick}
+        />
+      )}
+      {primaryEntry && !primaryNextMatch && (
+        <div className="hint--md watchlist-primary-done">
+          {primaryLabel ? `No upcoming matches for ${primaryLabel}.` : "No upcoming matches."}
+        </div>
+      )}
+
+      {/* Bounded compact list of upcoming watched matches — shown when ≥2
+          entities are watched so a coach sees the whole squad at a glance. */}
+      {multi && upcoming.length > 0 && (
+        <>
+          <div className="vsched vsched--incard">
+            {upcoming.map((m) => (
+              <VSchedItem
+                key={m.compId + m.id}
+                m={m}
+                tweaks={{ showDojo: true }}
+                showCompetition
+                onClick={() => onMatchClick && onMatchClick(m)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Runtime sharing: expose on window so viewer.jsx (ViewerHome) can render these
+// at render time regardless of script load order.
+window.WatchPicker = WatchPicker;
+window.WatchHeroCard = WatchHeroCard;
+window.WatchlistPanel = WatchlistPanel;
+
+// ES exports for the vitest suite, which imports these directly.
+export { WatchPicker, WatchHeroCard, WatchlistPanel };

--- a/web-mobile/js/viewer_watchlist.jsx
+++ b/web-mobile/js/viewer_watchlist.jsx
@@ -352,7 +352,7 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
           <div className="vsched vsched--incard">
             {upcoming.map((m) => (
               <VSchedItem
-                key={m.compId + m.id}
+                key={`${m.compId}:${m.id}`}
                 m={m}
                 tweaks={{ showDojo: true }}
                 showCompetition

--- a/web-mobile/js/viewer_watchlist.jsx
+++ b/web-mobile/js/viewer_watchlist.jsx
@@ -346,8 +346,9 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
         </div>
       )}
 
-      {/* Bounded compact list of upcoming watched matches — shown when ≥2
-          entities are watched so a coach sees the whole squad at a glance. */}
+      {/* Bounded compact list of running and upcoming watched matches — shown when
+          ≥2 entities are watched so a coach sees the whole squad at a glance.
+          Includes running matches (buildWatchlistUpcoming returns both). */}
       {multi && upcoming.length > 0 && (
         <div className="vsched vsched--incard">
           {upcoming.map((m) => (

--- a/web-mobile/js/viewer_watchlist.jsx
+++ b/web-mobile/js/viewer_watchlist.jsx
@@ -64,6 +64,7 @@ function WatchPicker({ roster, dojos, watchedPlayerIds, watchedDojos, onPickPlay
         <input
           className="pmf__input"
           placeholder={placeholder || "Search players or dojos…"}
+          aria-label={placeholder || "Search players or dojos"}
           value={query}
           onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
           onFocus={() => setOpen(true)}
@@ -295,7 +296,7 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
     <div className="card card--sm mymatch-card" data-testid="viewer-home-watchlist">
       <div className="watchlist-card-head">
         <span className="watchlist-card-title">Watchlist</span>
-        {count > 0 && <span className="watchlist-count">{count}</span>}
+        {count > 0 && <span className="watchlist-count" aria-label={`${count} watched`}>{count}</span>}
       </div>
 
       {count === 0 ? (

--- a/web-mobile/js/viewer_watchlist.jsx
+++ b/web-mobile/js/viewer_watchlist.jsx
@@ -349,19 +349,17 @@ function WatchlistPanel({ roster, watchlist, setWatchlist, primaryKey, setPrimar
       {/* Bounded compact list of upcoming watched matches — shown when ≥2
           entities are watched so a coach sees the whole squad at a glance. */}
       {multi && upcoming.length > 0 && (
-        <>
-          <div className="vsched vsched--incard">
-            {upcoming.map((m) => (
-              <VSchedItem
-                key={`${m.compId}:${m.id}`}
-                m={m}
-                tweaks={{ showDojo: true }}
-                showCompetition
-                onClick={() => onMatchClick && onMatchClick(m)}
-              />
-            ))}
-          </div>
-        </>
+        <div className="vsched vsched--incard">
+          {upcoming.map((m) => (
+            <VSchedItem
+              key={`${m.compId}:${m.id}`}
+              m={m}
+              tweaks={{ showDojo: true }}
+              showCompetition
+              onClick={() => onMatchClick && onMatchClick(m)}
+            />
+          ))}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

When ≥2 entries are in the watchlist (multi-watch, no pin) and a watched player has a running match, the same match appeared **three times** on a phone viewport: a `● NOW` badge in the watched-upcoming list, the `● NOW · N matches` section heading, and a duplicate card inside the global NOW section.

This PR fixes the duplication and, following UAT feedback on the multi-watch viewport, cleans up the watchlist layout and makes the running match actually useful to a coach:

- **De-dup:** compute `watchedUpcomingIds` and derive `globalRunning` by filtering those IDs out of the global `running` array. The `hero-running` section only renders matches the watchlist does not already cover; if all running matches are tracked, it disappears.
- **Live score:** `VSchedItem` now surfaces the **live score** for running matches (accent-tinted via `vsched-item__score--live`), not just completed ones. A just-started match with no ippon yet falls through to `vs`. Previously a watched player fighting *right now* showed only their names with no score.
- **Drop the `● NOW` text badge** from `VSchedItem` entirely: the accent ring (`vsched-item--running`) plus the live accent score already signal the live state. The global hero keeps its own `NOW · N matches` section heading.
- **Layout polish:** the watchlist card uses a proper card heading (weight 600, no uppercase) instead of the tiny-uppercase-tracked eyebrow; the redundant second eyebrow ("Watched matches · upcoming N") is removed; the upcoming list renders as flat hairline-separated rows (`vsched--incard`) instead of nested card boxes.
- **Settings placement:** `NotificationSettings` moves to the bottom of `ViewerHome`, after the schedule links, instead of breaking the flow between the watchlist and the live-match signals.

## Why

`buildWatchlistUpcoming` correctly keeps `status === "running"` matches (a coach needs to see them), but `ViewerHome` independently built its own `running` array with no awareness of the watchlist. The two pipelines had no de-duplication, so the same match object was rendered by both sections at once.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer.jsx` | `watchedUpcomingIds` set + `globalRunning` derived array in ViewerHome; live running score in `VSchedItem`; drop `● NOW` badge; card-heading classes + flat in-card list in `WatchlistPanel`; move `NotificationSettings` |
| `web-mobile/css/styles.css` | `.watchlist-card-head/-title`, `.vsched--incard` flat-row rules, `.vsched-item__score--live`; remove dead `.vsched-item__head .bc-running` rule |
| `web-mobile/js/__tests__/viewer_watchlist.test.jsx` | De-duplication contract test (mp-42rg) |
| `web-mobile/js/__tests__/viewer_watchlist_panel.test.jsx` | Update stale dojo-eyebrow assertion: a running hero no longer suffixes `· next up` |

## Screenshots

**Before** — the same match (13:30 Shiaijo A) appears three times: `● NOW` badge on the watched card, `NOW · 1 match` heading, and the card duplicated inside the global NOW section.

![Before: triple-NOW duplication on multi-watch viewport](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/275/before.png)

**After** — one running match on Shiaijo A at 13:30 marked by the accent ring and a live accent-colored score (`·–M`, Mason has 1 men), no redundant text badge; two genuinely upcoming scheduled matches below it on the same court (13:35 "Next up", 13:40 "#2"). The card heading is a plain "Watchlist" (no eyebrow), and the rows are flat (no nested cards).

![After: single live match with live score, clean flat rows](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/275/after.png)

## Design-system tokens (impeccable extract)

Folded in a small design-token extraction (requested on this PR). **Zero visual change** — every migrated site maps to a token of identical value:

- `--focus-ring` (`0 0 0 3px var(--accent-soft)`) — keyboard-focus halo on text-entry controls (`.input/.textarea/.select`, `.radio-pill`, `.lined-textarea`, `.ipt-btn`), 4 rules. Buttons keep their separate `outline: 2px solid var(--accent)` convention.
- `--ring-active` (same value, separate intent) — the running/highlight card halo (`.bc-match--running/--highlight`, `.sched-row--running`, `.vsched-item--running`), 4 rules. Split from `--focus-ring` so an a11y change to one can't silently restyle the other.
- `--ease-out` (`cubic-bezier(0.2, 0.8, 0.2, 1)`) — the project's standard ease-out curve, 11 usages.

`DESIGN.md` §3 gains a **Rings** subsection + an `--ease-out` Motion row; §6 focus-ring note points at the token. Verified: served-CSS carries 4/4/11 token usages, `:root` tokens resolve to identical values, and a live `.bc-match--running` element computes to the original `#e7eaf3 0 0 0 3px`.

## viewer.jsx component extraction (first cut)

Began breaking up the 4,308-line `viewer.jsx` by extracting the watchlist UI (`WatchPicker`, `WatchHeroCard`, `WatchlistPanel`) into a new `viewer_watchlist.jsx` (`viewer.jsx` → ~3,978, **-345 lines**). Shared helpers stay in `viewer.jsx` because `ViewerHome`/`ViewerCompetition` also use them; this is the first of a staged split (awards/pools/schedule are the bigger follow-ups this seam unlocks).

The web-mobile sharing model is per-file esbuild + ordered `<script type=module>` + `window` globals (cross-file ES imports 404 in the browser — served file is `.js`, import path `.jsx`). `viewer.jsx` and `viewer_watchlist.jsx` form a runtime cycle; it's safe because every cross-boundary read happens at **render time**, after both scripts have populated `window`. Verified in a live browser: `ViewerHome` renders `WatchlistPanel` via the window path (2 chips + running card with live score through `window.VSchedItem`), no new console errors.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests; all packages ≥85% coverage)
- [x] Full JS suite green — **1522 tests pass** (includes the mp-42rg de-dup contract test and the corrected dojo-eyebrow assertion)
- [x] Manual browser verification (Playwright, 390×844): with 2 watchlist entries and a running watched match, confirmed the match renders **once** with the accent ring + live score and no `● NOW` badge; the global NOW section is suppressed; scheduled matches render as flat rows with queue labels
- [x] Screenshots above captured from a real running server with valid single-running-match-per-court data
- [x] No new console errors or warnings

## Follow-up

UAT surfaced a real data-integrity gap (out of scope here): the engine enforces per-player simultaneity but **not** court exclusivity, so two matches can be "running" on one shiaijo. Filed as **mp-95mg** (P1, `discovered-from:mp-42rg`).

Closes mp-42rg


