### PR TITLE
fix(web-mobile): kill double module-eval + add type="button" (mp-zd1v, mp-9941)

### DIFF
--- a/web-mobile/index.html
+++ b/web-mobile/index.html
@@ -48,10 +48,17 @@
       </div>
     </div>
 
-    <script type="module" src="/dist/api_serializers.js?v=5"></script>
+    <!-- Modules that are BOTH script-tagged here AND ES-imported by other modules
+         (e.g. patch.jsx imports data.jsx/api_serializers.jsx; app.jsx imports
+         patch.jsx) use the ".jsx" specifier — identical to the import URL — so the
+         browser keys them as ONE module and evaluates them once. Using ".js?v=5"
+         here would be a second, distinct URL → double module-eval (mp-zd1v).
+         They keep their early position so the window globals they set are
+         available to eval-time readers in later modules. -->
+    <script type="module" src="/dist/api_serializers.jsx"></script>
     <script type="module" src="/dist/api_client.js?v=5"></script>
-    <script type="module" src="/dist/data.js?v=5"></script>
-    <script type="module" src="/dist/patch.js?v=5"></script>
+    <script type="module" src="/dist/data.jsx"></script>
+    <script type="module" src="/dist/patch.jsx"></script>
     <script type="module" src="/dist/router.js?v=5"></script>
     <script type="module" src="/dist/bracket.js?v=5"></script>
     <script type="module" src="/dist/ui.js?v=5"></script>
@@ -87,7 +94,7 @@
          viewer.jsx-owned deps it uses are read from window at render time. -->
     <script type="module" src="/dist/viewer_watchlist.js?v=5"></script>
     <script type="module" src="/dist/viewer.js?v=5"></script>
-    <script type="module" src="/dist/admin_helpers.js?v=5"></script>
+    <script type="module" src="/dist/admin_helpers.jsx"></script>
     <script type="module" src="/dist/admin_shell.js?v=5"></script>
     <script type="module" src="/dist/admin_scoring_modal.js?v=5"></script>
     <script type="module" src="/dist/admin_lineup.js?v=5"></script>
@@ -101,7 +108,7 @@
     <script type="module" src="/dist/admin_sponsors.js?v=5"></script>
     <!-- admin_branding.js exports BrandingManager. Loaded before admin_setup.js
          (which embeds it inside the Edit Tournament page) — mp-scf. -->
