### PR TITLE
feat(mp-95mg): enforce court exclusivity across all competitions

### DIFF
--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -191,15 +191,19 @@ func (e *Engine) checkCourtExclusivity(compID, matchID, skipCompID string) error
 // has no court assigned.
 func (e *Engine) lookupMatchCourt(compID, matchID string) (string, error) {
 	poolMatches, err := e.store.LoadPoolMatches(compID)
-	if err == nil {
-		for _, m := range poolMatches {
-			if m.ID == matchID {
-				return m.Court, nil
-			}
+	if err != nil {
+		return "", err
+	}
+	for _, m := range poolMatches {
+		if m.ID == matchID {
+			return m.Court, nil
 		}
 	}
 	bracket, err := e.store.LoadBracket(compID)
-	if err == nil && bracket != nil {
+	if err != nil {
+		return "", err
+	}
+	if bracket != nil {
 		for _, round := range bracket.Rounds {
 			for _, bm := range round {
 				if bm.ID == matchID {

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -34,6 +34,29 @@ func (e *IneligibleCompetitorError) Is(target error) bool {
 	return target == ErrIneligibleCompetitor
 }
 
+// ErrCourtBusy is the sentinel error matched by
+// errors.Is(err, engine.ErrCourtBusy). The concrete value is a
+// *CourtBusyError that carries Court, MatchID, and CompID.
+var ErrCourtBusy = errors.New("court already has a running match")
+
+// CourtBusyError is returned by StartMatch / StartMatchTx when the
+// target court already has a running match in any competition.
+// Courts are tournament-global: one physical shiaijo can host only
+// one match at a time regardless of which competition owns it.
+type CourtBusyError struct {
+	Court   string
+	MatchID string
+	CompID  string
+}
+
+func (e *CourtBusyError) Error() string {
+	return fmt.Sprintf("court %q already has running match %s (competition %s)", e.Court, e.MatchID, e.CompID)
+}
+
+func (e *CourtBusyError) Is(target error) bool {
+	return target == ErrCourtBusy
+}
+
 // AlreadyIneligibleError is returned by RecordDecision when the
 // intended loser already carries Eligible:false from a *different*
 // match — indicating two operators on different courts concurrently
@@ -127,6 +150,9 @@ func (e *Engine) CheckEligibility(compID string, playerIDs []string) error {
 //
 // FR-035, T084.
 func (e *Engine) StartMatch(compID, matchID string) error {
+	if err := e.checkCourtExclusivity(compID, matchID, ""); err != nil {
+		return err
+	}
 	if err := e.checkSimultaneousMatch(compID, matchID); err != nil {
 		return err
 	}
@@ -135,6 +161,51 @@ func (e *Engine) StartMatch(compID, matchID string) error {
 		return err
 	}
 	return e.checkEligibilityExcludingMatch(compID, ids, matchID)
+}
+
+// checkCourtExclusivity rejects StartMatch when the target match's court
+// already has a running match anywhere in the tournament. skipCompID is
+// the competition whose data the caller already holds a write lock for
+// (passed to store.RunningMatchOnCourt to avoid re-locking a non-reentrant
+// mutex). Pass "" when calling outside a WithTransaction body.
+func (e *Engine) checkCourtExclusivity(compID, matchID, skipCompID string) error {
+	court, err := e.lookupMatchCourt(compID, matchID)
+	if err != nil || court == "" {
+		return nil
+	}
+	occ, err := e.store.RunningMatchOnCourt(court, skipCompID)
+	if err != nil {
+		return nil
+	}
+	if occ != nil && (occ.CompID != compID || occ.MatchID != matchID) {
+		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}
+	}
+	return nil
+}
+
+// lookupMatchCourt returns the court assigned to matchID in compID's pool
+// matches or bracket. Returns "" (not an error) when the match exists but
+// has no court assigned.
+func (e *Engine) lookupMatchCourt(compID, matchID string) (string, error) {
+	poolMatches, err := e.store.LoadPoolMatches(compID)
+	if err == nil {
+		for _, m := range poolMatches {
+			if m.ID == matchID {
+				return m.Court, nil
+			}
+		}
+	}
+	bracket, err := e.store.LoadBracket(compID)
+	if err == nil && bracket != nil {
+		for _, round := range bracket.Rounds {
+			for _, bm := range round {
+				if bm.ID == matchID {
+					return bm.Court, nil
+				}
+			}
+		}
+	}
+	return "", notFoundErrorf("match %q not found in competition %q", matchID, compID)
 }
 
 // checkSimultaneousMatch returns an *IneligibleCompetitorError if either

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -170,12 +170,15 @@ func (e *Engine) StartMatch(compID, matchID string) error {
 // mutex). Pass "" when calling outside a WithTransaction body.
 func (e *Engine) checkCourtExclusivity(compID, matchID, skipCompID string) error {
 	court, err := e.lookupMatchCourt(compID, matchID)
-	if err != nil || court == "" {
+	if err != nil {
+		return err
+	}
+	if court == "" {
 		return nil
 	}
 	occ, err := e.store.RunningMatchOnCourt(court, skipCompID)
 	if err != nil {
-		return nil
+		return err
 	}
 	if occ != nil && (occ.CompID != compID || occ.MatchID != matchID) {
 		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -39,10 +39,15 @@ func (e *IneligibleCompetitorError) Is(target error) bool {
 // *CourtBusyError that carries Court, MatchID, and CompID.
 var ErrCourtBusy = errors.New("court already has a running match")
 
-// CourtBusyError is returned by StartMatch / StartMatchTx when the
-// target court already has a running match in any competition.
-// Courts are tournament-global: one physical shiaijo can host only
-// one match at a time regardless of which competition owns it.
+// CourtBusyError is returned when the target court already has a running
+// match. Which competitions are scanned depends on the call site:
+//   - StartMatch (non-tx): scans all competitions via store.RunningMatchOnCourt.
+//   - CheckCrossCompCourtBusy (pre-tx gate): scans all competitions except compID.
+//   - StartMatchTx (tx path): scans only within compID — cross-competition
+//     conflicts are caught by CheckCrossCompCourtBusy before the tx begins.
+//
+// Courts are tournament-global: one physical shiaijo can host only one match at
+// a time regardless of which competition owns it.
 type CourtBusyError struct {
 	Court   string
 	MatchID string

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -186,6 +186,27 @@ func (e *Engine) checkCourtExclusivity(compID, matchID, skipCompID string) error
 	return nil
 }
 
+// CheckCrossCompCourtBusy checks whether the court assigned to matchID is
+// currently occupied by a running match in a different competition.
+// It MUST be called before entering WithTransaction for compID: calling
+// store.RunningMatchOnCourt while holding a per-comp write lock risks a
+// circular-wait deadlock if another competition is simultaneously in its
+// own WithTransaction (both goroutines try to read-lock each other's mutex).
+func (e *Engine) CheckCrossCompCourtBusy(compID, matchID string) error {
+	court, err := e.lookupMatchCourt(compID, matchID)
+	if err != nil || court == "" {
+		return err
+	}
+	crossOcc, err := e.store.RunningMatchOnCourt(court, compID)
+	if err != nil {
+		return err
+	}
+	if crossOcc != nil {
+		return &CourtBusyError{Court: court, MatchID: crossOcc.MatchID, CompID: crossOcc.CompID}
+	}
+	return nil
+}
+
 // lookupMatchCourt returns the court assigned to matchID in compID's pool
 // matches or bracket. Returns "" (not an error) when the match exists but
 // has no court assigned.

--- a/internal/engine/eligibility_test.go
+++ b/internal/engine/eligibility_test.go
@@ -1153,7 +1153,12 @@ func TestStartMatchTx_CourtExclusivity(t *testing.T) {
 		assert.Equal(t, "P-0", courtErr.MatchID)
 	})
 
-	t.Run("court busy in different competition blocks via tx path", func(t *testing.T) {
+	// Cross-competition court detection is intentionally NOT performed inside
+	// StartMatchTx: calling store.RunningMatchOnCourt (which acquires read locks
+	// on all other competitions) while holding compID's write lock via
+	// WithTransaction risks a circular-wait deadlock. The check is split: callers
+	// must invoke CheckCrossCompCourtBusy BEFORE entering WithTransaction.
+	t.Run("court busy in different competition does NOT block via tx path", func(t *testing.T) {
 		eng, store, _ := setupTestEngine(t)
 
 		createTestCompetition(t, store, "comp1", "league", 3)
@@ -1166,18 +1171,74 @@ func TestStartMatchTx_CourtExclusivity(t *testing.T) {
 			{ID: "P-0", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "A"},
 		}))
 
+		// StartMatchTx only performs the intra-comp check; it should NOT return
+		// ErrCourtBusy for a cross-comp conflict (that is caught pre-tx by
+		// CheckCrossCompCourtBusy — tested below).
 		var engErr error
 		txErr := store.WithTransaction("comp2", func(tx state.StoreTx) error {
 			engErr = eng.StartMatchTx(tx, "comp2", "P-0")
 			return nil
 		})
 		require.NoError(t, txErr)
-		require.Error(t, engErr)
-		assert.True(t, errors.Is(engErr, ErrCourtBusy), "want ErrCourtBusy, got %v", engErr)
+		assert.NoError(t, engErr, "StartMatchTx must not block on cross-comp court conflict (pre-tx check handles it)")
+	})
+}
+
+// TestCheckCrossCompCourtBusy verifies that CheckCrossCompCourtBusy detects
+// cross-competition court occupancy when called before entering WithTransaction.
+func TestCheckCrossCompCourtBusy(t *testing.T) {
+	t.Run("no conflict when court is free", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		createTestCompetition(t, store, "comp1", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp1", []state.MatchResult{
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+		assert.NoError(t, eng.CheckCrossCompCourtBusy("comp1", "P-0"))
+	})
+
+	t.Run("no conflict when no other competition uses the court", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		createTestCompetition(t, store, "comp1", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp1", []state.MatchResult{
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+		}))
+		createTestCompetition(t, store, "comp2", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp2", []state.MatchResult{
+			{ID: "P-0", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "B"},
+		}))
+		// Court A is busy in comp1 but comp2's match is on court B — no conflict.
+		assert.NoError(t, eng.CheckCrossCompCourtBusy("comp2", "P-0"))
+	})
+
+	t.Run("conflict when other competition has a running match on same court", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+
+		createTestCompetition(t, store, "comp1", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp1", []state.MatchResult{
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+		}))
+
+		createTestCompetition(t, store, "comp2", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp2", []state.MatchResult{
+			{ID: "P-0", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+
+		err := eng.CheckCrossCompCourtBusy("comp2", "P-0")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrCourtBusy), "want ErrCourtBusy, got %v", err)
 
 		var courtErr *CourtBusyError
-		require.ErrorAs(t, engErr, &courtErr)
+		require.ErrorAs(t, err, &courtErr)
 		assert.Equal(t, "A", courtErr.Court)
 		assert.Equal(t, "comp1", courtErr.CompID)
+	})
+
+	t.Run("no error when match has no court assigned", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		createTestCompetition(t, store, "comp1", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp1", []state.MatchResult{
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled, Court: ""},
+		}))
+		assert.NoError(t, eng.CheckCrossCompCourtBusy("comp1", "P-0"))
 	})
 }

