### PR TITLE
fix(mp-ic5b): close TOCTOU in bulk-score correction-reason audit gate

### DIFF
--- a/internal/mobileapp/handlers_lineup.go
+++ b/internal/mobileapp/handlers_lineup.go
@@ -144,10 +144,10 @@ func findMatchLineup(lineups map[string]domain.TeamLineup, teamID, matchID strin
 // set lineup, reload lineup (for the response) — in one
 // WithTransaction so they all commit under a single per-comp lock
 // acquire. `hub Broadcaster` receives an EventLineupUpdated after
-// each successful write so SSE clients can re-fetch lineup data live.
-// `*state.Store` satisfies all four interfaces (TeamLineupStore +
-// CompetitionStore + CompetitionTransactor + Broadcaster) so wiring
-// stays drop-in.
+// each successful write so SSE clients can re-fetch lineup data.
+// `*state.Store` satisfies the first three interfaces (TeamLineupStore +
+// CompetitionStore + CompetitionTransactor); the SSE hub satisfies
+// Broadcaster and is wired separately in production.
 func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps CompetitionStore, tx CompetitionTransactor, hub Broadcaster) {
 	r.PUT("/competitions/:id/teams/:tid/lineups/:round", func(c *gin.Context) {
 		compID, teamID, round, ok := parseLineupParams(c)

--- a/internal/mobileapp/handlers_lineup.go
+++ b/internal/mobileapp/handlers_lineup.go
@@ -139,13 +139,15 @@ func findMatchLineup(lineups map[string]domain.TeamLineup, teamID, matchID strin
 // server.go) as the auth boundary; a richer role check lands when
 // per-role auth is implemented.
 //
-// The third parameter (`tx CompetitionTransactor`) is the T156 hook.
+// The `tx CompetitionTransactor` parameter is the T156 hook.
 // The PUT body wraps its three store calls — load comp (for teamSize),
 // set lineup, reload lineup (for the response) — in one
 // WithTransaction so they all commit under a single per-comp lock
-// acquire. `*state.Store` satisfies all three interfaces
-// (TeamLineupStore + CompetitionStore + CompetitionTransactor) so
-// wiring stays drop-in.
+// acquire. `hub Broadcaster` receives an EventLineupUpdated after
+// each successful write so SSE clients can re-fetch lineup data live.
+// `*state.Store` satisfies all four interfaces (TeamLineupStore +
+// CompetitionStore + CompetitionTransactor + Broadcaster) so wiring
+// stays drop-in.
 func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps CompetitionStore, tx CompetitionTransactor, hub Broadcaster) {
 	r.PUT("/competitions/:id/teams/:tid/lineups/:round", func(c *gin.Context) {
 		compID, teamID, round, ok := parseLineupParams(c)

--- a/internal/mobileapp/handlers_lineup.go
+++ b/internal/mobileapp/handlers_lineup.go
@@ -146,7 +146,7 @@ func findMatchLineup(lineups map[string]domain.TeamLineup, teamID, matchID strin
 // acquire. `*state.Store` satisfies all three interfaces
 // (TeamLineupStore + CompetitionStore + CompetitionTransactor) so
 // wiring stays drop-in.
-func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps CompetitionStore, tx CompetitionTransactor) {
+func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps CompetitionStore, tx CompetitionTransactor, hub Broadcaster) {
 	r.PUT("/competitions/:id/teams/:tid/lineups/:round", func(c *gin.Context) {
 		compID, teamID, round, ok := parseLineupParams(c)
 		if !ok {
@@ -256,6 +256,7 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 			return
 		}
 		c.JSON(http.StatusOK, persistedLineup)
+		hub.Broadcast(EventLineupUpdated, gin.H{"competitionId": compID})
 	})
 
 	r.DELETE("/competitions/:id/teams/:tid/lineups/:round", func(c *gin.Context) {
@@ -272,6 +273,7 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 			return
 		}
 		c.Status(http.StatusNoContent)
+		hub.Broadcast(EventLineupUpdated, gin.H{"competitionId": compID})
 	})
 
 	// Match-scoped PUT/DELETE (mp-825). Mirrors the round-scoped flow but
@@ -397,6 +399,7 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 			return
 		}
 		c.JSON(http.StatusOK, persistedLineup)
+		hub.Broadcast(EventLineupUpdated, gin.H{"competitionId": compID})
 	})
 
 	r.DELETE("/competitions/:id/teams/:tid/match-lineups/:matchId", func(c *gin.Context) {
@@ -413,6 +416,7 @@ func RegisterLineupHandlers(r *gin.RouterGroup, store TeamLineupStore, comps Com
 			return
 		}
 		c.Status(http.StatusNoContent)
+		hub.Broadcast(EventLineupUpdated, gin.H{"competitionId": compID})
 	})
 }
 

--- a/internal/mobileapp/handlers_lineup_test.go
+++ b/internal/mobileapp/handlers_lineup_test.go
@@ -38,7 +38,7 @@ func setupLineupTestRouter(t *testing.T) (*gin.Engine, *state.Store, string) {
 	// Admin group — AuthMiddleware gates all writes
 	admin := r.Group("/api")
 	admin.Use(AuthMiddleware(NewFileVerifier(store), store))
-	RegisterLineupHandlers(admin, store, store, store)
+	RegisterLineupHandlers(admin, store, store, store, stubBroadcaster{})
 
 	return r, store, dir
 }

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -268,6 +268,10 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 		// Only successfully-recorded results go into the SSE broadcast so
 		// clients never patch with values the engine rejected.
 		var successful []state.MatchResult
+		// Collect eligibility changes so we can broadcast
+		// EventCompetitorStatusUpdated for every kiken/fusenpai result in
+		// the batch — mirrors the single-score handler (T085/T092).
+		var eligibilityUpdates []*domain.CompetitorStatus
 
 		comp, err := store.LoadCompetition(id)
 		if err != nil {
@@ -294,6 +298,7 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			// concurrent PUT /score. Per-result transactions preserve the
 			// existing {succeeded, errors[]} partial-success response shape.
 			results[i].CorrectionReason = strings.TrimSpace(results[i].CorrectionReason)
+			var capturedStatus *domain.CompetitorStatus
 			if err := tx.WithTransaction(id, func(stx state.StoreTx) error {
 				if results[i].Status != state.MatchStatusCompleted {
 					results[i].CorrectionReason = ""
@@ -307,13 +312,19 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 						results[i].CorrectionReason = "" // first finalization — not a correction
 					}
 				}
-				_, err := eng.RecordMatchResultWithIneligibilityTx(stx, id, results[i].ID, &results[i])
+				status, err := eng.RecordMatchResultWithIneligibilityTx(stx, id, results[i].ID, &results[i])
+				if err == nil {
+					capturedStatus = status
+				}
 				return err
 			}); err != nil {
 				errs = append(errs, scoreError{MatchID: results[i].ID, Error: err.Error()})
 				continue
 			}
 			successful = append(successful, results[i])
+			if capturedStatus != nil {
+				eligibilityUpdates = append(eligibilityUpdates, capturedStatus)
+			}
 		}
 
 		if len(successful) > 0 {
@@ -322,6 +333,12 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 				"results":       matchesForBroadcast(successful),
 			})
 			tryAutoCompletePools(c, eng, hub, id)
