### PR TITLE
feat(mp-u6k1): Add GitHub logo and repo link

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7248,7 +7248,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 /* App version footer at the bottom of pages */
 .app-version-footer {
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   font-size: 11px;
   /* --ink-4 (#6c7480) is only 4.44:1 on --bg — just under AA. Step to the
      darker --ink-2 (#3a414e, 9.66:1 on --bg). Site-specific darken; do NOT

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7260,7 +7260,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .app-version-link {
   display: inline-flex;
   align-items: center;
-  color: inherit;
   text-decoration: none;
 }
 .app-version-link svg {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7257,6 +7257,15 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   padding: 16px 0;
   margin-top: 32px;
 }
+.app-version-link {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+}
+.app-version-link svg {
+  margin-right: 4px;
+}
 
 /* ---------- Pool standings draw-pos default (replaces inline styles) ---------- */
 .pool-standings__draw-pos {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7251,6 +7251,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
   font-size: 11px;
   /* --ink-4 (#6c7480) is only 4.44:1 on --bg — just under AA. Step to the
      darker --ink-2 (#3a414e, 9.66:1 on --bg). Site-specific darken; do NOT
@@ -7263,6 +7264,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   display: inline-flex;
   align-items: center;
   text-decoration: none;
+}
+.app-version-link:hover {
+  text-decoration: underline;
 }
 .app-version-link svg {
   margin-right: 4px;

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -15,7 +15,7 @@ describe('VersionFooter', () => {
     runtime.unmount();
     global.React = realReact;
     delete window.appVersionInfo;
-    delete window._versionPromise;
+    delete window.versionPromise;
     delete window.API;
   });
 

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -15,6 +15,7 @@ describe('VersionFooter', () => {
     runtime.unmount();
     global.React = realReact;
     delete window.appVersionInfo;
+    delete window._versionPromise;
     delete window.API;
   });
 

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -21,11 +21,11 @@ describe('VersionFooter', () => {
 
   it('renders a semver version with GitHub link', () => {
     window.appVersionInfo = { version: 'v1.2.3' };
-    const tree = runtime.mount(VersionFooter, {});
+    runtime.mount(VersionFooter, {});
     vi.advanceTimersByTime(200); // trigger setInterval check
 
     // The tree should be a div containing the versionText and the a tag
-    const treeStr = JSON.stringify(tree);
+    const treeStr = JSON.stringify(runtime.currentTree());
     expect(treeStr).toContain('v1.2.3');
     expect(treeStr).toContain('https://github.com/gitrgoliveira/bracket-creator');
     expect(treeStr).toContain('app-version-link');
@@ -33,10 +33,10 @@ describe('VersionFooter', () => {
 
   it('renders a non-semver version using gitCommit and buildDate with GitHub link', () => {
     window.appVersionInfo = { version: 'dev', gitCommit: 'fc928e0', buildDate: '2026-06-16' };
-    const tree = runtime.mount(VersionFooter, {});
+    runtime.mount(VersionFooter, {});
     vi.advanceTimersByTime(200);
 
-    const treeStr = JSON.stringify(tree);
+    const treeStr = JSON.stringify(runtime.currentTree());
     expect(treeStr).toContain('fc928e0');
     expect(treeStr).toContain('2026-06-16');
     expect(treeStr).toContain('https://github.com/gitrgoliveira/bracket-creator');
@@ -45,9 +45,9 @@ describe('VersionFooter', () => {
 
   it('renders nothing if version is missing', () => {
     window.appVersionInfo = { version: '' };
-    const tree = runtime.mount(VersionFooter, {});
+    runtime.mount(VersionFooter, {});
     vi.advanceTimersByTime(200);
 
-    expect(tree).toBeNull();
+    expect(runtime.currentTree()).toBeNull();
   });
 });

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { VersionFooter } from '../app.jsx';
 import { makeReactive } from './helpers/reactive_react.js';
 
@@ -9,20 +9,17 @@ describe('VersionFooter', () => {
     realReact = global.React;
     runtime = makeReactive();
     global.React = runtime.React;
-    vi.useFakeTimers();
   });
 
   afterEach(() => {
     runtime.unmount();
     global.React = realReact;
     delete window.appVersionInfo;
-    vi.useRealTimers();
   });
 
   it('renders a semver version with GitHub link', () => {
     window.appVersionInfo = { version: 'v1.2.3' };
     runtime.mount(VersionFooter, {});
-    vi.advanceTimersByTime(200); // trigger setInterval check
 
     // The tree should be a div containing the versionText and the a tag
     const treeStr = JSON.stringify(runtime.currentTree());
@@ -34,7 +31,6 @@ describe('VersionFooter', () => {
   it('renders a non-semver version using gitCommit and buildDate with GitHub link', () => {
     window.appVersionInfo = { version: 'dev', gitCommit: 'fc928e0', buildDate: '2026-06-16' };
     runtime.mount(VersionFooter, {});
-    vi.advanceTimersByTime(200);
 
     const treeStr = JSON.stringify(runtime.currentTree());
     expect(treeStr).toContain('fc928e0');
@@ -46,7 +42,6 @@ describe('VersionFooter', () => {
   it('renders nothing if version is missing', () => {
     window.appVersionInfo = { version: '' };
     runtime.mount(VersionFooter, {});
-    vi.advanceTimersByTime(200);
 
     expect(runtime.currentTree()).toBeNull();
   });

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -60,9 +60,10 @@ describe('VersionFooter', () => {
     expect(runtime.currentTree()).toBeNull();
 
     // resolve the promise
-    await runtime.act(async () => {
-      resolveFetch({ version: 'v2.0.0' });
-    });
+    resolveFetch({ version: 'v2.0.0' });
+    // flush microtask queue
+    await Promise.resolve();
+    await Promise.resolve();
 
     const treeStr = JSON.stringify(runtime.currentTree());
     expect(treeStr).toContain('v2.0.0');

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { VersionFooter } from '../app.jsx';
+import { makeReactive } from './helpers/reactive_react.js';
+
+describe('VersionFooter', () => {
+  let runtime, realReact;
+
+  beforeEach(() => {
+    realReact = global.React;
+    runtime = makeReactive();
+    global.React = runtime.React;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    delete window.appVersionInfo;
+    vi.useRealTimers();
+  });
+
+  it('renders a semver version with GitHub link', () => {
+    window.appVersionInfo = { version: 'v1.2.3' };
+    const tree = runtime.mount(VersionFooter, {});
+    vi.advanceTimersByTime(200); // trigger setInterval check
+
+    // The tree should be a div containing the versionText and the a tag
+    const treeStr = JSON.stringify(tree);
+    expect(treeStr).toContain('v1.2.3');
+    expect(treeStr).toContain('https://github.com/gitrgoliveira/bracket-creator');
+    expect(treeStr).toContain('app-version-link');
+  });
+
+  it('renders a non-semver version using gitCommit and buildDate with GitHub link', () => {
+    window.appVersionInfo = { version: 'dev', gitCommit: 'fc928e0', buildDate: '2026-06-16' };
+    const tree = runtime.mount(VersionFooter, {});
+    vi.advanceTimersByTime(200);
+
+    const treeStr = JSON.stringify(tree);
+    expect(treeStr).toContain('fc928e0');
+    expect(treeStr).toContain('2026-06-16');
+    expect(treeStr).toContain('https://github.com/gitrgoliveira/bracket-creator');
+    expect(treeStr).toContain('app-version-link');
+  });
+
+  it('renders nothing if version is missing', () => {
+    window.appVersionInfo = { version: '' };
+    const tree = runtime.mount(VersionFooter, {});
+    vi.advanceTimersByTime(200);
+
+    expect(tree).toBeNull();
+  });
+});

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -61,9 +61,8 @@ describe('VersionFooter', () => {
 
     // resolve the promise
     resolveFetch({ version: 'v2.0.0' });
-    // flush microtask queue
-    await Promise.resolve();
-    await Promise.resolve();
+    // flush all pending promise .then() chains
+    await new Promise(process.nextTick);
 
     const treeStr = JSON.stringify(runtime.currentTree());
     expect(treeStr).toContain('v2.0.0');

--- a/web-mobile/js/__tests__/version_footer.test.jsx
+++ b/web-mobile/js/__tests__/version_footer.test.jsx
@@ -15,6 +15,7 @@ describe('VersionFooter', () => {
     runtime.unmount();
     global.React = realReact;
     delete window.appVersionInfo;
+    delete window.API;
   });
 
   it('renders a semver version with GitHub link', () => {
@@ -44,5 +45,26 @@ describe('VersionFooter', () => {
     runtime.mount(VersionFooter, {});
 
     expect(runtime.currentTree()).toBeNull();
+  });
+
+  it('fetches version info on demand if missing and renders it', async () => {
+    // leave window.appVersionInfo undefined
+    let resolveFetch;
+    window.API = {
+      fetchVersion: () => new Promise(res => { resolveFetch = res; })
+    };
+
+    runtime.mount(VersionFooter, {});
+    // initially null because promise is pending
+    expect(runtime.currentTree()).toBeNull();
+
+    // resolve the promise
+    await runtime.act(async () => {
+      resolveFetch({ version: 'v2.0.0' });
+    });
+
+    const treeStr = JSON.stringify(runtime.currentTree());
+    expect(treeStr).toContain('v2.0.0');
+    expect(treeStr).toContain('app-version-link');
   });
 });

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1382,7 +1382,7 @@ export function VersionFooter() {
   const parts = [];
   if (commitShort) parts.push(commitShort);
   if (info.buildDate) parts.push(info.buildDate);
-  
+
   const versionText = isSemver ? versionStr : parts.join(' · ');
 
   return (

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -547,8 +547,6 @@ function App() {
     });
   }, []);
 
-
-
   // Mirror authConfig into the admin_helpers cache so promptAdminPassword()
   // (spec 004) can read the elevated-password bits at destructive call sites
   // without prop-drilling authConfig through every admin component.
@@ -1344,20 +1342,27 @@ export function VersionFooter() {
   const [info, setInfo] = React.useState(window.appVersionInfo || null);
 
   React.useEffect(() => {
+    // window.appVersionInfo is either:
+    //   undefined — fetch not yet started/completed
+    //   false     — fetch done, no data (null result or network error)
+    //   object    — fetch done with version data
     if (window.appVersionInfo !== undefined) {
       setInfo(window.appVersionInfo || null);
       return;
     }
 
-    if (!window._versionPromise) {
-      window._versionPromise = window.API.fetchVersion().then((res) => {
+    if (!window.API?.fetchVersion) return;
+
+    if (!window.versionPromise) {
+      window.versionPromise = window.API.fetchVersion().then((res) => {
+        // `false` = fetch done, no data; distinguishes from `undefined` = not yet fetched.
         window.appVersionInfo = res ?? false;
         return res ?? false;
       });
     }
 
     let cancelled = false;
-    window._versionPromise.then((res) => {
+    window.versionPromise.then((res) => {
       if (!cancelled) setInfo(res || null);
     });
     return () => { cancelled = true; };

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1352,7 +1352,7 @@ function CreateTournament({ onCreated, authConfig }) {
   );
 }
 
-function VersionFooter() {
+export function VersionFooter() {
   // Initialize from window.appVersionInfo if already set (e.g. fast-loading page
   // where App's fetch resolved before this component mounts). Treat the false
   // sentinel ("fetched, no data") as null so the render guard below hides the footer.
@@ -1390,7 +1390,7 @@ function VersionFooter() {
       {versionText}
       {" · "}
       <a href="https://github.com/gitrgoliveira/bracket-creator" target="_blank" rel="noopener noreferrer" className="app-version-link">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg aria-hidden="true" focusable="false" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
           <path d="M9 18c-4.51 2-5-2-7-2" />
         </svg>

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1389,8 +1389,8 @@ function VersionFooter() {
     <div className="app-version-footer" data-testid="app-version-footer">
       {versionText}
       {" · "}
-      <a href="https://github.com/gitrgoliveira/bracket-creator" target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', color: 'inherit', textDecoration: 'none' }}>
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 4 }}>
+      <a href="https://github.com/gitrgoliveira/bracket-creator" target="_blank" rel="noopener noreferrer" className="app-version-link">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
           <path d="M9 18c-4.51 2-5-2-7-2" />
         </svg>

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1339,7 +1339,6 @@ function CreateTournament({ onCreated, authConfig }) {
   );
 }
 
-let versionPromise = null;
 
 export function VersionFooter() {
   const [info, setInfo] = React.useState(window.appVersionInfo || null);
@@ -1350,15 +1349,15 @@ export function VersionFooter() {
       return;
     }
 
-    if (!versionPromise) {
-      versionPromise = window.API.fetchVersion().then((res) => {
+    if (!window._versionPromise) {
+      window._versionPromise = window.API.fetchVersion().then((res) => {
         window.appVersionInfo = res ?? false;
         return res ?? false;
       });
     }
 
     let cancelled = false;
-    versionPromise.then((res) => {
+    window._versionPromise.then((res) => {
       if (!cancelled) setInfo(res || null);
     });
     return () => { cancelled = true; };

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -547,20 +547,7 @@ function App() {
     });
   }, []);
 
-  useE(() => {
-    // Fetch once; store on window for VersionFooter to poll.
-    // Use false (not null) as the "fetched, no data" sentinel so the
-    // interval in VersionFooter can distinguish undefined (not yet done)
-    // from false (done, nothing to show) and always clears itself.
-    // fetchVersion() never rejects — api_client catches internally — so
-    // no .catch() is needed. Cancelled flag guards the window assignment
-    // against the (unlikely) case where App is re-mounted in tests.
-    let cancelled = false;
-    window.API.fetchVersion().then((info) => {
-      if (!cancelled) window.appVersionInfo = info ?? false;
-    });
-    return () => { cancelled = true; };
-  }, []);
+
 
   // Mirror authConfig into the admin_helpers cache so promptAdminPassword()
   // (spec 004) can read the elevated-password bits at destructive call sites
@@ -1352,27 +1339,29 @@ function CreateTournament({ onCreated, authConfig }) {
   );
 }
 
+let versionPromise = null;
+
 export function VersionFooter() {
-  // Initialize from window.appVersionInfo if already set (e.g. fast-loading page
-  // where App's fetch resolved before this component mounts). Treat the false
-  // sentinel ("fetched, no data") as null so the render guard below hides the footer.
   const [info, setInfo] = React.useState(window.appVersionInfo || null);
+
   React.useEffect(() => {
-    // window.appVersionInfo is either:
-    //   undefined — fetch not yet started/completed → poll
-    //   false     — fetch done, no data (null result or network error) → stop, show nothing
-    //   object    — fetch done with version data → show footer
     if (window.appVersionInfo !== undefined) {
       setInfo(window.appVersionInfo || null);
       return;
     }
-    const interval = setInterval(() => {
-      if (window.appVersionInfo !== undefined) {
-        setInfo(window.appVersionInfo || null);
-        clearInterval(interval);
-      }
-    }, 100);
-    return () => clearInterval(interval);
+
+    if (!versionPromise) {
+      versionPromise = window.API.fetchVersion().then((res) => {
+        window.appVersionInfo = res ?? false;
+        return res ?? false;
+      });
+    }
+
+    let cancelled = false;
+    versionPromise.then((res) => {
+      if (!cancelled) setInfo(res || null);
+    });
+    return () => { cancelled = true; };
   }, []);
 
   if (!info || !info.version) return null;

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -1378,20 +1378,24 @@ function VersionFooter() {
   if (!info || !info.version) return null;
   const versionStr = info.version;
   const isSemver = /^v?\d+\.\d+\.\d+/.test(versionStr);
-  if (isSemver) {
-    return (
-      <div className="app-version-footer" data-testid="app-version-footer">
-        {versionStr}
-      </div>
-    );
-  }
   const commitShort = info.gitCommit ? info.gitCommit.slice(0, 7) : '';
   const parts = [];
   if (commitShort) parts.push(commitShort);
   if (info.buildDate) parts.push(info.buildDate);
+  
+  const versionText = isSemver ? versionStr : parts.join(' · ');
+
   return (
     <div className="app-version-footer" data-testid="app-version-footer">
-      {parts.join(' · ')}
+      {versionText}
+      {" · "}
+      <a href="https://github.com/gitrgoliveira/bracket-creator" target="_blank" rel="noopener noreferrer" style={{ display: 'inline-flex', alignItems: 'center', color: 'inherit', textDecoration: 'none' }}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 4 }}>
+          <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+          <path d="M9 18c-4.51 2-5-2-7-2" />
+        </svg>
+        GitHub
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Added a GitHub logo and repository link next to the version number in the footer (`web-mobile/js/app.jsx`).
- Ensures the `VersionFooter` component renders the link regardless of whether it's showing a semver string or a commit/build date.
- **Refactored `VersionFooter`**: Removed the `setInterval` polling mechanism for version info. The footer now independently fetches the version data once using a cached Promise.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/app.jsx` | Updated `VersionFooter` component to include the inline GitHub SVG and repo link. Refactored version fetching logic out of `App` and into a single `VersionFooter` Promise, removing polling. |
| `web-mobile/css/styles.css` | Added `.app-version-link` CSS class. |
| `web-mobile/js/__tests__/version_footer.test.jsx` | Added structural unit tests for `VersionFooter`. Cleaned up the tests by removing `fakeTimers` and using `runtime.currentTree()`. |

## Screenshots

![desc](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u6k1/shot.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change
- [x] Manual browser verification (for `web-mobile/` or `web/` changes) — verified footer layout matches expectations and link points to repo.
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors or warnings

Closes mp-u6k1