--- a/internal/engine/eligibility_test.go
+++ b/internal/engine/eligibility_test.go
@@ -1036,3 +1036,145 @@ func TestStartMatch_RejectsSimultaneousMatch(t *testing.T) {
 		assert.Contains(t, ineligErr.Reason, "already fighting")
 	})
 }
+
+// TestStartMatch_CourtExclusivity verifies mp-95mg: StartMatch and
+// StartMatchTx must reject starting a match on a court that already
+// has a running match, across ALL competitions sharing the tournament.
+func TestStartMatch_CourtExclusivity(t *testing.T) {
+	t.Run("court busy in same competition blocks new match", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		compID := "court-same-comp"
+		createTestCompetition(t, store, compID, "league", 3)
+
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "m1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+			{ID: "m2", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+
+		err := eng.StartMatch(compID, "m2")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrCourtBusy), "want ErrCourtBusy, got %v", err)
+
+		var courtErr *CourtBusyError
+		require.ErrorAs(t, err, &courtErr)
+		assert.Equal(t, "A", courtErr.Court)
+		assert.Equal(t, "m1", courtErr.MatchID)
+	})
+
+	t.Run("court busy in different competition blocks new match", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+
+		// comp1 has a running match on court A.
+		createTestCompetition(t, store, "comp1", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp1", []state.MatchResult{
+			{ID: "m1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+		}))
+
+		// comp2 wants to start a match on court A.
+		createTestCompetition(t, store, "comp2", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp2", []state.MatchResult{
+			{ID: "m2", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+
+		err := eng.StartMatch("comp2", "m2")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrCourtBusy), "want ErrCourtBusy, got %v", err)
+
+		var courtErr *CourtBusyError
+		require.ErrorAs(t, err, &courtErr)
+		assert.Equal(t, "A", courtErr.Court)
+		assert.Equal(t, "m1", courtErr.MatchID)
+		assert.Equal(t, "comp1", courtErr.CompID)
+	})
+
+	t.Run("free court allows match to start", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		compID := "court-free"
+		createTestCompetition(t, store, compID, "league", 3)
+		saveTestParticipants(t, store, compID, []string{"Alice", "Bob"})
+
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "m1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "B"},
+			{ID: "m2", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+
+		// m2 is on court A which is free — but Alice is also in m1.
+		// Court check passes, but player simultaneity blocks it.
+		err := eng.StartMatch(compID, "m2")
+		// Error should be IneligibleCompetitor (player already fighting), not CourtBusy.
+		assert.False(t, errors.Is(err, ErrCourtBusy), "court A is free; should not get CourtBusy")
+	})
+
+	t.Run("match with no court assigned is never blocked by court exclusivity", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		compID := "no-court"
+		createTestCompetition(t, store, compID, "league", 3)
+		saveTestParticipants(t, store, compID, []string{"Alice", "Bob"})
+
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "m1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+			{ID: "m2", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: ""},
+		}))
+
+		err := eng.StartMatch(compID, "m2")
+		// No court assigned → court check skipped; other checks may pass or fail
+		// but ErrCourtBusy must not appear.
+		assert.False(t, errors.Is(err, ErrCourtBusy), "unassigned-court match must not trigger ErrCourtBusy")
+	})
+}
+
+func TestStartMatchTx_CourtExclusivity(t *testing.T) {
+	t.Run("court busy in same competition blocks via tx path", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+		compID := "tx-court-same"
+		createTestCompetition(t, store, compID, "league", 3)
+		// IDs must be hyphenated (PoolName-MatchIdx) so they survive the CSV
+		// round-trip that LoadPoolMatchesLocked uses inside a transaction.
+		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+			{ID: "P-1", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+
+		var engErr error
+		txErr := store.WithTransaction(compID, func(tx state.StoreTx) error {
+			engErr = eng.StartMatchTx(tx, compID, "P-1")
+			return nil
+		})
+		require.NoError(t, txErr)
+		require.Error(t, engErr)
+		assert.True(t, errors.Is(engErr, ErrCourtBusy), "want ErrCourtBusy, got %v", engErr)
+
+		var courtErr *CourtBusyError
+		require.ErrorAs(t, engErr, &courtErr)
+		assert.Equal(t, "A", courtErr.Court)
+		assert.Equal(t, "P-0", courtErr.MatchID)
+	})
+
+	t.Run("court busy in different competition blocks via tx path", func(t *testing.T) {
+		eng, store, _ := setupTestEngine(t)
+
+		createTestCompetition(t, store, "comp1", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp1", []state.MatchResult{
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
+		}))
+
+		createTestCompetition(t, store, "comp2", "league", 3)
+		require.NoError(t, store.SavePoolMatches("comp2", []state.MatchResult{
+			{ID: "P-0", SideA: "Charlie", SideB: "Dave", Status: state.MatchStatusScheduled, Court: "A"},
+		}))
+
+		var engErr error
+		txErr := store.WithTransaction("comp2", func(tx state.StoreTx) error {
+			engErr = eng.StartMatchTx(tx, "comp2", "P-0")
+			return nil
+		})
+		require.NoError(t, txErr)
+		require.Error(t, engErr)
+		assert.True(t, errors.Is(engErr, ErrCourtBusy), "want ErrCourtBusy, got %v", engErr)
+
+		var courtErr *CourtBusyError
+		require.ErrorAs(t, engErr, &courtErr)
+		assert.Equal(t, "A", courtErr.Court)
+		assert.Equal(t, "comp1", courtErr.CompID)
+	})
+}