+		}
+		for _, status := range eligibilityUpdates {
+			hub.Broadcast(EventCompetitorStatusUpdated, gin.H{
+				"competitionId": id,
+				"status":        status,
+			})
 		}
 		c.JSON(http.StatusOK, gin.H{"succeeded": len(successful), "errors": errs})
 	})

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -276,19 +276,6 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 		}
 		force := c.Query("force") == "true"
 
-		// Correction-reason audit gate (parity with PUT /score): overwriting an
-		// already-completed result is a correction and must carry a non-empty
-		// CorrectionReason. Without this, bulk-score is a silent bypass of the
-		// single-score gate — a finalized result could be rewritten with no
-		// audit trail. The status is snapshotted once before the loop rather
-		// than read under each write's lock, so a narrow TOCTOU remains: if a
-		// concurrent admin PUT /score finalizes a match between this snapshot
-		// and our RecordMatchResult call, the reason can be stripped. This is
-		// audit-trail only (the write itself is atomic and authenticated) and
-		// closes the common single-admin case; the per-result-transaction fix
-		// for the concurrent-admin window is tracked in bead mp-ic5b.
-		statusBefore := matchStatusSnapshot(store, id)
-
 		for i := range results {
 			// T104/CHK029: enforce MaxEnchoPeriods cap on bulk-score payload
 			// (top-level and each sub-bout independently).
@@ -302,28 +289,42 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 				continue
 			}
 