-    <script type="module" src="/dist/admin_branding.js?v=5"></script>
+    <script type="module" src="/dist/admin_branding.jsx"></script>
     <script type="module" src="/dist/admin_setup.js?v=5"></script>
     <!-- admin_shiaijo.js exports AdminShiaijoPage to window. Must load before
          admin.js which reads window.AdminShiaijoPage (mp-c2yr). -->

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -650,7 +650,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     if (!c) return (
       <div className="page">
         <div className="comp-shell-actions">
-          <button className="btn btn--ghost" onClick={() => setView({ kind: "dashboard" })}>← Back to dashboard</button>
+          <button type="button" className="btn btn--ghost" onClick={() => setView({ kind: "dashboard" })}>← Back to dashboard</button>
         </div>
         <div className="empty">
           <h3>Competition not available</h3>
@@ -670,7 +670,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
     if (adminLoading && !detail) return (
       <div className="page">
         <div className="comp-shell-actions">
-          <button className="btn btn--ghost" onClick={() => setView({ kind: "dashboard" })}>← Back to dashboard</button>
+          <button type="button" className="btn btn--ghost" onClick={() => setView({ kind: "dashboard" })}>← Back to dashboard</button>
         </div>
         <window.LoadingSpinner text="Loading details..." />
       </div>
@@ -735,7 +735,7 @@ function StartAllModal({ state, onConfirm, onRetry, onClose }) {
       <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label={title}>
         <div className="modal__head">
           <div className="modal__title">{title}</div>
-          {dismissable && <button className="modal__close" onClick={onClose} aria-label="Close">&times;</button>}
+          {dismissable && <button type="button" className="modal__close" onClick={onClose} aria-label="Close">&times;</button>}
         </div>
         <div className="modal__body">
           {phase === "confirm" && <>
@@ -772,12 +772,12 @@ function StartAllModal({ state, onConfirm, onRetry, onClose }) {
         </div>
         <div className="modal__foot">
           {phase === "confirm" && <>
-            <button className="btn btn--ghost" onClick={onClose}>Cancel</button>
-            <button className="btn btn--primary" onClick={onConfirm}>Start {window.pluralize(comps.length, "competition")}</button>
+            <button type="button" className="btn btn--ghost" onClick={onClose}>Cancel</button>
+            <button type="button" className="btn btn--primary" onClick={onConfirm}>Start {window.pluralize(comps.length, "competition")}</button>
           </>}
           {phase === "result" && <>
-            {failed.length > 0 && <button className="btn btn--primary" onClick={onRetry}>Retry failed</button>}
-            <button className="btn" onClick={onClose}>Close</button>
+            {failed.length > 0 && <button type="button" className="btn btn--primary" onClick={onRetry}>Retry failed</button>}
+            <button type="button" className="btn" onClick={onClose}>Close</button>
           </>}
         </div>
       </div>

--- a/web-mobile/js/admin_announcement.jsx
+++ b/web-mobile/js/admin_announcement.jsx
@@ -82,12 +82,12 @@ function AnnouncementComposer({ password, showToast }) {
         <div className="field" style={{ marginBottom: 16 }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
             <label className="field__label" style={{ marginBottom: 0 }}>Active announcements</label>
-            <button className="btn btn--sm btn--danger" onClick={handleClearAnnouncements}>Clear all</button>
+            <button type="button" className="btn btn--sm btn--danger" onClick={handleClearAnnouncements}>Clear all</button>
           </div>
           {activeAnnouncements.map(ann => (
             <div key={ann.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 8px", background: "var(--color-surface-raised, #f5f5f5)", borderRadius: 4, marginBottom: 4 }}>
               <span style={{ flex: 1, fontSize: "0.9em" }}>{ann.message}</span>
-              <button
+              <button type="button"
                 className="btn btn--sm"
                 onClick={() => handleDismissAnnouncement(ann.id)}
                 aria-label="Dismiss announcement"
@@ -129,7 +129,7 @@ function AnnouncementComposer({ password, showToast }) {
         </div>
       </div>
       <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
-        <button
+        <button type="button"
           className="btn btn--primary"
           disabled={isSendAnnouncementDisabled(announcementMessage, announcementInFlight)}
           onClick={handleSendAnnouncement}
@@ -155,7 +155,7 @@ function AnnouncementModal({ password, showToast, onClose }) {
       <div className="modal modal--lg" onClick={(e) => e.stopPropagation()}>
         <div className="modal__head">
           <div className="modal__title">Broadcast announcement</div>
-          <button className="modal__close" onClick={onClose} aria-label="Close">&times;</button>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="modal__body">
           <AnnouncementComposer password={password} showToast={showToast} />

--- a/web-mobile/js/admin_branding.jsx
+++ b/web-mobile/js/admin_branding.jsx
@@ -172,7 +172,7 @@ function BrandingManager({ tournament, password, showToast, onThemeChange }) {
             <div className="branding__logo-preview">
               <img key={logoKey} src={`/api/branding/logo?v=${logoKey}`} alt="Tournament logo" style={{ height: 48, width: "auto", maxWidth: 120, objectFit: "contain" }} />
               <div style={{ flex: 1 }}>Current logo</div>
-              <button className="btn btn--danger" disabled={busy} onClick={handleLogoDelete}>Remove</button>
+              <button type="button" className="btn btn--danger" disabled={busy} onClick={handleLogoDelete}>Remove</button>
             </div>
           )}
           <form onSubmit={handleLogoUpload} style={{ display: "flex", flexDirection: "column", gap: 10 }}>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -149,19 +149,19 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
         </div>
       </div>
       <div className="mode-tabs">
-        <button className={mode === "tap" ? "is-active" : ""} onClick={() => setMode("tap")}>Tap winner</button>
-        <button className={mode === "card" ? "is-active" : ""} onClick={() => setMode("card")}>Match card</button>
-        <button className={mode === "scoreboard" ? "is-active" : ""} onClick={() => setMode("scoreboard")}>Scoreboard</button>
+        <button type="button" className={mode === "tap" ? "is-active" : ""} onClick={() => setMode("tap")}>Tap winner</button>
+        <button type="button" className={mode === "card" ? "is-active" : ""} onClick={() => setMode("card")}>Match card</button>
+        <button type="button" className={mode === "scoreboard" ? "is-active" : ""} onClick={() => setMode("scoreboard")}>Scoreboard</button>
       </div>
       {mode === "tap" && (<>
         {/* Layout convention: SHIRO (White, sideB) on the LEFT, AKA (Red, sideA) on the RIGHT. */}
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 10 }}>
-          <button className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === b.id ? "var(--accent)" : "var(--line)", background: match.winner?.id === b.id ? "var(--accent)" : "var(--surface)", color: match.winner?.id === b.id ? "white" : "inherit" }} onClick={() => onRecord("b", "ippon")}>
+          <button type="button" className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === b.id ? "var(--accent)" : "var(--line)", background: match.winner?.id === b.id ? "var(--accent)" : "var(--surface)", color: match.winner?.id === b.id ? "white" : "inherit" }} onClick={() => onRecord("b", "ippon")}>
             <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em" }}>SHIRO (WHITE)</div>
             <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{b.name}</div>
             <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{b.dojo}</div>
           </button>
-          <button className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === a.id ? "var(--red)" : "var(--line)", background: match.winner?.id === a.id ? "var(--red)" : "var(--surface)", color: match.winner?.id === a.id ? "white" : "inherit" }} onClick={() => onRecord("a", "ippon")}>
+          <button type="button" className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === a.id ? "var(--red)" : "var(--line)", background: match.winner?.id === a.id ? "var(--red)" : "var(--surface)", color: match.winner?.id === a.id ? "white" : "inherit" }} onClick={() => onRecord("a", "ippon")}>
             {/* Label tinted red when unselected (button is on white), inherits white when selected (button background is red) */}
             <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em", color: match.winner?.id === a.id ? "inherit" : "var(--red)" }}>AKA (RED)</div>
             <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{a.name}</div>
@@ -174,12 +174,12 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
         <div className="score-card">
           <div className="score-side score-side--white">
             <div><div className="score-side__lbl">Shiro (White)</div><div className="score-side__name">{b.name}</div><div className="score-side__dojo">{b.dojo}</div></div>
-            <div className="score-side__buttons"><button className="btn btn--sm btn--primary" onClick={() => onRecord("b", "ippon", ["M"])}>Win (Ippon)</button></div>
+            <div className="score-side__buttons"><button type="button" className="btn btn--sm btn--primary" onClick={() => onRecord("b", "ippon", ["M"])}>Win (Ippon)</button></div>
           </div>
           <div className="score-vs">VS</div>
           <div className="score-side score-side--red">
             <div><div className="score-side__lbl">Aka (Red)</div><div className="score-side__name">{a.name}</div><div className="score-side__dojo">{a.dojo}</div></div>
-            <div className="score-side__buttons"><button className="btn btn--sm btn--danger" onClick={() => onRecord("a", "ippon", ["M"])}>Win (Ippon)</button></div>
+            <div className="score-side__buttons"><button type="button" className="btn btn--sm btn--danger" onClick={() => onRecord("a", "ippon", ["M"])}>Win (Ippon)</button></div>
           </div>
         </div>
       )}
@@ -193,8 +193,8 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
         <div className="sc-board">
           <div className="sc-board__rail sc-board__shiro">
             <div className="sc-board__btnrow">
-              {(isNaginata ? ["M", "K", "D", "T", "S"] : ["M", "K", "D", "T"]).map((cc) => (<button key={cc} className="ipt-btn" onClick={() => setBPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}
-              <button className="ipt-btn" onClick={() => setBPoints([])}>↺</button>
+              {(isNaginata ? ["M", "K", "D", "T", "S"] : ["M", "K", "D", "T"]).map((cc) => (<button type="button" key={cc} className="ipt-btn" onClick={() => setBPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}
+              <button type="button" className="ipt-btn" onClick={() => setBPoints([])}>↺</button>
             </div>
           </div>
           <div className="sc-board__who sc-board__who--shiro sc-board__shiro">
@@ -209,8 +209,8 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
           </div>
           <div className="sc-board__rail sc-board__aka">
             <div className="sc-board__btnrow">
-              {(isNaginata ? ["M", "K", "D", "T", "S"] : ["M", "K", "D", "T"]).map((cc) => (<button key={cc} className="ipt-btn ipt-btn--aka" onClick={() => setAPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}
-              <button className="ipt-btn" onClick={() => setAPoints([])}>↺</button>
+              {(isNaginata ? ["M", "K", "D", "T", "S"] : ["M", "K", "D", "T"]).map((cc) => (<button type="button" key={cc} className="ipt-btn ipt-btn--aka" onClick={() => setAPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}
+              <button type="button" className="ipt-btn" onClick={() => setAPoints([])}>↺</button>
             </div>
           </div>
           <div className="sc-board__vs">vs</div>
@@ -233,7 +233,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
         const loserArr = aWins ? bPoints : aPoints;
         return (
           <div className="running-panel__actions">
-            <button
+            <button type="button"
               className="btn btn--primary btn--full"
               disabled={!hasWinner}
               onClick={() => onRecord(aWins ? "a" : "b", "ippon", winnerArr, loserArr)}
@@ -252,7 +252,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
         </div>
       )}
       <div style={{ marginTop: 14, paddingTop: 14, borderTop: "1px dashed var(--line)" }}>
-        <button className="btn btn--sm btn--full" onClick={async () => {
+        <button type="button" className="btn btn--sm btn--full" onClick={async () => {
           // promptDialog returns null on empty/cancel and a string otherwise.
           // A whitespace-only value would be truthy under `if (name)` and would
           // persist a whitespace key as `m.Winner` on the backend (and then
@@ -307,11 +307,11 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
         </div>
       </div>
       <div className="row">
-        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection("scores")}>
+        <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection("scores")}>
           <div className="card__title" style={{ marginBottom: 6 }}>Scores →</div>
           <div className="card__sub">Update or correct match results</div>
         </button>
-        <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}>
+        <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}>
           <div className="card__title" style={{ marginBottom: 6 }}>Results →</div>
           <div className="card__sub">Visual bracket / pool standings</div>
         </button>
@@ -419,7 +419,7 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
             style={{ flex: "1 1 120px", minWidth: 90 }}
             data-testid={`fs-award-dojo-${idx}`}
           />
-          <button
+          <button type="button"
             className="btn btn--sm btn--ghost"
             onClick={() => removeRow(idx)}
             aria-label="Remove award"
@@ -428,8 +428,8 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
         </div>
       ))}
       <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
-        <button className="btn btn--sm btn--ghost" onClick={addRow} data-testid="fs-award-add">+ Add award</button>
-        <button className="btn btn--sm btn--primary" onClick={save} disabled={saving} data-testid="fs-award-save">
+        <button type="button" className="btn btn--sm btn--ghost" onClick={addRow} data-testid="fs-award-add">+ Add award</button>
+        <button type="button" className="btn btn--sm btn--primary" onClick={save} disabled={saving} data-testid="fs-award-save">
           {saving && <span className="spinner" />}
           {saving ? "Saving…" : "Save awards"}
         </button>
@@ -1045,7 +1045,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       <div style={{ marginTop: 24, padding: 16, borderTop: "1px solid var(--line)", display: "flex", flexDirection: "column", gap: 12 }}>
         {(local.status === "pools" || local.status === "playoffs") && (
           <div>
-            <button className="btn btn--danger btn--ghost" disabled={invalidating || deleting} onClick={async () => {
+            <button type="button" className="btn btn--danger btn--ghost" disabled={invalidating || deleting} onClick={async () => {
               if (await window.confirmDialog({ message: `Mark "${local.name}" as invalid? It will be excluded from results and can be deleted afterwards.`, confirmLabel: "Mark invalid", danger: true })) {
                 const admin = await window.promptAdminPassword();
                 if (admin === null) return;
@@ -1078,7 +1078,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
             <div className="field__hint" style={{ marginTop: 4 }}>Required before deleting an in-progress competition.</div>
           </div>
         )}
-        <button className="btn btn--danger btn--ghost" disabled={deleting || invalidating} onClick={async () => {
+        <button type="button" className="btn btn--danger btn--ghost" disabled={deleting || invalidating} onClick={async () => {
           const started = local.status && local.status !== "setup" && local.status !== "draw-ready";
           const msg = started
             ? `"${local.name}" has already started. Deleting it will remove ALL matches and results. This cannot be undone. Continue?`
@@ -1377,12 +1377,12 @@ function AdminSwissRounds({ c, poolMatches, password, onViewStandings, showToast
         <div style={{ display: "flex", flexDirection: "column", gap: 8, padding: 12, background: "var(--accent-soft, #ecfdf5)", border: "1px solid var(--accent, #a7f3d0)", borderRadius: 8 }}>
           <div style={{ fontWeight: 600, color: "var(--accent, #065f46)" }}>Competition complete</div>
           {onViewStandings && (
-            <button className="btn btn--primary btn--sm" onClick={onViewStandings}>View final standings →</button>
+            <button type="button" className="btn btn--primary btn--sm" onClick={onViewStandings}>View final standings →</button>
           )}
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <button
+          <button type="button"
             className="btn btn--primary"
             disabled={!canGenerate || generating}
             onClick={generate}
@@ -1614,11 +1614,11 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {(!c.status || c.status === "setup") && c.players.length >= 2 && (
               <>
                 <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                  <button className="btn btn--ghost" onClick={generateDraw} disabled={!isDateValid(c.date) || generating || starting}>
+                  <button type="button" className="btn btn--ghost" onClick={generateDraw} disabled={!isDateValid(c.date) || generating || starting}>
                     {generating && <span className="spinner" />}
                     {generating ? "Generating…" : "Preview draw"}
                   </button>
-                  <button className="btn btn--primary" onClick={start} disabled={!isDateValid(c.date) || starting || generating}>
+                  <button type="button" className="btn btn--primary" onClick={start} disabled={!isDateValid(c.date) || starting || generating}>
                     {starting && <span className="spinner" />}
                     {starting ? "Starting…" : "Start competition →"}
                   </button>
@@ -1638,15 +1638,15 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {isDrawReady && (
               <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
                 <div style={{ display: "flex", gap: 8 }}>
-                  <button className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting || generating}>
+                  <button type="button" className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting || generating}>
                     {discarding && <span className="spinner" />}
                     {discarding ? "Discarding…" : "Discard draw"}
                   </button>
-                  <button className="btn btn--ghost" onClick={regenerateDraw} disabled={generating || starting || discarding}>
+                  <button type="button" className="btn btn--ghost" onClick={regenerateDraw} disabled={generating || starting || discarding}>
                     {generating && <span className="spinner" />}
                     {generating ? "Regenerating…" : "Regenerate draw"}
                   </button>
-                  <button className="btn btn--primary" onClick={start} disabled={starting || generating || discarding}>
+                  <button type="button" className="btn btn--primary" onClick={start} disabled={starting || generating || discarding}>
                     {starting && <span className="spinner" />}
                     {starting ? "Starting…" : "Start competition →"}
                   </button>
@@ -1666,14 +1666,14 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
               <div key={sec.sec}>
                 <div className="side-nav__sec">{sec.sec}</div>
                 {sec.items.map((it) => (
-                  <button key={it.id} className={section === it.id ? "is-active" : ""} onClick={() => onSection(it.id)}>{it.label}</button>
+                  <button type="button" key={it.id} className={section === it.id ? "is-active" : ""} onClick={() => onSection(it.id)}>{it.label}</button>
                 ))}
               </div>
             ))}
             <div>
               <div className="side-nav__sec">Other competitions</div>
               {t.competitions.filter((cc) => cc.id !== c.id).map((cc) => (
-                <button key={cc.id} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
+                <button type="button" key={cc.id} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
               ))}
             </div>
           </div>

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -194,7 +194,7 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
             </span>
           )}
           {onClose && (
-            <button className="btn btn--ghost btn--sm" onClick={onClose}>✕ Close</button>
+            <button type="button" className="btn btn--ghost btn--sm" onClick={onClose}>✕ Close</button>
           )}
         </div>
       </div>
@@ -238,7 +238,7 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
 
         <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 20 }}>
           {isLocked ? (
-            <button
+            <button type="button"
               className="btn btn--primary"
               onClick={onRevise}
               disabled={!reviseEligible}
@@ -249,7 +249,7 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
               Revise
             </button>
           ) : (
-            <button
+            <button type="button"
               className="btn btn--primary"
               onClick={save}
               disabled={saving || roster.length === 0}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -731,7 +731,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
       )}
       {isStarted && (
         <div style={{ marginBottom: 16, display: "flex", justifyContent: "flex-end" }}>
-          <button className="btn btn--primary" onClick={() => onSection("scores")}>Go to Scoring →</button>
+          <button type="button" className="btn btn--primary" onClick={() => onSection("scores")}>Go to Scoring →</button>
         </div>
       )}
       <div className="row" style={{ alignItems: "start" }}>
@@ -806,14 +806,14 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                   </ul>
                 </div>
               )}
-              <button className="btn btn--sm" style={{ marginTop: 4 }} onClick={() => setSeedImportResult(null)}>Dismiss</button>
+              <button type="button" className="btn btn--sm" style={{ marginTop: 4 }} onClick={() => setSeedImportResult(null)}>Dismiss</button>
             </div>
           )}
           {allTags.length > 0 && (
             <div style={{ padding: "0 16px 10px", display: "flex", gap: 6, flexWrap: "wrap" }}>
-              <button className={`radio-pill ${!tagFilter ? "is-active" : ""}`} onClick={() => setTagFilter(null)}>All</button>
+              <button type="button" className={`radio-pill ${!tagFilter ? "is-active" : ""}`} onClick={() => setTagFilter(null)}>All</button>
               {allTags.map(t => (
-                <button key={t} className={`radio-pill ${tagFilter === t ? "is-active" : ""}`} onClick={() => setTagFilter(tagFilter === t ? null : t)}>{t}</button>
+                <button type="button" key={t} className={`radio-pill ${tagFilter === t ? "is-active" : ""}`} onClick={() => setTagFilter(tagFilter === t ? null : t)}>{t}</button>
               ))}
             </div>
           )}
@@ -841,10 +841,10 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                     <div className="field__label" style={{ fontSize: 11 }}>Dan grade</div>
                     <input className="input" style={{ width: 100 }} value={addDanGrade} onChange={e => setAddDanGrade(e.target.value)} placeholder="Optional" />
                   </div>
-                  <button className="btn btn--sm btn--primary" disabled={addLoading || !addName.trim() || !addDojo.trim()} onClick={handleAddParticipant}>
+                  <button type="button" className="btn btn--sm btn--primary" disabled={addLoading || !addName.trim() || !addDojo.trim()} onClick={handleAddParticipant}>
                     {addLoading ? "Adding…" : "Add"}
                   </button>
-                  <button className="btn btn--sm" onClick={() => { setShowAddForm(false); setAddName(""); setAddDojo(""); setAddDanGrade(""); setAddZekken(""); }}>Cancel</button>
+                  <button type="button" className="btn btn--sm" onClick={() => { setShowAddForm(false); setAddName(""); setAddDojo(""); setAddDanGrade(""); setAddZekken(""); }}>Cancel</button>
                 </div>
               )}
             </div>
@@ -875,8 +875,8 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                   </div>
                   <div className="field__hint">ID, seed, and check-in state are preserved. Seed rankings are updated to match the new name automatically.</div>
                   <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-                    <button className="btn" onClick={() => setReplaceTarget(null)}>Cancel</button>
-                    <button className="btn btn--primary" disabled={replaceLoading || !replaceName.trim() || !replaceDojo.trim()} onClick={handleReplaceParticipant}>
+                    <button type="button" className="btn" onClick={() => setReplaceTarget(null)}>Cancel</button>
+                    <button type="button" className="btn btn--primary" disabled={replaceLoading || !replaceName.trim() || !replaceDojo.trim()} onClick={handleReplaceParticipant}>
                       {replaceLoading ? "Saving…" : "Save"}
                     </button>
                   </div>
@@ -958,7 +958,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                       <div className="seed-row__dojo">
                         {p.dojo}
                         {c.checkInEnabled && dojoFirstRowSet.has(p.id ?? p.name) && (dojoUncheckedCount.get(p.dojo) || 0) > 0 && (
-                          <button
+                          <button type="button"
                             className="btn--link"
                             style={{ marginLeft: 8, fontSize: 10, padding: 0 }}
                             onClick={() => bulkCheckInDojo(p.dojo)}
@@ -969,10 +969,10 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                       </div>
                     </div>
                     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                      <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0 || reorderDisabled} aria-label="Move up">↑</button>
-                      <button className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1 || reorderDisabled} aria-label="Move down">↓</button>
+                      <button type="button" className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0 || reorderDisabled} aria-label="Move up">↑</button>
+                      <button type="button" className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1 || reorderDisabled} aria-label="Move down">↓</button>
                       {(isSetup || isDrawReady) && (
-                        <button className="btn btn--sm btn--icon-sm" style={{ fontSize: 11 }} title={`Edit ${p.name}`} onClick={() => { setReplaceTarget(p); setReplaceName(p.name); setReplaceDojo(p.dojo); setReplaceDanGrade(p.danGrade || ""); setReplaceZekken(c.withZekkenName ? (p.displayName || "") : ""); }} aria-label={`Edit ${p.name}`}>✎</button>
+                        <button type="button" className="btn btn--sm btn--icon-sm" style={{ fontSize: 11 }} title={`Edit ${p.name}`} onClick={() => { setReplaceTarget(p); setReplaceName(p.name); setReplaceDojo(p.dojo); setReplaceDanGrade(p.danGrade || ""); setReplaceZekken(c.withZekkenName ? (p.displayName || "") : ""); }} aria-label={`Edit ${p.name}`}>✎</button>
                       )}
                     </div>
                      <window.StableInput
@@ -1000,7 +1000,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               <div className="field__hint" style={{ marginTop: 2, fontSize: 11 }}>
                 Format: "{c.kind === "team" ? "Team name, Dojo" : c.withZekkenName ? "Name, Zekken, Dojo[, Dan]" : "Name, Dojo[, Dan grade]"}"
                 <br />* Dan = kendo grade (optional)
-                <br /><button className="btn--link" style={{ padding: 0, fontSize: 11, fontWeight: 600 }} onClick={downloadTemplate}>Download CSV template</button>
+                <br /><button type="button" className="btn--link" style={{ padding: 0, fontSize: 11, fontWeight: 600 }} onClick={downloadTemplate}>Download CSV template</button>
               </div>
             </div>
             <div style={{ display: "flex", gap: 6 }}>
@@ -1032,7 +1032,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
           {importSummary && (
             <div className="alert alert--success" style={{ marginBottom: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
               <span>✔ Loaded <strong>{importSummary.newCount}</strong> entries. {importSummary.existingCount > 0 ? `This will replace ${importSummary.existingCount} existing ${c.kind === "team" ? "teams" : "players"} on Apply.` : ""}</span>
-              <button className="btn btn--sm btn--ghost" onClick={() => setImportSummary(null)}>Dismiss</button>
+              <button type="button" className="btn btn--sm btn--ghost" onClick={() => setImportSummary(null)}>Dismiss</button>
             </div>
           )}
 
@@ -1045,7 +1045,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                 ))}
               </ul>
               <div style={{ display: "flex", gap: 8 }}>
-                <button
+                <button type="button"
                   className="btn btn--sm"
                   data-testid="near-dup-dismiss"
                   onClick={() => setNearDupPending(null)}
@@ -1082,7 +1082,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
                   <div className="field__hint">Preview of {Math.min(lines.length, previewLimit)} of {lines.length} rows</div>
                   {lines.length > 10 && (
-                    <button className="btn btn--ghost btn--sm" style={{ color: "var(--accent)", padding: "2px 6px" }} onClick={() => setShowAllPreview(!showAllPreview)}>
+                    <button type="button" className="btn btn--ghost btn--sm" style={{ color: "var(--accent)", padding: "2px 6px" }} onClick={() => setShowAllPreview(!showAllPreview)}>
                       {showAllPreview ? "Show less" : "Show all"}
                     </button>
                   )}

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -303,7 +303,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
       <>
       <div className="pool-detail">
         <div style={{ marginBottom: 16 }}>
-          <button className="btn btn--sm" onClick={() => setSelectedPoolName(null)}>← All pools</button>
+          <button type="button" className="btn btn--sm" onClick={() => setSelectedPoolName(null)}>← All pools</button>
         </div>
         <div className="card">
           <div className="card__head">
@@ -311,7 +311,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
               <h2 className="page-head__title">{selectedPool.poolName}</h2>
               <div className="card__sub">Shiaijo {court} · {pluralize(selectedPool.players.length, "participant")}</div>
             </div>
-            <button className="btn btn--sm btn--danger" onClick={resetOverrides}>Reset rankings</button>
+            <button type="button" className="btn btn--sm btn--danger" onClick={resetOverrides}>Reset rankings</button>
           </div>
 
           <div className="field__hint" style={{ marginBottom: 12 }}>
@@ -424,7 +424,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
                     <div className="sched-row__score" style={{ minWidth: 60, textAlign: "center" }}>
                       {m.status === "completed" ? window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei) : m.status === "running" ? "● NOW" : "—"}
                     </div>
-                    <button className={getScoreBtnClass(m.status)} onClick={() => setScoreOpenMatch(enrichPoolMatch(m, selectedPool.poolName))}>
+                    <button type="button" className={getScoreBtnClass(m.status)} onClick={() => setScoreOpenMatch(enrichPoolMatch(m, selectedPool.poolName))}>
                       {m.status === "completed" ? "Correct" : "Score"}
                     </button>
                   </div>
@@ -445,7 +445,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
         <div>
           <div style={{ fontSize: 14, fontWeight: 600 }}>{pluralize(pools.length, "pool")}</div>
         </div>
-        <button className="btn btn--sm btn--danger" onClick={resetOverrides}>Reset all overrides</button>
+        <button type="button" className="btn btn--sm btn--danger" onClick={resetOverrides}>Reset all overrides</button>
       </div>
       <div className="pools-grid">
         {pools.map((pool) => {
@@ -549,7 +549,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
                         <div style={{ fontSize: 11, fontWeight: 600, textAlign: "right", whiteSpace: "nowrap" }}>
                           {m.status === "completed" ? window.formatIpponsScore(m.ipponsB, m.ipponsA, m.score, m.decision, m.encho, m.decidedByHantei) : m.status === "running" ? "● NOW" : "—"}
                         </div>
-                        <button className={getScoreBtnClass(m.status)} style={{ minWidth: 0 }} onClick={(e) => { e.stopPropagation(); setScoreOpenMatch(enrichPoolMatch(m, pool.poolName)); }}>{m.status === "completed" ? "Correct" : "Score"}</button>
+                        <button type="button" className={getScoreBtnClass(m.status)} style={{ minWidth: 0 }} onClick={(e) => { e.stopPropagation(); setScoreOpenMatch(enrichPoolMatch(m, pool.poolName)); }}>{m.status === "completed" ? "Correct" : "Score"}</button>
                       </div>
                     ))}
                   </div>

--- a/web-mobile/js/admin_schedule.jsx
+++ b/web-mobile/js/admin_schedule.jsx
@@ -355,7 +355,7 @@ function AdminSchedulePage({ tournament, onBack, onMoveCourt, onLogout, onViewer
                 style={{ width: 80 }}
               />
             </div>
-            <button className="btn btn--primary" onClick={autoSchedule} disabled={autoSaving} style={{ alignSelf: "flex-end" }}>
+            <button type="button" className="btn btn--primary" onClick={autoSchedule} disabled={autoSaving} style={{ alignSelf: "flex-end" }}>
               {autoSaving ? "Scheduling…" : "Auto-schedule competition"}
             </button>
             {durationEstimate && (
@@ -418,7 +418,7 @@ function AdminSchedulePage({ tournament, onBack, onMoveCourt, onLogout, onViewer
               {tournament.competitions.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
             </select>
             {hasAnyFilter && (
-              <button className="btn btn--ghost btn--sm" onClick={() => { setPicked([]); setDojoText(""); setCompFilter("all"); }}>Clear</button>
+              <button type="button" className="btn btn--ghost btn--sm" onClick={() => { setPicked([]); setDojoText(""); setCompFilter("all"); }}>Clear</button>
             )}
             {/* T042 (US1, FR-001/FR-002): the court-scope badge mirrors the
                 operator's active filter. The "Show all courts" link clears
@@ -429,7 +429,7 @@ function AdminSchedulePage({ tournament, onBack, onMoveCourt, onLogout, onViewer
             {effectiveCourt && (
               <span className="bc-court-badge" style={{ display: "inline-flex", alignItems: "center", gap: 8, padding: "4px 10px", borderRadius: 14, background: "var(--bg-2, #eef2f7)", fontSize: 12, fontWeight: 600 }}>
                 Showing {window.Term ? React.createElement(window.Term, { name: "shiaijo" }, "Shiaijo") : "Shiaijo"} {effectiveCourt}
-                <button
+                <button type="button"
                   className="btn btn--ghost btn--sm"
                   style={{ padding: "0 6px", fontSize: 11, fontWeight: 500 }}
                   onClick={() => {
@@ -553,7 +553,7 @@ const AdminTWMatch = React.memo(({ m, highlight, courts, onMove, onTimeChange })
             />
           </form>
         ) : (
-          <button
+          <button type="button"
             className="tw-match__time tw-match__time--editable"
             onClick={(e) => { e.stopPropagation(); if (onTimeChange) { setTimeVal(m.scheduledAt || ""); setEditingTime(true); } }}
             title="Click to set time"
@@ -965,7 +965,7 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
       )}
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         {!isLocked && (
-          <button
+          <button type="button"
             className="btn btn--primary btn--sm"
             onClick={save}
             disabled={saving || copying || roster.length === 0}
@@ -973,7 +973,7 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
             {saving ? "Saving…" : "Save lineup"}
           </button>
         )}
-        <button
+        <button type="button"
           className="btn btn--sm"
           onClick={copyFromPrevious}
           disabled={!hasSiblings || copying || saving || isLocked}
@@ -1040,7 +1040,7 @@ function MatchLineupPanel({ match, tournament, password, showToast, onClose, var
                 : "Set per-match lineups below. Changes take effect when you save; the round-default lineup is used as a fallback until then."}
             </div>
           </div>
-          <button className="btn btn--ghost btn--sm" onClick={onClose}>{variant === "inline" ? "Done" : "✕ Close"}</button>
+          <button type="button" className="btn btn--ghost btn--sm" onClick={onClose}>{variant === "inline" ? "Done" : "✕ Close"}</button>
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}>
@@ -1216,10 +1216,10 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, pa
           </select>
         )}
         <div className="seg">
-          <button className={statusFilter === "all" ? "is-active" : ""} onClick={() => setStatusFilter("all")}>All</button>
-          <button className={statusFilter === "running" ? "is-active" : ""} onClick={() => setStatusFilter("running")}>Now</button>
-          <button className={statusFilter === "scheduled" ? "is-active" : ""} onClick={() => setStatusFilter("scheduled")}>Scheduled</button>
-          <button className={statusFilter === "complete" ? "is-active" : ""} onClick={() => setStatusFilter("complete")}>Completed</button>
+          <button type="button" className={statusFilter === "all" ? "is-active" : ""} onClick={() => setStatusFilter("all")}>All</button>
+          <button type="button" className={statusFilter === "running" ? "is-active" : ""} onClick={() => setStatusFilter("running")}>Now</button>
+          <button type="button" className={statusFilter === "scheduled" ? "is-active" : ""} onClick={() => setStatusFilter("scheduled")}>Scheduled</button>
+          <button type="button" className={statusFilter === "complete" ? "is-active" : ""} onClick={() => setStatusFilter("complete")}>Completed</button>
         </div>
         <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--ink-3)" }}>{pluralize(filtered.length, "match", "matches")}</span>
       </div>
@@ -1279,12 +1279,12 @@ function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCompId, pa
                 {m.status === "completed" && <span style={{ fontSize: 10, color: "var(--ink-3)" }}>{isCorrection ? "Corrected" : "Final"}</span>}
               </div>
               <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <button className={getScoreBtnClass(m.status)} onClick={() => setOpenMatch(m)}>
+                <button type="button" className={getScoreBtnClass(m.status)} onClick={() => setOpenMatch(m)}>
                   {m.status === "completed" ? "Correct" : "Score"}
                 </button>
                 {/* mp-bkg: show Lineup button only for team competitions */}
                 {(m.compKind === "team" || (m.teamSize || 0) > 0) && (
-                  <button
+                  <button type="button"
                     className="btn btn--ghost btn--sm"
                     style={{ fontSize: 11 }}
                     onClick={() => setLineupMatch(m)}
@@ -1431,7 +1431,7 @@ function AdminExport({ c, t, password }) {
       <div className="card">
         <div className="card__title" style={{ marginBottom: 8 }}>Export {c.name}</div>
         <div className="card__sub" style={{ marginBottom: 14 }}>Generate the official Excel workbook used during the day.</div>
-        <button className="btn btn--primary btn--full" onClick={downloadXlsx}>Download .xlsx</button>
+        <button type="button" className="btn btn--primary btn--full" onClick={downloadXlsx}>Download .xlsx</button>
         <div className="field__hint" style={{ marginTop: 10 }}>Includes pool draws, pool matches, and elimination brackets with linked formulas.</div>
       </div>
       <div className="card">
@@ -1439,7 +1439,7 @@ function AdminExport({ c, t, password }) {
         <div className="card__sub" style={{ marginBottom: 14 }}>Players & spectators see this competition's bracket, schedule and results.</div>
         <div style={{ display: "flex", gap: 8 }}>
           <input className="input" value={url} readOnly style={{ flex: 1 }} />
-          <button className="btn" onClick={copyUrl}>Copy</button>
+          <button type="button" className="btn" onClick={copyUrl}>Copy</button>
         </div>
       </div>
     </div>

--- a/web-mobile/js/admin_scoring_modal.jsx
+++ b/web-mobile/js/admin_scoring_modal.jsx
@@ -546,7 +546,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
             </div>
             {/* C2: sync status indicator — only visible while the match is running */}
             <SyncStatusPill isRunning={m.status === "running"} />
-            {canClose && <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}
+            {canClose && <button type="button" className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}
           </div>
         </div>
 
@@ -637,14 +637,14 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                       <div className="sb-name">{s.name}</div>
                       <div className="sb-slots">
                         {[0, 1].map((i) => (
-                          <button key={i} className={`sb-slot ${s.pts[i] ? "sb-slot--filled" : ""}`} onClick={() => removePt(s.key, i)} disabled={decidedByHantei} title={decidedByHantei ? (initialDecidedByHantei ? "Locked — hantei already recorded" : "Hantei armed — choose a winner above, or cancel") : "Click to remove"}>
+                          <button type="button" key={i} className={`sb-slot ${s.pts[i] ? "sb-slot--filled" : ""}`} onClick={() => removePt(s.key, i)} disabled={decidedByHantei} title={decidedByHantei ? (initialDecidedByHantei ? "Locked — hantei already recorded" : "Hantei armed — choose a winner above, or cancel") : "Click to remove"}>
                             {s.pts[i] || "·"}
                           </button>
                         ))}
                       </div>
                       <div className="sb-points-grid">
                         {getIpponButtons(isNaginata).map((cc) => (
-                          <button key={cc} className={`ipt-btn ${cc === "H" ? "ipt-btn--h" : ""}`} onClick={() => addPt(s.key, cc)} disabled={boutDecided || decidedByHantei}>{cc}</button>
+                          <button type="button" key={cc} className={`ipt-btn ${cc === "H" ? "ipt-btn--h" : ""}`} onClick={() => addPt(s.key, cc)} disabled={boutDecided || decidedByHantei}>{cc}</button>
                         ))}
                       </div>
                     </div>
@@ -655,7 +655,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                             {aTotal === 0 && bTotal === 0 ? "VS" : `${bTotal}–${aTotal}`}
                           </div>
                         )}
-                        <button
+                        <button type="button"
                           className={`sb-draw-toggle btn${isDrawToggled ? " sb-draw-toggle--active" : ""}`}
                           data-testid="scoring-modal-mark-draw"
                           onClick={() => {
@@ -783,18 +783,18 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
           )}
           <div className="score-nav">
             {prevMatch ? (
-              <button className="btn btn--sm score-nav__prev" onClick={onPrev} disabled={submitting} title={prevMatch.sideA?.name + " vs " + prevMatch.sideB?.name}>← Prev</button>
+              <button type="button" className="btn btn--sm score-nav__prev" onClick={onPrev} disabled={submitting} title={prevMatch.sideA?.name + " vs " + prevMatch.sideB?.name}>← Prev</button>
             ) : <span />}
 
             <div className="score-nav__actions">
               {m.status === "scheduled" && (
-                <button className="btn btn--sm" onClick={() => doSubmit(() => onSubmit(buildPatch("running")))} disabled={submitting}>
+                <button type="button" className="btn btn--sm" onClick={() => doSubmit(() => onSubmit(buildPatch("running")))} disabled={submitting}>
                   ▶ Start match
                 </button>
               )}
-              {canClose && <button className="btn" onClick={handleDismiss} disabled={submitting}>Cancel</button>}
+              {canClose && <button type="button" className="btn" onClick={handleDismiss} disabled={submitting}>Cancel</button>}
               {onSubmitAndNext ? (
-                <button className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
+                <button type="button" className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
                   if (isComplete && !correctionReason) { setShowCorrectionPrompt(true); return; }
                   if (!isComplete && !finishArmed) { setFinishArmed(true); return; }
                   doSubmit(() => (isComplete ? onSubmit : onSubmitAndNext)(buildPatch("completed")));
@@ -802,7 +802,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
                   {submitting ? "Saving…" : isComplete ? "Save correction" : finishArmed ? `Confirm · ${finishSummary} →` : "Finish + Start Next →"}
                 </button>
               ) : (
-                <button className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
+                <button type="button" className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
                   if (isComplete && !correctionReason) { setShowCorrectionPrompt(true); return; }
                   if (!isComplete && !finishArmed) { setFinishArmed(true); return; }
                   doSubmit(() => onSubmit(buildPatch("completed")));
@@ -813,7 +813,7 @@ function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch
             </div>
 
             {nextMatch ? (
-              <button className="btn btn--sm score-nav__next" onClick={onNext} disabled={submitting} title={nextMatch.sideA?.name + " vs " + nextMatch.sideB?.name}>Next →</button>
+              <button type="button" className="btn btn--sm score-nav__next" onClick={onNext} disabled={submitting} title={nextMatch.sideA?.name + " vs " + nextMatch.sideB?.name}>Next →</button>
             ) : <span />}
           </div>
           {/* Quiet, always-present keyboard-shortcut reminder. */}
@@ -1426,7 +1426,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
             </div>
             {/* C2: sync status indicator — only visible while the match is running */}
             <SyncStatusPill isRunning={m.status === "running"} />
-            {canClose && <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}
+            {canClose && <button type="button" className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}
           </div>
         </div>
 
@@ -1679,7 +1679,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                               individual bout. H (hansoku point) renders as △ there. */}
                           <div className="team-sub-match__btns">
                             {getIpponButtons(isNaginataTeam).map(cc => (
-                              <button key={cc} className={`ipt-btn ipt-btn--sm ${cc === "H" ? "ipt-btn--h" : ""}`}
+                              <button type="button" key={cc} className={`ipt-btn ipt-btn--sm ${cc === "H" ? "ipt-btn--h" : ""}`}
                                 onClick={() => rs.setPts(rs.pts.length < MAX_IPPONS_PER_SIDE ? [...rs.pts, cc] : rs.pts)}
                                 disabled={subBoutDecided}>{cc}</button>
                             ))}
@@ -1699,9 +1699,9 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                           <div className="tsm-fouls" data-testid={`scoring-modal-hansoku-${rs.color}`}>
                             <span className="tsm-fouls__label">{rs.label} Fouls</span>
                             <div className="tsm-fouls__controls">
-                              <button className="tsm-fouls__btn" onClick={() => rs.setFouls(nextFoulOnDecrement(rs.fouls))} disabled={rs.fouls === 0}>−</button>
+                              <button type="button" className="tsm-fouls__btn" onClick={() => rs.setFouls(nextFoulOnDecrement(rs.fouls))} disabled={rs.fouls === 0}>−</button>
                               <span className={`tsm-fouls__count ${rs.fouls >= 1 ? "tsm-fouls__count--warn" : ""}`}>{rs.fouls}</span>
-                              <button className="tsm-fouls__btn" onClick={rs.onIncrement} disabled={subBoutDecided}>+</button>
+                              <button type="button" className="tsm-fouls__btn" onClick={rs.onIncrement} disabled={subBoutDecided}>+</button>
                             </div>
                           </div>
                           <div className="tsm-fusensho">
@@ -1731,7 +1731,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                                 this. (running_a_kendo_tournament.md: ▲ next to name.) */}
                             {rowSides[0].fouls >= 1 && <span className="tsm-foul-tri" title="Hansoku — 1 foul">▲</span>}
                             {[0, 1].map(i => (
-                              <button key={i} className={`editor-side__pt ${rowSides[0].pts[i] ? "editor-side__pt--filled" : ""}`}
+                              <button type="button" key={i} className={`editor-side__pt ${rowSides[0].pts[i] ? "editor-side__pt--filled" : ""}`}
                                 onClick={() => rowSides[0].setPts(rowSides[0].pts.filter((_, j) => j !== i))} title="Click to remove">
                                 {rowSides[0].pts[i] || "·"}
                               </button>
@@ -1745,7 +1745,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                                 outer (right) edge nearest the Aka name, so render
                                 the slots in reverse (pts[1] then pts[0]). */}
                             {[1, 0].map(i => (
-                              <button key={i} className={`editor-side__pt ${rowSides[1].pts[i] ? "editor-side__pt--filled" : ""}`}
+                              <button type="button" key={i} className={`editor-side__pt ${rowSides[1].pts[i] ? "editor-side__pt--filled" : ""}`}
                                 onClick={() => rowSides[1].setPts(rowSides[1].pts.filter((_, j) => j !== i))} title="Click to remove">
                                 {rowSides[1].pts[i] || "·"}
                               </button>
@@ -2041,15 +2041,15 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
           )}
           <div className="score-nav">
             {prevMatch ? (
-              <button className="btn btn--sm score-nav__prev" onClick={onPrev} disabled={submitting}>← Prev</button>
+              <button type="button" className="btn btn--sm score-nav__prev" onClick={onPrev} disabled={submitting}>← Prev</button>
             ) : <span />}
             <div className="score-nav__actions">
               {m.status === "scheduled" && (
-                <button className="btn btn--sm" onClick={() => doSubmit(() => onSubmit(buildPatch("running")))} disabled={submitting}>▶ Start match</button>
+                <button type="button" className="btn btn--sm" onClick={() => doSubmit(() => onSubmit(buildPatch("running")))} disabled={submitting}>▶ Start match</button>
               )}
-              {canClose && <button className="btn" onClick={handleDismiss} disabled={submitting}>Cancel</button>}
+              {canClose && <button type="button" className="btn" onClick={handleDismiss} disabled={submitting}>Cancel</button>}
               {onSubmitAndNext ? (
-                <button className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
+                <button type="button" className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
                   if (isComplete && !correctionReason) { setShowCorrectionPrompt(true); return; }
                   if (!isComplete && !finishArmed) { setFinishArmed(true); return; }
                   doSubmit(() => (isComplete ? onSubmit : onSubmitAndNext)(buildPatch("completed")));
@@ -2058,7 +2058,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
                   {submitting ? "Saving…" : isComplete ? "Save correction" : koTieBlocked ? "Needs a winner" : finishArmed ? `Confirm · ${finishSummary} →` : "Finish + Start Next →"}
                 </button>
               ) : (
-                <button className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
+                <button type="button" className={`btn btn--primary ${finishArmed && !isComplete ? "btn--confirm" : ""}`} onClick={() => {
                   if (isComplete && !correctionReason) { setShowCorrectionPrompt(true); return; }
                   if (!isComplete && !finishArmed) { setFinishArmed(true); return; }
                   doSubmit(() => onSubmit(buildPatch("completed")));
@@ -2069,7 +2069,7 @@ function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndN
               )}
             </div>
             {nextMatch ? (
-              <button className="btn btn--sm score-nav__next" onClick={onNext} disabled={submitting}>Next →</button>
+              <button type="button" className="btn btn--sm score-nav__next" onClick={onNext} disabled={submitting}>Next →</button>
             ) : <span />}
           </div>
           {/* Quiet, always-present keyboard-shortcut reminder. */}

--- a/web-mobile/js/admin_scoring_shared.jsx
+++ b/web-mobile/js/admin_scoring_shared.jsx
@@ -615,7 +615,7 @@ function RemainingMatchesPanel({ compID, password, withdrawnPlayer, onAwarded, o
     <div className="remaining-matches" style={{ border: "1px solid var(--line, #ddd)", borderRadius: 6, padding: 12, marginTop: 12, background: "var(--bg-2, #fafafa)" }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
         <div style={{ fontSize: 13, fontWeight: 700 }}>Remaining matches for {playerName}</div>
-        {onClose && <button className="btn btn--ghost btn--sm" onClick={onClose} style={{ padding: "2px 8px" }}>✕</button>}
+        {onClose && <button type="button" className="btn btn--ghost btn--sm" onClick={onClose} style={{ padding: "2px 8px" }}>✕</button>}
       </div>
       {err && <div style={{ color: "var(--danger, #c00)", fontSize: 12, marginBottom: 6 }}>{err}</div>}
       {matches === null && <div style={{ fontSize: 12, color: "var(--ink-3)" }}>Loading…</div>}
@@ -637,7 +637,7 @@ function RemainingMatchesPanel({ compID, password, withdrawnPlayer, onAwarded, o
                     {m.phase === "pool" ? m.poolName : m.round}{m.court ? ` · Shiaijo ${m.court}` : ""}{m.scheduledAt ? ` · ${m.scheduledAt}` : ""}
                   </span>
                 </div>
-                <button
+                <button type="button"
                   className="btn btn--sm"
                   onClick={() => award(m)}
                   disabled={busyId === m.id}
@@ -669,11 +669,11 @@ function FoulCounter({ label, fouls, setFouls, onIncrement, color, disabled }) {
     <div className={`foul-counter foul-counter--${color}`} data-testid={`scoring-modal-hansoku-${color}`}>
       <div className="foul-counter__label">{label} Fouls</div>
       <div className="foul-counter__controls">
-        <button className="foul-counter__btn foul-counter__btn--dec" onClick={() => setFouls(Math.max(0, fouls - 1))} disabled={fouls === 0}>−</button>
+        <button type="button" className="foul-counter__btn foul-counter__btn--dec" onClick={() => setFouls(Math.max(0, fouls - 1))} disabled={fouls === 0}>−</button>
         <div className="foul-counter__count">
           <span className={`foul-counter__num ${fouls >= 1 ? "foul-counter__num--warn" : ""}`}>{fouls}</span>
         </div>
-        <button className="foul-counter__btn foul-counter__btn--inc" onClick={onIncrement} disabled={disabled}>+</button>
+        <button type="button" className="foul-counter__btn foul-counter__btn--inc" onClick={onIncrement} disabled={disabled}>+</button>
       </div>
     </div>
   );

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -534,11 +534,11 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
                 <div key={ct._key} style={{ display: "flex", gap: 8, marginBottom: 6 }}>
                   <input className="input" style={{ flex: "0 0 120px" }} value={ct.label} onChange={(e) => { const next = [...contacts]; next[i] = { ...next[i], label: e.target.value }; setContacts(next); }} placeholder="Label" />
                   <input className="input" style={{ flex: 1 }} value={ct.value} onChange={(e) => { const next = [...contacts]; next[i] = { ...next[i], value: e.target.value }; setContacts(next); }} placeholder="Value (email, phone, URL, etc.)" />
-                  <button className="btn" style={{ padding: "4px 10px" }} onClick={() => setContacts(contacts.filter((_, j) => j !== i))}>✕</button>
+                  <button type="button" className="btn" style={{ padding: "4px 10px" }} onClick={() => setContacts(contacts.filter((_, j) => j !== i))}>✕</button>
                 </div>
               ))}
               {contacts.length < 10 && (
-                <button className="btn" style={{ fontSize: 12, marginTop: 4 }} onClick={() => setContacts([...contacts, { label: "", value: "", _key: nextKeyRef.current++ }])}>+ Add contact</button>
+                <button type="button" className="btn" style={{ fontSize: 12, marginTop: 4 }} onClick={() => setContacts([...contacts, { label: "", value: "", _key: nextKeyRef.current++ }])}>+ Add contact</button>
               )}
             </div>
           </div>
@@ -576,7 +576,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               )}
               <div style={{ display: "flex", gap: 8 }}>
                 <input className="input" type="password" value={adminNew} onChange={(e) => setAdminNew(e.target.value)} placeholder={elevatedConfigured ? "New destructive-ops password" : "Set destructive-ops password"} autoComplete="new-password" />
-                <button className="btn" disabled={adminSaving} onClick={handleSetAdminPassword}>
+                <button type="button" className="btn" disabled={adminSaving} onClick={handleSetAdminPassword}>
                   {adminSaving ? "Saving…" : (elevatedConfigured ? "Update" : "Set")}
                 </button>
               </div>
@@ -625,8 +625,8 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
           </div>
           <div className="edit-actions__buttons">
             {dirty && <span className="edit-actions__dirty" aria-live="polite">Unsaved changes</span>}
-            <button className="btn" onClick={handleCancel} disabled={saving}>Cancel</button>
-            <button className="btn btn--primary" onClick={handleSave} disabled={saving}>{saving ? "Saving…" : "Save changes"}</button>
+            <button type="button" className="btn" onClick={handleCancel} disabled={saving}>Cancel</button>
+            <button type="button" className="btn btn--primary" onClick={handleSave} disabled={saving}>{saving ? "Saving…" : "Save changes"}</button>
           </div>
         </div>
         </div>
@@ -1032,8 +1032,8 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
           </div>
 
           <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
-            <button className="btn" onClick={onCancel}>Cancel</button>
-            <button className="btn btn--primary" onClick={create}>Create & continue →</button>
+            <button type="button" className="btn" onClick={onCancel}>Cancel</button>
+            <button type="button" className="btn btn--primary" onClick={create}>Create & continue →</button>
           </div>
         </div>
       </div>
@@ -1154,8 +1154,8 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
               The manifest must list competitions with their CSV file names.
             </p>
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginBottom: 12 }}>
-              <button className="btn btn--primary" onClick={() => folderRef.current?.click()}>Select folder</button>
-              <button className="btn" onClick={() => filesRef.current?.click()}>Select files individually</button>
+              <button type="button" className="btn btn--primary" onClick={() => folderRef.current?.click()}>Select folder</button>
+              <button type="button" className="btn" onClick={() => filesRef.current?.click()}>Select files individually</button>
             </div>
             <input ref={folderRef} type="file" style={{ display: "none" }} webkitdirectory="true" multiple onChange={e => collectFiles(e.target.files)} />
             <input ref={filesRef} type="file" style={{ display: "none" }} multiple accept=".yaml,.yml,.json,.csv,.txt" onChange={e => collectFiles(e.target.files)} />
@@ -1219,10 +1219,10 @@ function AdminImportPage({ tournament, onBack, onImported, onLogout, onViewerMod
         )}
 
         <div style={{ display: "flex", gap: 10 }}>
-          <button className="btn btn--primary" onClick={doImport} disabled={!manifestFile || loading}>
+          <button type="button" className="btn btn--primary" onClick={doImport} disabled={!manifestFile || loading}>
             {loading ? "Importing…" : "Import"}
           </button>
-          <button className="btn" onClick={onBack}>Cancel</button>
+          <button type="button" className="btn" onClick={onBack}>Cancel</button>
         </div>
       </div>
     </div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -45,7 +45,7 @@ function Breadcrumbs({ items }) {
             // keyboard / hover dismissal, but a blanket blur is the wrong tool —
             // it breaks keyboard users for a problem the browser already handles
             // when the navigated-away input unmounts.)
-            <button onClick={() => item.onClick()}>
+            <button type="button" onClick={() => item.onClick()}>
               {i === 0 && <span style={{ marginRight: 4 }}>←</span>}
               {item.label}
             </button>
@@ -170,8 +170,8 @@ function AdminTopbar({ onLogout, onViewerMode, tournament, hideRunningStrip }) {
           <span aria-hidden="true" className="topbar__conn__dot"></span>
           {connected ? "Connected" : "Reconnecting…"}
         </span>
-        <button className="viewer-toggle" onClick={onViewerMode}><Icon name="eye" /> Public viewer</button>
-        <button className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
+        <button type="button" className="viewer-toggle" onClick={onViewerMode}><Icon name="eye" /> Public viewer</button>
+        <button type="button" className="btn btn--ghost btn--sm" onClick={onLogout}>Sign out</button>
       </div>
       {!connected && sustainedDown && (
         <div className="conn-alert" role="alert">
@@ -189,7 +189,7 @@ function AdminTopbar({ onLogout, onViewerMode, tournament, hideRunningStrip }) {
               const courtLabel = m.court ? `Shiaijo ${m.court}` : "Unassigned";
               const courtPhrase = m.court ? `on Shiaijo ${m.court}` : "with no court assigned";
               return (
-                <button
+                <button type="button"
                   key={`${m.compId}:${m.id}`}
                   className="running-strip__chip"
                   onClick={() => onOpenScore && onOpenScore(m)}
@@ -276,7 +276,7 @@ function AllWinnersModal({ comps, onClose }) {
       <div className="modal" style={{ maxWidth: 640, width: "95%" }} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="All winners">
         <div className="modal__head">
           <div className="modal__title" style={{ display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="trophy" size={18} />All winners</div>
-          <button className="modal__close" onClick={onClose} aria-label="Close">✕</button>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close">✕</button>
         </div>
         <div className="modal__body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           {state.loading && (
@@ -324,7 +324,7 @@ function AllWinnersModal({ comps, onClose }) {
           ))}
         </div>
         <div className="modal__foot">
-          <button className="btn" onClick={onClose}>Close</button>
+          <button type="button" className="btn" onClick={onClose}>Close</button>
         </div>
       </div>
     </div>
@@ -423,16 +423,16 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             </div>
           </div>
           <div className="page-head__actions">
-            <button className="btn" onClick={onAnnounce}><Icon name="megaphone" />Announce</button>
-            <button className="btn" onClick={() => setExportPdfOpen(true)}><Icon name="printer" />Export PDFs</button>
+            <button type="button" className="btn" onClick={onAnnounce}><Icon name="megaphone" />Announce</button>
+            <button type="button" className="btn" onClick={() => setExportPdfOpen(true)}><Icon name="printer" />Export PDFs</button>
             {comps.some(c => c.status === "completed") && (
-              <button className="btn" onClick={() => setAllWinnersOpen(true)}><Icon name="trophy" />All winners</button>
+              <button type="button" className="btn" onClick={() => setAllWinnersOpen(true)}><Icon name="trophy" />All winners</button>
             )}
-            <button className="btn" onClick={onEditTournament}>Edit details</button>
+            <button type="button" className="btn" onClick={onEditTournament}>Edit details</button>
             {comps.some(c => c.status === "setup" && (c.players || []).length >= 2) && (
-              <button className="btn btn--danger" onClick={onStartAll}>Start all</button>
+              <button type="button" className="btn btn--danger" onClick={onStartAll}>Start all</button>
             )}
-            <button className="btn btn--primary" onClick={onCreateCompetition}>+ Add competition</button>
+            <button type="button" className="btn btn--primary" onClick={onCreateCompetition}>+ Add competition</button>
           </div>
         </div>
 
@@ -444,11 +444,11 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
         </div>
 
         <div className="row" style={{ marginBottom: 24 }}>
-          <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenSchedule}>
+          <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenSchedule}>
             <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="calendar" size={18} />Tournament schedule →</div>
             <div className="card__sub">All matches across courts. Move matches between shiaijo, filter by player.</div>
           </button>
-          <button className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenScoreEditor}>
+          <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenScoreEditor}>
             <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="pencil" size={18} />Score editor →</div>
             <div className="card__sub">Update results or correct past matches across the tournament.</div>
           </button>
@@ -458,7 +458,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             <div className="section-title">Shiaijo operator views</div>
             <div className="row" style={{ flexWrap: "wrap", gap: 8 }}>
               {(t.courts || []).map(court => (
-                <button key={court} className="btn" style={{ minWidth: 120 }} onClick={() => onOpenShiaijo(court)}>
+                <button type="button" key={court} className="btn" style={{ minWidth: 120 }} onClick={() => onOpenShiaijo(court)}>
                   Shiaijo {court} →
                 </button>
               ))}
@@ -482,12 +482,12 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
         <div className="section-title">All competitions</div>
         <div className="tlist">
           {comps.map((c) => <CompCard key={c.id} c={c} onOpen={() => onOpenCompetition(c.id, initialSectionFor(c.status))} onStart={() => onStartCompetition(c.id)} tournament={t} showToast={showToast} />)}
-          <button className="tcard tcard--add" onClick={onCreateCompetition}>
+          <button type="button" className="tcard tcard--add" onClick={onCreateCompetition}>
             <div style={{ fontSize: 28, color: "var(--ink-3)" }}>+</div>
             <div style={{ fontWeight: 600, marginTop: 4 }}>Add competition</div>
             <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>Individual or Team</div>
           </button>
-          <button className="tcard tcard--add" onClick={onOpenImport}>
+          <button type="button" className="tcard tcard--add" onClick={onOpenImport}>
             <div style={{ color: "var(--ink-3)" }}><Icon name="folder" size={28} /></div>
             <div style={{ fontWeight: 600, marginTop: 4 }}>Import competitions</div>
             <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>From folder with manifest.yaml</div>
@@ -552,7 +552,7 @@ function ShareRegistrationModal({ url, onClose, showToast }) {
       <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Share registration link">
         <div className="modal__head">
           <div className="modal__title">Share registration link</div>
-          <button className="modal__close" onClick={onClose} aria-label="Close">✕</button>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close">✕</button>
         </div>
         <div className="modal__body" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
           <canvas ref={canvasRef} style={{ display: "block", imageRendering: "pixelated" }} />
@@ -564,10 +564,10 @@ function ShareRegistrationModal({ url, onClose, showToast }) {
           </p>
         </div>
         <div className="modal__foot">
-          <button className="btn btn--primary" onClick={() => {
+          <button type="button" className="btn btn--primary" onClick={() => {
             copyToClipboard(url).then(() => showToast && showToast("Registration link copied!")).catch(() => showToast && showToast("Copy failed — select the link above manually", "error"));
           }}>Copy link</button>
-          <button className="btn" onClick={onClose}>Close</button>
+          <button type="button" className="btn" onClick={onClose}>Close</button>
         </div>
       </div>
     </div>
@@ -629,7 +629,7 @@ function ExportPdfModal({ tournament, password, onClose, showToast }) {
       <div className="modal" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Export PDFs">
         <div className="modal__head">
           <div className="modal__title">Export PDFs</div>
-          <button className="modal__close" onClick={onClose} aria-label="Close" disabled={!!busyType}>✕</button>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close" disabled={!!busyType}>✕</button>
         </div>
         <div className="modal__body" style={{ display: "flex", flexDirection: "column", gap: 10 }}>
           <p style={{ margin: "0 0 4px", fontSize: 13, color: "var(--ink-3)" }}>
@@ -653,7 +653,7 @@ function ExportPdfModal({ tournament, password, onClose, showToast }) {
           ))}
         </div>
         <div className="modal__foot">
-          <button className="btn" onClick={onClose} disabled={!!busyType}>Close</button>
+          <button type="button" className="btn" onClick={onClose} disabled={!!busyType}>Close</button>
         </div>
       </div>
     </div>
@@ -710,16 +710,16 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
         </div>
         <div className="tcard__actions">
           {c.status === "setup" && playerCount >= 2 && (
-            <button className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
+            <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
           )}
           {(c.status === "pools" || c.status === "playoffs") && (
-            <button className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onOpen(); }}>Go to Scoring →</button>
+            <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onOpen(); }}>Go to Scoring →</button>
           )}
           {c.status === "completed" && (
-            <button className="btn btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onOpen(); }}>View Results</button>
+            <button type="button" className="btn btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onOpen(); }}>View Results</button>
           )}
           {canShare && (
-            <button className="btn btn--sm btn--full" onClick={(e) => { e.stopPropagation(); setShareOpen(true); }}>
+            <button type="button" className="btn btn--sm btn--full" onClick={(e) => { e.stopPropagation(); setShareOpen(true); }}>
               Share registration link
             </button>
           )}
@@ -803,7 +803,7 @@ function CourtPicker({ value, courts, onChange, btnClassName = "", label = "", a
 
   return (
     <div ref={ref} style={{ position: "relative", display: "inline-block" }}>
-      <button
+      <button type="button"
         ref={triggerRef}
         className={btnClassName}
         onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
@@ -820,7 +820,7 @@ function CourtPicker({ value, courts, onChange, btnClassName = "", label = "", a
           style={{ [align === "right" ? "right" : "left"]: 0, top: "100%", marginTop: 4 }}
         >
           {courts.map((cc, idx) => (
-            <button
+            <button type="button"
               key={cc}
               ref={(el) => { optionRefs.current[idx] = el; }}
               role="option"

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -335,11 +335,11 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                         <div className="shiaijo-upnext__time">{upNext.scheduledAt || "—"} · {upNext.compName}</div>
                                         <MatchSides m={upNext} large />
                                         <div className="shiaijo-upnext__actions">
-                                            <button className="btn btn--primary" disabled={startingKey === matchKey(upNext)} onClick={() => startMatch(upNext)}>
+                                            <button type="button" className="btn btn--primary" disabled={startingKey === matchKey(upNext)} onClick={() => startMatch(upNext)}>
                                                 {startingKey === matchKey(upNext) ? "Starting…" : "Start match"}
                                             </button>
                                             {isTeamMatch(upNext) && (
-                                                <button className="btn btn--sm" onClick={() => setLineupMatch(upNext)}
+                                                <button type="button" className="btn btn--sm" onClick={() => setLineupMatch(upNext)}
                                                     title="Set the team lineup before starting">
                                                     Enter lineup
                                                 </button>
@@ -347,7 +347,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                             {/* Optional: announce the call to spectators/competitors.
                                                 Never required — Start match works on its own. */}
                                             {window.API && typeof window.API.sendAnnouncement === "function" && (
-                                                <button
+                                                <button type="button"
                                                     className="btn btn--sm"
                                                     disabled={callingKey === matchKey(upNext)}
                                                     onClick={() => callToCourt(upNext)}
@@ -358,7 +358,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                                 </button>
                                             )}
                                             {window.API && typeof window.API.updateMatchTime === "function" && (
-                                                <button className="btn btn--sm btn--ghost" onClick={() => skipMatch(upNext)} title="Run the next match first, then return here">Defer</button>
+                                                <button type="button" className="btn btn--sm btn--ghost" onClick={() => skipMatch(upNext)} title="Run the next match first, then return here">Defer</button>
                                             )}
                                         </div>
                                         {startError && <div className="shiaijo-upnext__error" role="alert">{startError}</div>}
@@ -484,10 +484,10 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                             the queue on Shiaijo {pendingMove.to}.
                         </p>
                         <div className="shiaijo-move-confirm__actions">
-                            <button className="btn" onClick={() => setPendingMove(null)} disabled={movingCourt}>
+                            <button type="button" className="btn" onClick={() => setPendingMove(null)} disabled={movingCourt}>
                                 Cancel
                             </button>
-                            <button className="btn btn--primary" onClick={confirmMoveCourt} disabled={movingCourt}>
+                            <button type="button" className="btn btn--primary" onClick={confirmMoveCourt} disabled={movingCourt}>
                                 {movingCourt ? "Moving…" : `Move to Shiaijo ${pendingMove.to}`}
                             </button>
                         </div>
@@ -575,10 +575,10 @@ function ShiaijoQueueRow({ m, courts, onMoveCourt, onSkip, onEnterLineup }) {
                     />
                 )}
                 {onEnterLineup && isTeamMatch(m) && m.status === "scheduled" && (
-                    <button className="btn btn--ghost btn--sm" onClick={() => onEnterLineup(m)} title="Set the team lineup before starting">Lineup</button>
+                    <button type="button" className="btn btn--ghost btn--sm" onClick={() => onEnterLineup(m)} title="Set the team lineup before starting">Lineup</button>
                 )}
                 {onSkip && m.status === "scheduled" && (
-                    <button className="btn btn--ghost btn--sm shiaijo-row__skip" onClick={() => onSkip(m)} title="Run the next match first, then return here">Defer</button>
+                    <button type="button" className="btn btn--ghost btn--sm shiaijo-row__skip" onClick={() => onSkip(m)} title="Run the next match first, then return here">Defer</button>
                 )}
             </div>
         </div>

--- a/web-mobile/js/admin_sponsors.jsx
+++ b/web-mobile/js/admin_sponsors.jsx
@@ -102,7 +102,7 @@ function SponsorsManager({ tournament, password, showToast, maxSponsors }) {
                   </div>
                 )}
               </div>
-              <button
+              <button type="button"
                 className="btn btn--danger"
                 disabled={busy}
                 onClick={() => handleDelete(i, s.name)}

--- a/web-mobile/js/glossary.jsx
+++ b/web-mobile/js/glossary.jsx
@@ -198,7 +198,7 @@ function GlossaryPage({ onBack }) {
       <div className="viewer__shell">
         <div className="viewer__head">
           {onBack && (
-            <button className="btn btn--ghost btn--sm" onClick={onBack} style={{ marginRight: 12 }}>
+            <button type="button" className="btn btn--ghost btn--sm" onClick={onBack} style={{ marginRight: 12 }}>
               ← Back
             </button>
           )}

--- a/web-mobile/js/registration.jsx
+++ b/web-mobile/js/registration.jsx
@@ -145,7 +145,7 @@ function RegistrationForm({ compId, onBack }) {
           <h2 style={{ marginBottom: 8 }}>Registration unavailable</h2>
           <p style={{ color: "var(--ink-3)", marginBottom: 24 }}>{metaErr}</p>
           {onBack && (
-            <button className="btn btn--ghost" onClick={onBack}>← Back</button>
+            <button type="button" className="btn btn--ghost" onClick={onBack}>← Back</button>
           )}
         </div>
       </div>
@@ -173,9 +173,9 @@ function RegistrationForm({ compId, onBack }) {
           </p>
           <div style={{ display: "flex", gap: 12 }}>
             {onBack && (
-              <button className="btn btn--ghost" onClick={onBack}>← Back to home</button>
+              <button type="button" className="btn btn--ghost" onClick={onBack}>← Back to home</button>
             )}
-            <button className="btn btn--primary" onClick={registerAnother} style={{ flex: 1 }}>
+            <button type="button" className="btn btn--primary" onClick={registerAnother} style={{ flex: 1 }}>
               Register another participant
             </button>
           </div>

--- a/web-mobile/js/reset.jsx
+++ b/web-mobile/js/reset.jsx
@@ -61,7 +61,7 @@ function ResetPasswordForm({ authConfig, onBack, onSuccess, originatorId }) {
             Contact your tournament administrator for the credential.
           </p>
           {onBack && (
-            <button className="btn btn--ghost" onClick={onBack}>← Back</button>
+            <button type="button" className="btn btn--ghost" onClick={onBack}>← Back</button>
           )}
         </div>
       </div>

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -107,7 +107,7 @@ function Toast({ message, type, onClose }) {
       <div className="toast__icon" aria-hidden="true">{shownIsError ? '⚠️' : '✅'}</div>
       <div className="toast__msg">{shown.message}</div>
       {shownIsError && (
-        <button
+        <button type="button"
           className="toast__dismiss"
           aria-label="Dismiss"
           onClick={() => { setVisible(false); if (onCloseRef.current) onCloseRef.current(); }}
@@ -387,7 +387,7 @@ function DialogHost() {
       <div key={req._id} className="modal" ref={dialogRefCb} tabIndex={-1} role="dialog" aria-modal="true" aria-label={req.title} onKeyDown={onDialogKeyDown} onClick={(e) => e.stopPropagation()}>
         <div className="modal__head">
           <div className="modal__title">{req.title}</div>
-          <button className="modal__close" onClick={onCancel} aria-label="Cancel">&times;</button>
+          <button type="button" className="modal__close" onClick={onCancel} aria-label="Cancel">&times;</button>
         </div>
         <div className="modal__body">
           {req.message && <p className="dialog-msg">{req.message}</p>}
@@ -409,8 +409,8 @@ function DialogHost() {
           )}
         </div>
         <div className="modal__foot">
-          <button className="btn btn--ghost" onClick={onCancel}>{req.cancelLabel}</button>
-          <button className={`btn ${req.danger ? "btn--danger" : "btn--primary"}`} onClick={onConfirm}>{req.confirmLabel}</button>
+          <button type="button" className="btn btn--ghost" onClick={onCancel}>{req.cancelLabel}</button>
+          <button type="button" className={`btn ${req.danger ? "btn--danger" : "btn--primary"}`} onClick={onConfirm}>{req.confirmLabel}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Follow-up to PR #290 (viewer.jsx split), closing the two hardening classes that should have been finished in that PR rather than deferred.

- **Eliminates double module-evaluation of 5 shared modules** (`data`, `api_serializers`, `patch`, `admin_helpers`, `admin_branding`). A real browser network capture showed each was fetched **twice** on both viewer.html and admin.html — once as the `.js?v=5` script tag, once as the `.jsx` ES import (distinct URLs → two module instances, double fetch/parse, split module-level singleton state).
- **Adds `type="button"` to all 163 untyped admin/shared buttons.** A `<button>` with no explicit type defaults to `type="submit"` and can trigger unintended form submission inside a `<form>` (the admin surface has real forms).

## Why

Both are pre-existing, codebase-wide patterns surfaced by Copilot during PR #290's review. PR #290 fixed the viewer-module instances and I filed mp-zd1v / mp-9941 for the rest; this PR finishes the classes across the whole web-mobile surface.

For the shared modules, the viewer-style fix (remove the redundant script tag) is **unsafe**: these set `window` globals read at module-**eval** time by many later modules (e.g. `admin_competition.jsx` reads `window.formatDate`, `admin_schedule.jsx` reads `window.hasBothSides`), so they must keep their early `<script>` position. Instead, their script tags now use the **same `.jsx` specifier** the imports use, so the browser dedupes to one instance while load order is preserved.

## Files changed

| File | What |
|---|---|
| `web-mobile/index.html` | point the 5 double-loaded modules' script tags at `.jsx` (matching the import URL) so the browser evaluates each once; added an explanatory comment |
| `web-mobile/js/admin*.jsx` (14 files) | `type="button"` on all untyped buttons |
| `web-mobile/js/{ui,glossary,registration,reset}.jsx` | `type="button"` on all untyped buttons |

## Screenshots

No visual / layout / copy change — `type="button"` only affects form-submit semantics and the module-dedup is internal. Verified in a real headless browser (Playwright) that both pages still render intact post-change:

- **viewer.html**: `#root` populated (5283 chars), **0** console errors
- **admin.html**: `#root` populated (6420 chars), **0** console errors
- **Double-load audit**: modules loaded twice went **5 → 0** on both pages

![viewer after](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/292/viewer.png)
![admin after](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/292/admin.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — eslint `--max-warnings 0` (confirms no duplicate-prop violations) + 1652 JS tests + Go suite all green
- [x] New/updated unit tests cover the change — N/A: attribute/config-only change; enforced by eslint `react/jsx-no-duplicate-props` and the browser double-load audit rather than a unit test
- [x] Manual browser verification — rendered viewer.html + admin.html in Playwright; confirmed both render, 0 console errors, and double-loads 5→0
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-zd1v
Closes mp-9941