--- a/internal/engine/eligibility_test.go
+++ b/internal/engine/eligibility_test.go
@@ -1093,16 +1093,19 @@ func TestStartMatch_CourtExclusivity(t *testing.T) {
 		createTestCompetition(t, store, compID, "league", 3)
 		saveTestParticipants(t, store, compID, []string{"Alice", "Bob"})
 
+		// Use hyphenated IDs so they survive the CSV round-trip used by the
+		// tx-path simultaneity check (LoadPoolMatchesLocked reads disk).
 		require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
-			{ID: "m1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "B"},
-			{ID: "m2", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled, Court: "A"},
+			{ID: "P-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "B"},
+			{ID: "P-1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled, Court: "A"},
 		}))
 
-		// m2 is on court A which is free — but Alice is also in m1.
-		// Court check passes, but player simultaneity blocks it.
-		err := eng.StartMatch(compID, "m2")
-		// Error should be IneligibleCompetitor (player already fighting), not CourtBusy.
-		assert.False(t, errors.Is(err, ErrCourtBusy), "court A is free; should not get CourtBusy")
+		// P-1 is on court A which is free — but Alice is also in P-0 on court B.
+		// Court check passes, but player simultaneity should block it.
+		err := eng.StartMatch(compID, "P-1")
+		require.Error(t, err, "Alice is already fighting; StartMatch should return an error")
+		assert.False(t, errors.Is(err, ErrCourtBusy), "court A is free; should not get ErrCourtBusy")
+		assert.True(t, errors.Is(err, ErrIneligibleCompetitor), "want ErrIneligibleCompetitor (player already fighting), got %v", err)
 	})
 
 	t.Run("match with no court assigned is never blocked by court exclusivity", func(t *testing.T) {

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -636,6 +636,14 @@ func (e *Engine) checkSimultaneousMatchTx(tx state.StoreTx, compID, matchID stri
 // It checks court exclusivity with careful lock discipline: compID's data
 // is read via tx (which bypasses re-acquiring the already-held write lock),
 // while all other competitions are scanned via the store's public methods.
+//
+// Residual TOCTOU: the intra-comp check (via tx) and the cross-comp check
+// (via store.RunningMatchOnCourt) are not atomic with each other. Two
+// simultaneous StartMatchTx calls on different competitions but the same
+// court can both pass the check and both commit. This is an inherent
+// limitation of the per-competition lock model; at real tournament scale
+// (human operators, seconds between button presses) it is not a practical
+// risk, but it is worth noting for future per-court locking.
 func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID string) error {
 	court, err := lookupMatchCourtTx(tx, compID, matchID)
 	if err != nil {
@@ -645,31 +653,39 @@ func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID strin
 		return nil
 	}
 	// Check compID's own matches via tx (avoids deadlock on non-reentrant mutex).
-	if occ := courtOccupiedInCompTx(tx, compID, court, matchID); occ != nil {
-		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}
-	}
-	// Check all other competitions via the store (safe: their write locks are free).
-	occ, err := e.store.RunningMatchOnCourt(court, compID)
+	occ, err := courtOccupiedInCompTx(tx, compID, court, matchID)
 	if err != nil {
 		return err
 	}
 	if occ != nil {
 		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}
 	}
+	// Check all other competitions via the store (safe: their write locks are free).
+	crossOcc, err := e.store.RunningMatchOnCourt(court, compID)
+	if err != nil {
+		return err
+	}
+	if crossOcc != nil {
+		return &CourtBusyError{Court: court, MatchID: crossOcc.MatchID, CompID: crossOcc.CompID}
+	}
 	return nil
 }
 
 func lookupMatchCourtTx(tx state.StoreTx, compID, matchID string) (string, error) {
 	poolMatches, err := tx.LoadPoolMatches(compID)
-	if err == nil {
-		for _, m := range poolMatches {
-			if m.ID == matchID {
-				return m.Court, nil
-			}
+	if err != nil {
+		return "", err
+	}
+	for _, m := range poolMatches {
+		if m.ID == matchID {
+			return m.Court, nil
 		}
 	}
 	bracket, err := tx.LoadBracket(compID)
-	if err == nil && bracket != nil {
+	if err != nil {
+		return "", err
+	}
+	if bracket != nil {
 		for _, round := range bracket.Rounds {
 			for _, bm := range round {
 				if bm.ID == matchID {
@@ -678,37 +694,41 @@ func lookupMatchCourtTx(tx state.StoreTx, compID, matchID string) (string, error
 			}
 		}
 	}
-	return "", nil
+	return "", notFoundErrorf("match %q not found in competition %q", matchID, compID)
 }
 
 // courtOccupiedInCompTx scans compID's pool matches and bracket (via tx)
 // for any match — other than skipMatchID — that is Running on court.
-func courtOccupiedInCompTx(tx state.StoreTx, compID, court, skipMatchID string) *state.CourtOccupancy {
+func courtOccupiedInCompTx(tx state.StoreTx, compID, court, skipMatchID string) (*state.CourtOccupancy, error) {
 	poolMatches, err := tx.LoadPoolMatches(compID)
-	if err == nil {
-		for _, m := range poolMatches {
-			if m.ID == skipMatchID || m.Status != state.MatchStatusRunning {
-				continue
-			}
-			if m.Court == court {
-				return &state.CourtOccupancy{CompID: compID, MatchID: m.ID}
-			}
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range poolMatches {
+		if m.ID == skipMatchID || m.Status != state.MatchStatusRunning {
+			continue
+		}
+		if m.Court == court {
+			return &state.CourtOccupancy{CompID: compID, MatchID: m.ID}, nil
 		}
 	}
 	bracket, err := tx.LoadBracket(compID)
-	if err == nil && bracket != nil {
+	if err != nil {
+		return nil, err
+	}
+	if bracket != nil {
 		for _, round := range bracket.Rounds {
 			for _, bm := range round {
 				if bm.ID == skipMatchID || bm.Status != state.MatchStatusRunning {
 					continue
 				}
 				if bm.Court == court {
-					return &state.CourtOccupancy{CompID: compID, MatchID: bm.ID}
+					return &state.CourtOccupancy{CompID: compID, MatchID: bm.ID}, nil
 				}
 			}
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func resolvePlayerIDsTx(tx state.StoreTx, compID, sideA, sideB string) (string, string) {

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -638,7 +638,10 @@ func (e *Engine) checkSimultaneousMatchTx(tx state.StoreTx, compID, matchID stri
 // while all other competitions are scanned via the store's public methods.
 func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID string) error {
 	court, err := lookupMatchCourtTx(tx, compID, matchID)
-	if err != nil || court == "" {
+	if err != nil {
+		return err
+	}
+	if court == "" {
 		return nil
 	}
 	// Check compID's own matches via tx (avoids deadlock on non-reentrant mutex).
@@ -648,7 +651,7 @@ func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID strin
 	// Check all other competitions via the store (safe: their write locks are free).
 	occ, err := e.store.RunningMatchOnCourt(court, compID)
 	if err != nil {
-		return nil
+		return err
 	}
 	if occ != nil {
 		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -533,6 +533,9 @@ func (e *Engine) lookupMatchSidesTx(tx state.StoreTx, compID, matchID string) (s
 // RecordDecisionTx, which intentionally bypasses this gate — they ARE
 // the act of recording a new withdrawal.
 func (e *Engine) StartMatchTx(tx state.StoreTx, compID, matchID string) error {
+	if err := e.checkCourtExclusivityTx(tx, compID, matchID); err != nil {
+		return err
+	}
 	if err := e.checkSimultaneousMatchTx(tx, compID, matchID); err != nil {
 		return err
 	}
@@ -626,6 +629,82 @@ func (e *Engine) checkSimultaneousMatchTx(tx state.StoreTx, compID, matchID stri
 		}
 	}
 
+	return nil
+}
+
+// checkCourtExclusivityTx is the tx-aware twin of checkCourtExclusivity.
+// It checks court exclusivity with careful lock discipline: compID's data
+// is read via tx (which bypasses re-acquiring the already-held write lock),
+// while all other competitions are scanned via the store's public methods.
+func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID string) error {
+	court, err := lookupMatchCourtTx(tx, compID, matchID)
+	if err != nil || court == "" {
+		return nil
+	}
+	// Check compID's own matches via tx (avoids deadlock on non-reentrant mutex).
+	if occ := courtOccupiedInCompTx(tx, compID, court, matchID); occ != nil {
+		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}
+	}
+	// Check all other competitions via the store (safe: their write locks are free).
+	occ, err := e.store.RunningMatchOnCourt(court, compID)
+	if err != nil {
+		return nil
+	}
+	if occ != nil {
+		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}
+	}
+	return nil
+}
+
+func lookupMatchCourtTx(tx state.StoreTx, compID, matchID string) (string, error) {
+	poolMatches, err := tx.LoadPoolMatches(compID)
+	if err == nil {
+		for _, m := range poolMatches {
+			if m.ID == matchID {
+				return m.Court, nil
+			}
+		}
+	}
+	bracket, err := tx.LoadBracket(compID)
+	if err == nil && bracket != nil {
+		for _, round := range bracket.Rounds {
+			for _, bm := range round {
+				if bm.ID == matchID {
+					return bm.Court, nil
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+// courtOccupiedInCompTx scans compID's pool matches and bracket (via tx)
+// for any match — other than skipMatchID — that is Running on court.
+func courtOccupiedInCompTx(tx state.StoreTx, compID, court, skipMatchID string) *state.CourtOccupancy {
+	poolMatches, err := tx.LoadPoolMatches(compID)
+	if err == nil {
+		for _, m := range poolMatches {
+			if m.ID == skipMatchID || m.Status != state.MatchStatusRunning {
+				continue
+			}
+			if m.Court == court {
+				return &state.CourtOccupancy{CompID: compID, MatchID: m.ID}
+			}
+		}
+	}
+	bracket, err := tx.LoadBracket(compID)
+	if err == nil && bracket != nil {
+		for _, round := range bracket.Rounds {
+			for _, bm := range round {
+				if bm.ID == skipMatchID || bm.Status != state.MatchStatusRunning {
+					continue
+				}
+				if bm.Court == court {
+					return &state.CourtOccupancy{CompID: compID, MatchID: bm.ID}
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -632,18 +632,13 @@ func (e *Engine) checkSimultaneousMatchTx(tx state.StoreTx, compID, matchID stri
 	return nil
 }
 
-// checkCourtExclusivityTx is the tx-aware twin of checkCourtExclusivity.
-// It checks court exclusivity with careful lock discipline: compID's data
-// is read via tx (which bypasses re-acquiring the already-held write lock),
-// while all other competitions are scanned via the store's public methods.
-//
-// Residual TOCTOU: the intra-comp check (via tx) and the cross-comp check
-// (via store.RunningMatchOnCourt) are not atomic with each other. Two
-// simultaneous StartMatchTx calls on different competitions but the same
-// court can both pass the check and both commit. This is an inherent
-// limitation of the per-competition lock model; at real tournament scale
-// (human operators, seconds between button presses) it is not a practical
-// risk, but it is worth noting for future per-court locking.
+// checkCourtExclusivityTx checks that no OTHER match in compID's own pool or
+// bracket is already running on the same court. The cross-competition check is
+// intentionally omitted here: calling store.RunningMatchOnCourt (which acquires
+// read locks on other competitions) while holding compID's write lock via
+// WithTransaction risks a circular-wait deadlock if another competition is
+// simultaneously in its own WithTransaction. The cross-competition check is
+// performed by CheckCrossCompCourtBusy before WithTransaction is entered.
 func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID string) error {
 	court, err := lookupMatchCourtTx(tx, compID, matchID)
 	if err != nil {
@@ -652,21 +647,12 @@ func (e *Engine) checkCourtExclusivityTx(tx state.StoreTx, compID, matchID strin
 	if court == "" {
 		return nil
 	}
-	// Check compID's own matches via tx (avoids deadlock on non-reentrant mutex).
 	occ, err := courtOccupiedInCompTx(tx, compID, court, matchID)
 	if err != nil {
 		return err
 	}
 	if occ != nil {
 		return &CourtBusyError{Court: court, MatchID: occ.MatchID, CompID: occ.CompID}
-	}
-	// Check all other competitions via the store (safe: their write locks are free).
-	crossOcc, err := e.store.RunningMatchOnCourt(court, compID)
-	if err != nil {
-		return err
-	}
-	if crossOcc != nil {
-		return &CourtBusyError{Court: court, MatchID: crossOcc.MatchID, CompID: crossOcc.CompID}
 	}
 	return nil
 }

--- a/internal/mobileapp/deps.go
+++ b/internal/mobileapp/deps.go
@@ -180,10 +180,9 @@ type Broadcaster interface {
 // CompetitionStore / TeamLineupStore / etc. interfaces at the
 // registration site, same pattern the other handler families use.
 //
-// Consumers (current): handlers_lineup.go (the PUT, T156). The score
-// and decision handlers are queued for migration once the engine
-// methods learn tx-aware variants; until then they hold the concrete
-// *engine.Engine which internally locks per-comp.
+// Consumers (current): handlers_lineup.go (the PUT, T156);
+// handlers_match.go (score, mp-95mg — wraps WithCourtExclusivityLock +
+// WithTransaction); handlers_decision.go (decision, T156).
 type CompetitionTransactor interface {
 	// WithTransaction runs fn under the per-competition write lock for
 	// compID. fn receives a state.StoreTx handle whose methods skip

--- a/internal/mobileapp/deps.go
+++ b/internal/mobileapp/deps.go
@@ -83,6 +83,12 @@ type ScoringEngine interface {
 	// match that itself created the ineligibility) is permitted.
 	// Score handler wraps fought/hikiwake submissions with this.
 	StartMatchTx(tx state.StoreTx, compID, matchID string) error
+	// CheckCrossCompCourtBusy checks whether the court for matchID is
+	// already occupied by a running match in a different competition.
+	// Must be called before entering WithTransaction to avoid a deadlock
+	// (store.RunningMatchOnCourt acquires read locks on other competitions;
+	// calling it while holding a write lock risks a circular wait).
+	CheckCrossCompCourtBusy(compID, matchID string) error
 	// RecordDecision auto-fills the scoreline + winner from the
 	// decision/decisionBy/encho triple and persists the result. Used by
 	// the dedicated POST /decision endpoint (T090). When the prior

--- a/internal/mobileapp/deps.go
+++ b/internal/mobileapp/deps.go
@@ -190,4 +190,11 @@ type CompetitionTransactor interface {
 	// re-locking; the lock is released on return (success or error).
 	// Mirrors state.Store.WithTransaction.
 	WithTransaction(compID string, fn func(tx state.StoreTx) error) error
+	// WithCourtExclusivityLock runs fn under the store's court-exclusivity
+	// mutex, which must be acquired BEFORE any per-comp lock. Use this to
+	// wrap a cross-competition court-busy check + WithTransaction pair so
+	// two concurrent match-starts on the same court in different
+	// competitions can't both pass the check before either commits (TOCTOU).
+	// Mirrors state.Store.WithCourtExclusivityLock.
+	WithCourtExclusivityLock(fn func() error) error
 }

--- a/internal/mobileapp/deps_test.go
+++ b/internal/mobileapp/deps_test.go
@@ -55,6 +55,10 @@ func (stubScoringEngine) StartMatchTx(state.StoreTx, string, string) error {
 	return nil
 }
 
+func (stubScoringEngine) CheckCrossCompCourtBusy(string, string) error {
+	return nil
+}
+
 func (stubScoringEngine) RecordDecision(string, string, string, string, string, *state.EnchoMetadata, bool) (*state.MatchResult, *domain.CompetitorStatus, error) {
 	return nil, nil, nil
 }

--- a/internal/mobileapp/deps_test.go
+++ b/internal/mobileapp/deps_test.go
@@ -144,6 +144,10 @@ func (stubCompetitionTransactor) WithTransaction(string, func(state.StoreTx) err
 	return nil
 }
 
+func (stubCompetitionTransactor) WithCourtExclusivityLock(fn func() error) error {
+	return fn()
+}
+
 // TestDepsInterfacesCompile is a compile-time guard that the consumer-
 // boundary interfaces (deps.go) are satisfied by both the stub
 // implementations above AND the production concrete types. If a method

--- a/internal/mobileapp/handlers_daihyosen.go
+++ b/internal/mobileapp/handlers_daihyosen.go
@@ -130,6 +130,11 @@ func RegisterDaihyosenHandlers(r *gin.RouterGroup, eng DaihyosenEngine, store Da
 			}
 			u := *match
 			u.SubResults = filtered
+			// Court exclusivity (mp-95mg) is not required here: DELETE /daihyosen
+			// only proceeds when the DH sub is an unscored placeholder (the guard
+			// above rejects if the sub has ippons, a winner, or a non-daihyosen
+			// decision), which means the parent match is still in MatchStatusRunning
+			// — no cross-comp conflict can be introduced by this write.
 			u.Status = state.MatchStatusRunning
 			// Clear ALL DH-derived match-level result/decision metadata so the
 			// match returns to a clean running state. MatchResult.Decision has no
@@ -237,6 +242,11 @@ func RegisterDaihyosenHandlers(r *gin.RouterGroup, eng DaihyosenEngine, store Da
 
 			// Append the placeholder to the match's SubResults and persist via
 			// the Tx score path so the append commits under the held lock.
+			// Court exclusivity (mp-95mg) is not required here: AddDaihyosen
+			// returns ErrNotTied unless the parent match is in a tied completed-
+			// bouts state (i.e. already MatchStatusRunning on the court). The
+			// court slot was committed when the match was first started via the
+			// score endpoint, which holds WithCourtExclusivityLock.
 			u := *match
 			u.SubResults = append(append([]state.SubMatchResult{}, match.SubResults...), *sub)
 			u.Status = state.MatchStatusRunning // daihyosen bout in progress

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -297,6 +297,10 @@ func RegisterMatchHandlers(r *gin.RouterGroup, eng *engine.Engine, store Competi
 			// same per-comp lock so the status read is race-free against a
 			// concurrent PUT /score. Per-result transactions preserve the
 			// existing {succeeded, errors[]} partial-success response shape.
+			// Court exclusivity (mp-95mg) is intentionally NOT enforced here:
+			// bulk-score is an admin batch-import/correction tool, not a live
+			// match-start path. It also bypasses StartMatchTx for the same
+			// reason — admin corrections are meant to override normal flow.
 			results[i].CorrectionReason = strings.TrimSpace(results[i].CorrectionReason)
 			var capturedStatus *domain.CompetitorStatus
 			if err := tx.WithTransaction(id, func(stx state.StoreTx) error {

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -784,96 +784,104 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 			result.CorrectionReason = ""
 		}
 
-		// FR-035 court exclusivity: cross-competition check runs BEFORE
-		// WithTransaction to avoid a potential deadlock. Calling
-		// store.RunningMatchOnCourt while holding a write lock would deadlock
-		// if another competition is simultaneously in its own WithTransaction
-		// (both goroutines try to read-lock each other's mutex).
-		// Withdrawal decisions skip this gate — operators must record
-		// kiken/fusenpai regardless of court state.
 		isWithdrawal := domain.IsKikenDecisionStr(result.Decision) || result.Decision == "fusenpai"
-		if !isWithdrawal {
-			if err := eng.CheckCrossCompCourtBusy(id, mid); err != nil {
-				var courtBusyErr *engine.CourtBusyError
-				if errors.As(err, &courtBusyErr) {
-					c.JSON(http.StatusConflict, gin.H{
-						"error":   "court_busy",
-						"court":   courtBusyErr.Court,
-						"matchId": courtBusyErr.MatchID,
-						"compId":  courtBusyErr.CompID,
-						"message": fmt.Sprintf("Court %s already has a running match (%s). Finish that match before starting a new one.", courtBusyErr.Court, courtBusyErr.MatchID),
-					})
-				} else {
-					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-				}
-				return
-			}
-		}
 
-		// T156: run the score write + ineligibility update + lineup-freeze
-		// inside a single per-comp lock acquire via WithTransaction. The
-		// engine's RecordMatchResultWithIneligibilityTx dispatches every
-		// store call through `stx`, so no internal call re-acquires the
-		// lock (non-reentrant; nesting would deadlock).
-		//
-		// FR-035: intra-competition eligibility and court gate. Checks that
-		// no OTHER match in compID's own pool/bracket is running on the same
-		// court, plus participant ineligibility. Withdrawal decisions bypass
-		// so operators can record kiken on matches with ineligible participants.
+		// FR-035: WithCourtExclusivityLock serializes the cross-competition
+		// court-busy check + per-competition write under a tournament-level
+		// mutex so two concurrent match-starts on the same court in different
+		// competitions can't both pass the cross-comp check before either
+		// commits (TOCTOU). Withdrawal decisions skip the court gate — operators
+		// must record kiken/fusenpai regardless of court state.
 		var (
 			engStatus *domain.CompetitorStatus
 			engErr    error
 		)
-		txErr := tx.WithTransaction(id, func(stx state.StoreTx) error {
-			// mp-ba3: finalized guard runs under the per-comp lock to
-			// prevent TOCTOU races between concurrent anonymous submissions.
-			if resultSource == "self-reported" {
-				if err := checkFinalizedUnderTx(stx, id, mid); err != nil {
-					engErr = err
-					return nil
+		txErr := tx.WithCourtExclusivityLock(func() error {
+			if !isWithdrawal {
+				if err := eng.CheckCrossCompCourtBusy(id, mid); err != nil {
+					return err
 				}
 			}
-			// Correction audit: overwriting an already-completed result
-			// (completed -> completed) is a correction and requires a non-empty
-			// CorrectionReason for traceability. This applies to ANY decision
-			// type, including a withdrawal (kiken/fusenpai) submitted via /score
-			// — exempting those would let a finalized result be overwritten with
-			// no audit reason. The check runs inside the tx so the is-completed
-			// read is race-free (same lock). A first finalization (existing
-			// status is not completed) needs no reason.
-			if result.Status == state.MatchStatusCompleted {
-				existing := lookupMatchStatusUnderTx(stx, id, mid)
-				if existing == state.MatchStatusCompleted {
-					// Overwriting a finalized result is a correction — require a reason.
-					if result.CorrectionReason == "" {
-						engErr = &ValidationError{
-							Field:   "correctionReason",
-							Message: "correcting a completed match result requires a non-empty correctionReason",
-						}
+			// T156: run the score write + ineligibility update + lineup-freeze
+			// inside a single per-comp lock acquire via WithTransaction. The
+			// engine's RecordMatchResultWithIneligibilityTx dispatches every
+			// store call through `stx`, so no internal call re-acquires the
+			// lock (non-reentrant; nesting would deadlock).
+			//
+			// FR-035: intra-competition eligibility and court gate. Checks that
+			// no OTHER match in compID's own pool/bracket is running on the same
+			// court, plus participant ineligibility. Withdrawal decisions bypass
+			// so operators can record kiken on matches with ineligible participants.
+			return tx.WithTransaction(id, func(stx state.StoreTx) error {
+				// mp-ba3: finalized guard runs under the per-comp lock to
+				// prevent TOCTOU races between concurrent anonymous submissions.
+				if resultSource == "self-reported" {
+					if err := checkFinalizedUnderTx(stx, id, mid); err != nil {
+						engErr = err
 						return nil
 					}
-				} else {
-					// First finalization — not a correction. The contract says the
-					// reason is omitted here, so drop any client-supplied value.
-					result.CorrectionReason = ""
 				}
-			}
-			if !isWithdrawal {
-				if err := eng.StartMatchTx(stx, id, mid); err != nil {
-					engErr = err
-					return nil
+				// Correction audit: overwriting an already-completed result
+				// (completed -> completed) is a correction and requires a non-empty
+				// CorrectionReason for traceability. This applies to ANY decision
+				// type, including a withdrawal (kiken/fusenpai) submitted via /score
+				// — exempting those would let a finalized result be overwritten with
+				// no audit reason. The check runs inside the tx so the is-completed
+				// read is race-free (same lock). A first finalization (existing
+				// status is not completed) needs no reason.
+				if result.Status == state.MatchStatusCompleted {
+					existing := lookupMatchStatusUnderTx(stx, id, mid)
+					if existing == state.MatchStatusCompleted {
+						// Overwriting a finalized result is a correction — require a reason.
+						if result.CorrectionReason == "" {
+							engErr = &ValidationError{
+								Field:   "correctionReason",
+								Message: "correcting a completed match result requires a non-empty correctionReason",
+							}
+							return nil
+						}
+					} else {
+						// First finalization — not a correction. The contract says the
+						// reason is omitted here, so drop any client-supplied value.
+						result.CorrectionReason = ""
+					}
 				}
-			}
-			engStatus, engErr = eng.RecordMatchResultWithIneligibilityTx(stx, id, mid, result)
-			// engErr is a normal application-level signal (AlreadyIneligible
-			// → 409, validation/not-found → other codes); we surface it
-			// after the tx returns. The score-write inside the tx already
-			// includes the K3 rollback for the AlreadyIneligible path —
-			// returning nil here commits whatever final state the engine
-			// settled on.
-			return nil
+				if !isWithdrawal {
+					if err := eng.StartMatchTx(stx, id, mid); err != nil {
+						engErr = err
+						return nil
+					}
+				}
+				engStatus, engErr = eng.RecordMatchResultWithIneligibilityTx(stx, id, mid, result)
+				// engErr is a normal application-level signal (AlreadyIneligible
+				// → 409, validation/not-found → other codes); we surface it
+				// after the tx returns. The score-write inside the tx already
+				// includes the K3 rollback for the AlreadyIneligible path —
+				// returning nil here commits whatever final state the engine
+				// settled on.
+				return nil
+			})
 		})
 		if txErr != nil {
+			// txErr carries errors from CheckCrossCompCourtBusy (cross-comp
+			// court conflict or match-not-found) or from the WithTransaction
+			// infrastructure itself (WAL commit failure, etc.).
+			var courtBusyErr *engine.CourtBusyError
+			if errors.As(txErr, &courtBusyErr) {
+				c.JSON(http.StatusConflict, gin.H{
+					"error":   "court_busy",
+					"court":   courtBusyErr.Court,
+					"matchId": courtBusyErr.MatchID,
+					"compId":  courtBusyErr.CompID,
+					"message": fmt.Sprintf("Court %s already has a running match (%s). Finish that match before starting a new one.", courtBusyErr.Court, courtBusyErr.MatchID),
+				})
+				return
+			}
+			var notFoundErr *engine.NotFoundError
+			if errors.As(txErr, &notFoundErr) {
+				c.JSON(http.StatusNotFound, gin.H{"error": txErr.Error()})
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": txErr.Error()})
 			return
 		}

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -948,6 +948,11 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 				})
 				return
 			}
+			var notFoundEngErr *engine.NotFoundError
+			if errors.As(engErr, &notFoundEngErr) {
+				c.JSON(http.StatusNotFound, gin.H{"error": engErr.Error()})
+				return
+			}
 			var valErr *ValidationError
 			if errors.As(engErr, &valErr) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": valErr.Error()})

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -922,6 +922,7 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 					"error":   "court_busy",
 					"court":   courtBusyErr.Court,
 					"matchId": courtBusyErr.MatchID,
+					"compId":  courtBusyErr.CompID,
 					"message": fmt.Sprintf("Court %s already has a running match (%s). Finish that match before starting a new one.", courtBusyErr.Court, courtBusyErr.MatchID),
 				})
 				return

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -916,6 +916,16 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 				})
 				return
 			}
+			var courtBusyErr *engine.CourtBusyError
+			if errors.As(engErr, &courtBusyErr) {
+				c.JSON(http.StatusConflict, gin.H{
+					"error":   "court_busy",
+					"court":   courtBusyErr.Court,
+					"matchId": courtBusyErr.MatchID,
+					"message": fmt.Sprintf("Court %s already has a running match (%s). Finish that match before starting a new one.", courtBusyErr.Court, courtBusyErr.MatchID),
+				})
+				return
+			}
 			var downstreamKnockoutErr *engine.DownstreamKnockoutScoredError
 			if errors.As(engErr, &downstreamKnockoutErr) {
 				c.JSON(http.StatusConflict, gin.H{

--- a/internal/mobileapp/handlers_match.go
+++ b/internal/mobileapp/handlers_match.go
@@ -801,22 +801,42 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 			result.CorrectionReason = ""
 		}
 
+		// FR-035 court exclusivity: cross-competition check runs BEFORE
+		// WithTransaction to avoid a potential deadlock. Calling
+		// store.RunningMatchOnCourt while holding a write lock would deadlock
+		// if another competition is simultaneously in its own WithTransaction
+		// (both goroutines try to read-lock each other's mutex).
+		// Withdrawal decisions skip this gate — operators must record
+		// kiken/fusenpai regardless of court state.
+		isWithdrawal := domain.IsKikenDecisionStr(result.Decision) || result.Decision == "fusenpai"
+		if !isWithdrawal {
+			if err := eng.CheckCrossCompCourtBusy(id, mid); err != nil {
+				var courtBusyErr *engine.CourtBusyError
+				if errors.As(err, &courtBusyErr) {
+					c.JSON(http.StatusConflict, gin.H{
+						"error":   "court_busy",
+						"court":   courtBusyErr.Court,
+						"matchId": courtBusyErr.MatchID,
+						"compId":  courtBusyErr.CompID,
+						"message": fmt.Sprintf("Court %s already has a running match (%s). Finish that match before starting a new one.", courtBusyErr.Court, courtBusyErr.MatchID),
+					})
+				} else {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				}
+				return
+			}
+		}
+
 		// T156: run the score write + ineligibility update + lineup-freeze
 		// inside a single per-comp lock acquire via WithTransaction. The
 		// engine's RecordMatchResultWithIneligibilityTx dispatches every
 		// store call through `stx`, so no internal call re-acquires the
 		// lock (non-reentrant; nesting would deadlock).
 		//
-		// FR-035: pre-flight eligibility gate. A "fought" or "hikiwake"
-		// score is the act of starting/finishing real play — refuse it
-		// when a participant is marked ineligible by a *different*
-		// match. Kiken/fusenpai go through this same endpoint to record
-		// a new withdrawal on this match (decisionBy chooses the
-		// loser); StartMatchTx excludes status sourced from this match
-		// so the undo path is permitted, and we additionally skip the
-		// gate entirely for withdrawal-type decisions so the operator
-		// can record kiken on a match whose other participant is
-		// already ineligible.
+		// FR-035: intra-competition eligibility and court gate. Checks that
+		// no OTHER match in compID's own pool/bracket is running on the same
+		// court, plus participant ineligibility. Withdrawal decisions bypass
+		// so operators can record kiken on matches with ineligible participants.
 		var (
 			engStatus *domain.CompetitorStatus
 			engErr    error
@@ -855,7 +875,6 @@ func registerScoreHandler(r *gin.RouterGroup, eng ScoringEngine, store Competiti
 					result.CorrectionReason = ""
 				}
 			}
-			isWithdrawal := domain.IsKikenDecisionStr(result.Decision) || result.Decision == "fusenpai"
 			if !isWithdrawal {
 				if err := eng.StartMatchTx(stx, id, mid); err != nil {
 					engErr = err

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -2047,23 +2047,23 @@ func TestMatchHandlers(t *testing.T) {
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 
-	// PUT /api/competitions/:id/matches/:mid/score (not found)
+	// PUT /api/competitions/:id/matches/:mid/score (not found — match doesn't exist → 404)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("PUT", "/api/competitions/c1/matches/not-exists/score", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	// Verify update
 	updatedMatches, _ := store.LoadPoolMatches("c1")
 	assert.Equal(t, "A", updatedMatches[0].Winner)
 
-	// PUT /api/competitions/:id/matches/:mid/score (invalid competition)
+	// PUT /api/competitions/:id/matches/:mid/score (invalid competition — not found → 404)
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("PUT", "/api/competitions/not-exists/matches/PoolA-1/score", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestMatchHandlers_BracketMatch(t *testing.T) {

--- a/internal/state/match.go
+++ b/internal/state/match.go
@@ -2,6 +2,74 @@ package state
 
 import "sort"
 
+// CourtOccupancy carries the first running match found on a given court.
+type CourtOccupancy struct {
+	CompID  string
+	MatchID string
+}
+
+// RunningMatchOnCourt scans every competition for a match with the given
+// court that is currently in MatchStatusRunning. It returns the first
+// occupant found, or nil if the court is free. An empty court string is
+// never considered busy (unassigned matches don't block anything).
+//
+// Lock discipline: each competition's data is loaded under its own
+// per-comp READ lock (via the public Load* methods). The caller MUST NOT
+// already hold the write lock for any competition that this method
+// scans — that would deadlock the non-reentrant RWMutex. On the
+// StartMatchTx path the caller holds compID_X's write lock, so
+// skipCompID must be set to compID_X; that competition is checked by
+// the caller via StoreTx instead.
+func (s *Store) RunningMatchOnCourt(court, skipCompID string) (*CourtOccupancy, error) {
+	if court == "" {
+		return nil, nil
+	}
+	ids, err := s.ListCompetitions()
+	if err != nil {
+		return nil, err
+	}
+	for _, compID := range ids {
+		if compID == skipCompID {
+			continue
+		}
+		if occ := runningOnCourtInPoolMatches(s, compID, court); occ != nil {
+			return occ, nil
+		}
+		if occ, err := runningOnCourtInBracket(s, compID, court); err == nil && occ != nil {
+			return occ, nil
+		}
+	}
+	return nil, nil
+}
+
+func runningOnCourtInPoolMatches(s *Store, compID, court string) *CourtOccupancy {
+	matches, err := s.LoadPoolMatches(compID)
+	if err != nil {
+		return nil
+	}
+	for _, m := range matches {
+		if m.Status == MatchStatusRunning && m.Court == court {
+			return &CourtOccupancy{CompID: compID, MatchID: m.ID}
+		}
+	}
+	return nil
+}
+
+func runningOnCourtInBracket(s *Store, compID, court string) (*CourtOccupancy, error) {
+	bracket, err := s.LoadBracket(compID)
+	if err != nil || bracket == nil {
+		return nil, err
+	}
+	for _, round := range bracket.Rounds {
+		for _, bm := range round {
+			if bm.Status == MatchStatusRunning && bm.Court == court {
+				return &CourtOccupancy{CompID: compID, MatchID: bm.ID}, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
 // DeriveQueuePositions assigns a 1-indexed queue position to each
 // scheduled match per court. Live (running) and completed matches
 // receive 0.

--- a/internal/state/match.go
+++ b/internal/state/match.go
@@ -32,27 +32,35 @@ func (s *Store) RunningMatchOnCourt(court, skipCompID string) (*CourtOccupancy, 
 		if compID == skipCompID {
 			continue
 		}
-		if occ := runningOnCourtInPoolMatches(s, compID, court); occ != nil {
+		occ, err := runningOnCourtInPoolMatches(s, compID, court)
+		if err != nil {
+			return nil, err
+		}
+		if occ != nil {
 			return occ, nil
 		}
-		if occ, err := runningOnCourtInBracket(s, compID, court); err == nil && occ != nil {
+		occ, err = runningOnCourtInBracket(s, compID, court)
+		if err != nil {
+			return nil, err
+		}
+		if occ != nil {
 			return occ, nil
 		}
 	}
 	return nil, nil
 }
 
-func runningOnCourtInPoolMatches(s *Store, compID, court string) *CourtOccupancy {
+func runningOnCourtInPoolMatches(s *Store, compID, court string) (*CourtOccupancy, error) {
 	matches, err := s.LoadPoolMatches(compID)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	for _, m := range matches {
 		if m.Status == MatchStatusRunning && m.Court == court {
-			return &CourtOccupancy{CompID: compID, MatchID: m.ID}
+			return &CourtOccupancy{CompID: compID, MatchID: m.ID}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func runningOnCourtInBracket(s *Store, compID, court string) (*CourtOccupancy, error) {

--- a/internal/state/match_test.go
+++ b/internal/state/match_test.go
@@ -1,9 +1,11 @@
 package state
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestQueuePositionDerivation verifies FR-025: per-court queue positions
@@ -59,4 +61,128 @@ func TestQueuePositionDerivation_MultipleCourts(t *testing.T) {
 
 	assert.Equal(t, []int{1, 1, 2, 0}, got,
 		"per-court counters are independent; running gets 0")
+}
+
+func TestRunningMatchOnCourt_FreeCourt(t *testing.T) {
+	dir, err := os.MkdirTemp("", "court-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp1"}))
+	require.NoError(t, store.SavePoolMatches("comp1", []MatchResult{
+		{ID: "m1", Status: MatchStatusScheduled, Court: "A"},
+	}))
+
+	occ, err := store.RunningMatchOnCourt("A", "")
+	require.NoError(t, err)
+	assert.Nil(t, occ, "scheduled match should not block the court")
+}
+
+func TestRunningMatchOnCourt_BusySameCourt(t *testing.T) {
+	dir, err := os.MkdirTemp("", "court-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp1"}))
+	require.NoError(t, store.SavePoolMatches("comp1", []MatchResult{
+		{ID: "m1", Status: MatchStatusRunning, Court: "A"},
+	}))
+
+	occ, err := store.RunningMatchOnCourt("A", "")
+	require.NoError(t, err)
+	require.NotNil(t, occ)
+	assert.Equal(t, "comp1", occ.CompID)
+	assert.Equal(t, "m1", occ.MatchID)
+}
+
+func TestRunningMatchOnCourt_SkipCompID(t *testing.T) {
+	dir, err := os.MkdirTemp("", "court-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp1"}))
+	require.NoError(t, store.SavePoolMatches("comp1", []MatchResult{
+		{ID: "m1", Status: MatchStatusRunning, Court: "A"},
+	}))
+
+	// With skipCompID=comp1, the running match in comp1 should be ignored.
+	occ, err := store.RunningMatchOnCourt("A", "comp1")
+	require.NoError(t, err)
+	assert.Nil(t, occ, "skipCompID competition should be excluded from scan")
+}
+
+func TestRunningMatchOnCourt_CrossCompetition(t *testing.T) {
+	dir, err := os.MkdirTemp("", "court-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	// comp1 has a running match on court A; comp2 wants to start on court A.
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp1"}))
+	require.NoError(t, store.SavePoolMatches("comp1", []MatchResult{
+		{ID: "m1", Status: MatchStatusRunning, Court: "A"},
+	}))
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp2"}))
+	require.NoError(t, store.SavePoolMatches("comp2", []MatchResult{
+		{ID: "m2", Status: MatchStatusScheduled, Court: "A"},
+	}))
+
+	// Scanning from comp2's perspective (skipCompID=comp2) should find comp1's match.
+	occ, err := store.RunningMatchOnCourt("A", "comp2")
+	require.NoError(t, err)
+	require.NotNil(t, occ)
+	assert.Equal(t, "comp1", occ.CompID)
+	assert.Equal(t, "m1", occ.MatchID)
+}
+
+func TestRunningMatchOnCourt_BracketMatch(t *testing.T) {
+	dir, err := os.MkdirTemp("", "court-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp1"}))
+	bracket := &Bracket{
+		Rounds: [][]BracketMatch{
+			{{ID: "bm1", Status: MatchStatusRunning, Court: "B"}},
+		},
+	}
+	require.NoError(t, store.SaveBracket("comp1", bracket))
+
+	occ, err := store.RunningMatchOnCourt("B", "")
+	require.NoError(t, err)
+	require.NotNil(t, occ)
+	assert.Equal(t, "comp1", occ.CompID)
+	assert.Equal(t, "bm1", occ.MatchID)
+}
+
+func TestRunningMatchOnCourt_EmptyCourtIsNeverBusy(t *testing.T) {
+	dir, err := os.MkdirTemp("", "court-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, store.SaveCompetition(&Competition{ID: "comp1"}))
+	require.NoError(t, store.SavePoolMatches("comp1", []MatchResult{
+		{ID: "m1", Status: MatchStatusRunning, Court: ""},
+	}))
+
+	occ, err := store.RunningMatchOnCourt("", "")
+	require.NoError(t, err)
+	assert.Nil(t, occ, "empty court string should never be considered busy")
 }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -38,6 +38,13 @@ type Store struct {
 	// remain concurrent across competitions.
 	compRenameMu sync.Mutex
 
+	// courtCheckMu serializes the "cross-comp court-busy check + per-comp
+	// match write" sequence so two concurrent match-starts in different
+	// competitions on the same court can't both pass the cross-comp check
+	// before either commits (TOCTOU). Same pattern as compRenameMu.
+	// Lock ordering: courtCheckMu is always acquired BEFORE any per-comp lock.
+	courtCheckMu sync.Mutex
+
 	// cache for tournament configuration to avoid redundant disk I/O.
 	tournamentMu sync.RWMutex
 	cachedTourn  *Tournament
@@ -177,6 +184,20 @@ func (s *Store) GetFolder() string {
 func (s *Store) WithCompetitionRenameLock(fn func() error) error {
 	s.compRenameMu.Lock()
 	defer s.compRenameMu.Unlock()
+	return fn()
+}
+
+// WithCourtExclusivityLock runs fn while holding the store's court-exclusivity
+// mutex. Use this to wrap a cross-competition court-busy check followed by a
+// per-competition WithTransaction call, so two concurrent match-starts on the
+// same court in different competitions can't both pass the check before either
+// commits (TOCTOU).
+//
+// Lock ordering: courtCheckMu is acquired BEFORE any per-comp lock.
+// fn MUST NOT recursively call WithCourtExclusivityLock — non-reentrant.
+func (s *Store) WithCourtExclusivityLock(fn func() error) error {
+	s.courtCheckMu.Lock()
+	defer s.courtCheckMu.Unlock()
 	return fn()
 }
 

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1553,7 +1553,7 @@ paths:
                     description: Pool ID containing the scored downstream match (downstream_knockout_scored only).
                   finisher:
                     type: string
-                    description: Match ID of the scored downstream match (downstream_knockout_scored only).
+                    description: Name of the pool finisher whose bracket placement is locked (downstream_knockout_scored only).
 
   /api/competitions/{id}/matches/{mid}/court:
     put:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1504,12 +1504,13 @@ paths:
             - `ineligible_competitor`: a participant is ineligible (kiken/fusenpai in a prior match).
               Extra fields: `playerId`, `reason`, `reasonHuman`.
             - `already_ineligible`: participant was already marked ineligible before this match.
-              Extra fields: `playerId`, `reason`, `reasonHuman`.
-            - `result_finalized`: the match result is locked because a downstream knockout
-              match has already been scored. Extra fields: `pool`, `finisher`.
+              Extra fields: `playerId`, `matchId`, `reason`, `reasonHuman`.
+            - `result_finalized`: the match result is already locked (self-reported only).
+              Extra fields: `message`.
             - `side_mismatch`: the submitted winner does not match either side of the match.
-            - `downstream_knockout_scored`: a downstream elimination match was already
-              scored; use `force=true` to override.
+              Extra fields: `message`.
+            - `downstream_knockout_scored`: a downstream elimination match was already scored.
+              Extra fields: `pool`, `finisher`, `matchId`, `message`.
           content:
             application/json:
               schema:
@@ -1531,13 +1532,13 @@ paths:
                     description: Court label (court_busy only).
                   matchId:
                     type: string
-                    description: Conflicting match ID (court_busy only).
+                    description: Conflicting match ID (court_busy, already_ineligible, downstream_knockout_scored).
                   compId:
                     type: string
                     description: Conflicting competition ID (court_busy only).
                   message:
                     type: string
-                    description: Human-readable detail (court_busy only).
+                    description: Human-readable detail (court_busy, result_finalized, side_mismatch, downstream_knockout_scored).
                   playerId:
                     type: string
                     description: Ineligible participant ID (ineligible_competitor / already_ineligible).
@@ -1549,10 +1550,10 @@ paths:
                     description: Human-readable reason (ineligible_competitor / already_ineligible).
                   pool:
                     type: string
-                    description: Pool ID of the finalized match (result_finalized only).
+                    description: Pool ID containing the scored downstream match (downstream_knockout_scored only).
                   finisher:
                     type: string
-                    description: Match ID that finalized the result (result_finalized only).
+                    description: Match ID of the scored downstream match (downstream_knockout_scored only).
 
   /api/competitions/{id}/matches/{mid}/court:
     put:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1496,6 +1496,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MatchResult'
+        '409':
+          description: |
+            Conflict — one of: court already has a running match (`court_busy`),
+            competitor ineligible (`ineligible_competitor`), result already finalised
+            (`result_finalized`), or downstream knockout already scored
+            (`downstream_knockout_scored`).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /api/competitions/{id}/matches/{mid}/court:
     put:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1498,14 +1498,61 @@ paths:
                 $ref: '#/components/schemas/MatchResult'
         '409':
           description: |
-            Conflict — one of: court already has a running match (`court_busy`),
-            competitor ineligible (`ineligible_competitor`), result already finalised
-            (`result_finalized`), or downstream knockout already scored
-            (`downstream_knockout_scored`).
+            Conflict — one of six codes returned in the `error` field:
+            - `court_busy`: court already has a running match in this or another competition.
+              Extra fields: `court`, `matchId`, `compId`, `message`.
+            - `ineligible_competitor`: a participant is ineligible (kiken/fusenpai in a prior match).
+              Extra fields: `playerId`, `reason`, `reasonHuman`.
+            - `already_ineligible`: participant was already marked ineligible before this match.
+              Extra fields: `playerId`, `reason`, `reasonHuman`.
+            - `result_finalized`: the match result is locked because a downstream knockout
+              match has already been scored. Extra fields: `pool`, `finisher`.
+            - `side_mismatch`: the submitted winner does not match either side of the match.
+            - `downstream_knockout_scored`: a downstream elimination match was already
+              scored; use `force=true` to override.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                type: object
+                required: [error]
+                properties:
+                  error:
+                    type: string
+                    enum:
+                      - court_busy
+                      - ineligible_competitor
+                      - already_ineligible
+                      - result_finalized
+                      - side_mismatch
+                      - downstream_knockout_scored
+                    description: Machine-readable conflict code.
+                  court:
+                    type: string
+                    description: Court label (court_busy only).
+                  matchId:
+                    type: string
+                    description: Conflicting match ID (court_busy only).
+                  compId:
+                    type: string
+                    description: Conflicting competition ID (court_busy only).
+                  message:
+                    type: string
+                    description: Human-readable detail (court_busy only).
+                  playerId:
+                    type: string
+                    description: Ineligible participant ID (ineligible_competitor / already_ineligible).
+                  reason:
+                    type: string
+                    description: Decision that caused ineligibility (ineligible_competitor / already_ineligible).
+                  reasonHuman:
+                    type: string
+                    description: Human-readable reason (ineligible_competitor / already_ineligible).
+                  pool:
+                    type: string
+                    description: Pool ID of the finalized match (result_finalized only).
+                  finisher:
+                    type: string
+                    description: Match ID that finalized the result (result_finalized only).
 
   /api/competitions/{id}/matches/{mid}/court:
     put:


### PR DESCRIPTION
## Summary

- A shiaijo (court) can now only host one running match at a time, across ALL competitions sharing the tournament — not just within a single competition.
- `StartMatch` and `StartMatchTx` both call a new `checkCourtExclusivity` gate that queries `store.RunningMatchOnCourt` before allowing any match to start.
- HTTP handler maps the new `*CourtBusyError` (sentinel `ErrCourtBusy`) to a 409 with `error:"court_busy"`, the blocking match ID, and a human-readable message.

## Why

Before this fix `checkSimultaneousMatch` only guarded against the same player appearing in two matches simultaneously, within one competition. The shiaijo was never checked globally, so two competitions could both start matches on court A at the same time — a real physical conflict at live tournaments.

## Files changed

| File | What |
|---|---|
| `internal/state/match.go` | New `CourtOccupancy` struct + `RunningMatchOnCourt(court, skipCompID)` scans all competitions for a running match on the given court |
| `internal/state/match_test.go` | 6 new tests: free court, busy pool match, skip-compID, cross-competition, bracket match, empty court |
| `internal/engine/eligibility.go` | `ErrCourtBusy` sentinel + `CourtBusyError`; `StartMatch` calls `checkCourtExclusivity` before other checks; `lookupMatchCourt` helper |
| `internal/engine/scoring_tx.go` | `StartMatchTx` calls `checkCourtExclusivityTx` — tx-safe twin that reads the locked comp via `tx`, all others via `store` |
| `internal/engine/eligibility_test.go` | 6 new tests covering both `StartMatch` and `StartMatchTx` court exclusivity paths |
| `internal/mobileapp/handlers_match.go` | Map `*CourtBusyError` → HTTP 409 `court_busy` before existing 409 handlers |

## Screenshots

No UI changes — this is a pure backend enforcement change. The SPA already receives HTTP 409 for other match-start conflicts; `court_busy` will surface via the existing error-display path.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change — 12 new tests total across state and engine packages
- [x] Manual browser verification — no UI changes; server-side gate only
- [x] Screenshots added above — N/A (no UI impact)
- [x] No new console errors or warnings

Closes mp-95mg