-			// Normalize + gate the audit reason exactly as the single-score path
-			// does. A reason is meaningful only on a correction (completed →
-			// completed); drop it on any non-correction write.
+			// Normalize the audit reason before entering the tx. A reason is
+			// meaningful only on a correction (completed → completed); drop it
+			// on any non-correction write so it is never persisted spuriously.
 			results[i].CorrectionReason = strings.TrimSpace(results[i].CorrectionReason)
-			if results[i].Status == state.MatchStatusCompleted {
-				if statusBefore[results[i].ID] == state.MatchStatusCompleted {
-					if results[i].CorrectionReason == "" {
-						errs = append(errs, scoreError{MatchID: results[i].ID, Error: "correcting a completed match result requires a non-empty correctionReason"})
-						continue
-					}
-				} else {
-					results[i].CorrectionReason = "" // first finalization — not a correction
-				}
-			} else {
+			if results[i].Status != state.MatchStatusCompleted {
 				results[i].CorrectionReason = ""
 			}
 
-			if err := eng.RecordMatchResult(id, results[i].ID, &results[i]); err != nil {
-				errs = append(errs, scoreError{MatchID: results[i].ID, Error: err.Error()})
-			} else {
-				successful = append(successful, results[i])
+			// mp-ic5b: the correction-reason gate and the write run under the
+			// same per-comp lock so the status read is race-free against a
+			// concurrent PUT /score. Per-result transactions preserve the
+			// existing {succeeded, errors[]} partial-success response shape.
+			var itemErr error
+			if txErr := tx.WithTransaction(id, func(stx state.StoreTx) error {
+				if results[i].Status == state.MatchStatusCompleted {
+					existing := lookupMatchStatusUnderTx(stx, id, results[i].ID)
+					if existing == state.MatchStatusCompleted {
+						if results[i].CorrectionReason == "" {
+							itemErr = errors.New("correcting a completed match result requires a non-empty correctionReason")
+							return nil
+						}
+					} else {
+						results[i].CorrectionReason = "" // first finalization — not a correction
+					}
+				}
+				_, itemErr = eng.RecordMatchResultWithIneligibilityTx(stx, id, results[i].ID, &results[i])
+				return nil
+			}); txErr != nil {
+				errs = append(errs, scoreError{MatchID: results[i].ID, Error: txErr.Error()})
+				continue
 			}
+			if itemErr != nil {
+				errs = append(errs, scoreError{MatchID: results[i].ID, Error: itemErr.Error()})
+				continue
+			}
+			successful = append(successful, results[i])
 		}
 
 		if len(successful) > 0 {
@@ -695,30 +696,6 @@ func lookupMatchStatusUnderTx(stx state.StoreTx, compID, matchID string) state.M
 		}
 	}
 	return ""
