### PR TITLE
style: unify running-match color to accent navy (mp-oe9u)

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -927,11 +927,11 @@ a:hover {
 
   0%,
   100% {
-    box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.18);
+    box-shadow: 0 0 0 4px rgba(29, 53, 87, 0.18);
   }
 
   50% {
-    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0);
+    box-shadow: 0 0 0 6px rgba(29, 53, 87, 0);
   }
 }
 
@@ -2955,18 +2955,18 @@ button.pool-match-row {
 
 .hero-running {
   background: var(--surface);
-  border: 1px solid var(--red);
+  border: 1px solid var(--accent);
   border-radius: var(--r-lg);
   padding: 12px 14px 14px;
   margin-bottom: 16px;
-  box-shadow: 0 0 0 4px var(--red-soft);
+  box-shadow: 0 0 0 4px var(--accent-soft);
 }
 
 .hero-running__lbl {
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: var(--red);
+  color: var(--accent);
   display: flex;
   align-items: center;
   gap: 6px;


### PR DESCRIPTION
## Summary

- Refactors `.hero-running` and `.dot--running` to use `var(--accent)` instead of `var(--red)`.
- Bumps the `.hero-running__lbl` font size to 11px for consistency.

## Why

This aligns with the `impeccable` colorize principles. In this UI's design vocabulary, red is reserved for Aka (one of the competitor sides) and danger/errors. Using red for a "running" state creates semantic confusion (it looks like an error state). The accent navy border (already established on `vsched-item--running`) is the correct semantic idiom for a live, active state.

## Files changed

| File | What |
|---|---|
| `web-mobile/css/styles.css` | Update `@keyframes pulse` and `.hero-running` classes to use `--accent` variables and RGB values. |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] No new console errors or warnings

Closes mp-oe9u
