### PR TITLE
feat(bracket): polish bracket view — remove seed badge, shorten round labels, add scroll affordance

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1293,7 +1293,6 @@ a:hover {
   margin: 0 12px;
 }
 
-
 .bc-name-wrap {
   flex: 1;
   min-width: 0;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1169,6 +1169,11 @@ a:hover {
   font-weight: 600;
 }
 
+.bc-match-num {
+  color: var(--ink-4);
+  margin-right: 2px;
+}
+
 .bc-court {
   color: var(--ink-2);
 }
@@ -1185,6 +1190,42 @@ a:hover {
 .bc-bye-tag {
   color: var(--ink-4);
   margin-left: auto;
+}
+
+/* Structural-bye placeholder rendered in the upstream bracket column so the
+   tree gap is visible — matches the Excel Tree sheet's empty-slot treatment. */
+.bc-bye-slot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 8px 13px;
+  min-height: 44px;
+  border: 1.5px dashed var(--line-strong, #c7cdd9);
+  border-radius: var(--r);
+  background: var(--line, #f0f2f5);
+  pointer-events: none;
+  user-select: none;
+  position: relative;
+  z-index: 1;
+}
+
+.bc-bye-slot__name {
+  flex: 1;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--ink-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bc-bye-slot__tag {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  flex-shrink: 0;
 }
 
 .bc-side {
@@ -1252,22 +1293,6 @@ a:hover {
   margin: 0 12px;
 }
 
-.bc-seed {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--ink-3);
-  background: var(--line-2);
-  padding: 1px 6px;
-  border-radius: 4px;
-  font-family: var(--font-mono);
-  min-width: 20px;
-  text-align: center;
-}
-
-.bc-seed--empty {
-  background: transparent;
-  color: transparent;
-}
 
 .bc-name-wrap {
   flex: 1;
@@ -1348,11 +1373,6 @@ a:hover {
   color: white;
 }
 
-.bc-match--v2 .bc-side--winner.bc-side--a .bc-seed {
-  background: rgba(255, 255, 255, 0.2);
-  color: white;
-}
-
 .bc-match--v2 .bc-side--winner.bc-side--b {
   background: var(--accent);
   color: var(--accent-fg);
@@ -1362,11 +1382,6 @@ a:hover {
 .bc-match--v2 .bc-side--winner.bc-side--b .bc-name,
 .bc-match--v2 .bc-side--winner.bc-side--b .bc-dojo,
 .bc-match--v2 .bc-side--winner.bc-side--b .bc-score {
-  color: var(--accent-fg);
-}
-
-.bc-match--v2 .bc-side--winner.bc-side--b .bc-seed {
-  background: rgba(255, 255, 255, 0.2);
   color: var(--accent-fg);
 }
 
@@ -2835,6 +2850,19 @@ button.vsched-item:not([data-clickable]) {
 .viewer-bracket-bleed {
   margin-left: -16px;
   margin-right: -16px;
+  position: relative;
+}
+
+.viewer-bracket-bleed--overflow-right::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 56px;
+  background: linear-gradient(to right, transparent, var(--bg));
+  pointer-events: none;
+  z-index: 2;
 }
 @media (min-width: 768px) {
   .viewer-bracket-bleed {

--- a/web-mobile/js/__tests__/admin_helpers.test.jsx
+++ b/web-mobile/js/__tests__/admin_helpers.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sideName, hasBothSides, hasPoolOriginPlaceholder, compMatchStats, normalizeDate, dmyToIso, isoToDmy, compareDmy, isValidDate, validateAndNormalizeDate, decideNumericUpdate, getScoreBtnClass, deriveTournamentDays, normalizeCourts, courtCount, DATE_ERR_INVALID_FORMAT, DATE_ERR_YEAR_RANGE, MIN_YEAR, MAX_YEAR, MAX_TEAM_SIZE, MAX_COURTS, MAX_RANK, MAX_TOURNAMENT_DURATION_DAYS } from '../admin_helpers.jsx';
+import { sideName, hasBothSides, hasPoolOriginPlaceholder, compMatchStats, normalizeDate, dmyToIso, isoToDmy, compareDmy, isValidDate, validateAndNormalizeDate, decideNumericUpdate, getScoreBtnClass, deriveTournamentDays, normalizeCourts, courtCount, resolveRoundIndex, DATE_ERR_INVALID_FORMAT, DATE_ERR_YEAR_RANGE, MIN_YEAR, MAX_YEAR, MAX_TEAM_SIZE, MAX_COURTS, MAX_RANK, MAX_TOURNAMENT_DURATION_DAYS } from '../admin_helpers.jsx';
 
 describe('sideName', () => {
   it('returns "" for null / undefined', () => {
@@ -753,5 +753,32 @@ describe('courtCount', () => {
 
   it('returns 1 for a truthy non-array like a string', () => {
     expect(courtCount("AB")).toBe(1);
+  });
+});
+
+describe('resolveRoundIndex', () => {
+  it('returns m.roundIndex when non-negative', () => {
+    expect(resolveRoundIndex({ roundIndex: 0 })).toBe(0);
+    expect(resolveRoundIndex({ roundIndex: 3 })).toBe(3);
+  });
+
+  it('falls back to numeric m.round when roundIndex is absent', () => {
+    expect(resolveRoundIndex({ round: 2 })).toBe(2);
+  });
+
+  it('clamps negative numeric round to 0 via fallback', () => {
+    expect(resolveRoundIndex({ round: -1 })).toBe(0);
+  });
+
+  it('returns 0 for pool matches with no roundIndex or numeric round', () => {
+    expect(resolveRoundIndex({ round: 'Pool A', status: 'completed' })).toBe(0);
+  });
+
+  it('returns 0 when match has no round fields at all', () => {
+    expect(resolveRoundIndex({})).toBe(0);
+  });
+
+  it('prefers roundIndex over numeric round', () => {
+    expect(resolveRoundIndex({ roundIndex: 1, round: 5 })).toBe(1);
   });
 });

--- a/web-mobile/js/__tests__/admin_lineup.test.jsx
+++ b/web-mobile/js/__tests__/admin_lineup.test.jsx
@@ -36,118 +36,102 @@ describe('canRevise', () => {
     expect(canRevise({ id: 'c1' }, 0)).toBe(false);
   });
 
-  describe('wire-format-drift guard (the recent hardening)', () => {
-    // Regression anchor: the heuristic previously returned true whenever
-    // no `Round N+2` match was running AND no `Round N+1` was running.
-    // For a pool-only competition (no `Round N` labels at all), both
-    // checks evaluated to false and the helper unconditionally returned
-    // true — allowing Revise even when we have no idea what round the
-    // server is on. The fix requires at least one `^Round \d+$` label
-    // before delegating to the round-specific checks.
+  describe('fail-closed when no bracket matches exist for the round', () => {
+    // canRevise now filters on phase==="bracket" && roundIndex===round.
+    // Any comp shape that produces no matching bracket matches returns false.
 
     it('returns false when compMatches returns an empty list', () => {
       window.compMatches = () => [];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
-    it('returns false when no match has a `Round N` label (pool-only shape)', () => {
+    it('returns false for pool-only comp (no phase=bracket matches)', () => {
       window.compMatches = () => [
-        { id: 'm1', round: 'Pool A', status: 'completed' },
-        { id: 'm2', round: 'Pool A', status: 'completed' },
-        { id: 'm3', round: 'Pool B', status: 'scheduled' },
+        { id: 'm1', phase: 'pool', round: 'Pool A', status: 'completed' },
+        { id: 'm2', phase: 'pool', round: 'Pool A', status: 'completed' },
+        { id: 'm3', phase: 'pool', round: 'Pool B', status: 'scheduled' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
-    it('returns false when round labels exist but are not the `Round N` shape', () => {
-      // Custom labels (e.g. "Final", "Semifinals") that don't match the
-      // strict regex must also fail-closed — the round-specific checks
-      // would never match these strings anyway.
+    it('returns false when bracket matches exist but not for the requested roundIndex', () => {
+      // round=0 but all bracket matches have roundIndex=1 → currentMatches empty.
       window.compMatches = () => [
-        { id: 'm1', round: 'Finals', status: 'completed' },
-        { id: 'm2', round: 'Semifinals', status: 'completed' },
+        { id: 'm1', phase: 'bracket', roundIndex: 1, status: 'completed' },
+        { id: 'm2', phase: 'bracket', roundIndex: 1, status: 'completed' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
-    it('returns false when round field is non-string (e.g. numeric)', () => {
-      // If the wire format ever switches to a numeric round, the regex
-      // won't match — must still fail-closed.
+    it('returns false when matches have no roundIndex (old shape without the field)', () => {
+      // roundIndex undefined !== 0 (strict), so currentMatches is empty → false.
       window.compMatches = () => [
-        { id: 'm1', round: 1, status: 'completed' },
-        { id: 'm2', round: 2, status: 'scheduled' },
-      ];
-      expect(canRevise({ id: 'c1' }, 0)).toBe(false);
-    });
-
-    it('returns false when round is "Round 1.5" or "round 1" (case/format drift)', () => {
-      // The regex is /^Round \d+$/ — strict. Lowercase, decimals, or
-      // trailing text should all fail-closed.
-      window.compMatches = () => [
-        { id: 'm1', round: 'round 1', status: 'completed' },
-        { id: 'm2', round: 'Round 1.5', status: 'completed' },
-        { id: 'm3', round: 'Round 1 (Quarterfinal)', status: 'completed' },
+        { id: 'm1', phase: 'bracket', round: 'Finals', status: 'completed' },
+        { id: 'm2', phase: 'bracket', round: 'Semifinals', status: 'completed' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
   });
 
-  describe('round-specific gating (after wire-format guard passes)', () => {
+  describe('round-specific gating (uses m.roundIndex + m.phase)', () => {
     it('returns false when a current-round match is still running', () => {
-      // round=0 (display "Round 1"); a current-round match is in
-      // "Round 1" (round + 1 == 1). Running → block revise.
+      // round=0; a bracket match with roundIndex=0 is running → block.
       window.compMatches = () => [
-        { id: 'm1', round: 'Round 1', status: 'running' },
-        { id: 'm2', round: 'Round 1', status: 'completed' },
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'running' },
+        { id: 'm2', phase: 'bracket', roundIndex: 0, status: 'completed' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
     it('returns false when a next-round match has already started (running)', () => {
-      // round=0; next round is "Round 2" (round + 2 == 2). Running
-      // there means the operator can't revise — the round we'd be
-      // revising the lineup for is already in flight.
+      // round=0; roundIndex=1 (next) is running → revise blocked.
       window.compMatches = () => [
-        { id: 'm1', round: 'Round 1', status: 'completed' },
-        { id: 'm2', round: 'Round 2', status: 'running' },
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'completed' },
+        { id: 'm2', phase: 'bracket', roundIndex: 1, status: 'running' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
     it('returns false when a next-round match has already started (completed)', () => {
-      // Symmetric with the "running" case — once a Round 2 match has
-      // finished, Round 1's lineup is fully consumed.
+      // Symmetric: once roundIndex=1 is finished, roundIndex=0 lineup is consumed.
       window.compMatches = () => [
-        { id: 'm1', round: 'Round 1', status: 'completed' },
-        { id: 'm2', round: 'Round 2', status: 'completed' },
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'completed' },
+        { id: 'm2', phase: 'bracket', roundIndex: 1, status: 'completed' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
     it('returns true on the happy path (current round done, next round not yet started)', () => {
       window.compMatches = () => [
-        { id: 'm1', round: 'Round 1', status: 'completed' },
-        { id: 'm2', round: 'Round 1', status: 'completed' },
-        { id: 'm3', round: 'Round 2', status: 'scheduled' },
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'completed' },
+        { id: 'm2', phase: 'bracket', roundIndex: 0, status: 'completed' },
+        { id: 'm3', phase: 'bracket', roundIndex: 1, status: 'scheduled' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(true);
     });
 
-    it('returns true when no Round 2 match exists yet (final-round lineup correction)', () => {
+    it('returns true when no next-round match exists yet (final-round lineup correction)', () => {
       window.compMatches = () => [
-        { id: 'm1', round: 'Round 1', status: 'completed' },
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'completed' },
       ];
       expect(canRevise({ id: 'c1' }, 0)).toBe(true);
     });
 
-    it('handles round offset correctly: round=1 looks at Round 2/3', () => {
-      // round=1 (display "Round 2"); current round is Round 2,
-      // next round is Round 3. A running Round 2 match blocks revise.
+    it('handles round offset correctly: round=1 gates on roundIndex=1', () => {
+      // round=1; a bracket match with roundIndex=1 is running → block.
       window.compMatches = () => [
-        { id: 'm1', round: 'Round 1', status: 'completed' },
-        { id: 'm2', round: 'Round 2', status: 'running' },
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'completed' },
+        { id: 'm2', phase: 'bracket', roundIndex: 1, status: 'running' },
       ];
       expect(canRevise({ id: 'c1' }, 1)).toBe(false);
+    });
+
+    it('returns false when no bracket matches exist for the requested round', () => {
+      // Pool-only comp: no phase=bracket matches → currentMatches empty → false.
+      window.compMatches = () => [
+        { id: 'm1', phase: 'pool', round: 'Pool A', status: 'completed' },
+      ];
+      expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
   });
 });

--- a/web-mobile/js/__tests__/admin_lineup.test.jsx
+++ b/web-mobile/js/__tests__/admin_lineup.test.jsx
@@ -101,6 +101,15 @@ describe('canRevise', () => {
       expect(canRevise({ id: 'c1' }, 0)).toBe(false);
     });
 
+    it('returns false when current-round matches are scheduled but not yet played', () => {
+      // All roundIndex=0 matches still scheduled — round not complete → block.
+      window.compMatches = () => [
+        { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'scheduled' },
+        { id: 'm2', phase: 'bracket', roundIndex: 0, status: 'scheduled' },
+      ];
+      expect(canRevise({ id: 'c1' }, 0)).toBe(false);
+    });
+
     it('returns true on the happy path (current round done, next round not yet started)', () => {
       window.compMatches = () => [
         { id: 'm1', phase: 'bracket', roundIndex: 0, status: 'completed' },

--- a/web-mobile/js/__tests__/bracket_display_model.test.jsx
+++ b/web-mobile/js/__tests__/bracket_display_model.test.jsx
@@ -1,21 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { buildDisplayModel, computeMetaTops, roundLabel } from '../bracket.jsx';
 
-// mp-13y: roundLabel renders "Round N" where N is the round's bracket size
-// (2^(fromEnd+1)), generically — so large brackets read "Round 128"/"Round 256"
-// rather than falling back to "Round 1". total = number of rounds (log2 size);
+// mp-13y: roundLabel renders abbreviated "R{N}" where N is the bracket size
+// (2^(fromEnd+1)) for generic early rounds. total = number of rounds (log2 size);
 // roundIdx is 0-based from the first round, so fromEnd = total-1-roundIdx.
-describe('roundLabel — generic "Round N" for early rounds', () => {
-  it('names the terminal rounds and Round 16', () => {
+describe('roundLabel — abbreviated R{N} for early rounds', () => {
+  it('names the terminal rounds and R16', () => {
     expect(roundLabel(3, 4)).toBe('Final');         // fromEnd 0
     expect(roundLabel(2, 4)).toBe('Semifinals');    // fromEnd 1
     expect(roundLabel(1, 4)).toBe('Quarterfinals'); // fromEnd 2
-    expect(roundLabel(0, 4)).toBe('Round 16');      // fromEnd 3 → 2^4
+    expect(roundLabel(0, 4)).toBe('R16');           // fromEnd 3 → 2^4
   });
-  it('computes Round N for 64/128/256-player brackets', () => {
-    expect(roundLabel(0, 6)).toBe('Round 64');   // fromEnd 5 → 2^6
-    expect(roundLabel(0, 7)).toBe('Round 128');  // fromEnd 6 → 2^7
-    expect(roundLabel(0, 8)).toBe('Round 256');  // fromEnd 7 → 2^8
+  it('computes R{N} for 64/128/256-player brackets', () => {
+    expect(roundLabel(0, 6)).toBe('R64');   // fromEnd 5 → 2^6
+    expect(roundLabel(0, 7)).toBe('R128');  // fromEnd 6 → 2^7
+    expect(roundLabel(0, 8)).toBe('R256');  // fromEnd 7 → 2^8
   });
 });
 
@@ -50,22 +49,23 @@ describe('buildDisplayModel', () => {
     const model = buildDisplayModel(fivePlayerRounds());
     expect(model.hasMeta).toBe(true);
     // Columns ordered first round → final: [QF, SF, Final].
-    expect(model.columns.map((c) => c.length)).toEqual([1, 2, 1]);
+    expect(model.columns.map((c) => c.filter((m) => !m.isByeSlot).length)).toEqual([1, 2, 1]);
     const ids = (col) => col.map((m) => m.id).sort();
-    expect(ids(model.columns[0])).toEqual(['m-r1-3']); // QF: Dave/Eve
+    expect(ids(model.columns[0].filter((m) => !m.isByeSlot))).toEqual(['m-r1-3']); // QF: Dave/Eve
     expect(ids(model.columns[1])).toEqual(['m-r1-0', 'm-r2-1']); // SF: Alice/Bob + Carol
     expect(ids(model.columns[2])).toEqual(['m-r3-0']); // Final
     // No hidden/phantom match leaks into any column.
     const all = model.columns.flat();
     expect(all.some((m) => m.hidden)).toBe(false);
-    expect(all).toHaveLength(4); // N-1 real matches
+    expect(all.filter((m) => !m.isByeSlot)).toHaveLength(4); // N-1 real matches
   });
 
   it('exposes a feeder graph keyed by match id (byes carry no feeder)', () => {
     const model = buildDisplayModel(fivePlayerRounds());
     expect(model.feedersById['m-r3-0']).toEqual(['m-r1-0', 'm-r2-1']); // final ← Alice/Bob, Carol SF
-    expect(model.feedersById['m-r2-1']).toEqual(['m-r1-3']); // Carol SF ← Dave/Eve (Carol side is a bye)
-    expect(model.feedersById['m-r1-0']).toEqual([]); // Alice/Bob seeded in
+    expect(model.feedersById['m-r2-1']).toEqual(['bye-m-r2-1-0', 'm-r1-3']); // Carol SF ← bye slot + Dave/Eve
+    expect(model.feedersById['m-r1-0']).toEqual(['bye-m-r1-0-0', 'bye-m-r1-0-1']); // Alice/Bob seeded in — both sides are byes
+    expect(model.feedersById['bye-m-r1-0-0']).toEqual([]); // bye slot is a leaf
     expect(model.feedersById['m-r1-3']).toEqual([]); // Dave/Eve seeded in
   });
 
@@ -97,11 +97,12 @@ describe('computeMetaTops', () => {
     const model = buildDisplayModel(fivePlayerRounds());
     const heights = { 'm-r1-0': 100, 'm-r1-3': 100, 'm-r2-1': 100, 'm-r3-0': 100 };
     const tops = computeMetaTops(model.columns, model.feedersById, heights);
-    const centre = (id) => tops[id] + heights[id] / 2;
+    // bye slots have no entry in heights; use the DEFAULT_H fallback (110).
+    const centre = (id) => tops[id] + (heights[id] ?? 110) / 2;
     // Alice/Bob (leaf) is stacked first, Dave/Eve second.
     expect(centre('m-r1-0')).toBeLessThan(centre('m-r1-3'));
-    // Carol's SF sits on its single feeder (Dave/Eve).
-    expect(centre('m-r2-1')).toBeCloseTo(centre('m-r1-3'), 5);
+    // Carol's SF is centred on its two feeders: bye-m-r2-1-0 (Carol side) + Dave/Eve.
+    expect(centre('m-r2-1')).toBeCloseTo((centre('bye-m-r2-1-0') + centre('m-r1-3')) / 2, 5);
     // Final is centred between Alice/Bob and Carol's SF.
     expect(centre('m-r3-0')).toBeCloseTo((centre('m-r1-0') + centre('m-r2-1')) / 2, 5);
   });

--- a/web-mobile/js/__tests__/bracket_display_model.test.jsx
+++ b/web-mobile/js/__tests__/bracket_display_model.test.jsx
@@ -69,6 +69,16 @@ describe('buildDisplayModel', () => {
     expect(model.feedersById['m-r1-3']).toEqual([]); // Dave/Eve seeded in
   });
 
+  it('assigns sequential match numbers left-to-right, top-to-bottom (matchNumById)', () => {
+    const model = buildDisplayModel(fivePlayerRounds());
+    // Column order: QF (col 0) → SF (col 1) → Final (col 2)
+    // Within each column top card first, so: m-r1-3 (QF) → m-r1-0, m-r2-1 (SF) → m-r3-0 (Final)
+    expect(model.matchNumById['m-r1-3']).toBe(1); // QF: Dave/Eve
+    expect(model.matchNumById['m-r1-0']).toBe(2); // SF: Alice/Bob
+    expect(model.matchNumById['m-r2-1']).toBe(3); // SF: Carol
+    expect(model.matchNumById['m-r3-0']).toBe(4); // Final
+  });
+
   it('falls back to balanced rounds unchanged when no metadata', () => {
     // 4-player balanced bracket with no displayRound/hidden fields. The legacy
     // renderer draws connectors positionally inside BracketConnectors (from

--- a/web-mobile/js/admin_helpers.jsx
+++ b/web-mobile/js/admin_helpers.jsx
@@ -320,16 +320,12 @@ function courtCount(courts) {
 }
 
 // Resolves the 0-based round index from a match object. Bracket matches
-// carry m.roundIndex (stamped by compMatches/viewer.jsx); fall back through
-// numeric m.round, then the legacy "Round N" string for any stale shapes.
+// carry m.roundIndex (stamped by compMatches/viewer.jsx); fall back to a
+// non-negative numeric m.round for any older shapes.
 // Returns 0 for pool matches (no per-round lineup).
 function resolveRoundIndex(match) {
   if (typeof match.roundIndex === "number" && match.roundIndex >= 0) return match.roundIndex;
-  if (typeof match.round === "number") return match.round;
-  if (typeof match.round === "string") {
-    const mr = /^Round\s+(\d+)$/.exec(match.round);
-    if (mr) return parseInt(mr[1], 10) - 1;
-  }
+  if (typeof match.round === "number" && match.round >= 0) return match.round;
   return 0;
 }
 

--- a/web-mobile/js/admin_helpers.jsx
+++ b/web-mobile/js/admin_helpers.jsx
@@ -319,9 +319,24 @@ function courtCount(courts) {
   return normalizeCourts(courts).length;
 }
 
+// Resolves the 0-based round index from a match object. Bracket matches
+// carry m.roundIndex (stamped by compMatches/viewer.jsx); fall back through
+// numeric m.round, then the legacy "Round N" string for any stale shapes.
+// Returns 0 for pool matches (no per-round lineup).
+function resolveRoundIndex(match) {
+  if (typeof match.roundIndex === "number" && match.roundIndex >= 0) return match.roundIndex;
+  if (typeof match.round === "number") return match.round;
+  if (typeof match.round === "string") {
+    const mr = /^Round\s+(\d+)$/.exec(match.round);
+    if (mr) return parseInt(mr[1], 10) - 1;
+  }
+  return 0;
+}
+
 // Guard window assignments so this file stays safely importable in
 // non-browser test environments (matches the pattern in data.jsx / ui.jsx).
 if (typeof window !== "undefined") {
+  window.resolveRoundIndex = resolveRoundIndex;
   window.sideName = sideName;
   window.hasBothSides = hasBothSides;
   window.hasPoolOriginPlaceholder = hasPoolOriginPlaceholder;
@@ -440,4 +455,5 @@ export {
   deriveTournamentDays,
   normalizeCourts,
   courtCount,
+  resolveRoundIndex,
 };

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -81,7 +81,7 @@ function canRevise(competition, round) {
   if (!currentMatches.length) return false;
   const inProgressNext = nextMatches.some(m => m.status === "running" || m.status === "completed");
   if (inProgressNext) return false;
-  return !currentMatches.some(m => m.status === "running");
+  return currentMatches.every(m => m.status === "completed");
 }
 
 function AdminLineup({ comp, team, round, password, showToast, onClose }) {

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -71,33 +71,17 @@ function teamIdOf(team) {
 }
 
 // "Revise" is enabled when the current round's matches are all completed
-// AND the next round hasn't started yet. We use the in-memory competition
-// detail (pools + bracket) to evaluate that — when the shape isn't a
-// clean fit we fall back to "current round completed" and surface a
-// TODO for cleaner round-aware gating.
+// AND the next round hasn't started yet. Uses m.roundIndex (0-based
+// backend index stamped by compMatches) for precise round filtering.
 function canRevise(competition, round) {
   if (!competition || !window.compMatches) return false;
   const all = window.compMatches(competition);
-  // Heuristic: rounds in this codebase are usually "round" (bracket) or
-  // "poolName"-shaped strings on pool matches. Without a robust per-
-  // round filter, gate Revise on:
-  //   1) at least one match exists for the team's competition, AND
-  //   2) every running/scheduled match in round+1 hasn't started yet.
-  // TODO(T130): once the wire shape exposes a numeric round on every
-  // match, switch to a strict (round === r && completed) test.
-  const currentLabel = `Round ${round + 1}`;
-  const nextLabel = `Round ${round + 2}`;
-  // Fail closed if NO match in the comp uses the "Round N" label we
-  // expect — that means the wire format has drifted and the heuristic
-  // below is unreliable. Erring toward "cannot revise" is safer than
-  // surfacing a Revise button mid-round.
-  const recognisable = all.some(m => typeof m.round === "string" && /^Round \d+$/.test(m.round));
-  if (!recognisable) return false;
-  const inProgressNext = all.some(m => (m.status === "running" || m.status === "completed") && m.round === nextLabel);
+  const currentMatches = all.filter(m => m.phase === "bracket" && m.roundIndex === round);
+  const nextMatches = all.filter(m => m.phase === "bracket" && m.roundIndex === round + 1);
+  if (!currentMatches.length) return false;
+  const inProgressNext = nextMatches.some(m => m.status === "running" || m.status === "completed");
   if (inProgressNext) return false;
-  // Otherwise allow revise as long as no current-round match is still running
-  const currentRunning = all.some(m => m.status === "running" && m.round === currentLabel);
-  return !currentRunning;
+  return !currentMatches.some(m => m.status === "running");
 }
 
 function AdminLineup({ comp, team, round, password, showToast, onClose }) {

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -749,15 +749,7 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
         } else {
           // No per-match entry — reflect the round default (fetch-and-show,
           // but do NOT set isMatchOverride so the label says "inheriting").
-          let round = 0;
-          if (typeof match.roundIndex === "number" && match.roundIndex >= 0) {
-            round = match.roundIndex;
-          } else if (typeof match.round === "number") {
-            round = match.round;
-          } else if (typeof match.round === "string") {
-            const mr = /^Round\s+(\d+)$/.exec(match.round);
-            if (mr) round = parseInt(mr[1], 10) - 1;
-          }
+          const round = window.resolveRoundIndex(match);
           try {
             const roundLineup = await window.API.fetchTeamLineup(compId, teamId, round);
             if (cancelled) return;

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -750,11 +750,13 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
           // No per-match entry — reflect the round default (fetch-and-show,
           // but do NOT set isMatchOverride so the label says "inheriting").
           let round = 0;
-          if (typeof match.round === "string") {
-            const mr = /^Round\s+(\d+)$/.exec(match.round);
-            if (mr) round = parseInt(mr[1], 10) - 1;
+          if (typeof match.roundIndex === "number" && match.roundIndex >= 0) {
+            round = match.roundIndex;
           } else if (typeof match.round === "number") {
             round = match.round;
+          } else if (typeof match.round === "string") {
+            const mr = /^Round\s+(\d+)$/.exec(match.round);
+            if (mr) round = parseInt(mr[1], 10) - 1;
           }
           try {
             const roundLineup = await window.API.fetchTeamLineup(compId, teamId, round);

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -1330,18 +1330,9 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
     if (!m.compId) return;
     // compMatches injects m.roundIndex (0-based) for bracket matches, and
     // m.round as a string label for display ("R16", "Quarterfinals", ...).
-    // Prefer roundIndex when present; fall back through the numeric/string
-    // forms for legacy shapes. Pool matches don't have a per-round lineup,
-    // so round stays 0 in that case.
-    let round = 0;
-    if (typeof m.roundIndex === "number" && m.roundIndex >= 0) {
-      round = m.roundIndex;
-    } else if (typeof m.round === "number") {
-      round = m.round;
-    } else if (typeof m.round === "string") {
-      const mr = /^Round\s+(\d+)$/.exec(m.round);
-      if (mr) round = parseInt(mr[1], 10) - 1;
-    }
+    // resolveRoundIndex prefers roundIndex, falls back for legacy shapes.
+    // Pool matches return 0 (no per-round lineup).
+    const round = window.resolveRoundIndex(m);
     // Side keys are NAME-keyed (api_serializers.buildPlayerMap sets id =
     // name); lineups are stored under the participant's real id (UUID).
     const sideAKey = m.sideA?.id || m.sideA?.name || (typeof m.sideA === "string" ? m.sideA : "");

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -1328,18 +1328,19 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
   useEffectA(() => {
     let cancelled = false;
     if (!m.compId) return;
-    // compMatches injects m.round as a string label ("Round 2",
-    // "Quarterfinals", ...) — for bracket matches we extract the numeric
-    // index from "Round N" when possible. Pool matches don't have a
-    // per-round lineup in the current model, so we fall back to round 0.
-    // TODO(T131): plumb a numeric round through compMatches so this
-    // lookup is exact for every phase / label.
+    // compMatches injects m.roundIndex (0-based) for bracket matches, and
+    // m.round as a string label for display ("R16", "Quarterfinals", ...).
+    // Prefer roundIndex when present; fall back through the numeric/string
+    // forms for legacy shapes. Pool matches don't have a per-round lineup,
+    // so round stays 0 in that case.
     let round = 0;
-    if (typeof m.round === "string") {
-      const mr = /^Round\s+(\d+)$/.exec(m.round);
-      if (mr) round = parseInt(mr[1], 10) - 1;
+    if (typeof m.roundIndex === "number" && m.roundIndex >= 0) {
+      round = m.roundIndex;
     } else if (typeof m.round === "number") {
       round = m.round;
+    } else if (typeof m.round === "string") {
+      const mr = /^Round\s+(\d+)$/.exec(m.round);
+      if (mr) round = parseInt(mr[1], 10) - 1;
     }
     // Side keys are NAME-keyed (api_serializers.buildPlayerMap sets id =
     // name); lineups are stored under the participant's real id (UUID).

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -584,33 +584,31 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
               const wrapStyle = top != null
                 ? { "--mi": mi, position: "absolute", top: `${top}px`, left: 0, right: 0 }
                 : { "--mi": mi };
-              if (m.isByeSlot) {
-                return (
-                  <div className="bc-match-wrap" key={m.id} style={wrapStyle}>
-                    <div
-                      className="bc-bye-slot"
-                      aria-label={`${m.playerName || "Bye"} — advances without an opponent`}
-                      ref={(el) => { if (el) refMap.current[m.id] = el; }}
-                    >
-                      {m.playerName
-                        ? <span className="bc-bye-slot__name">{m.playerName}</span>
-                        : <span className="bc-bye-slot__tag">BYE</span>}
-                    </div>
-                  </div>
-                );
-              }
+              const inner = m.isByeSlot ? (
+                <div
+                  className="bc-bye-slot"
+                  aria-label={`${m.playerName || "Bye"} — advances without an opponent`}
+                  ref={(el) => { if (el) refMap.current[m.id] = el; }}
+                >
+                  {m.playerName
+                    ? <span className="bc-bye-slot__name">{m.playerName}</span>
+                    : <span className="bc-bye-slot__tag">BYE</span>}
+                </div>
+              ) : (
+                <MatchCard
+                  match={m}
+                  variant={variant}
+                  showDojo={showDojo}
+                  highlighted={m.id === highlightedMatchId}
+                  matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
+                  onClick={() => onMatchClick && onMatchClick(m, ci, mi, columns.length)}
+                  highlightPlayers={highlightPlayers}
+                  matchNum={matchNumById[m.id]}
+                />
+              );
               return (
                 <div className="bc-match-wrap" key={m.id} style={wrapStyle}>
-                  <MatchCard
-                    match={m}
-                    variant={variant}
-                    showDojo={showDojo}
-                    highlighted={m.id === highlightedMatchId}
-                    matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
-                    onClick={() => onMatchClick && onMatchClick(m, ci, mi)}
-                    highlightPlayers={highlightPlayers}
-                    matchNum={matchNumById[m.id]}
-                  />
+                  {inner}
                 </div>
               );
             })}
@@ -741,7 +739,7 @@ function BracketTreeLegacy({ rounds, variant = 1, showDojo = true, onMatchClick,
                     showDojo={showDojo}
                     highlighted={m.id === highlightedMatchId}
                     matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
-                    onClick={() => onMatchClick && onMatchClick(m, ri, mi)}
+                    onClick={() => onMatchClick && onMatchClick(m, ri, mi, rounds.length)}
                     highlightPlayers={highlightPlayers}
                   />
                 </div>

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -182,7 +182,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
 });
 PlayerLine.displayName = "PlayerLine";
 
-const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder, highlightPlayers, matchNum }) => {
+const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, highlightPlayers, matchNum }) => {
   const aWin = match.winner && match.sideA && match.winner.id === match.sideA.id;
   const bWin = match.winner && match.sideB && match.winner.id === match.sideB.id;
   const running = match.status === "running";
@@ -194,8 +194,8 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
   const aScore = isDone ? (ipponsA.join("") || null) : null;
   const bScore = isDone ? (ipponsB.join("") || null) : null;
 
-  const aTBD = isPlaceholder || (match.sideA && typeof match.sideA.id === "string" && match.sideA.id.startsWith("tbd-"));
-  const bTBD = isPlaceholder || (match.sideB && typeof match.sideB.id === "string" && match.sideB.id.startsWith("tbd-"));
+  const aTBD = match.sideA && typeof match.sideA.id === "string" && match.sideA.id.startsWith("tbd-");
+  const bTBD = match.sideB && typeof match.sideB.id === "string" && match.sideB.id.startsWith("tbd-");
 
   // mp-xhaa: highlight any watched player (Set of ids+names). Lazy window
   // lookup mirrors the prior pattern so bracket.jsx stays decoupled from

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -375,7 +375,7 @@ function buildDisplayModel(rounds) {
     });
     // Match numbers: earliest round first (highest displayRound), then by position
     // extracted from the id suffix — mirrors the Excel FillInMatches order so
-    // card labels ("M 1", "M 2") match what referees see on the printed sheet.
+    // card labels ("M1", "M2") match what referees see on the printed sheet.
     // id format: "m-r{ROUND}-{POS}" — last segment is the 0-based within-round index.
     const posFromId = (id) => { const p = id.split("-"); return parseInt(p[p.length - 1], 10) || 0; };
     const numbered = [...real].sort((a, b) => {

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -210,7 +210,7 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
       data-match-id={match.id}
       className={`bc-match bc-match--v${variant} ${running ? "bc-match--running" : ""} ${match.status === "completed" ? "bc-match--done" : ""} ${highlighted ? "bc-match--highlight" : ""} ${playerHighlight ? "bc-match--my-match" : ""}`}
       onClick={onClick}
-      aria-label={matchNum != null ? `Match M${matchNum}` : `Match ${match.id}`}
+      aria-label={matchNum != null ? `Match ${matchNum}` : `Match ${match.id}`}
     >
       <div className="bc-match-meta">
         {matchNum != null ? <span className="bc-match-num">M{matchNum}</span> : null}
@@ -354,24 +354,22 @@ function buildDisplayModel(rounds) {
     // players; those don't need placeholders.
     const feedersById = {};
     real.forEach((m) => {
-      if (m.displayRound >= maxDR) return;
+      const hasUpstream = m.displayRound < maxDR;
+      const resolvedFeeders = [];
       (m.feeders || []).forEach((feederId, idx) => {
-        if (feederId === "") {
+        if (feederId === "" && hasUpstream) {
           const playerObj = idx === 0 ? m.sideA : m.sideB;
           const playerName = typeof playerObj === "object" ? (playerObj?.name || "") : (playerObj || "");
           const slot = { id: `bye-${m.id}-${idx}`, isByeSlot: true, displayRound: m.displayRound + 1, playerName };
           feedersById[slot.id] = [];
           const colIdx = maxDR - slot.displayRound;
           if (colIdx >= 0 && colIdx < columns.length) columns[colIdx].push(slot);
+          resolvedFeeders.push(slot.id);
+        } else if (feederId !== "") {
+          resolvedFeeders.push(feederId);
         }
       });
-    });
-    real.forEach((m) => {
-      const hasUpstream = m.displayRound < maxDR;
-      feedersById[m.id] = (m.feeders || []).map((feederId, idx) => {
-        if (feederId === "" && hasUpstream) return `bye-${m.id}-${idx}`;
-        return feederId;
-      }).filter(Boolean);
+      feedersById[m.id] = resolvedFeeders;
     });
     // Match numbers: earliest round first (highest displayRound), then by position
     // extracted from the id suffix — mirrors the Excel FillInMatches order so

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -376,6 +376,7 @@ function buildDisplayModel(rounds) {
     // Match numbers: earliest round first (highest displayRound), then by position
     // extracted from the id suffix — mirrors the Excel FillInMatches order so
     // card labels ("M 1", "M 2") match what referees see on the printed sheet.
+    // id format: "m-r{ROUND}-{POS}" — last segment is the 0-based within-round index.
     const posFromId = (id) => { const p = id.split("-"); return parseInt(p[p.length - 1], 10) || 0; };
     const numbered = [...real].sort((a, b) => {
       const dr = b.displayRound - a.displayRound;

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -594,8 +594,9 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
                       aria-label={`${m.playerName || "Bye"} — advances without an opponent`}
                       ref={(el) => { if (el) refMap.current[m.id] = el; }}
                     >
-                      <span className="bc-bye-slot__name">{m.playerName}</span>
-                      {m.playerName ? null : <span className="bc-bye-slot__tag">BYE</span>}
+                      {m.playerName
+                        ? <span className="bc-bye-slot__name">{m.playerName}</span>
+                        : <span className="bc-bye-slot__tag">BYE</span>}
                     </div>
                   </div>
                 );

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -26,7 +26,7 @@ function roundLabel(roundIdx, total) {
   // mp-13y #8: "Round N" (drop the "of"), where N is the round's bracket size
   // = 2^(fromEnd+1). Computed generically so 128/256-player brackets read
   // "Round 128" / "Round 256" instead of falling back to "Round 1".
-  if (fromEnd >= 3) return `Round ${2 ** (fromEnd + 1)}`;
+  if (fromEnd >= 3) return `R${2 ** (fromEnd + 1)}`;
   return `Round ${roundIdx + 1}`;
 }
 
@@ -164,7 +164,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
   return (
     <div className={`bc-side bc-side--${side} ${isWinner ? "bc-side--winner" : ""}`}>
       <span className={`bc-color-badge bc-color-badge--${isAka ? "aka" : "shiro"}`}>{isAka ? "AKA" : "SHIRO"}</span>
-      {player.seed ? <span className="bc-seed">{player.seed}</span> : <span className="bc-seed bc-seed--empty"></span>}
+
       <div className="bc-name-wrap">
         <span className="bc-name">
           {isWinner ? <span className="bc-winner-tick" aria-label="Winner" title="Winner">✓</span> : null}
@@ -184,7 +184,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD 
 });
 PlayerLine.displayName = "PlayerLine";
 
-const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder, highlightPlayers }) => {
+const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, isPlaceholder, highlightPlayers, matchNum }) => {
   const aWin = match.winner && match.sideA && match.winner.id === match.sideA.id;
   const bWin = match.winner && match.sideB && match.winner.id === match.sideB.id;
   const running = match.status === "running";
@@ -215,6 +215,7 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
       aria-label={`Match ${match.id}`}
     >
       <div className="bc-match-meta">
+        {matchNum != null ? <span className="bc-match-num">M{matchNum}</span> : null}
         <span className="bc-court"><TermBC name="shiaijo">Shiaijo</TermBC> {match.court}</span>
         {match.scheduledAt ? <span className="bc-time">{match.scheduledAt}</span> : null}
         {running ? <span className="bc-running">● NOW</span> : null}
@@ -347,9 +348,46 @@ function buildDisplayModel(rounds) {
     }));
     const columns = [];
     for (let dr = maxDR; dr >= 1; dr--) columns.push(real.filter((m) => m.displayRound === dr));
+    // Structural-bye slots: for non-leaf matches whose feeder[i] is "" (meaning
+    // one side had no upstream match and the player seeded directly), insert a
+    // visible placeholder card in the upstream column so the tree layout
+    // communicates the skip spatially — mirroring the Excel Tree sheet output.
+    // Leaf-round matches (displayRound === maxDR) always have "" feeders for real
+    // players; those don't need placeholders.
+    const byeSlots = [];
+    real.forEach((m) => {
+      if (m.displayRound >= maxDR) return;
+      (m.feeders || []).forEach((feederId, idx) => {
+        if (feederId === "") {
+          const playerObj = idx === 0 ? m.sideA : m.sideB;
+          const playerName = typeof playerObj === "object" ? (playerObj?.name || "") : (playerObj || "");
+          const slot = { id: `bye-${m.id}-${idx}`, isByeSlot: true, displayRound: m.displayRound + 1, playerName };
+          byeSlots.push(slot);
+          const colIdx = maxDR - slot.displayRound;
+          if (colIdx >= 0 && colIdx < columns.length) columns[colIdx].push(slot);
+        }
+      });
+    });
     const feedersById = {};
-    real.forEach((m) => { feedersById[m.id] = (m.feeders || []).filter(Boolean); });
-    return { hasMeta: true, columns, feedersById };
+    real.forEach((m) => {
+      const hasUpstream = m.displayRound < maxDR;
+      feedersById[m.id] = (m.feeders || []).map((feederId, idx) => {
+        if (feederId === "" && hasUpstream) return `bye-${m.id}-${idx}`;
+        return feederId;
+      }).filter(Boolean);
+    });
+    byeSlots.forEach((slot) => { feedersById[slot.id] = []; });
+    // Match numbers: earliest round first (highest displayRound), then by position
+    // extracted from the id suffix — mirrors the Excel FillInMatches order so
+    // card labels ("M 1", "M 2") match what referees see on the printed sheet.
+    const posFromId = (id) => { const p = id.split("-"); return parseInt(p[p.length - 1], 10) || 0; };
+    const numbered = [...real].sort((a, b) => {
+      const dr = b.displayRound - a.displayRound;
+      return dr !== 0 ? dr : posFromId(a.id) - posFromId(b.id);
+    });
+    const matchNumById = {};
+    numbered.forEach((m, i) => { matchNumById[m.id] = i + 1; });
+    return { hasMeta: true, columns, feedersById, matchNumById };
   }
   // Legacy: columns = rounds. Connectors are positional (BracketConnectors
   // derives the 2i/2i+1 feeders from `rounds` itself), so no feeder graph is
@@ -467,7 +505,7 @@ function BracketConnectorsMeta({ columns, feedersById, treeRef, refMap, version,
 // real match; structural byes are absent. Cards in column 0 plus every card is
 // absolutely positioned at the feeder-graph-derived top so parents sit centred
 // on their feeders (see computeMetaTops).
-function BracketTreeMeta({ columns, feedersById, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers }) {
+function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers }) {
   const treeRef = useRef(null);
   const refMap = useRef({});
   const [version, setVersion] = useStateBC(0);
@@ -549,6 +587,20 @@ function BracketTreeMeta({ columns, feedersById, variant = 1, showDojo = true, o
               const wrapStyle = top != null
                 ? { "--mi": mi, position: "absolute", top: `${top}px`, left: 0, right: 0 }
                 : { "--mi": mi };
+              if (m.isByeSlot) {
+                return (
+                  <div className="bc-match-wrap" key={m.id} style={wrapStyle}>
+                    <div
+                      className="bc-bye-slot"
+                      aria-label={`${m.playerName || "Bye"} — advances without an opponent`}
+                      ref={(el) => { if (el) refMap.current[m.id] = el; }}
+                    >
+                      <span className="bc-bye-slot__name">{m.playerName || "BYE"}</span>
+                      {m.playerName ? null : <span className="bc-bye-slot__tag">BYE</span>}
+                    </div>
+                  </div>
+                );
+              }
               return (
                 <div className="bc-match-wrap" key={m.id} style={wrapStyle}>
                   <MatchCard
@@ -559,6 +611,7 @@ function BracketTreeMeta({ columns, feedersById, variant = 1, showDojo = true, o
                     matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
                     onClick={() => onMatchClick && onMatchClick(m, ci, mi)}
                     highlightPlayers={highlightPlayers}
+                    matchNum={matchNumById ? matchNumById[m.id] : undefined}
                   />
                 </div>
               );
@@ -578,7 +631,7 @@ function BracketTree(props) {
   // the measured layout in a loop.
   const model = React.useMemo(() => buildDisplayModel(props.rounds), [props.rounds]);
   if (model.hasMeta) {
-    return <BracketTreeMeta {...props} columns={model.columns} feedersById={model.feedersById} />;
+    return <BracketTreeMeta {...props} columns={model.columns} feedersById={model.feedersById} matchNumById={model.matchNumById} />;
   }
   return <BracketTreeLegacy {...props} />;
 }

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -210,7 +210,7 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
       data-match-id={match.id}
       className={`bc-match bc-match--v${variant} ${running ? "bc-match--running" : ""} ${match.status === "completed" ? "bc-match--done" : ""} ${highlighted ? "bc-match--highlight" : ""} ${playerHighlight ? "bc-match--my-match" : ""}`}
       onClick={onClick}
-      aria-label={`Match ${match.id}`}
+      aria-label={matchNum != null ? `Match M${matchNum}` : `Match ${match.id}`}
     >
       <div className="bc-match-meta">
         {matchNum != null ? <span className="bc-match-num">M{matchNum}</span> : null}
@@ -448,8 +448,9 @@ function computeMetaTops(columns, feedersById, heights) {
 // BracketConnectorsMeta draws feeder→parent elbows for the effective-round
 // layout (mp-7f2w). Unlike the legacy BracketConnectors it pairs by the explicit
 // feeder graph, not binary (2i, 2i+1) positions, so uneven columns connect
-// correctly. A match with a single feeder (the other side is a bye/seeded
-// entrant) gets one elbow; the bye side draws no line.
+// correctly. Bye-slot placeholder cards (isByeSlot) appear in the feeder graph
+// and in refMap, so they DO receive connector lines from their parent match —
+// the elbow terminates at the bye card, mirroring the Excel Tree sheet.
 function BracketConnectorsMeta({ columns, feedersById, treeRef, refMap, version, showDojo, variant }) {
   const [paths, setPaths] = useStateBC([]);
   const [size, setSize] = useStateBC({ w: 0, h: 0 });
@@ -498,10 +499,11 @@ function BracketConnectorsMeta({ columns, feedersById, treeRef, refMap, version,
   );
 }
 
-// BracketTreeMeta renders the effective-round columns (mp-7f2w). Every card is a
-// real match; structural byes are absent. Cards in column 0 plus every card is
-// absolutely positioned at the feeder-graph-derived top so parents sit centred
-// on their feeders (see computeMetaTops).
+// BracketTreeMeta renders the effective-round columns (mp-7f2w). Real match cards
+// plus structural-bye placeholder cards (isByeSlot=true) are included; phantoms
+// (hidden) are dropped. All cards are absolutely positioned at the
+// feeder-graph-derived top so parents sit centred on their feeders
+// (see computeMetaTops).
 function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers }) {
   const treeRef = useRef(null);
   const refMap = useRef({});

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -341,8 +341,8 @@ function buildDisplayModel(rounds) {
   if (hasMeta) {
     let maxDR = 0;
     const real = [];
-    rounds.forEach((r) => r.forEach((m) => {
-      if (!m.hidden && (m.displayRound || 0) > 0) { real.push(m); if (m.displayRound > maxDR) maxDR = m.displayRound; }
+    rounds.forEach((r, backendRi) => r.forEach((m) => {
+      if (!m.hidden && (m.displayRound || 0) > 0) { real.push({ ...m, roundIndex: backendRi }); if (m.displayRound > maxDR) maxDR = m.displayRound; }
     }));
     const columns = [];
     for (let dr = maxDR; dr >= 1; dr--) columns.push(real.filter((m) => m.displayRound === dr));

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -23,9 +23,8 @@ function roundLabel(roundIdx, total) {
   if (fromEnd === 0) return "Final";
   if (fromEnd === 1) return "Semifinals";
   if (fromEnd === 2) return "Quarterfinals";
-  // mp-13y #8: "Round N" (drop the "of"), where N is the round's bracket size
-  // = 2^(fromEnd+1). Computed generically so 128/256-player brackets read
-  // "Round 128" / "Round 256" instead of falling back to "Round 1".
+  // mp-13y #8: abbreviated column header — R{N} where N is the bracket size
+  // = 2^(fromEnd+1). Keeps column labels tight for wide brackets (R32, R128).
   if (fromEnd >= 3) return `R${2 ** (fromEnd + 1)}`;
   return `Round ${roundIdx + 1}`;
 }

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -25,8 +25,7 @@ function roundLabel(roundIdx, total) {
   if (fromEnd === 2) return "Quarterfinals";
   // mp-13y #8: abbreviated column header — R{N} where N is the bracket size
   // = 2^(fromEnd+1). Keeps column labels tight for wide brackets (R32, R128).
-  if (fromEnd >= 3) return `R${2 ** (fromEnd + 1)}`;
-  return `Round ${roundIdx + 1}`;
+  return `R${2 ** (fromEnd + 1)}`;
 }
 
 const DECISION_CHIPS = {
@@ -353,7 +352,7 @@ function buildDisplayModel(rounds) {
     // communicates the skip spatially — mirroring the Excel Tree sheet output.
     // Leaf-round matches (displayRound === maxDR) always have "" feeders for real
     // players; those don't need placeholders.
-    const byeSlots = [];
+    const feedersById = {};
     real.forEach((m) => {
       if (m.displayRound >= maxDR) return;
       (m.feeders || []).forEach((feederId, idx) => {
@@ -361,13 +360,12 @@ function buildDisplayModel(rounds) {
           const playerObj = idx === 0 ? m.sideA : m.sideB;
           const playerName = typeof playerObj === "object" ? (playerObj?.name || "") : (playerObj || "");
           const slot = { id: `bye-${m.id}-${idx}`, isByeSlot: true, displayRound: m.displayRound + 1, playerName };
-          byeSlots.push(slot);
+          feedersById[slot.id] = [];
           const colIdx = maxDR - slot.displayRound;
           if (colIdx >= 0 && colIdx < columns.length) columns[colIdx].push(slot);
         }
       });
     });
-    const feedersById = {};
     real.forEach((m) => {
       const hasUpstream = m.displayRound < maxDR;
       feedersById[m.id] = (m.feeders || []).map((feederId, idx) => {
@@ -375,7 +373,6 @@ function buildDisplayModel(rounds) {
         return feederId;
       }).filter(Boolean);
     });
-    byeSlots.forEach((slot) => { feedersById[slot.id] = []; });
     // Match numbers: earliest round first (highest displayRound), then by position
     // extracted from the id suffix — mirrors the Excel FillInMatches order so
     // card labels ("M 1", "M 2") match what referees see on the printed sheet.
@@ -594,7 +591,7 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
                       aria-label={`${m.playerName || "Bye"} — advances without an opponent`}
                       ref={(el) => { if (el) refMap.current[m.id] = el; }}
                     >
-                      <span className="bc-bye-slot__name">{m.playerName || "BYE"}</span>
+                      <span className="bc-bye-slot__name">{m.playerName}</span>
                       {m.playerName ? null : <span className="bc-bye-slot__tag">BYE</span>}
                     </div>
                   </div>
@@ -610,7 +607,7 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
                     matchRef={(el) => { if (el) refMap.current[m.id] = el; }}
                     onClick={() => onMatchClick && onMatchClick(m, ci, mi)}
                     highlightPlayers={highlightPlayers}
-                    matchNum={matchNumById ? matchNumById[m.id] : undefined}
+                    matchNum={matchNumById[m.id]}
                   />
                 </div>
               );

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1719,6 +1719,9 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
     el.addEventListener("scroll", check, { passive: true });
     const ro = new ResizeObserver(check);
     ro.observe(el);
+    // Also observe the inner canvas so bracket content width changes (e.g.
+    // new bracket payload rendered into the same tab) trigger a recheck.
+    if (el.firstElementChild) ro.observe(el.firstElementChild);
     return () => { el.removeEventListener("scroll", check); ro.disconnect(); };
   }, [hasBracketEl]);
 

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1709,8 +1709,9 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
     }
   }, [tab, currentMatch?.id]);
 
+  const hasBracketEl = tab === "bracket" && !!derivedBracket;
   React.useEffect(() => {
-    if (tab !== "bracket") return;
+    if (!hasBracketEl) return;
     const el = bracketScrollRef.current;
     if (!el) return;
     const check = () => setBracketOverflowRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
@@ -1719,7 +1720,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
     const ro = new ResizeObserver(check);
     ro.observe(el);
     return () => { el.removeEventListener("scroll", check); ro.disconnect(); };
-  }, [tab]);
+  }, [hasBracketEl]);
 
   return (
     <div className="viewer">

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1714,7 +1714,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
     if (!hasBracketEl) return;
     const el = bracketScrollRef.current;
     if (!el) return;
-    const check = () => setBracketOverflowRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+    const check = () => { const next = el.scrollLeft + el.clientWidth < el.scrollWidth - 4; setBracketOverflowRight((cur) => (cur === next ? cur : next)); };
     check();
     el.addEventListener("scroll", check, { passive: true });
     const ro = new ResizeObserver(check);

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1822,10 +1822,11 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     highlightPlayers={highlightPlayers}
                     onMatchClick={(m, ri, _mi, total) => {
                       const label = window.roundLabel(ri, total ?? derivedBracket.rounds.length);
-                      // m.roundIndex is already the backend round array index
-                      // (stamped by compMatches); prefer it over the display-
-                      // column index (ri) so team lineup fetches use the right
-                      // round even when phantom leading rounds shift the indices.
+                      // m.roundIndex is the backend round array index, stamped by
+                      // buildDisplayModel (meta mode) or the raw rounds[ri] position
+                      // (legacy mode where ri equals the backend index). Prefer it
+                      // over the display-column index so lineup fetches use the right
+                      // round when phantom leading rounds shift the display column.
                       setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, roundIndex: m.roundIndex ?? ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize });
                     }}
                   />

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1701,12 +1701,25 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
   const [bracketScrollTarget, setBracketScrollTarget] = useState(null);
   const bracketScrollRef = useRefV(null);
   const [selectedMatch, setSelectedMatch] = useState(null);
+  const [bracketOverflowRight, setBracketOverflowRight] = useState(false);
 
   React.useEffect(() => {
     if (tab === "bracket" && currentMatch) {
       setBracketScrollTarget(currentMatch.id + "::" + Date.now());
     }
   }, [tab, currentMatch?.id]);
+
+  React.useEffect(() => {
+    if (tab !== "bracket") return;
+    const el = bracketScrollRef.current;
+    if (!el) return;
+    const check = () => setBracketOverflowRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+    check();
+    el.addEventListener("scroll", check, { passive: true });
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => { el.removeEventListener("scroll", check); ro.disconnect(); };
+  }, [tab]);
 
   return (
     <div className="viewer">
@@ -1792,7 +1805,7 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
             />
           )}
           {tab === "bracket" && derivedBracket && (
-            <div className="viewer-bracket-bleed">
+            <div className={`viewer-bracket-bleed${bracketOverflowRight ? " viewer-bracket-bleed--overflow-right" : ""}`}>
               <div ref={bracketScrollRef} className="bracket-canvas" style={{ borderRadius: 0, borderLeft: 0, borderRight: 0 }}>
                 <div className="bracket-canvas__inner" style={{ padding: 18 }}>
                   <window.BracketTree

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -1820,9 +1820,13 @@ function ViewerCompetition({ tournament, competition, pools, poolMatches, standi
                     autoScrollMatchId={bracketScrollTarget}
                     scrollContainerRef={bracketScrollRef}
                     highlightPlayers={highlightPlayers}
-                    onMatchClick={(m, ri) => {
-                      const label = window.roundLabel(ri, derivedBracket.rounds.length);
-                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize });
+                    onMatchClick={(m, ri, _mi, total) => {
+                      const label = window.roundLabel(ri, total ?? derivedBracket.rounds.length);
+                      // m.roundIndex is already the backend round array index
+                      // (stamped by compMatches); prefer it over the display-
+                      // column index (ri) so team lineup fetches use the right
+                      // round even when phantom leading rounds shift the indices.
+                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, roundIndex: m.roundIndex ?? ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize });
                     }}
                   />
                 </div>


### PR DESCRIPTION
## Summary

- Remove seed rank badge from every match card in the bracket view. The badge cluttered all cards; seed information is not surfaced to spectators in a live bracket.
- Shorten generic round-column headers: `Round N` → `RN` (e.g. R32, R16) so column labels stay tight in wide brackets. Named rounds (Quarterfinals, Semifinals, Final) are unchanged.
- Add right-edge scroll affordance: a `ResizeObserver` + scroll listener on the bracket canvas detects horizontal overflow and applies `viewer-bracket-bleed--overflow-right`, activating a `::after` gradient (transparent → `--bg`) that signals more columns exist to the right.
- Add structural-bye placeholder cards: when a non-leaf match has one side seeded directly (feeder = `""`), a placeholder card showing the player name is inserted in the upstream column so the tree communicates the skip spatially — mirrors the Excel Tree sheet output.
- Add per-card match numbers: matches are numbered sequentially (earliest round first, then by position) and displayed as `M 1`, `M 2`, … so operators can reference bracket positions by number as they do on the printed sheet.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/bracket.jsx` | Remove seed badge from `PlayerLine`; shorten `roundLabel()` generic case to `R{N}`; add structural-bye slot logic and match numbering to `buildDisplayModel`; render `bc-match-num` chip in `MatchCard` |
| `web-mobile/js/viewer.jsx` | Add `bracketOverflowRight` state + `ResizeObserver`/scroll effect; apply overflow class to `.viewer-bracket-bleed` |
| `web-mobile/css/styles.css` | Remove `.bc-seed` / `.bc-seed--empty` blocks and two dead v2 winner overrides; add `.viewer-bracket-bleed` `position: relative` + `::after` gradient rule |

## Screenshots

![Bracket view mobile — seed badges removed, R32/R16 labels, match numbers](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/281/bracket-mobile.png)

![Bracket view desktop — scroll affordance at right edge](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/281/bracket-desktop.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all 17 packages pass, all ≥85% coverage
- [x] New/updated unit tests cover the change — frontend-only change; no Go logic altered
- [x] Manual browser verification — opened Teams competition bracket tab: seed badges absent from all match cards; column headers show R32/R16/QUARTERFINALS/SEMIFINALS/FINAL; `viewer-bracket-bleed--overflow-right` class applied on load (scrollWidth 1410 > clientWidth 1024); right-edge gradient confirmed; match numbers `M1`…`MN` visible on each card; bye-slot placeholder cards shown with player names where applicable
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-qa49