### PR TITLE
fix(mp-lssw): reset scroll position on shiaijo page mount

### DIFF
--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -107,7 +107,10 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     const court = (routeCourt || "").trim();
 
     const mountedRef = useRefSh(true);
-    useEffectSh(() => () => { mountedRef.current = false; }, []);
+    useEffectSh(() => {
+        window.scrollTo(0, 0);
+        return () => { mountedRef.current = false; };
+    }, []);
 
     // Selected match for the inline scoring panel. `calledKey` marks the match
     // the operator has announced this session (local cue only); `callingKey`

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -108,7 +108,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 
     const mountedRef = useRefSh(true);
     useEffectSh(() => {
-        window.scrollTo(0, 0);
+        if (typeof window.scrollTo === "function") window.scrollTo(0, 0);
         return () => { mountedRef.current = false; };
     }, []);
 


### PR DESCRIPTION
## Summary

- When navigating to `/admin/shiaijo/:court` while a match is in progress, the page now explicitly resets the scroll position to the top.
- This prevents the page from loading scrolled down to the upcoming schedule section due to the router retaining the scroll position from the referring page (e.g., the dashboard).

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_shiaijo.jsx` | Added `window.scrollTo(0, 0)` to the mount effect |

## Screenshots

No screenshots were captured because this is purely a scroll position behavior change on route transition. Textual attestation: On mount, `window.scrollTo(0, 0)` forces the viewport to the top of the Document, ensuring the inline `.shiaijo__main` (scoring editor) is visible at `scrollTop: 0` instead of the browser retaining the `scrollTop` from the previous route.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (N/A for simple scroll behavior)
- [x] Manual browser verification (for `web-mobile/` or `web/` changes) — Navigated from the dashboard to a shiaijo page while scrolled down on the dashboard and verified it loads at the top.
- [x] Screenshots added above (N/A: attestation provided instead)
- [x] No new console errors or warnings

Closes mp-lssw
