### PR TITLE
feat(mp-55v): free-forever cloud deployment (GCP + Oracle) + multi-arch images

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,17 +1,35 @@
+---
 name: Publish latest Docker image
 
-on:
+"on":
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
+  build-and-push:
+    name: Build and push ${{ matrix.image.name }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+        image:
+          - name: bracket-creator
+            file: Dockerfile
+            tag_suffix: ""
+          - name: bracket-creator-mobile
+            file: Dockerfile.mobile
+            tag_suffix: "-mobile"
+          - name: bracket-creator-mobile-pdf
+            file: Dockerfile.mobile-pdf
+            tag_suffix: "-mobile-pdf"
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           # Need tags + full history so `git describe` produces a real version
           # for the build args below (the binary embeds these via go generate).
@@ -20,48 +38,102 @@ jobs:
       - name: Compute build metadata
         id: meta
         run: |
-          echo "version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" >> "$GITHUB_OUTPUT"
+          echo "version=$(git describe --tags --always --dirty 2>/dev/null \
+            || echo dev)" >> "$GITHUB_OUTPUT"
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "build_date=$(date -u +'%Y-%m-%d %H:%M:%S %z')" >> "$GITHUB_OUTPUT"
+          BUILD_DATE="$(date -u +'%Y-%m-%d %H:%M:%S %z')"
+          echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
+          # Derive the target platform from the runner arch
+          case "${{ runner.arch }}" in
+            ARM64) echo "platform=linux/arm64" >> "$GITHUB_OUTPUT" ;;
+            *)     echo "platform=linux/amd64" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+      - name: Build and push image digest (${{ steps.meta.outputs.platform }})
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.image.file }}
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          platforms: ${{ steps.meta.outputs.platform }}
+          # Push by digest only; the merge job assembles the manifest list.
+          # Keep this on ONE line: a YAML folded scalar would inject stray
+          # spaces into the CSV, which buildx rejects.
+          outputs: type=image,name=ghcr.io/${{ github.repository }}${{ matrix.image.tag_suffix }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             GIT_COMMIT=${{ steps.meta.outputs.commit }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
 
-      - name: Build and push Mobile Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile.mobile
-          push: true
-          tags: ghcr.io/${{ github.repository }}-mobile:latest
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
-            GIT_COMMIT=${{ steps.meta.outputs.commit }}
-            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Build and push Mobile PDF Docker image
-        uses: docker/build-push-action@v7
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
         with:
-          context: .
-          file: Dockerfile.mobile-pdf
-          push: true
-          tags: ghcr.io/${{ github.repository }}-mobile-pdf:latest
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
-            GIT_COMMIT=${{ steps.meta.outputs.commit }}
-            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+          name: digest-${{ matrix.image.name }}-${{ runner.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifests:
+    name: Merge manifests for ${{ matrix.image.name }}
+    runs-on: ubuntu-24.04
+    needs: build-and-push
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: bracket-creator
+            tag_suffix: ""
+          - name: bracket-creator-mobile
+            tag_suffix: "-mobile"
+          - name: bracket-creator-mobile-pdf
+            tag_suffix: "-mobile-pdf"
+    steps:
+      - name: Download AMD64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}-X64
+          path: /tmp/digests
+
+      - name: Download ARM64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}-ARM64
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}${{ matrix.image.tag_suffix }}"
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,6 +1,7 @@
+---
 name: Publish Released Docker image
 
-on:
+"on":
   workflow_dispatch:
     inputs:
       tag:
@@ -17,60 +18,136 @@ permissions:
   contents: read
   packages: write
 
+# The published tag, derived once for all jobs: the release tag for a
+# release/tag-push event, the supplied input for a manual dispatch.
+env:
+  IMAGE_TAG: >-
+    ${{ github.event_name == 'release' && github.event.release.tag_name
+    || github.event_name == 'workflow_dispatch' && inputs.tag
+    || github.ref_name }}
+
 jobs:
-  push_to_registry:
-    name: Push Docker image to GitHub Packages
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  build-and-push:
+    name: Build and push ${{ matrix.image.name }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+        image:
+          - name: bracket-creator
+            file: Dockerfile
+            tag_suffix: ""
+          - name: bracket-creator-mobile
+            file: Dockerfile.mobile
+            tag_suffix: "-mobile"
+          - name: bracket-creator-mobile-pdf
+            file: Dockerfile.mobile-pdf
+            tag_suffix: "-mobile-pdf"
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Compute build metadata
         id: meta
         run: |
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "build_date=$(date -u +'%Y-%m-%d %H:%M:%S %z')" >> "$GITHUB_OUTPUT"
+          BUILD_DATE="$(date -u +'%Y-%m-%d %H:%M:%S %z')"
+          echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
+          # Derive the target platform from the runner arch
+          case "${{ runner.arch }}" in
+            ARM64) echo "platform=linux/arm64" >> "$GITHUB_OUTPUT" ;;
+            *)     echo "platform=linux/amd64" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+      - name: Build and push image digest (${{ steps.meta.outputs.platform }})
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.image.file }}
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+          platforms: ${{ steps.meta.outputs.platform }}
+          # Push by digest only; the merge job assembles the manifest list.
+          # Keep this on ONE line: a YAML folded scalar would inject stray
+          # spaces into the CSV, which buildx rejects.
+          outputs: type=image,name=ghcr.io/${{ github.repository }}${{ matrix.image.tag_suffix }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             VERSION=${{ env.IMAGE_TAG }}
             GIT_COMMIT=${{ steps.meta.outputs.commit }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
 
-      - name: Build and push Mobile Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile.mobile
-          push: true
-          tags: ghcr.io/${{ github.repository }}-mobile:${{ env.IMAGE_TAG }}
-          build-args: |
-            VERSION=${{ env.IMAGE_TAG }}
-            GIT_COMMIT=${{ steps.meta.outputs.commit }}
-            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Build and push Mobile PDF Docker image
-        uses: docker/build-push-action@v7
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
         with:
-          context: .
-          file: Dockerfile.mobile-pdf
-          push: true
-          tags: ghcr.io/${{ github.repository }}-mobile-pdf:${{ env.IMAGE_TAG }}
-          build-args: |
-            VERSION=${{ env.IMAGE_TAG }}
-            GIT_COMMIT=${{ steps.meta.outputs.commit }}
-            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+          name: digest-${{ matrix.image.name }}-${{ runner.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifests:
+    name: Merge manifests for ${{ matrix.image.name }}
+    runs-on: ubuntu-24.04
+    needs: build-and-push
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: bracket-creator
+            tag_suffix: ""
+          - name: bracket-creator-mobile
+            tag_suffix: "-mobile"
+          - name: bracket-creator-mobile-pdf
+            tag_suffix: "-mobile-pdf"
+    steps:
+      - name: Download AMD64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}-X64
+          path: /tmp/digests
+
+      - name: Download ARM64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}-ARM64
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}${{ matrix.image.tag_suffix }}"
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${IMAGE_TAG}" \
+            $(printf "${IMAGE}@sha256:%s " *)

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,14 @@ mp-*/
 .claude/scheduled_tasks.lock
 .claude/*.lock
 .impeccable/
+
+# Terraform local state (provider binaries, lock files from terraform init)
+**/.terraform/
+**/.terraform.lock.hcl
+
+# Terraform state and variable files — may contain secrets (e.g. password
+# hashes) in plaintext; never commit them.
+**/*.tfstate
+**/*.tfstate.*
+**/*.tfvars
+!**/*.tfvars.example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Production-hardening defaults applied in the `mobile-app` command. Constants liv
 | `MaxHeaderBytes` | 1 MB | — | Header-bomb defense |
 | Body cap (admin JSON) | 1 MB | `DefaultMaxBodyBytes` const | `c.BindJSON` payloads are tiny in practice; cap is enforced by `MaxBodyBytes` middleware (returns 413) |
 | Body cap (`/tournament/import`) | 64 MB | `MaxImportBodyBytes` const | Matches `ParseMultipartForm` already in the handler |
-| SSE subscribers | 5000 | `SSE_MAX_CLIENTS` env var | Bounds fan-out cost + per-client goroutine/channel allocation (~4–10 KB resident per client); raised from 1000 → 5000 by mp-9afd for EKC-scale (1000+ viewers); real hardware load test still required |
+| SSE subscribers | 5000 | `SSE_MAX_CLIENTS` env var | Bounds fan-out cost + per-client goroutine/channel allocation (~4–10 KB resident per client); raised from 1000 → 5000 by mp-9afd for large-scale events (1000+ viewers); real hardware load test still required |
 | Graceful shutdown | 30s | `httpShutdownTimeout` const | `Hub.Close` is wired via `srv.RegisterOnShutdown` so SSE goroutines exit before the deadline |
 
 **`safeGo` convention.** Any goroutine spawned inside a request handler MUST use the `safeGo` helper in [internal/mobileapp/safego.go](internal/mobileapp/safego.go). Gin's Recovery middleware only catches panics on the request goroutine — a panic in a spawned goroutine crashes the entire process. The helper guarantees `wg.Done()` on panic and captures the recovered value into a shared `atomic.Pointer[recoveredPanic]` so the handler can return a single HTTP 500 without leaking internals. Pattern:

--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -1,0 +1,13 @@
+# Replace "tournament.example.com" with your actual domain name.
+# Caddy will automatically obtain and renew a Let's Encrypt TLS certificate
+# for this hostname.  The VM (or bare-metal host) must be publicly reachable
+# on ports 80 and 443 with a DNS A record pointing at its public IP before
+# you start the stack.
+#
+# Caddy streams responses by default, so SSE connections work without any
+# additional configuration.  Do NOT add "flush_interval" or response-buffering
+# directives — they would break the live-score event stream.
+
+tournament.example.com {
+    reverse_proxy app:8080
+}

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,104 @@
+# deploy/docker — provider-agnostic baseline
+
+This directory is the **reusable core** for every bracket-creator cloud deploy.
+The provider-specific Terraform modules (GCP, Oracle) render this compose +
+Caddyfile onto a VM via cloud-init.  You can also use it directly on any
+Linux machine with Docker installed.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yaml` | App + Caddy stack |
+| `Caddyfile` | Automatic-HTTPS reverse proxy |
+| `app.env.example` | Environment-variable template |
+
+## Prerequisites
+
+- Docker Engine + Docker Compose plugin installed on the host.
+- A domain name (e.g. `tournament.example.com`) with an A record pointing at
+  the host's public IP address.
+- Ports 80 and 443 open in any host or cloud firewall (port 80 is required for
+  the ACME HTTP-01 challenge that issues the TLS certificate).
+
+## Quick start
+
+```bash
+# 1. Clone / copy these files to the host
+git clone https://github.com/gitrgoliveira/bracket-creator
+cd bracket-creator/deploy/docker
+
+# 2. Edit Caddyfile — replace "tournament.example.com" with your real domain
+nano Caddyfile
+
+# 3. Create the data directory with the correct owner
+#    The app container runs as uid 65534 (non-root scratch image).
+#    Without this chown, the app cannot write to the data directory and exits.
+sudo mkdir -p ./tournament-data
+sudo chown -R 65534:65534 ./tournament-data
+
+# 4. Create your app.env from the example (keep this file chmod 600)
+cp app.env.example app.env
+chmod 600 app.env
+$EDITOR app.env   # fill in LOCK_PASSWORD / TOURNAMENT_PASSWORD_HASH
+
+# 5. Start the stack
+docker compose up -d
+
+# 6. Verify — Caddy will obtain a Let's Encrypt cert automatically (may take
+#    a few seconds on first boot).
+curl -s https://tournament.example.com/health
+```
+
+## uid 65534 and volume ownership
+
+The app image runs as **uid 65534** (`nonroot`).  The host-mounted
+`./tournament-data` directory **must** be owned by that uid:
+
+```bash
+sudo chown -R 65534:65534 ./tournament-data
+```
+
+If you skip this step, the app cannot write to the data directory (a permission
+error) and exits on first write. The app logs a clear diagnostic in this case —
+check `docker compose logs app` if the container exits immediately.
+
+## SSE and Caddy buffering
+
+Caddy **streams** responses by default.  The live-score event stream (`/api/
+events` SSE endpoint) requires streaming — do **not** add `flush_interval -1`
+or any response-buffering directive to the Caddyfile.  The included Caddyfile
+is correct as-is.
+
+## Locking the admin password
+
+Set `LOCK_PASSWORD=true` and `TOURNAMENT_PASSWORD_HASH=<bcrypt>` in `app.env`
+for public deployments.  Generate the hash:
+
+```bash
+# Using htpasswd (apache2-utils / httpd-tools)
+htpasswd -bnBC 12 "" 'MySecretPassword' | tr -d ':\n'
+
+# Using the openssl fallback
+openssl passwd -6 'MySecretPassword'   # SHA-512, also accepted
+```
+
+## Teardown
+
+```bash
+docker compose down
+# To also remove the Caddy TLS data (certs):
+docker compose down -v
+```
+
+Data in `./tournament-data` is a host bind-mount and is **not** removed by
+`docker compose down` — back it up first if you want to keep tournament state.
+
+## Updating the image
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Compose will replace only the containers whose image changed.

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -76,11 +76,9 @@ Set `LOCK_PASSWORD=true` and `TOURNAMENT_PASSWORD_HASH=<bcrypt>` in `app.env`
 for public deployments.  Generate the hash:
 
 ```bash
-# Using htpasswd (apache2-utils / httpd-tools)
+# The hash MUST be bcrypt — the server validates it with bcrypt and refuses
+# to start in locked mode otherwise (SHA-512 / MD5 crypt hashes are rejected).
 htpasswd -bnBC 12 "" 'MySecretPassword' | tr -d ':\n'
-
-# Using the openssl fallback
-openssl passwd -6 'MySecretPassword'   # SHA-512, also accepted
 ```
 
 ## Teardown

--- a/deploy/docker/app.env.example
+++ b/deploy/docker/app.env.example
@@ -1,0 +1,37 @@
+# Copy this file to app.env and fill in the values.
+# app.env must be chmod 600 and owned by root (or the deploy user) so
+# secrets are not world-readable.
+#
+# The docker-compose.yaml references app.env via env_file.
+
+# --------------------------------------------------------------------------
+# Password mode
+# --------------------------------------------------------------------------
+# Set to "true" to enable bcrypt-locked mode (recommended for public deploys).
+# When false, the plaintext password in tournament-data/tournament.md is used.
+LOCK_PASSWORD=false
+
+# When LOCK_PASSWORD=true, set this to the bcrypt hash of the admin password.
+# Generate with: htpasswd -bnBC 12 "" <password> | tr -d ':\n'
+# Example (do NOT use this in production):
+# TOURNAMENT_PASSWORD_HASH=$2b$12$...
+TOURNAMENT_PASSWORD_HASH=
+
+# --------------------------------------------------------------------------
+# SSE client cap
+# --------------------------------------------------------------------------
+# Maximum concurrent live-update (SSE) connections.  The application default
+# is 5000.  Lower this on small instances (e.g. GCP e2-micro with 1 GB RAM).
+SSE_MAX_CLIENTS=5000
+
+# --------------------------------------------------------------------------
+# API rate limiting (global circuit breaker)
+# --------------------------------------------------------------------------
+# Caps total requests/second to the API so a traffic spike can't overwhelm a
+# small free-tier instance; excess requests receive HTTP 429. The application
+# defaults (5000 req/s, burst 10000) are generous; the values below are
+# conservative starting points suitable for a demo or small event. Increase
+# them for larger events, or lower them to throttle more eagerly. A built-in
+# per-client (per-IP) limit also applies and needs no configuration.
+API_RATE_LIMIT=500
+API_RATE_LIMIT_BURST=1000

--- a/deploy/docker/app.env.example
+++ b/deploy/docker/app.env.example
@@ -12,7 +12,7 @@
 LOCK_PASSWORD=false
 
 # When LOCK_PASSWORD=true, set this to the bcrypt hash of the admin password.
-# Generate with: htpasswd -bnBC 12 "" <password> | tr -d ':\n'
+# Generate with: htpasswd -bnBC 12 "" 'YOUR_PASSWORD' | tr -d ':\n'
 # Example (do NOT use this in production):
 # TOURNAMENT_PASSWORD_HASH=$2b$12$...
 TOURNAMENT_PASSWORD_HASH=

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -1,0 +1,44 @@
+---
+# Provider-agnostic baseline for deploying the bracket-creator mobile-app
+# with Caddy as TLS terminator.
+#
+# Usage:
+#   cp app.env.example app.env     # fill in secrets
+#   docker compose up -d
+#
+# The app container runs as uid 65534.  The host volume MUST be owned by
+# that uid or the app cannot write to the data directory and will exit:
+#   sudo chown -R 65534:65534 ./tournament-data
+#
+# See README.md for full setup instructions.
+
+services:
+  app:
+    image: ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest
+    restart: unless-stopped
+    env_file:
+      - app.env
+    environment:
+      - TOURNAMENT_DATA_DIR=/tournament-data
+    volumes:
+      - ./tournament-data:/tournament-data
+    expose:
+      - "8080"
+    # Never publish 8080 directly to the host; Caddy proxies it.
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - app
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/deploy/gcp/ARCHITECTURE.md
+++ b/deploy/gcp/ARCHITECTURE.md
@@ -1,0 +1,100 @@
+# GCP Deployment Architecture
+
+This document explains how the bracket-creator live tournament app is deployed on the
+**Google Cloud Always Free tier**, what gets created, and what to expect. For step-by-step
+deployment instructions, see [README.md](README.md).
+
+> Cloud free-tier allowances change over time. The figures below were accurate as of June 2026 —
+> confirm them against Google's current [Free Tier](https://cloud.google.com/free) page before you
+> rely on them.
+
+## What this deployment is for
+
+The Always Free `e2-micro` instance runs the tournament app **continuously, at no cost**, and is a
+great fit for **club and regional events**. Its monthly free network allowance (1 GB egress)
+limits how many simultaneous live viewers it can serve, so for very large events (1000+ concurrent
+viewers) we recommend the Oracle Always-Free deployment (`deploy/oracle/`) instead.
+
+## Resources created
+
+| Resource | Free-tier allowance | What this deployment uses |
+|---|---|---|
+| Compute | 1× `e2-micro` (shared vCPU, 1 GB RAM), Always Free | one instance, running 24/7 |
+| Region | `us-west1`, `us-central1`, or `us-east1` only | one of these (enforced by the module) |
+| Disk | 30 GB standard persistent disk | a single boot + data disk |
+| Network egress | 1 GB/month (from North America) | your live-viewer ceiling — see [Capacity](#capacity-and-scale) |
+| External IP | ephemeral included free | ephemeral by default; a stable static IP is optional |
+
+> The deployment **only runs in the three free regions above.** Choosing another region would incur
+> charges, so the module rejects any other value.
+
+## Topology
+
+```
+  Internet ──443/80──▶  Firewall (allow 80, 443, 22)
+                              │
+                   ┌──────────▼───────────┐   e2-micro
+                   │  Caddy  (port 443)   │   automatic HTTPS (Let's Encrypt)
+                   │        │ proxy         │
+                   │        ▼               │
+                   │  tournament app :8080 │
+                   └──────────┬───────────┘
+                              │
+                   /opt/tournament-data    (on the persistent disk; survives reboots)
+```
+
+The app runs in a container as a non-root user. Caddy sits in front of it, terminates HTTPS, and
+forwards requests to the app. Live updates stream to browsers over Server-Sent Events (SSE), which
+pass through Caddy unbuffered.
+
+## Persistence
+
+All tournament state is stored on the instance's persistent disk at `/opt/tournament-data`, mounted
+into the container. This disk survives instance reboots and stop/start, so your tournament data is
+retained. The container is configured to restart automatically, so the app comes back on its own
+after a reboot.
+
+## Networking and HTTPS
+
+- **Automatic HTTPS** is handled by Caddy using Let's Encrypt — no manual certificate management.
+- The firewall allows inbound HTTP (80), HTTPS (443), and SSH (22). For SSH you can restrict access
+  to your own IP range.
+- **DNS:** point an `A` record for your chosen hostname at the instance's public IP. Caddy needs the
+  hostname to issue the certificate. If you use the default ephemeral IP, note that it can change if
+  the instance is stopped and started — reserve a static IP if you need a stable address.
+
+## Authentication
+
+- By default the app uses the password stored in your tournament configuration.
+- For public deployments you can enable **locked mode** (`LOCK_PASSWORD=true`) and supply a bcrypt
+  password hash via `TOURNAMENT_PASSWORD_HASH`. These are written to a protected, root-owned file on
+  the instance and are never stored in the container image. See the [README](README.md) for details.
+
+## Capacity and scale
+
+Live updates are delivered to every connected viewer, so **network egress is the practical limit**
+on this tier, not CPU or memory. With 1 GB of free egress per month:
+
+| Audience size | Suitability on GCP Always Free |
+|---|---|
+| Up to ~50 concurrent viewers | Comfortable |
+| ~100–300 concurrent viewers | Possible, but watch your egress usage |
+| 1000+ concurrent viewers | Use the Oracle deployment (`deploy/oracle/`) instead |
+
+We recommend setting a **billing budget alert** (e.g. $1) so you're notified immediately if usage
+ever exceeds the free allowance. The README covers how.
+
+## Operations
+
+- **Teardown:** `terraform destroy` removes everything. Run it when the event is over so no stray
+  resources (such as a reserved static IP) remain.
+- **Backups:** tournament data is small; you can snapshot the disk or copy `tournament-data`
+  elsewhere. The README includes commands.
+- **Monitoring:** keep an eye on the egress meter and your budget alert during busy events.
+
+## Provisioning summary
+
+The module provisions the instance, network, and firewall, then automatically: installs Docker,
+prepares the data directory, writes the app and Caddy configuration, and starts the app. Within a
+few minutes of `terraform apply` the app is reachable over HTTPS at your hostname. Full instructions
+are in the [README](README.md).

--- a/deploy/gcp/Caddyfile.tftpl
+++ b/deploy/gcp/Caddyfile.tftpl
@@ -1,0 +1,12 @@
+# Rendered by Terraform (templatefile) — see main.tf in this folder.
+#
+# Caddy automatically obtains and renews a Let's Encrypt TLS certificate for
+# this hostname. The host must be reachable on ports 80 and 443 with a DNS A
+# record pointing at its public IP before the stack starts.
+#
+# Caddy streams responses by default, so SSE works without extra configuration.
+# Do NOT add flush_interval or response-buffering directives — they would break
+# the live-score event stream.
+${hostname} {
+    reverse_proxy app:8080
+}

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,151 @@
+# deploy/gcp — GCP Always-Free e2-micro
+
+Deploys the bracket-creator mobile-app on a **GCP Always-Free e2-micro**
+(1 GB RAM, x86-64) using Terraform.  Auto-HTTPS via Caddy.
+
+> **Scale ceiling:** GCP's free tier includes **1 GB/month egress from North
+> America**.  A single busy tournament day with a few hundred live SSE viewers
+> can exceed this.  Overage is billed (~$0.12/GB).  Set a **$1 budget alert**
+> (see below) as a tripwire.  For 1000+ viewer events, use the Oracle module.
+
+## Prerequisites
+
+- Terraform >= 1.5 installed locally.
+- A GCP project with billing enabled (the Always-Free tier still requires a
+  billing account; you will not be charged if you stay within limits).
+- `gcloud auth application-default login` completed, or a service-account JSON
+  key exported to `GOOGLE_APPLICATION_CREDENTIALS`.
+- A domain name with an A record you can update.
+
+## One-command deploy
+
+```bash
+cd deploy/gcp
+
+# Copy the example tfvars and fill in your values
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+
+terraform init
+terraform plan
+terraform apply
+```
+
+After `apply` completes, the output `instance_public_ip` is shown.  Update
+your DNS A record to that IP, then wait for propagation (typically < 5 min).
+Caddy will issue the Let's Encrypt certificate automatically on first HTTPS
+request — allow ~30 seconds for the ACME challenge to complete.
+
+## terraform.tfvars example
+
+```hcl
+project  = "my-gcp-project-id"
+region   = "us-central1"         # MUST be us-west1 / us-central1 / us-east1
+zone     = "us-central1-a"
+hostname = "tournament.example.com"
+
+ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
+
+# Optional — tighten SSH to your IP only
+# operator_cidrs = ["203.0.113.10/32"]
+
+# Optional — reserve a stable IP (free while attached to a running instance)
+# reserve_static_ip = true
+
+# Optional — PDF export (heavier image, ~500 MB, more RAM pressure)
+# image_ref = "ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest"
+
+# Optional — locked password mode
+# lock_password            = "true"
+# tournament_password_hash = "$2b$12$..."
+```
+
+## DNS guide
+
+1. Run `terraform apply` and note `instance_public_ip`.
+2. In your DNS provider, create/update an A record:
+   `tournament.example.com. 300 IN A <instance_public_ip>`
+3. Caddy fetches the TLS cert on the first HTTPS request.  Check logs with:
+   `gcloud compute ssh <instance-name> -- docker compose -f /opt/app/docker-compose.yaml logs caddy`
+
+**Ephemeral IP caveat:** if `reserve_static_ip = false` (default), the
+instance's external IP changes every time you stop and start it.  You must
+update the DNS A record after each stop.  Set `reserve_static_ip = true` to
+avoid this — the IP is free while the instance is running.
+
+## Watching the egress meter ($1 budget alert)
+
+Set a budget alert in GCP Console → Billing → Budgets & Alerts:
+
+- Budget amount: **$1**
+- Scope: this project
+- Alert threshold: 50% (to catch creep early)
+
+This is a tripwire, not a hard cap.  GCP does not auto-stop instances on
+budget breach.  Check the metric `compute.googleapis.com/instance/network/
+sent_bytes_count` in Cloud Monitoring, or navigate to:
+  Compute Engine → VM Instances → (instance) → Monitoring → Network tab.
+
+Free egress resets on the 1st of each month.
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+This removes the VM, disk, firewall, VPC, and (if created) the static IP.
+The static IP costs ~$0.01/hr when unattached — `terraform destroy` removes
+it.  A forgotten static IP is the most common surprise-charge vector.
+
+## Backups
+
+Tournament data lives at `/opt/tournament-data` on the VM's 30 GB pd-standard
+disk.  Back it up before `terraform destroy`:
+
+```bash
+# Ad-hoc: copy to your laptop
+gcloud compute scp --recurse \
+  <instance-name>:/opt/tournament-data ./tournament-data-backup
+
+# Or snapshot the disk (free within the 30 GB free tier)
+gcloud compute disks snapshot <disk-name> \
+  --snapshot-names tournament-snap-$(date +%Y%m%d)
+```
+
+## Security notes
+
+- **Never commit `terraform.tfstate` or `terraform.tfvars`.** Both can contain
+  secrets in plaintext — in particular `tournament_password_hash`. They are
+  already covered by `.gitignore`; keep them out of version control.
+- For shared or team use, configure a **remote backend** (a GCS bucket) so state
+  is encrypted at rest and never stored on a laptop.
+- Locking down SSH: set `operator_cidrs` to your own IP range. Ports 80 and 443
+  always remain open to the world (viewers and Let's Encrypt need them).
+
+## Module variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `project` | — | GCP project ID |
+| `region` | `us-central1` | Must be us-west1/us-central1/us-east1 |
+| `zone` | `""` (auto) | Zone within the region |
+| `hostname` | — | FQDN for the app |
+| `image_ref` | lean mobile image | Docker image tag |
+| `lock_password` | `"false"` | Enable bcrypt locked mode |
+| `tournament_password_hash` | `""` | Bcrypt hash (sensitive) |
+| `sse_max_clients` | `5000` | SSE subscriber cap |
+| `api_rate_limit` | `500` | Global API requests/sec limit (conservative default; raise for larger events) |
+| `api_rate_limit_burst` | `1000` | Global API rate-limit burst |
+| `ssh_user` | `ubuntu` | SSH username |
+| `ssh_pubkey` | — | SSH public key |
+| `operator_cidrs` | `[]` | CIDRs allowed SSH (empty = all) |
+| `reserve_static_ip` | `false` | Reserve a stable static IP |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `instance_public_ip` | Public IP — use for DNS A record |
+| `app_url` | `https://<hostname>` |
+| `ssh_command` | Ready-to-run SSH command |

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -56,7 +56,7 @@ ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
 # image_ref = "ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest"
 
 # Optional — locked password mode
-# lock_password            = "true"
+# lock_password            = true
 # tournament_password_hash = "$2b$12$..."
 ```
 
@@ -132,7 +132,7 @@ gcloud compute disks snapshot <disk-name> \
 | `zone` | `""` (auto) | Zone within the region |
 | `hostname` | — | FQDN for the app |
 | `image_ref` | lean mobile image | Docker image tag |
-| `lock_password` | `"false"` | Enable bcrypt locked mode |
+| `lock_password` | `false` | Enable bcrypt locked mode |
 | `tournament_password_hash` | `""` | Bcrypt hash (sensitive) |
 | `sse_max_clients` | `5000` | SSE subscriber cap |
 | `api_rate_limit` | `500` | Global API requests/sec limit (conservative default; raise for larger events) |

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -252,8 +252,8 @@ resource "google_compute_instance" "app" {
     # Fail at plan/apply rather than at container startup: locked mode with an
     # empty hash makes the app exit immediately (it fails closed).
     precondition {
-      condition     = lower(trimspace(var.lock_password)) != "true" || trimspace(var.tournament_password_hash) != ""
-      error_message = "tournament_password_hash must be set when lock_password is \"true\" — the app fails closed and exits at startup with an empty hash."
+      condition     = !var.lock_password || trimspace(var.tournament_password_hash) != ""
+      error_message = "tournament_password_hash must be set when lock_password is true — the app fails closed and exits at startup with an empty hash."
     }
 
     ignore_changes = [

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -249,6 +249,13 @@ resource "google_compute_instance" "app" {
   # Omitting the block avoids handing the instance a broad API token.
 
   lifecycle {
+    # Fail at plan/apply rather than at container startup: locked mode with an
+    # empty hash makes the app exit immediately (it fails closed).
+    precondition {
+      condition     = lower(trimspace(var.lock_password)) != "true" || trimspace(var.tournament_password_hash) != ""
+      error_message = "tournament_password_hash must be set when lock_password is \"true\" — the app fails closed and exits at startup with an empty hash."
+    }
+
     ignore_changes = [
       # Prevent Terraform from recreating the instance when cloud-init
       # user-data changes after initial deploy.

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -159,9 +159,10 @@ locals {
               - TOURNAMENT_DATA_DIR=/tournament-data
             volumes:
               - ${local.data_dir}:/tournament-data
-            # The app never needs the cloud metadata service; map its hostname
-            # to loopback so a compromised container cannot read instance
-            # metadata (which includes the cloud-init user-data).
+            # Defense-in-depth: the app never needs the cloud metadata service,
+            # so map its hostname to loopback. NOTE this is not a hard block —
+            # the metadata server is still reachable via the link-local IP
+            # (169.254.169.254); a full block needs host-level firewalling.
             extra_hosts:
               - "metadata.google.internal:127.0.0.1"
             expose:

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -28,7 +28,10 @@ provider "google" {
 
 locals {
   # Sanitise hostname for use as a resource-name prefix (RFC 1035).
-  name_prefix = replace(lower(var.hostname), ".", "-")
+  # GCP resource names are capped at 63 chars and may not end in a hyphen.
+  # Resource names append suffixes up to ~10 chars (e.g. "-allow-web"), so cap
+  # the prefix at 53 and strip any trailing hyphens left by truncation.
+  name_prefix = replace(substr(replace(lower(var.hostname), ".", "-"), 0, 53), "/-+$/", "")
 
   # Default zone to region-a when the caller omits the variable.
   effective_zone = (

--- a/deploy/gcp/main.tf
+++ b/deploy/gcp/main.tf
@@ -1,0 +1,258 @@
+##############################################################################
+# bracket-creator — GCP Always-Free e2-micro deployment
+#
+# Free-forever resources used:
+#   - 1× e2-micro (us-west1 / us-central1 / us-east1 ONLY)
+#   - 30 GB pd-standard boot disk
+#   - 1 GB/month egress free (North America) — see README for the scale ceiling
+#
+# !! Region validation is a billing guard — an e2-micro outside the three US
+#    free regions is NOT free and will generate charges. !!
+##############################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+locals {
+  # Sanitise hostname for use as a resource-name prefix (RFC 1035).
+  name_prefix = replace(lower(var.hostname), ".", "-")
+
+  # Default zone to region-a when the caller omits the variable.
+  effective_zone = (
+    var.zone != ""
+    ? var.zone
+    : "${var.region}-a"
+  )
+
+  # The app writes to /opt/tournament-data on the VM; compose bind-mounts it.
+  data_dir = "/opt/tournament-data"
+  app_dir  = "/opt/app"
+
+  # Caddyfile rendered from the template in this folder (kept self-contained so
+  # the module can be copied and deployed on its own).
+  caddyfile = templatefile("${path.module}/Caddyfile.tftpl", {
+    hostname = var.hostname
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Networking
+# ---------------------------------------------------------------------------
+
+resource "google_compute_network" "default" {
+  name                    = "${local.name_prefix}-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "${local.name_prefix}-subnet"
+  region        = var.region
+  network       = google_compute_network.default.self_link
+  ip_cidr_range = "10.0.0.0/24"
+}
+
+# Web traffic (HTTP/HTTPS) is ALWAYS open to the world: viewers come from
+# anywhere, and Caddy's Let's Encrypt HTTP-01 challenge requires inbound port
+# 80 from any IP. This is intentionally separate from the SSH rule so that
+# restricting SSH never restricts public web access.
+resource "google_compute_firewall" "allow_web" {
+  name    = "${local.name_prefix}-allow-web"
+  network = google_compute_network.default.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+# SSH is restricted to operator CIDRs when provided; otherwise open to all
+# (acceptable for personal deployments, tighten for production).
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "${local.name_prefix}-allow-ssh"
+  network = google_compute_network.default.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = (
+    length(var.operator_cidrs) > 0
+    ? var.operator_cidrs
+    : ["0.0.0.0/0"]
+  )
+}
+
+# Optional reserved static IP — costs nothing while attached to a running
+# instance.  Use it so the DNS A record never needs updating after a
+# stop/start cycle.
+resource "google_compute_address" "static" {
+  count  = var.reserve_static_ip ? 1 : 0
+  name   = "${local.name_prefix}-ip"
+  region = var.region
+}
+
+# ---------------------------------------------------------------------------
+# Cloud-init user-data
+# ---------------------------------------------------------------------------
+
+locals {
+  cloud_init = <<-CLOUDINIT
+    #cloud-config
+    packages:
+      - ca-certificates
+      - curl
+      - gnupg
+
+    runcmd:
+      # --- Install Docker (official repo) ---
+      - install -m 0755 -d /etc/apt/keyrings
+      - |
+        curl -fsSL https://download.docker.com/linux/debian/gpg \
+          | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      - chmod a+r /etc/apt/keyrings/docker.gpg
+      - |
+        echo "deb [arch=$(dpkg --print-architecture) \
+          signed-by=/etc/apt/keyrings/docker.gpg] \
+          https://download.docker.com/linux/debian \
+          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+          > /etc/apt/sources.list.d/docker.list
+      - apt-get update -y
+      - >
+        apt-get install -y
+        docker-ce docker-ce-cli containerd.io
+        docker-buildx-plugin docker-compose-plugin
+      - systemctl enable --now docker
+
+      # --- Data directory (uid 65534 = nonroot in the container image) ---
+      - mkdir -p ${local.data_dir}
+      - chown -R 65534:65534 ${local.data_dir}
+
+      # --- App directory ---
+      - mkdir -p ${local.app_dir}
+
+      # --- docker-compose.yaml ---
+      - |
+        cat > ${local.app_dir}/docker-compose.yaml <<'EOF'
+        services:
+          app:
+            image: ${var.image_ref}
+            restart: unless-stopped
+            env_file:
+              - ${local.app_dir}/app.env
+            environment:
+              - TOURNAMENT_DATA_DIR=/tournament-data
+            volumes:
+              - ${local.data_dir}:/tournament-data
+            # The app never needs the cloud metadata service; map its hostname
+            # to loopback so a compromised container cannot read instance
+            # metadata (which includes the cloud-init user-data).
+            extra_hosts:
+              - "metadata.google.internal:127.0.0.1"
+            expose:
+              - "8080"
+
+          caddy:
+            image: caddy:2-alpine
+            restart: unless-stopped
+            ports:
+              - "80:80"
+              - "443:443"
+            volumes:
+              - ${local.app_dir}/Caddyfile:/etc/caddy/Caddyfile:ro
+              - caddy_data:/data
+              - caddy_config:/config
+            depends_on:
+              - app
+
+        volumes:
+          caddy_data:
+          caddy_config:
+        EOF
+
+      # --- Caddyfile (rendered from Caddyfile.tftpl) ---
+      - echo ${base64encode(local.caddyfile)} | base64 -d > ${local.app_dir}/Caddyfile
+
+      # --- app.env (chmod 600 — contains secrets) ---
+      - |
+        cat > ${local.app_dir}/app.env <<'EOF'
+        LOCK_PASSWORD=${var.lock_password}
+        TOURNAMENT_PASSWORD_HASH=${var.tournament_password_hash}
+        SSE_MAX_CLIENTS=${var.sse_max_clients}
+        API_RATE_LIMIT=${var.api_rate_limit}
+        API_RATE_LIMIT_BURST=${var.api_rate_limit_burst}
+        EOF
+      - chmod 600 ${local.app_dir}/app.env
+      - chown root:root ${local.app_dir}/app.env
+
+      # --- Start the stack ---
+      - cd ${local.app_dir} && docker compose pull
+      - cd ${local.app_dir} && docker compose up -d
+  CLOUDINIT
+}
+
+# ---------------------------------------------------------------------------
+# Compute instance
+# ---------------------------------------------------------------------------
+
+resource "google_compute_instance" "app" {
+  name         = local.name_prefix
+  machine_type = "e2-micro"
+  zone         = local.effective_zone
+
+  # Debian 12 (Bookworm) — keep in sync with Dockerfile.mobile base image
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+      size  = 30 # GiB — free-tier pd-standard cap
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.default.self_link
+
+    access_config {
+      nat_ip = (
+        var.reserve_static_ip
+        ? google_compute_address.static[0].address
+        : null
+      )
+    }
+  }
+
+  metadata = {
+    user-data              = local.cloud_init
+    ssh-keys               = "${var.ssh_user}:${var.ssh_pubkey}"
+    block-project-ssh-keys = "true"
+  }
+
+  tags = ["${local.name_prefix}-web"]
+
+  # No service account is attached: the app only needs anonymous outbound
+  # HTTPS to pull the public GHCR image, which requires no GCP credential.
+  # Omitting the block avoids handing the instance a broad API token.
+
+  lifecycle {
+    ignore_changes = [
+      # Prevent Terraform from recreating the instance when cloud-init
+      # user-data changes after initial deploy.
+      metadata["user-data"],
+    ]
+  }
+}

--- a/deploy/gcp/outputs.tf
+++ b/deploy/gcp/outputs.tf
@@ -1,0 +1,25 @@
+locals {
+  public_ip = (
+    var.reserve_static_ip
+    ? google_compute_address.static[0].address
+    : google_compute_instance.app.network_interface[0].access_config[0].nat_ip
+  )
+}
+
+output "instance_public_ip" {
+  description = <<-EOT
+    Public IP address of the e2-micro instance.
+    Point your DNS A record here, then Caddy will auto-obtain a TLS cert.
+  EOT
+  value       = local.public_ip
+}
+
+output "app_url" {
+  description = "HTTPS URL of the deployed mobile app."
+  value       = "https://${var.hostname}"
+}
+
+output "ssh_command" {
+  description = "SSH command to reach the instance."
+  value       = "ssh ${var.ssh_user}@${local.public_ip}"
+}

--- a/deploy/gcp/terraform.tfvars.example
+++ b/deploy/gcp/terraform.tfvars.example
@@ -1,0 +1,19 @@
+project  = "my-gcp-project-id"
+region   = "us-central1" # MUST be us-west1 / us-central1 / us-east1
+zone     = "us-central1-a"
+hostname = "tournament.example.com"
+
+ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
+
+# Optional — tighten SSH to your IP only
+# operator_cidrs = ["203.0.113.10/32"]
+
+# Optional — reserve a stable IP (free while attached to a running instance)
+# reserve_static_ip = true
+
+# Optional — PDF export (heavier image, ~500 MB, more RAM pressure)
+# image_ref = "ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest"
+
+# Optional — locked password mode (hash must be bcrypt; see README)
+# lock_password            = "true"
+# tournament_password_hash = "$2b$12$..."

--- a/deploy/gcp/terraform.tfvars.example
+++ b/deploy/gcp/terraform.tfvars.example
@@ -15,5 +15,5 @@ ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
 # image_ref = "ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest"
 
 # Optional — locked password mode (hash must be bcrypt; see README)
-# lock_password            = "true"
+# lock_password            = true
 # tournament_password_hash = "$2b$12$..."

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -100,6 +100,14 @@ variable "sse_max_clients" {
   EOT
   type        = number
   default     = 5000
+
+  validation {
+    # The app reads SSE_MAX_CLIENTS with strconv.Atoi (integer-only); a
+    # non-integer would be ignored at runtime and silently fall back to the
+    # default, so reject it at plan time instead.
+    condition     = var.sse_max_clients > 0 && var.sse_max_clients == floor(var.sse_max_clients)
+    error_message = "sse_max_clients must be a positive integer."
+  }
 }
 
 variable "api_rate_limit" {
@@ -112,12 +120,24 @@ variable "api_rate_limit" {
   EOT
   type        = number
   default     = 500
+
+  validation {
+    # The app parses API_RATE_LIMIT with ParseFloat and ignores values <= 0.
+    condition     = var.api_rate_limit > 0
+    error_message = "api_rate_limit must be greater than 0."
+  }
 }
 
 variable "api_rate_limit_burst" {
   description = "Burst allowance for the global API rate limit. The application default is 10000."
   type        = number
   default     = 1000
+
+  validation {
+    # The server reads API_RATE_LIMIT_BURST with strconv.Atoi (integer-only).
+    condition     = var.api_rate_limit_burst > 0 && var.api_rate_limit_burst == floor(var.api_rate_limit_burst)
+    error_message = "api_rate_limit_burst must be a positive integer."
+  }
 }
 
 variable "ssh_user" {

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -1,0 +1,157 @@
+variable "project" {
+  description = "GCP project ID."
+  type        = string
+}
+
+variable "region" {
+  description = <<-EOT
+    GCP region for the e2-micro instance.  MUST be one of us-west1,
+    us-central1, or us-east1 — these are the only regions where the e2-micro
+    is part of the Always-Free tier.  Any other region silently incurs charges.
+  EOT
+  type        = string
+  default     = "us-central1"
+
+  validation {
+    condition = contains(
+      ["us-west1", "us-central1", "us-east1"],
+      var.region,
+    )
+    error_message = <<-EOT
+      region must be one of us-west1, us-central1, or us-east1.
+      Only those three regions include the e2-micro in GCP's Always-Free tier.
+      Deploying to any other region will generate charges.
+    EOT
+  }
+}
+
+variable "zone" {
+  description = <<-EOT
+    GCP zone within the chosen region, e.g. "us-central1-a".
+    Defaults to the -a zone of whichever region is selected.
+  EOT
+  type        = string
+  default     = ""
+
+  # Caller can leave this empty; main.tf uses region + "-a" if blank.
+  # (We handle it in the locals rather than here to avoid a complex default.)
+}
+
+variable "hostname" {
+  description = <<-EOT
+    Fully-qualified domain name for the deployment, e.g. "tournament.example.com".
+    Caddy uses this to obtain a Let's Encrypt TLS certificate — the DNS A record
+    must point at the instance IP before the stack starts.
+  EOT
+  type        = string
+
+  validation {
+    # Must begin with a letter: the hostname is also used to derive GCP
+    # resource names (RFC 1035), which may not start with a digit.
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9.-]*[a-zA-Z0-9]$", var.hostname))
+    error_message = "hostname must be a valid FQDN beginning with a letter (letters, digits, dots, and hyphens only — no spaces, newlines, or shell metacharacters)."
+  }
+}
+
+variable "image_ref" {
+  description = <<-EOT
+    Docker image to deploy.  Defaults to the lean non-PDF mobile image
+    (~20 MB, FROM scratch) which is the natural fit for the 1 GB RAM e2-micro.
+    Override to the PDF image only if bracket→PDF export is required on this box:
+      ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest
+    Note: the PDF image includes LibreOffice (~500 MB) and requires more RAM.
+  EOT
+  type        = string
+  default     = "ghcr.io/gitrgoliveira/bracket-creator-mobile:latest"
+
+  validation {
+    condition     = !can(regex("[[:space:]]", var.image_ref))
+    error_message = "image_ref must not contain whitespace or newlines."
+  }
+}
+
+variable "lock_password" {
+  description = <<-EOT
+    Set to "true" to enable bcrypt locked-mode auth.
+    When true, TOURNAMENT_PASSWORD_HASH must also be provided.
+    When false, the plaintext password in tournament-data/tournament.md is used.
+  EOT
+  type        = string
+  default     = "false"
+}
+
+variable "tournament_password_hash" {
+  description = <<-EOT
+    Bcrypt hash of the admin password, used when lock_password = "true".
+    Generate with: htpasswd -bnBC 12 "" '<password>' | tr -d ':\n'
+    This value is written to app.env (chmod 600, root-owned) on the VM.
+    Mark as sensitive in your tfvars — never commit the plaintext.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "sse_max_clients" {
+  description = <<-EOT
+    Maximum concurrent live-update (SSE) connections. Application default is
+    5000. On the e2-micro the practical limit for a public event is the free
+    monthly network allowance (1 GB egress) rather than this cap — see README.
+  EOT
+  type        = number
+  default     = 5000
+}
+
+variable "api_rate_limit" {
+  description = <<-EOT
+    Global API rate limit in requests per second across all clients. Requests
+    beyond this receive HTTP 429, protecting the instance from traffic spikes.
+    The application default is 5000; this conservative default suits a demo or
+    small event and can be raised for larger audiences. A built-in per-client
+    limit also applies and needs no configuration.
+  EOT
+  type        = number
+  default     = 500
+}
+
+variable "api_rate_limit_burst" {
+  description = "Burst allowance for the global API rate limit. The application default is 10000."
+  type        = number
+  default     = 1000
+}
+
+variable "ssh_user" {
+  description = "Linux username for the SSH public key."
+  type        = string
+  default     = "ubuntu"
+}
+
+variable "ssh_pubkey" {
+  description = <<-EOT
+    SSH public key to install on the instance (openssh format,
+    e.g. "ssh-ed25519 AAAA... user@host").
+  EOT
+  type        = string
+}
+
+variable "operator_cidrs" {
+  description = <<-EOT
+    List of CIDR ranges allowed to reach port 22 (SSH).
+    Empty list allows SSH from 0.0.0.0/0 — acceptable for personal use;
+    tighten for production deployments.
+    Ports 80 and 443 are always open to 0.0.0.0/0.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+variable "reserve_static_ip" {
+  description = <<-EOT
+    Reserve a static external IP address.  The address is free while attached
+    to a running instance; it is billed (~$0.01/hr) if the instance is stopped
+    and the IP remains reserved.  Without a static IP, the instance's external
+    IP changes on each stop/start — requiring a DNS update and a new TLS cert.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/deploy/gcp/variables.tf
+++ b/deploy/gcp/variables.tf
@@ -72,17 +72,17 @@ variable "image_ref" {
 
 variable "lock_password" {
   description = <<-EOT
-    Set to "true" to enable bcrypt locked-mode auth.
-    When true, TOURNAMENT_PASSWORD_HASH must also be provided.
+    Set to true to enable bcrypt locked-mode auth.
+    When true, tournament_password_hash must also be provided.
     When false, the plaintext password in tournament-data/tournament.md is used.
   EOT
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "tournament_password_hash" {
   description = <<-EOT
-    Bcrypt hash of the admin password, used when lock_password = "true".
+    Bcrypt hash of the admin password, used when lock_password = true.
     Generate with: htpasswd -bnBC 12 "" '<password>' | tr -d ':\n'
     This value is written to app.env (chmod 600, root-owned) on the VM.
     Mark as sensitive in your tfvars — never commit the plaintext.

--- a/deploy/oracle/ARCHITECTURE.md
+++ b/deploy/oracle/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Oracle Cloud (OCI) Deployment Architecture
+
+This document explains how the bracket-creator live tournament app is deployed on the
+**Oracle Cloud Always Free tier**, what gets created, and what to expect. For step-by-step
+deployment instructions, see [README.md](README.md).
+
+> Cloud free-tier allowances change over time. The figures below were accurate as of June 2026 —
+> confirm them against Oracle's current [Always Free](https://www.oracle.com/cloud/free/) page before
+> you rely on them.
+
+## What this deployment is for
+
+The Always Free **Ampere A1** instance (2 OCPU / 12 GB RAM, with a 10 TB/month network allowance)
+runs the tournament app **continuously, at no cost**, and comfortably handles **large events** —
+including audiences of 1000+ concurrent live viewers. It is the recommended choice when you expect a
+big crowd. For smaller club events you may also use the simpler GCP deployment (`deploy/gcp/`).
+
+## Resources created
+
+| Resource | Free-tier allowance (June 2026) | What this deployment uses |
+|---|---|---|
+| Compute | Ampere A1 (Arm), up to 2 OCPU / 12 GB RAM, Always Free | one instance: 2 OCPU / 12 GB |
+| Block storage | 200 GB total, Always Free | boot volume holds the app and data |
+| Network egress | 10 TB/month | effectively unlimited for this app |
+| Networking | 1 virtual cloud network + public IP | one network, subnet, and a reserved public IP |
+
+> Oracle's Always Free Ampere allowance is **2 OCPU / 12 GB** as of mid-June 2026 (reduced from an
+> earlier 4 OCPU / 24 GB). The deployment requests 2 OCPU / 12 GB to stay within the free limit.
+
+## Architecture note: Arm processors
+
+Ampere A1 instances use **Arm (aarch64)** processors, so they run the Arm build of the application
+image. The project publishes multi-architecture images (Arm and x86), so the instance simply pulls
+the correct one — no special action is needed on your part.
+
+## Topology
+
+```
+  Internet ──443/80──▶  Firewall: cloud Security List  +  on-host firewall (both required)
+                              │
+                   ┌──────────▼───────────┐  Ampere A1 (2 OCPU / 12 GB), Arm
+                   │  Caddy  (port 443)   │  automatic HTTPS (Let's Encrypt)
+                   │        │ proxy         │
+                   │        ▼               │
+                   │  tournament app :8080 │
+                   └──────────┬───────────┘
+                              │
+                   /opt/tournament-data    (on the block volume; survives reboots)
+```
+
+The app runs in a container as a non-root user. Caddy sits in front of it, terminates HTTPS, and
+forwards requests to the app. Live updates stream to browsers over Server-Sent Events (SSE), which
+pass through Caddy unbuffered.
+
+## Persistence
+
+All tournament state is stored on the instance's block volume at `/opt/tournament-data`, mounted
+into the container. This volume survives reboots and stop/start, so your tournament data is retained.
+The container restarts automatically, so the app comes back on its own after a reboot.
+
+## Networking and HTTPS
+
+- **Automatic HTTPS** is handled by Caddy using Let's Encrypt — no manual certificate management.
+- **Two firewall layers** must both allow web traffic, and the deployment configures both for you:
+  1. The cloud-level **Security List** (opens ports 80, 443, and 22).
+  2. The **on-host firewall** inside Oracle's Linux images, which blocks web ports by default — a
+     common Oracle pitfall. The deployment opens and persists the necessary rules automatically.
+- **DNS:** point an `A` record for your chosen hostname at the instance's public IP. Caddy needs the
+  hostname to issue the certificate. The deployment uses a **reserved public IP** (included in Always
+  Free), so the address stays stable across stop/start.
+
+## Authentication
+
+- By default the app uses the password stored in your tournament configuration.
+- For public deployments you can enable **locked mode** (`LOCK_PASSWORD=true`) and supply a bcrypt
+  password hash via `TOURNAMENT_PASSWORD_HASH`. These are written to a protected, root-owned file on
+  the instance and are never stored in the container image. See the [README](README.md) for details.
+
+## Capacity and scale
+
+With 12 GB of RAM and a 10 TB monthly network allowance, this deployment serves large live audiences
+comfortably; network egress is not a practical concern. `SSE_MAX_CLIENTS` (default 5000) bounds the
+number of simultaneous live-update connections and can be adjusted in the configuration. For
+exceptionally large events, validate capacity with a trial run at your expected audience size.
+
+## Operations
+
+- **Teardown:** `terraform destroy` removes everything. Running it also frees the Always Free
+  Ampere capacity for future use.
+- **Availability note:** Always Free Ampere capacity is occasionally unavailable in busy regions
+  ("out of host capacity"). If that happens, retry or try a different availability domain — the
+  README explains how.
+- **Backups:** tournament data is small; you can back up the block volume or copy `tournament-data`
+  elsewhere. The README includes commands.
+
+## Provisioning summary
+
+The module provisions the instance, network, firewall, and reserved IP, then automatically: installs
+Docker, opens the on-host firewall, prepares the data directory, writes the app and Caddy
+configuration, and starts the app by pulling the published image. Within a few minutes of
+`terraform apply` the app is reachable over HTTPS at your hostname. Full instructions are in the
+[README](README.md).

--- a/deploy/oracle/Caddyfile.tftpl
+++ b/deploy/oracle/Caddyfile.tftpl
@@ -1,0 +1,12 @@
+# Rendered by Terraform (templatefile) — see main.tf in this folder.
+#
+# Caddy automatically obtains and renews a Let's Encrypt TLS certificate for
+# this hostname. The host must be reachable on ports 80 and 443 with a DNS A
+# record pointing at its public IP before the stack starts.
+#
+# Caddy streams responses by default, so SSE works without extra configuration.
+# Do NOT add flush_interval or response-buffering directives — they would break
+# the live-score event stream.
+${hostname} {
+    reverse_proxy app:8080
+}

--- a/deploy/oracle/README.md
+++ b/deploy/oracle/README.md
@@ -1,0 +1,197 @@
+# deploy/oracle — Oracle Always-Free Ampere A1
+
+Deploys the bracket-creator mobile-app on an **Oracle Always-Free Ampere A1**
+instance (2 OCPU / 12 GB RAM, Arm64) using Terraform.  Auto-HTTPS via Caddy.
+
+> **Current A1 Always-Free cap (2026-06-15 reduction):** Oracle reduced the cap
+> from 4 OCPU / 24 GB to **2 OCPU / 12 GB**.  Older guides cite 4/24 — they
+> are stale.  This module requests 2 OCPU / 12 GB to stay within Always-Free.
+
+> **Scale target:** Oracle is the only free-forever tier that matches the app's
+> 1000+-viewer SSE target.  10 TB/month egress means fan-out is never the cost
+> problem here.
+
+## Prerequisites
+
+- Terraform >= 1.5 installed locally.
+- An OCI account (free tier) with an API key configured.
+- OCI CLI installed and `~/.oci/config` populated (see "OCI provider auth"
+  below).
+- A domain name with an A record you can update.
+- The OCID of an Ubuntu 22.04 Minimal Arm64 platform image in your region.
+
+## OCI provider auth setup
+
+OCI Terraform uses API key auth by default.  One-time setup:
+
+```bash
+# 1. Install the OCI CLI
+# https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm
+oci setup config   # interactive wizard; generates ~/.oci/config + key pair
+
+# 2. Upload the PUBLIC key to the OCI Console
+#    Profile (top-right) → My Profile → API Keys → Add API Key
+#    Paste the contents of ~/.oci/oci_api_key_public.pem
+
+# 3. Verify
+oci iam user get --user-id <your-user-ocid>
+```
+
+The Terraform provider reads `~/.oci/config` automatically.  Alternatively,
+set these environment variables:
+
+```bash
+export OCI_TENANCY_OCID="ocid1.tenancy.oc1..."
+export OCI_USER_OCID="ocid1.user.oc1..."
+export OCI_FINGERPRINT="aa:bb:cc:..."
+export OCI_PRIVATE_KEY_PATH="$HOME/.oci/oci_api_key.pem"
+export OCI_REGION="us-ashburn-1"
+```
+
+## Finding the Ubuntu Arm64 image OCID
+
+```bash
+oci compute image list \
+  --compartment-id <tenancy-ocid> \
+  --operating-system "Canonical Ubuntu" \
+  --operating-system-version "22.04 Minimal aarch64" \
+  --shape VM.Standard.A1.Flex \
+  --query 'data[0].id' \
+  --raw-output
+```
+
+OCIDs are region-specific — run this in the same region you intend to deploy.
+
+## One-command deploy
+
+```bash
+cd deploy/oracle
+
+# Copy the example tfvars and fill in your values
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+
+terraform init
+terraform plan
+terraform apply
+```
+
+After `apply`, the output `instance_public_ip` shows the reserved public IP.
+Update your DNS A record to that IP.  Caddy obtains the TLS certificate
+automatically on the first HTTPS request (allow ~30 seconds).
+
+## terraform.tfvars example
+
+```hcl
+tenancy_ocid     = "ocid1.tenancy.oc1..aaaa..."
+compartment_ocid = "ocid1.tenancy.oc1..aaaa..."  # or a child compartment
+region           = "us-ashburn-1"
+availability_domain = "Uocm:US-ASHBURN-AD-1"
+
+instance_image_ocid = "ocid1.image.oc1.iad.aaaa..."  # Ubuntu 22.04 Minimal aarch64
+
+hostname   = "tournament.example.com"
+ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
+
+# Optional — restrict SSH to your IP
+# operator_cidrs = ["203.0.113.10/32"]
+
+# Optional — locked password mode
+# lock_password            = "true"
+# tournament_password_hash = "$2b$12$..."
+```
+
+## DNS guide
+
+1. Note `instance_public_ip` from `terraform apply` output.
+2. In your DNS provider: `tournament.example.com. 300 IN A <public_ip>`
+3. The reserved IP is stable — it does not change across instance stop/start,
+   so you only set the DNS record once.
+4. Check cert provisioning: `ssh ubuntu@<ip> -- docker compose -f /opt/app/docker-compose.yaml logs caddy`
+
+## The #1 OCI footgun — two firewall layers
+
+Traffic to ports 80/443 must be allowed at **both** levels:
+
+1. **OCI Security List** — opened by Terraform (this module).
+2. **In-instance iptables** — Oracle's stock Ubuntu images ship a `iptables`
+   ruleset that **drops 80/443 by default**.  The cloud-init script adds
+   accept rules and persists them via `netfilter-persistent`.
+
+If the site times out even though the Security List is open, SSH into the VM
+and check: `sudo iptables -L INPUT -n | grep -E '80|443'`
+
+If the accept rules are missing: `sudo iptables -I INPUT 1 -p tcp --dport 443 -j ACCEPT && sudo netfilter-persistent save`
+
+## A1 "Out of capacity" — retry note
+
+Oracle A1 Always-Free instances are popular.  If `terraform apply` returns:
+```
+Out of host capacity.
+```
+
+Try:
+1. A different availability domain in the same region (`var.availability_domain`).
+2. Retry after a few hours — capacity is released as other tenants stop/delete
+   instances.
+3. Try a different region (you can move the `tenancy_ocid` home region once).
+
+This is a known Oracle-wide issue, not a module bug.
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+Always-Free means no ongoing charges, but destroy to release the A1 capacity
+for re-creation and to clean up the VCN/subnet/IGW.
+
+Before destroying, back up tournament data:
+
+```bash
+rsync -avz ubuntu@<ip>:/opt/tournament-data ./tournament-data-backup
+```
+
+## Backups
+
+OCI block-volume backups are Always-Free within the 5-backup quota.  In the
+OCI Console: Storage → Block Volumes → (your boot volume) → Create Manual
+Backup.
+
+## Security notes
+
+- **Never commit `terraform.tfstate` or `terraform.tfvars`.** Both can contain
+  secrets in plaintext — in particular `tournament_password_hash`. They are
+  already covered by `.gitignore`; keep them out of version control.
+- For shared or team use, configure a **remote backend** (OCI Object Storage) so
+  state is encrypted at rest and never stored on a laptop.
+- Locking down SSH: set `operator_cidrs` to your own IP range. Ports 80 and 443
+  always remain open to the world (viewers and Let's Encrypt need them).
+
+## Module variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `tenancy_ocid` | — | OCI tenancy OCID |
+| `compartment_ocid` | — | Compartment OCID |
+| `region` | — | OCI region identifier |
+| `availability_domain` | — | AD within region |
+| `instance_image_ocid` | — | Ubuntu 22.04 Arm64 image OCID |
+| `hostname` | — | FQDN for the app |
+| `image_ref` | PDF mobile image | Multi-arch Docker tag |
+| `lock_password` | `"false"` | Enable bcrypt locked mode |
+| `tournament_password_hash` | `""` | Bcrypt hash (sensitive) |
+| `sse_max_clients` | `5000` | SSE subscriber cap |
+| `api_rate_limit` | `1000` | Global API requests/sec limit (conservative default; raise for larger events) |
+| `api_rate_limit_burst` | `2000` | Global API rate-limit burst |
+| `ssh_pubkey` | — | SSH public key |
+| `operator_cidrs` | `[]` | CIDRs allowed SSH (empty = all) |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `instance_public_ip` | Reserved public IP — use for DNS A record |
+| `app_url` | `https://<hostname>` |
+| `ssh_command` | Ready-to-run SSH command |

--- a/deploy/oracle/README.md
+++ b/deploy/oracle/README.md
@@ -97,7 +97,7 @@ ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
 # operator_cidrs = ["203.0.113.10/32"]
 
 # Optional — locked password mode
-# lock_password            = "true"
+# lock_password            = true
 # tournament_password_hash = "$2b$12$..."
 ```
 
@@ -180,7 +180,7 @@ Backup.
 | `instance_image_ocid` | — | Ubuntu 22.04 Arm64 image OCID |
 | `hostname` | — | FQDN for the app |
 | `image_ref` | PDF mobile image | Multi-arch Docker tag |
-| `lock_password` | `"false"` | Enable bcrypt locked mode |
+| `lock_password` | `false` | Enable bcrypt locked mode |
 | `tournament_password_hash` | `""` | Bcrypt hash (sensitive) |
 | `sse_max_clients` | `5000` | SSE subscriber cap |
 | `api_rate_limit` | `1000` | Global API requests/sec limit (conservative default; raise for larger events) |

--- a/deploy/oracle/main.tf
+++ b/deploy/oracle/main.tf
@@ -336,6 +336,13 @@ resource "oci_core_instance" "app" {
   }
 
   lifecycle {
+    # Fail at plan/apply rather than at container startup: locked mode with an
+    # empty hash makes the app exit immediately (it fails closed).
+    precondition {
+      condition     = lower(trimspace(var.lock_password)) != "true" || trimspace(var.tournament_password_hash) != ""
+      error_message = "tournament_password_hash must be set when lock_password is \"true\" — the app fails closed and exits at startup with an empty hash."
+    }
+
     ignore_changes = [
       # Prevent Terraform from recreating when cloud-init changes post-deploy.
       metadata["user_data"],

--- a/deploy/oracle/main.tf
+++ b/deploy/oracle/main.tf
@@ -339,8 +339,8 @@ resource "oci_core_instance" "app" {
     # Fail at plan/apply rather than at container startup: locked mode with an
     # empty hash makes the app exit immediately (it fails closed).
     precondition {
-      condition     = lower(trimspace(var.lock_password)) != "true" || trimspace(var.tournament_password_hash) != ""
-      error_message = "tournament_password_hash must be set when lock_password is \"true\" — the app fails closed and exits at startup with an empty hash."
+      condition     = !var.lock_password || trimspace(var.tournament_password_hash) != ""
+      error_message = "tournament_password_hash must be set when lock_password is true — the app fails closed and exits at startup with an empty hash."
     }
 
     ignore_changes = [

--- a/deploy/oracle/main.tf
+++ b/deploy/oracle/main.tf
@@ -1,0 +1,346 @@
+##############################################################################
+# bracket-creator — Oracle Always-Free Ampere A1 deployment
+#
+# Free-forever resources used (current as of 2026-06-15 reduction):
+#   - Ampere A1 Flex: 2 OCPU / 12 GB RAM (Arm64)
+#   - Boot volume from the 200 GB block-storage Always-Free pool
+#   - 10 TB/month egress (effectively unlimited for this workload)
+#   - 1 reserved public IP (Always-Free)
+#
+# A1 is Arm64 — the CI-published multi-arch image must include linux/arm64.
+# The VM never builds; it only pulls from GHCR.
+#
+# WARNING — TWO firewall layers must BOTH be open (§6 in ARCHITECTURE.md):
+#   1. OCI Security List (Terraform — this file)
+#   2. In-instance iptables (cloud-init — this file)
+# Forgetting the iptables rules = security list is open but traffic still
+# times out inside the VM.  This is the #1 OCI gotcha.
+##############################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+# OCI provider reads auth from ~/.oci/config (or env vars — see README).
+provider "oci" {
+  tenancy_ocid = var.tenancy_ocid
+  region       = var.region
+}
+
+locals {
+  name_prefix = replace(lower(var.hostname), ".", "-")
+  data_dir    = "/opt/tournament-data"
+  app_dir     = "/opt/app"
+
+  # OCI dns_label / hostname_label are alphanumeric and capped at 15 chars.
+  # Strip hyphens and truncate so any real FQDN produces a valid label.
+  dns_label = substr(replace(local.name_prefix, "-", ""), 0, 15)
+
+  # Caddyfile rendered from the template in this folder (kept self-contained so
+  # the module can be copied and deployed on its own).
+  caddyfile = templatefile("${path.module}/Caddyfile.tftpl", {
+    hostname = var.hostname
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Networking: VCN, subnet, internet gateway, route table
+# ---------------------------------------------------------------------------
+
+resource "oci_core_vcn" "main" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${local.name_prefix}-vcn"
+  cidr_blocks    = ["10.0.0.0/16"]
+  dns_label      = local.dns_label
+}
+
+resource "oci_core_internet_gateway" "main" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.main.id
+  display_name   = "${local.name_prefix}-igw"
+  enabled        = true
+}
+
+resource "oci_core_route_table" "public" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.main.id
+  display_name   = "${local.name_prefix}-rt"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.main.id
+  }
+}
+
+resource "oci_core_security_list" "public" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.main.id
+  display_name   = "${local.name_prefix}-sl"
+
+  # Outbound: allow all (needed for Docker pull, Let's Encrypt ACME, etc.)
+  egress_security_rules {
+    protocol    = "all"
+    destination = "0.0.0.0/0"
+  }
+
+  # Inbound: HTTPS
+  ingress_security_rules {
+    protocol = "6" # TCP
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+
+  # Inbound: HTTP (Let's Encrypt ACME HTTP-01 challenge + redirect)
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+
+  # Inbound: SSH (restrict to operator CIDRs when provided)
+  dynamic "ingress_security_rules" {
+    for_each = (
+      length(var.operator_cidrs) > 0
+      ? var.operator_cidrs
+      : ["0.0.0.0/0"]
+    )
+    content {
+      protocol = "6"
+      source   = ingress_security_rules.value
+      tcp_options {
+        min = 22
+        max = 22
+      }
+    }
+  }
+
+  # Inbound: ICMP type 3 code 4 (fragmentation needed) — required for path MTU
+  # discovery so large responses are not silently dropped. Matches OCI's own
+  # default security-list template.
+  ingress_security_rules {
+    protocol = "1" # ICMP
+    source   = "0.0.0.0/0"
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
+  # Inbound: ICMP type 3 (all codes) from within the VCN — destination
+  # unreachable / network diagnostics between hosts in the network.
+  ingress_security_rules {
+    protocol = "1"
+    source   = "10.0.0.0/16"
+    icmp_options {
+      type = 3
+    }
+  }
+}
+
+resource "oci_core_subnet" "public" {
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_vcn.main.id
+  display_name      = "${local.name_prefix}-subnet"
+  cidr_block        = "10.0.1.0/24"
+  route_table_id    = oci_core_route_table.public.id
+  security_list_ids = [oci_core_security_list.public.id]
+  dns_label         = "public"
+}
+
+# Reserved public IP — Always-Free; stable across instance stop/start.
+# This means the DNS A record (and Let's Encrypt cert) survive reboots.
+resource "oci_core_public_ip" "app" {
+  compartment_id = var.compartment_ocid
+  lifetime       = "RESERVED"
+  display_name   = "${local.name_prefix}-ip"
+
+  # Attach to the VNIC after the instance is created (see lifecycle below).
+  private_ip_id = data.oci_core_private_ips.app_vnic.private_ips[0].id
+
+  lifecycle {
+    ignore_changes = [private_ip_id]
+  }
+}
+
+# Discover the primary VNIC private IP so we can attach the reserved public IP.
+data "oci_core_vnic_attachments" "app" {
+  compartment_id = var.compartment_ocid
+  instance_id    = oci_core_instance.app.id
+}
+
+data "oci_core_vnic" "app" {
+  vnic_id = data.oci_core_vnic_attachments.app.vnic_attachments[0].vnic_id
+}
+
+data "oci_core_private_ips" "app_vnic" {
+  vnic_id = data.oci_core_vnic.app.id
+}
+
+# ---------------------------------------------------------------------------
+# Cloud-init user-data
+# ---------------------------------------------------------------------------
+
+locals {
+  cloud_init = <<-CLOUDINIT
+    #cloud-config
+    packages:
+      - ca-certificates
+      - curl
+      - gnupg
+      - iptables-persistent
+      - netfilter-persistent
+
+    runcmd:
+      # --- Install Docker (official repo, arm64) ---
+      - install -m 0755 -d /etc/apt/keyrings
+      - |
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+          | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      - chmod a+r /etc/apt/keyrings/docker.gpg
+      - |
+        echo "deb [arch=$(dpkg --print-architecture) \
+          signed-by=/etc/apt/keyrings/docker.gpg] \
+          https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+          > /etc/apt/sources.list.d/docker.list
+      - apt-get update -y
+      - >
+        apt-get install -y
+        docker-ce docker-ce-cli containerd.io
+        docker-buildx-plugin docker-compose-plugin
+      - systemctl enable --now docker
+
+      # --- Open in-instance iptables for 80 and 443 ---
+      # OCI stock Ubuntu images ship a restrictive iptables that DROPS 80/443
+      # even when the OCI Security List allows them.  Both layers must be open.
+      - iptables -I INPUT 1 -p tcp --dport 80 -j ACCEPT
+      - iptables -I INPUT 1 -p tcp --dport 443 -j ACCEPT
+      # Persist across reboots via iptables-persistent / netfilter-persistent
+      - netfilter-persistent save
+
+      # --- Data directory (uid 65534 = nonroot in the container image) ---
+      - mkdir -p ${local.data_dir}
+      - chown -R 65534:65534 ${local.data_dir}
+
+      # --- App directory ---
+      - mkdir -p ${local.app_dir}
+
+      # --- docker-compose.yaml ---
+      - |
+        cat > ${local.app_dir}/docker-compose.yaml <<'EOF'
+        services:
+          app:
+            image: ${var.image_ref}
+            restart: unless-stopped
+            env_file:
+              - ${local.app_dir}/app.env
+            environment:
+              - TOURNAMENT_DATA_DIR=/tournament-data
+            volumes:
+              - ${local.data_dir}:/tournament-data
+            expose:
+              - "8080"
+
+          caddy:
+            image: caddy:2-alpine
+            restart: unless-stopped
+            ports:
+              - "80:80"
+              - "443:443"
+            volumes:
+              - ${local.app_dir}/Caddyfile:/etc/caddy/Caddyfile:ro
+              - caddy_data:/data
+              - caddy_config:/config
+            depends_on:
+              - app
+
+        volumes:
+          caddy_data:
+          caddy_config:
+        EOF
+
+      # --- Caddyfile (rendered from Caddyfile.tftpl) ---
+      - echo ${base64encode(local.caddyfile)} | base64 -d > ${local.app_dir}/Caddyfile
+
+      # --- app.env (chmod 600 — contains secrets) ---
+      - |
+        cat > ${local.app_dir}/app.env <<'EOF'
+        LOCK_PASSWORD=${var.lock_password}
+        TOURNAMENT_PASSWORD_HASH=${var.tournament_password_hash}
+        SSE_MAX_CLIENTS=${var.sse_max_clients}
+        API_RATE_LIMIT=${var.api_rate_limit}
+        API_RATE_LIMIT_BURST=${var.api_rate_limit_burst}
+        EOF
+      - chmod 600 ${local.app_dir}/app.env
+      - chown root:root ${local.app_dir}/app.env
+
+      # --- Pull image and start the stack ---
+      # No build tooling on the VM — pull only.
+      - cd ${local.app_dir} && docker compose pull
+      - cd ${local.app_dir} && docker compose up -d
+  CLOUDINIT
+}
+
+# ---------------------------------------------------------------------------
+# Compute instance — Ampere A1 Flex (Arm64)
+# ---------------------------------------------------------------------------
+
+resource "oci_core_instance" "app" {
+  compartment_id      = var.compartment_ocid
+  availability_domain = var.availability_domain
+  display_name        = local.name_prefix
+  shape               = "VM.Standard.A1.Flex"
+
+  shape_config {
+    # 2 OCPU / 12 GB is the current Always-Free Ampere A1 cap (as of 2026-06-15).
+    # Oracle reduced this from 4/24; do not exceed 2/12 to stay free.
+    ocpus         = 2
+    memory_in_gbs = 12
+  }
+
+  source_details {
+    # Ubuntu 22.04 Minimal for Arm64 — use the OCID from your tenancy's region.
+    # List OCIDs: oci compute image list --compartment-id <tenancy-ocid>
+    #             --operating-system "Canonical Ubuntu" --shape VM.Standard.A1.Flex
+    source_type = "image"
+    source_id   = var.instance_image_ocid
+
+    # Boot volume — keep on the Always-Free boot volume pool.
+    boot_volume_size_in_gbs = 50
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public.id
+    display_name     = "${local.name_prefix}-vnic"
+    assign_public_ip = false # We use a reserved IP; see oci_core_public_ip
+    hostname_label   = local.dns_label
+  }
+
+  metadata = {
+    ssh_authorized_keys = var.ssh_pubkey
+    user_data           = base64encode(local.cloud_init)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Prevent Terraform from recreating when cloud-init changes post-deploy.
+      metadata["user_data"],
+      # Image OCIDs can change (security patches); ignore after initial create.
+      source_details[0].source_id,
+    ]
+  }
+}

--- a/deploy/oracle/main.tf
+++ b/deploy/oracle/main.tf
@@ -168,12 +168,11 @@ resource "oci_core_public_ip" "app" {
   lifetime       = "RESERVED"
   display_name   = "${local.name_prefix}-ip"
 
-  # Attach to the VNIC after the instance is created (see lifecycle below).
+  # Attach to the instance's primary private IP (discovered via the data
+  # sources below). No ignore_changes here: if the instance/VNIC is ever
+  # replaced, Terraform must re-attach the reserved IP to the new private IP,
+  # otherwise the deployment would be left without a reachable public address.
   private_ip_id = data.oci_core_private_ips.app_vnic.private_ips[0].id
-
-  lifecycle {
-    ignore_changes = [private_ip_id]
-  }
 }
 
 # Discover the primary VNIC private IP so we can attach the reserved public IP.

--- a/deploy/oracle/outputs.tf
+++ b/deploy/oracle/outputs.tf
@@ -1,0 +1,18 @@
+output "instance_public_ip" {
+  description = <<-EOT
+    Reserved public IP address of the Ampere A1 instance.
+    Point your DNS A record here.
+    This IP is Always-Free and stable across instance stop/start.
+  EOT
+  value       = oci_core_public_ip.app.ip_address
+}
+
+output "app_url" {
+  description = "HTTPS URL of the deployed mobile app."
+  value       = "https://${var.hostname}"
+}
+
+output "ssh_command" {
+  description = "SSH command to reach the instance."
+  value       = "ssh ubuntu@${oci_core_public_ip.app.ip_address}"
+}

--- a/deploy/oracle/terraform.tfvars.example
+++ b/deploy/oracle/terraform.tfvars.example
@@ -12,5 +12,5 @@ ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
 # operator_cidrs = ["203.0.113.10/32"]
 
 # Optional — locked password mode (hash must be bcrypt; see README)
-# lock_password            = "true"
+# lock_password            = true
 # tournament_password_hash = "$2b$12$..."

--- a/deploy/oracle/terraform.tfvars.example
+++ b/deploy/oracle/terraform.tfvars.example
@@ -1,0 +1,16 @@
+tenancy_ocid        = "ocid1.tenancy.oc1..aaaa..."
+compartment_ocid    = "ocid1.tenancy.oc1..aaaa..." # or a child compartment
+region              = "us-ashburn-1"
+availability_domain = "Uocm:US-ASHBURN-AD-1"
+
+instance_image_ocid = "ocid1.image.oc1.iad.aaaa..." # Ubuntu 22.04 Minimal aarch64
+
+hostname   = "tournament.example.com"
+ssh_pubkey = "ssh-ed25519 AAAA... you@laptop"
+
+# Optional — restrict SSH to your IP
+# operator_cidrs = ["203.0.113.10/32"]
+
+# Optional — locked password mode (hash must be bcrypt; see README)
+# lock_password            = "true"
+# tournament_password_hash = "$2b$12$..."

--- a/deploy/oracle/variables.tf
+++ b/deploy/oracle/variables.tf
@@ -103,6 +103,14 @@ variable "sse_max_clients" {
   EOT
   type        = number
   default     = 5000
+
+  validation {
+    # The app reads SSE_MAX_CLIENTS with strconv.Atoi (integer-only); a
+    # non-integer would be ignored at runtime and silently fall back to the
+    # default, so reject it at plan time instead.
+    condition     = var.sse_max_clients > 0 && var.sse_max_clients == floor(var.sse_max_clients)
+    error_message = "sse_max_clients must be a positive integer."
+  }
 }
 
 variable "api_rate_limit" {
@@ -115,12 +123,24 @@ variable "api_rate_limit" {
   EOT
   type        = number
   default     = 1000
+
+  validation {
+    # The app parses API_RATE_LIMIT with ParseFloat and ignores values <= 0.
+    condition     = var.api_rate_limit > 0
+    error_message = "api_rate_limit must be greater than 0."
+  }
 }
 
 variable "api_rate_limit_burst" {
   description = "Burst allowance for the global API rate limit. The application default is 10000."
   type        = number
   default     = 2000
+
+  validation {
+    # The server reads API_RATE_LIMIT_BURST with strconv.Atoi (integer-only).
+    condition     = var.api_rate_limit_burst > 0 && var.api_rate_limit_burst == floor(var.api_rate_limit_burst)
+    error_message = "api_rate_limit_burst must be a positive integer."
+  }
 }
 
 variable "ssh_pubkey" {

--- a/deploy/oracle/variables.tf
+++ b/deploy/oracle/variables.tf
@@ -1,0 +1,142 @@
+variable "tenancy_ocid" {
+  description = "OCID of your OCI tenancy."
+  type        = string
+}
+
+variable "compartment_ocid" {
+  description = <<-EOT
+    OCID of the compartment to deploy into.
+    The root compartment OCID equals tenancy_ocid — acceptable for personal
+    accounts.  Organisations typically use a dedicated child compartment.
+  EOT
+  type        = string
+}
+
+variable "region" {
+  description = <<-EOT
+    OCI region identifier, e.g. "us-ashburn-1".
+    Always-Free A1 capacity is per-tenancy home region — deploying to your
+    home region is recommended.  Availability varies; see README for the
+    "Out of capacity" retry note.
+  EOT
+  type        = string
+}
+
+variable "availability_domain" {
+  description = <<-EOT
+    Availability domain name within the region, e.g. "Uocm:US-ASHBURN-AD-1".
+    List ADs: oci iam availability-domain list --compartment-id <tenancy-ocid>
+    If one AD is out of A1 capacity, try another in the same region.
+  EOT
+  type        = string
+}
+
+variable "instance_image_ocid" {
+  description = <<-EOT
+    OCID of the Ubuntu 22.04 Minimal (Arm64) platform image for your region.
+    List: oci compute image list --compartment-id <tenancy-ocid> \
+           --operating-system "Canonical Ubuntu" \
+           --shape VM.Standard.A1.Flex --query 'data[].id'
+    OCIDs are region-specific — use the one that matches var.region.
+  EOT
+  type        = string
+}
+
+variable "hostname" {
+  description = <<-EOT
+    Fully-qualified domain name for the deployment, e.g. "tournament.example.com".
+    Caddy uses this to obtain a Let's Encrypt TLS certificate.
+  EOT
+  type        = string
+
+  validation {
+    # Must begin with a letter: the hostname is also used to derive the OCI
+    # dns_label / hostname_label, which must start with a letter (RFC 952).
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9.-]*[a-zA-Z0-9]$", var.hostname))
+    error_message = "hostname must be a valid FQDN beginning with a letter (letters, digits, dots, and hyphens only — no spaces, newlines, or shell metacharacters)."
+  }
+}
+
+variable "image_ref" {
+  description = <<-EOT
+    Multi-arch Docker image to deploy (must include linux/arm64).
+    Defaults to the PDF-capable image — Oracle A1 has 12 GB RAM, so
+    LibreOffice headless fits comfortably.
+    The arm64 layer is published by the CI workflow (docker-publish.yaml /
+    docker-release.yaml) via native ubuntu-24.04-arm runners.
+  EOT
+  type        = string
+  default     = "ghcr.io/gitrgoliveira/bracket-creator-mobile-pdf:latest"
+
+  validation {
+    condition     = !can(regex("[[:space:]]", var.image_ref))
+    error_message = "image_ref must not contain whitespace or newlines."
+  }
+}
+
+variable "lock_password" {
+  description = <<-EOT
+    Set to "true" to enable bcrypt locked-mode auth.
+    When true, tournament_password_hash must also be provided.
+  EOT
+  type        = string
+  default     = "false"
+}
+
+variable "tournament_password_hash" {
+  description = <<-EOT
+    Bcrypt hash of the admin password, used when lock_password = "true".
+    Generate: htpasswd -bnBC 12 "" '<password>' | tr -d ':\n'
+    Written to app.env (chmod 600, root-owned) by cloud-init.
+    Mark sensitive in your tfvars — never commit the plaintext.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "sse_max_clients" {
+  description = <<-EOT
+    Maximum concurrent live-update (SSE) connections. Application default is
+    5000, which the Ampere A1 (12 GB RAM) supports comfortably. For very large
+    events, validate capacity with a trial run at your expected audience size.
+  EOT
+  type        = number
+  default     = 5000
+}
+
+variable "api_rate_limit" {
+  description = <<-EOT
+    Global API rate limit in requests per second across all clients. Requests
+    beyond this receive HTTP 429, protecting the instance from traffic spikes.
+    The application default is 5000; this conservative default suits typical
+    events and can be raised for larger audiences. A built-in per-client limit
+    also applies and needs no configuration.
+  EOT
+  type        = number
+  default     = 1000
+}
+
+variable "api_rate_limit_burst" {
+  description = "Burst allowance for the global API rate limit. The application default is 10000."
+  type        = number
+  default     = 2000
+}
+
+variable "ssh_pubkey" {
+  description = <<-EOT
+    SSH public key to install on the instance (openssh format,
+    e.g. "ssh-ed25519 AAAA... user@host").
+  EOT
+  type        = string
+}
+
+variable "operator_cidrs" {
+  description = <<-EOT
+    List of CIDR ranges allowed to reach port 22 (SSH).
+    Empty list allows SSH from 0.0.0.0/0 — acceptable for personal use;
+    tighten for production.  Ports 80 and 443 are always open to 0.0.0.0/0.
+  EOT
+  type        = list(string)
+  default     = []
+}

--- a/deploy/oracle/variables.tf
+++ b/deploy/oracle/variables.tf
@@ -76,16 +76,16 @@ variable "image_ref" {
 
 variable "lock_password" {
   description = <<-EOT
-    Set to "true" to enable bcrypt locked-mode auth.
+    Set to true to enable bcrypt locked-mode auth.
     When true, tournament_password_hash must also be provided.
   EOT
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "tournament_password_hash" {
   description = <<-EOT
-    Bcrypt hash of the admin password, used when lock_password = "true".
+    Bcrypt hash of the admin password, used when lock_password = true.
     Generate: htpasswd -bnBC 12 "" '<password>' | tr -d ':\n'
     Written to app.env (chmod 600, root-owned) by cloud-init.
     Mark sensitive in your tfvars — never commit the plaintext.

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -79,7 +79,7 @@ const DefaultHistorySize = 100
 //
 // At 5000 active (draining) clients the base cost is ~20–50 MB — comfortably
 // within the RAM budget of a single-core VPS or RPi-class hardware used for
-// EKC-scale deployments (~45 teams, 1000+ live spectators).
+// large-scale deployments (tens of teams, 1000+ live spectators).
 //
 // Broadcast fan-out is O(N) in the subscriber count and serialises under
 // h.mu.Lock(). At 5000 clients the lock window is bounded by the
@@ -91,9 +91,9 @@ const DefaultHistorySize = 100
 // value disables the cap entirely — used by tests that need to exceed
 // the default and not enforced anywhere in production. The cap is mp-663
 // Phase 4 mitigation for resource-exhaustion via unbounded subscriber maps.
-// Raised from 1000 → 5000 by mp-9afd to support EKC-scale (1000+ viewers).
-// A real hardware load test (goroutine/fd/memory budget at 5000 clients) is
-// still required before a live EKC deployment.
+// Raised from 1000 → 5000 by mp-9afd to support large-scale events (1000+
+// viewers). A real hardware load test (goroutine/fd/memory budget at 5000
+// clients) is still required before a large live deployment.
 const DefaultMaxSSEClients = 5000
 
 // SSEEvent represents the payload sent to clients.

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -308,11 +308,11 @@ const SAMPLE_TOURNAMENTS = [
   (() => {
     const courts = ["A", "B", "C"];
     const comps = [
-      buildCompetition({ id: "ek25-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
-      buildCompetition({ id: "ek25-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
-      buildCompetition({ id: "ek25-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "completed", teamSize: 5, courts: ["A","B","C"] }),
+      buildCompetition({ id: "ako25-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
+      buildCompetition({ id: "ako25-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
+      buildCompetition({ id: "ako25-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "completed", teamSize: 5, courts: ["A","B","C"] }),
     ];
-    return buildTournament({ id: "european-2025", name: "European Kendo Championships 2025", date: "2025-11-08", venue: "Paris Bercy", courts, status: "completed", competitions: comps });
+    return buildTournament({ id: "autumn-open-2025", name: "Autumn Kendo Open 2025", date: "2025-11-08", venue: "City Arena", courts, status: "completed", competitions: comps });
   })(),
 ];
 


### PR DESCRIPTION
## Summary

- Adds **free-forever** (no-trial) cloud deployment for the live-tournament `mobile-app`, targeting the two providers that actually qualify after analysis: **GCP Always-Free e2-micro** and **Oracle Always-Free Ampere A1**. AWS and Azure were evaluated and rejected (no free-forever VM tier).
- Each provider ships a **self-contained** Terraform module (`deploy/gcp/`, `deploy/oracle/`) plus a provider-agnostic **Docker baseline** (`deploy/docker/`): Caddy automatic-HTTPS reverse proxy, persistent volume for `tournament-data`, cloud-init bootstrap, one-command deploy.
- Reworks the container CI to publish **multi-arch (amd64 + arm64)** images via native `ubuntu-24.04-arm` runners + manifest merge, so Oracle's Arm64 A1 can pull the same tag.
- Rate limiting is configured through the app's **existing** env vars (`API_RATE_LIMIT` / `API_RATE_LIMIT_BURST`) with conservative documented defaults — no application-code change.
- Repo hygiene done alongside: removed internal references to a specific named event from shipped code/docs and demo seed data (kept only the public-rulebook citations in `running_a_kendo_tournament.md`).

## Why

Tournament organisers need to self-host the app publicly (HTTPS, custom domain) at zero cost. The app is a single Go binary with a **POSIX-filesystem state store** (atomic temp-file + rename), which rules out serverless/object-store hosting — only a VM with a real block volume works. GCP e2-micro and Oracle A1 are the only free-forever options that fit; egress (not RAM/CPU) is the binding limit, so GCP suits club/regional events and Oracle handles large (1000+ viewer) crowds.

## Files changed

| File | What |
|---|---|
| `deploy/docker/docker-compose.yaml` | Provider-agnostic baseline: app + Caddy sidecar, persistent volume, restart policy |
| `deploy/docker/Caddyfile` | Static Caddyfile (automatic-HTTPS reverse_proxy; SSE-safe, no buffering) |
| `deploy/docker/app.env.example` | Env template: password mode, `SSE_MAX_CLIENTS`, API rate-limit vars |
| `deploy/docker/README.md` | Baseline setup guide incl. data-volume ownership note |
| `deploy/gcp/main.tf` | e2-micro + VPC/subnet + split web/SSH firewalls + cloud-init |
| `deploy/gcp/variables.tf` | Inputs incl. region validation (3 free regions), sensitive hash, rate limits, hostname/image validation |
| `deploy/gcp/outputs.tf` | Public IP / app URL / SSH command (via shared local) |
| `deploy/gcp/Caddyfile.tftpl` | Per-module Caddyfile template (folder self-contained) |
| `deploy/gcp/README.md` | One-command deploy, DNS, budget alert, teardown, Security notes |
| `deploy/gcp/ARCHITECTURE.md` | Customer-facing architecture overview |
| `deploy/oracle/main.tf` | Ampere A1 (2 OCPU/12 GB) + VCN + security list + iptables in cloud-init + reserved IP |
| `deploy/oracle/variables.tf` | Inputs incl. sensitive hash, rate limits, hostname/image validation |
| `deploy/oracle/outputs.tf` | Public IP / app URL / SSH command |
| `deploy/oracle/Caddyfile.tftpl` | Per-module Caddyfile template (folder self-contained) |
| `deploy/oracle/README.md` | OCI auth setup, deploy, the dual-firewall gotcha, Security notes |
| `deploy/oracle/ARCHITECTURE.md` | Customer-facing architecture overview |
| `.github/workflows/docker-publish.yaml` | Multi-arch (amd64+arm64) publish via native arm runners + manifest merge |
| `.github/workflows/docker-release.yaml` | Same multi-arch rework for the release workflow; hoisted `IMAGE_TAG` env |
| `.gitignore` | Ignore Terraform state/vars (secret-bearing) + provider binaries/lockfiles |
| `internal/mobileapp/hub.go` | Comment-only: generalised a scale-target reference (no logic change) |
| `web-mobile/js/data.jsx` | Renamed a sample tournament in `SAMPLE_TOURNAMENTS` (dev/console seed data; no UI consumer) |
| `CLAUDE.md` | Generalised one scale-target reference in the runtime-defaults table |

## Screenshots

N/A — no UI impact. The only frontend change is a label rename inside `SAMPLE_TOURNAMENTS` in `web-mobile/js/data.jsx`, which is exposed solely as a `window.` global with **no rendering component consuming it**. There is nothing for a screenshot to show.

## Test plan

- [x] `make go/test` passes (lint + govulncheck + tests; all packages ≥85% coverage)
- [x] `terraform fmt -check -recursive deploy/` passes
- [x] `terraform validate` passes for both `deploy/gcp` and `deploy/oracle` (providers downloaded via `init`)
- [x] Each deployment folder is self-contained (no cross-folder `../` references)
- [x] Caddyfile template renders + base64 round-trips to a valid Caddyfile
- [x] Provider usage validated against current `hashicorp/google` and `oracle/oci` documentation (semantic, not just schema)
- [x] No new console errors or warnings (JS lint clean)
- [ ] Live smoke deploy (bring up over HTTPS, confirm SSE survives Caddy, reboot persistence) — requires real cloud accounts; tracked as follow-up, see ARCHITECTURE.md validation sections

> Note: this is infrastructure/IaC plus one comment-only Go change and a dev-only seed-data rename. `terraform plan/apply` against live GCP/OCI accounts is out of reach in CI (no credentials); the architecture docs define the manual smoke test.

Closes mp-55v

🤖 Generated with [Claude Code](https://claude.com/claude-code)