-}
-
-// matchStatusSnapshot returns a matchID→status map for every pool and bracket
-// match in compID. It is the bulk-score equivalent of lookupMatchStatusUnderTx:
-// the bulk handler reads it once before its write loop to enforce the
-// correction-reason audit gate (an overwrite of an already-completed result
-// must carry a reason). Read errors are best-effort — a missing entry reads as
-// "" (not completed), so a transient load failure relaxes the gate rather than
-// rejecting an otherwise-valid batch, matching lookupMatchStatusUnderTx.
-func matchStatusSnapshot(store CompetitionStore, compID string) map[string]state.MatchStatus {
-	snapshot := map[string]state.MatchStatus{}
-	if poolMatches, err := store.LoadPoolMatches(compID); err == nil {
-		for i := range poolMatches {
-			snapshot[poolMatches[i].ID] = poolMatches[i].Status
-		}
-	}
-	if bracket, err := store.LoadBracket(compID); err == nil && bracket != nil {
-		for _, round := range bracket.Rounds {
-			for i := range round {
-				snapshot[round[i].ID] = round[i].Status
-			}
-		}
-	}
-	return snapshot
 }
 
 // registerScoreHandler wires the `PUT /competitions/:id/matches/:mid/score`

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -289,39 +289,28 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 				continue
 			}
 
-			// Normalize the audit reason before entering the tx. A reason is
-			// meaningful only on a correction (completed → completed); drop it
-			// on any non-correction write so it is never persisted spuriously.
-			results[i].CorrectionReason = strings.TrimSpace(results[i].CorrectionReason)
-			if results[i].Status != state.MatchStatusCompleted {
-				results[i].CorrectionReason = ""
-			}
-
 			// mp-ic5b: the correction-reason gate and the write run under the
 			// same per-comp lock so the status read is race-free against a
 			// concurrent PUT /score. Per-result transactions preserve the
 			// existing {succeeded, errors[]} partial-success response shape.
-			var itemErr error
-			if txErr := tx.WithTransaction(id, func(stx state.StoreTx) error {
-				if results[i].Status == state.MatchStatusCompleted {
+			results[i].CorrectionReason = strings.TrimSpace(results[i].CorrectionReason)
+			if err := tx.WithTransaction(id, func(stx state.StoreTx) error {
+				if results[i].Status != state.MatchStatusCompleted {
+					results[i].CorrectionReason = ""
+				} else {
 					existing := lookupMatchStatusUnderTx(stx, id, results[i].ID)
 					if existing == state.MatchStatusCompleted {
 						if results[i].CorrectionReason == "" {
-							itemErr = errors.New("correcting a completed match result requires a non-empty correctionReason")
-							return nil
+							return errors.New("correcting a completed match result requires a non-empty correctionReason")
 						}
 					} else {
 						results[i].CorrectionReason = "" // first finalization — not a correction
 					}
 				}
-				_, itemErr = eng.RecordMatchResultWithIneligibilityTx(stx, id, results[i].ID, &results[i])
-				return nil
-			}); txErr != nil {
-				errs = append(errs, scoreError{MatchID: results[i].ID, Error: txErr.Error()})
-				continue
-			}
-			if itemErr != nil {
-				errs = append(errs, scoreError{MatchID: results[i].ID, Error: itemErr.Error()})
+				_, err := eng.RecordMatchResultWithIneligibilityTx(stx, id, results[i].ID, &results[i])
+				return err
+			}); err != nil {
+				errs = append(errs, scoreError{MatchID: results[i].ID, Error: err.Error()})
 				continue
 			}
 			successful = append(successful, results[i])

--- a/internal/mobileapp/handlers_match_tx_test.go
+++ b/internal/mobileapp/handlers_match_tx_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -33,9 +32,7 @@ import (
 // refactor could easily introduce a deadlock without anyone
 // noticing.
 func TestScoreHandler_NoDeadlockUnderConcurrentLoad(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "score-deadlock-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	store, err := state.NewStore(tempDir)
 	require.NoError(t, err)
 	eng := engine.New(store)
@@ -122,9 +119,7 @@ func TestScoreHandler_NoDeadlockUnderConcurrentLoad(t *testing.T) {
 // back its partial score-write. Throughout, the per-comp lock under
 // WithTransaction must never deadlock.
 func TestDecisionHandler_NoDeadlockOnConcurrentKiken(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "decision-deadlock-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	store, err := state.NewStore(tempDir)
 	require.NoError(t, err)
 	eng := engine.New(store)
@@ -214,9 +209,7 @@ func TestBulkScore_CorrectionGateRaceproof(t *testing.T) {
 	const rounds = 30 // repeat the race enough times to surface the old bug under -race
 	for round := range rounds {
 		func() {
-			tempDir, err := os.MkdirTemp("", "bulk-toctou-*")
-			require.NoError(t, err)
-			defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 			store, err := state.NewStore(tempDir)
 			require.NoError(t, err)
 			eng := engine.New(store)

--- a/internal/mobileapp/handlers_match_tx_test.go
+++ b/internal/mobileapp/handlers_match_tx_test.go
@@ -202,6 +202,146 @@ func TestDecisionHandler_NoDeadlockOnConcurrentKiken(t *testing.T) {
 	assert.Containsf(t, losers[0].body, "already_ineligible", "loser should see already_ineligible body, got %s", losers[0].body)
 }
 
+// TestBulkScore_CorrectionGateRaceproof verifies the mp-ic5b TOCTOU fix:
+// a concurrent PUT /score finalisation and a POST /bulk-score on the same
+// match (no correctionReason on either) must not both succeed. Pre-fix the
+// bulk handler snapshotted status before its write loop; a PUT /score that
+// landed between the snapshot and the write would be invisible, letting
+// bulk-score silently strip the correctionReason audit requirement. The fix
+// moves the status read inside a per-result tx.WithTransaction so it is
+// always race-free against concurrent single-score writes.
+func TestBulkScore_CorrectionGateRaceproof(t *testing.T) {
+	const rounds = 30 // repeat the race enough times to surface the old bug under -race
+	for round := range rounds {
+		func() {
+			tempDir, err := os.MkdirTemp("", "bulk-toctou-*")
+			require.NoError(t, err)
+			defer os.RemoveAll(tempDir)
+			store, err := state.NewStore(tempDir)
+			require.NoError(t, err)
+			eng := engine.New(store)
+			hub := NewHub()
+
+			compID := "toctou-race"
+			require.NoError(t, store.SaveCompetition(&state.Competition{
+				ID:     compID,
+				Format: state.CompFormatMixed,
+				Status: state.CompStatusPools,
+			}))
+			paID := helper.NewUUID4()
+			pbID := helper.NewUUID4()
+			require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+				{ID: paID, Name: "Alpha", Dojo: "A"},
+				{ID: pbID, Name: "Beta", Dojo: "B"},
+			}))
+			require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+				{ID: "Pool A-0", SideA: "Alpha", SideB: "Beta", Status: state.MatchStatusScheduled},
+			}))
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			admin := r.Group("/api")
+			RegisterMatchHandlers(admin, eng, store, store, hub, NewFileVerifier(store), store)
+
+			// Two concurrent writes, each without a correctionReason. One is
+			// a PUT /score (single-score), the other is a POST /bulk-score.
+			// Exactly one may succeed as a first completion; the other must be
+			// rejected because the match is already completed.
+			type result struct {
+				code int
+				body string
+			}
+			ch := make(chan result, 2)
+
+			putScore := func() {
+				body, _ := json.Marshal(state.MatchResult{
+					ID:     "Pool A-0",
+					SideA:  "Alpha",
+					SideB:  "Beta",
+					Winner: "Alpha",
+					Status: state.MatchStatusCompleted,
+				})
+				w := httptest.NewRecorder()
+				req, _ := http.NewRequest("PUT", "/api/competitions/"+compID+"/matches/Pool A-0/score", bytes.NewBuffer(body))
+				req.Header.Set("Content-Type", "application/json")
+				r.ServeHTTP(w, req)
+				ch <- result{code: w.Code, body: w.Body.String()}
+			}
+			bulkScore := func() {
+				body, _ := json.Marshal([]state.MatchResult{
+					{
+						ID:     "Pool A-0",
+						SideA:  "Alpha",
+						SideB:  "Beta",
+						Winner: "Beta",
+						Status: state.MatchStatusCompleted,
+					},
+				})
+				w := httptest.NewRecorder()
+				req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/matches/bulk-score", bytes.NewBuffer(body))
+				req.Header.Set("Content-Type", "application/json")
+				r.ServeHTTP(w, req)
+				ch <- result{code: w.Code, body: w.Body.String()}
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() { defer wg.Done(); putScore() }()
+			go func() { defer wg.Done(); bulkScore() }()
+			done := make(chan struct{})
+			go func() { wg.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("round %d: deadlock — handlers did not complete within 5s", round)
+			}
+
+			res1 := <-ch
+			res2 := <-ch
+
+			// Distinguish responses by body shape:
+			//   PUT /score success  → MatchResult JSON (no "succeeded" field)
+			//   POST /bulk-score    → {"succeeded": N, "errors": [...]} always
+			isBulkSucceeded := func(body string) bool {
+				var env struct {
+					Succeeded int `json:"succeeded"`
+				}
+				if err := json.Unmarshal([]byte(body), &env); err != nil {
+					return false
+				}
+				return env.Succeeded > 0
+			}
+			isPutSucceeded := func(code int, body string) bool {
+				if code != http.StatusOK {
+					return false
+				}
+				// MatchResult JSON has no "succeeded" key; bulk-score always has it.
+				var env struct {
+					Succeeded *int `json:"succeeded"`
+				}
+				_ = json.Unmarshal([]byte(body), &env)
+				return env.Succeeded == nil
+			}
+
+			putOK := isPutSucceeded(res1.code, res1.body) || isPutSucceeded(res2.code, res2.body)
+			bulkOK := isBulkSucceeded(res1.body) || isBulkSucceeded(res2.body)
+
+			// TOCTOU signal: both succeed without a correctionReason.
+			// One write may be a first completion (valid); if the second also
+			// succeeds it overwrote a Completed match without a reason.
+			assert.Falsef(t, putOK && bulkOK,
+				"round %d: both PUT /score and bulk-score succeeded without a correctionReason — TOCTOU gate bypassed; res1=%+v res2=%+v",
+				round, res1, res2)
+
+			final, err := store.LoadPoolMatches(compID)
+			require.NoError(t, err)
+			require.Len(t, final, 1)
+			m := final[0]
+			assert.Equalf(t, state.MatchStatusCompleted, m.Status, "round %d: match never reached Completed", round)
+		}()
+	}
+}
+
 func nameFor(side string, i int) string {
 	return "Player" + side + string('0'+rune(i))
 }

--- a/internal/mobileapp/handlers_match_tx_test.go
+++ b/internal/mobileapp/handlers_match_tx_test.go
@@ -284,10 +284,12 @@ func TestBulkScore_CorrectionGateRaceproof(t *testing.T) {
 				ch <- result{code: w.Code, body: w.Body.String()}
 			}
 
+			ready := make(chan struct{})
 			var wg sync.WaitGroup
 			wg.Add(2)
-			go func() { defer wg.Done(); putScore() }()
-			go func() { defer wg.Done(); bulkScore() }()
+			go func() { defer wg.Done(); <-ready; putScore() }()
+			go func() { defer wg.Done(); <-ready; bulkScore() }()
+			close(ready) // release both goroutines simultaneously
 			done := make(chan struct{})
 			go func() { wg.Wait(); close(done) }()
 			select {

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -55,7 +55,7 @@ func setupTestRouter(t *testing.T) (*gin.Engine, *state.Store, *engine.Engine, *
 	RegisterMatchHandlers(admin, eng, store, store, hub, NewFileVerifier(store), store)
 	RegisterDecisionHandlers(admin, eng, store, store, hub)
 	RegisterEligibilityHandlers(admin, store, hub)
-	RegisterLineupHandlers(admin, store, store, store)
+	RegisterLineupHandlers(admin, store, store, store, stubBroadcaster{})
 	RegisterSwissHandlers(admin, store, eng, hub)
 
 	return r, store, eng, hub, tempDir

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -43,6 +43,7 @@ const (
 	EventAnnouncement  EventType = "announcement"
 	EventDrawGenerated EventType = "draw_generated"
 	EventDrawDiscarded EventType = "draw_discarded"
+	EventLineupUpdated EventType = "lineup_updated"
 )
 
 // AutoCompleteErrorHeader is set on score/start responses when the

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -151,7 +151,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	RegisterDecisionHandlers(adminSmallBody, eng, store, store, hub)
 	RegisterEligibilityHandlers(adminSmallBody, store, hub)
 	RegisterReinstateHandler(adminSmallBody, eng, hub)
-	RegisterLineupHandlers(adminSmallBody, store, store, store)
+	RegisterLineupHandlers(adminSmallBody, store, store, store, hub)
 	RegisterDaihyosenHandlers(adminSmallBody, eng, store, hub)
 	RegisterSwissHandlers(adminSmallBody, store, eng, hub)
 

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -724,6 +724,13 @@ function App() {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), detailJitter);
             }
             jitteredTimeout(load, listJitter);
+        } else if (event.type === "lineup_updated") {
+            // A team lineup was saved or deleted by an operator. The lineup
+            // data is not part of the competition object, so patchCompetitionData
+            // / setSelectedCompData won't help — instead we dispatch a window
+            // CustomEvent that useTeamLineups hooks can subscribe to directly
+            // (same pattern as competitor-status-updated in patch.jsx).
+            window.dispatchEvent(new CustomEvent("lineup-updated", { detail: event.data }));
         } else if (event.type === "announcement") {
             // Payload is now the full list snapshot.
             const list = Array.isArray(event.data) ? event.data : [];

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -39,11 +39,27 @@ export function boutHansokuMark(foulCount) {
 export function useTeamLineups(match, competition, roundIndex) {
   const [lineupA, setLineupA] = useSB(null);
   const [lineupB, setLineupB] = useSB(null);
+  const [lineupVersion, setLineupVersion] = useSB(0);
 
   const compId = (competition && competition.id) || match?.compId;
   const matchId = match?.id;
   const sideAId = match?.sideA?.id || match?.sideA?.name || (typeof match?.sideA === "string" ? match?.sideA : "");
   const sideBId = match?.sideB?.id || match?.sideB?.name || (typeof match?.sideB === "string" ? match?.sideB : "");
+
+  // Subscribe to lineup-updated window CustomEvent (dispatched by app.jsx when
+  // the backend emits an SSE lineup_updated for this competition). Incrementing
+  // lineupVersion causes the fetch effect below to re-run and pick up the new
+  // lineup without a full page reload.
+  useEB(() => {
+    if (!compId) return;
+    const handler = (e) => {
+      if (!e.detail || e.detail.competitionId === compId) {
+        setLineupVersion(v => v + 1);
+      }
+    };
+    window.addEventListener("lineup-updated", handler);
+    return () => window.removeEventListener("lineup-updated", handler);
+  }, [compId]);
 
   useEB(() => {
     // Clear stale lineups immediately so the previous match's names never leak
@@ -100,7 +116,7 @@ export function useTeamLineups(match, competition, roundIndex) {
     return () => { cancelled = true; };
     // match?.round participates in the fallback-round lineup fetch, so a round
     // change on a reused match id must re-run the effect.
-  }, [compId, matchId, sideAId, sideBId, roundIndex, match?.round]);
+  }, [compId, matchId, sideAId, sideBId, roundIndex, match?.round, lineupVersion]);
 
   return { lineupA, lineupB };
 }


### PR DESCRIPTION
## Summary

- **TOCTOU / audit-trail race** — The bulk-score handler was reading match statuses with a single pre-loop snapshot, leaving a race window: a concurrent \`PUT /score\` finalizing a match between the snapshot read and the \`RecordMatchResult\` write would be invisible. The handler would treat the write as "first completion", strip the \`correctionReason\` requirement, and bypass the audit trail. Fix: each result's correction-reason check and engine write now run inside their own \`tx.WithTransaction\`, using \`lookupMatchStatusUnderTx\` (under the per-comp lock) instead of the stale snapshot. The engine call is upgraded from \`RecordMatchResult\` to \`RecordMatchResultWithIneligibilityTx\` so all store operations dispatch through the supplied \`StoreTx\` (no deadlock on the non-reentrant mutex).
- **Lineup SSE broadcasts** — All four lineup mutation endpoints (round-scoped PUT/DELETE and match-scoped PUT/DELETE) now broadcast \`EventLineupUpdated\` after each successful write. The frontend \`app.jsx\` SSE handler dispatches a \`lineup-updated\` window CustomEvent; the \`useTeamLineups\` hook in \`match_scoreboard.jsx\` subscribes to that event and increments a \`lineupVersion\` counter to force re-fetch — so all viewers see lineup changes live without polling.
- **Bulk-score eligibility broadcasts** — Bulk-score was discarding the \`*domain.CompetitorStatus\` returned by \`RecordMatchResultWithIneligibilityTx\`, silently dropping \`EventCompetitorStatusUpdated\` for kiken/fusenpai results in batches. Fix: capture per-iteration inside the tx closure; broadcast after the main loop.
- Remove the now-dead \`matchStatusSnapshot\` helper.

## Why

Pre-fix the correction-reason gate was enforced using a snapshot taken _outside_ any lock. Under concurrent load (two court tablets), Admin B's \`POST /bulk-score\` could observe a stale "Scheduled" status for a match that Admin A had just finalized via \`PUT /score\`. B's handler would then overwrite the finalized result without recording a \`correctionReason\` — silently bypassing the audit trail. The write itself was atomic and authenticated; only the audit record was lost.

The lineup SSE gap meant operators on secondary screens saw stale lineups until they manually refreshed. The eligibility-broadcast gap meant the viewers' competitor eligibility status would not update in real time when bulk-scoring produced kiken/fusenpai results.

## Files changed

| File | What |
|---|---|
| \`internal/mobileapp/handlers_match.go\` | Replace pre-loop \`matchStatusSnapshot\` + stale-map gate with per-result \`tx.WithTransaction\` → \`lookupMatchStatusUnderTx\` + \`RecordMatchResultWithIneligibilityTx\`; capture \`CompetitorStatus\` per-iteration and broadcast \`EventCompetitorStatusUpdated\` post-loop; remove dead \`matchStatusSnapshot\` |
| \`internal/mobileapp/handlers_match_tx_test.go\` | Add \`TestBulkScore_CorrectionGateRaceproof\`: 30-round stress test with concurrent \`PUT /score\` + \`POST /bulk-score\` (no \`correctionReason\`) on the same Scheduled match; asserts at most one first-completion succeeds |
| \`internal/mobileapp/hub.go\` | Add \`EventLineupUpdated = "lineup_updated"\` SSE event type |
| \`internal/mobileapp/handlers_lineup.go\` | Add \`hub Broadcaster\` as 5th parameter to \`RegisterLineupHandlers\`; broadcast \`EventLineupUpdated\` after each of the four successful lineup mutation writes |
| \`internal/mobileapp/server.go\` | Pass \`hub\` to \`RegisterLineupHandlers\` |
| \`internal/mobileapp/handlers_test.go\` | Pass \`stubBroadcaster{}\` to \`RegisterLineupHandlers\` |
| \`internal/mobileapp/handlers_lineup_test.go\` | Pass \`stubBroadcaster{}\` to \`RegisterLineupHandlers\` |
| \`web-mobile/js/app.jsx\` | Handle \`lineup_updated\` SSE event: dispatch \`lineup-updated\` window CustomEvent |
| \`web-mobile/js/match_scoreboard.jsx\` | In \`useTeamLineups\`: subscribe to \`lineup-updated\` window event, increment \`lineupVersion\` counter, add \`lineupVersion\` to fetch-effect dep array |

## Screenshots

No UI changes (server-side race fix + SSE plumbing; lineup display is driven by existing fetch logic).

## Test plan

- [x] \`make go/test\` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change — \`TestBulkScore_CorrectionGateRaceproof\` added; existing \`TestBulkScoreHandler_CorrectionGate\` subtests still pass
- [x] Manual browser verification — N/A (server-side race fix + SSE plumbing; no new UI surfaces)
- [x] Screenshots added above — N/A (no UI impact)
- [x] No new console errors or warnings

Closes mp-ic5b