### PR TITLE
fix(shiaijo): operator scoring window bug fixes + UX (mp-nwds)

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4218,9 +4218,21 @@ button.pool-match-row {
   border-radius: 10px;
 }
 
+/* Shared running-row highlight. A match in progress is signalled by highlighting
+   its row (accent ring), NEVER a centre "●" dot. Apply `is-running` to any
+   compact match-row container. The labelled "● NOW" badge is a separate status
+   affordance (headers/bracket nodes) and is unaffected. */
+.is-running {
+  box-shadow: inset 0 0 0 2px var(--accent);
+  background: var(--accent-soft);
+  border-radius: 8px;
+}
+
+/* The score editor's running row keeps its own border-color shift but inherits
+   the shared highlight via the shared class on the element; this rule only adds
+   the accent border so the ring + bg come from .is-running (no double-styling). */
 .score-edit-row--running {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-soft);
 }
 
 .score-edit-row--complete {
@@ -5996,6 +6008,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .league-matrix__cell--self { color: var(--ink-4); background: var(--bg-2); }
 .league-matrix__cell--empty { background: var(--bg-2); }
 .league-matrix__cell--pending { color: var(--ink-3); }
+/* A bout in progress: the cell highlight alone signals "now" (no centre dot).
+   Inset accent ring on the accent-soft fill, matching the shared .is-running. */
+.league-matrix__cell--running { background: var(--accent-soft); box-shadow: inset 0 0 0 2px var(--accent); }
 .league-matrix__cell--win { background: rgba(22, 163, 74, 0.08); }
 .league-matrix__cell--loss { background: rgba(220, 38, 38, 0.06); }
 .league-matrix__cell--draw { background: rgba(0, 0, 0, 0.04); }
@@ -7710,9 +7725,11 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
    scoring panel would be. */
 .lineup-panel--inline { padding: 16px 18px; }
 
-/* Queue-row action cell: court picker + skip, kept compact. */
+/* Queue-row action cell: court picker, Score, and ↑/↓ reorder, kept compact. */
 .shiaijo-row__actions { display: flex; align-items: center; gap: 6px; }
-.shiaijo-row__skip { padding: 2px 8px; font-size: 11px; }
+.shiaijo-row__pick { padding: 2px 10px; font-size: 11px; }
+/* ↑/↓ reorder arrows: square, monospace-centred glyph so the arrow sits true. */
+.shiaijo-row__move { padding: 2px 7px; font-size: 12px; line-height: 1; min-width: 26px; text-align: center; }
 
 /* Big sides block for the Up Next card */
 .shiaijo-sides { display: flex; align-items: center; gap: 12px; }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7745,19 +7745,20 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
    scoring panel would be. */
 .lineup-panel--inline { padding: 16px 18px; }
 
-/* Queue-row action cell: court picker, Score, and ↑/↓ reorder, kept compact. */
-.shiaijo-row__actions { display: flex; align-items: center; gap: 6px; }
+/* Queue-row controls bar — its own full-width line below the matchup, so the
+   court picker / Score / ↑ / ↓ never crowd the names. Right-aligned; wraps if
+   the row gets very narrow. */
+.shiaijo-qrow__actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
 .shiaijo-row__pick { padding: 2px 10px; font-size: 11px; }
 /* ↑/↓ reorder arrows: square, monospace-centred glyph so the arrow sits true. */
 .shiaijo-row__move { padding: 2px 7px; font-size: 12px; line-height: 1; min-width: 26px; text-align: center; }
 
 /* Touch devices: the Score / ↑ / ↓ controls must each meet the 44px target
    (DESIGN.md §6 / Principle 4). The base .btn coarse rule already floors
-   height; we floor width too and widen the gap so three controls don't crowd
-   into a mis-tappable cluster. The actions grid column also widens to fit
-   them (see .shiaijo-row coarse override below). Desktop stays compact. */
+   height; we floor width too and widen the gap so the controls don't crowd
+   into a mis-tappable cluster. They sit on their own line, so there's room. */
 @media (pointer: coarse) {
-  .shiaijo-row__actions { gap: 10px; }
+  .shiaijo-qrow__actions { gap: 10px; }
   .shiaijo-row__pick,
   .shiaijo-row__move {
     min-width: 44px;
@@ -7773,22 +7774,33 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .shiaijo-sides__vs { font-size: 12px; color: var(--ink-3); }
 .shiaijo-sides--lg .name { font-size: 18px; }
 
-/* Queue rows: 4-column variant of score-edit-row (no standalone court cell). */
-/* Fixed status + actions columns (not auto) so the "Final" badge and the
-   court-picker / Skip controls line up vertically across every queue row
-   regardless of each row's content width. */
-.shiaijo-row { grid-template-columns: 52px 1fr 44px 84px; }
-/* Touch: widen the actions column so three 44px controls (Score ↑ ↓) plus
-   their gaps fit without crowding (DESIGN.md §6). Desktop keeps 84px. */
-@media (pointer: coarse) {
-  .shiaijo-row { grid-template-columns: 52px 1fr 44px 160px; }
+/* Queue row (Upcoming / Completed): a compact stacked card. The matchup gets a
+   full-width line so player NAMES stay readable in the narrow queue column;
+   meta sits above, controls below. Replaces the old wide score-edit-row grid
+   that squeezed the names to nothing. */
+.shiaijo-qrow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
 }
-/* Upcoming rows are informational (start via Up Next, manage via the row's
-   own controls) — not openable in the scoring panel, so no button affordance. */
-.shiaijo-row--static { cursor: default; }
-.shiaijo-row__comp { font-size: 12px; color: var(--ink-2); margin-top: 2px; }
-.shiaijo-row__status { display: flex; align-items: center; justify-content: flex-end; }
-.shiaijo-row__actions { justify-content: flex-end; }
+.shiaijo-qrow--complete { opacity: 0.72; }
+.shiaijo-qrow__top {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+  font-size: 12px;
+}
+.shiaijo-qrow__time { font-weight: 600; color: var(--ink-2); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shiaijo-qrow__state { font-family: var(--font-mono); font-weight: 700; font-size: 13px; color: var(--ink); white-space: nowrap; display: inline-flex; align-items: center; gap: 6px; }
+.shiaijo-qrow__final { font-family: var(--font-sans); font-weight: 600; font-size: 10px; color: var(--ink-3); }
+/* Matchup: two equal name columns flanking the centre "vs", names hug centre. */
+.shiaijo-qrow__match { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 8px; }
+.shiaijo-qrow__side { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.shiaijo-qrow__side--aka { flex-direction: row-reverse; text-align: right; }
+.shiaijo-qrow__name { font-weight: 600; font-size: 14px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.shiaijo-qrow__vs { font-size: 11px; color: var(--ink-3); }
 
 /* Team encounter score in the queue row: always carries an IV label so a
    bare figure is never shown out of context (a team number could read as

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6028,16 +6028,12 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 .league-matrix__win { color: #16a34a; }
 .league-matrix__loss { color: #dc2626; }
-/* Draw must be distinguishable from win/loss WITHOUT colour (Principle 2):
-   the near-invisible 0.04-alpha cell tint can't carry the signal for a
-   colour-blind operator, so the draw letter (or "X") gets an underline —
-   a treatment, not a hue. Win/loss carry no underline, so the three states
-   are separable in greyscale. --ink-2 holds >4.5:1 on the faint draw bg. */
+/* Draw = neutral ippon letters (no win/loss hue). Plain text — never underlined:
+   an underline reads as a hyperlink on static data. The draw is already the
+   visual odd-one-out (uncoloured letters on the neutral cell), and the Matches
+   list above carries the authoritative "M–K". --ink-2 holds >4.5:1 on the cell. */
 .league-matrix__draw {
   color: var(--ink-2);
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 2px;
 }
 
 .league-matrix__legend {
@@ -6057,9 +6053,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 .league-matrix__legend-item--win { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
 .league-matrix__legend-item--loss { color: #dc2626; background: rgba(220, 38, 38, 0.08); }
-/* Mirror the cell's non-colour draw treatment (underline) so the legend key
-   matches what's rendered in the matrix. */
-.league-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); text-decoration: underline; text-decoration-thickness: 2px; text-underline-offset: 2px; }
+.league-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); }
 
 /* ---------- FoulCounter (Individual Scoring) ---------- */
 .sb-fouls {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4226,7 +4226,9 @@ button.pool-match-row {
 .is-running {
   box-shadow: inset 0 0 0 2px var(--accent);
   background: var(--accent-soft);
-  border-radius: 8px;
+  /* No border-radius here: each host keeps its own (score-edit-row 10px,
+     shiaijo-qrow 8px, …). The inset ring follows the host's radius, so running
+     rows don't change shape vs their non-running siblings. */
 }
 
 /* The score editor's running row keeps its own border-color shift but inherits

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3763,8 +3763,9 @@ button.pool-match-row {
     min-height: 44px;
   }
   /* Shiaijo console court controls: the per-row reassign picker (A▾) and the
-     header court switcher. The Defer button already forces the queue row to
-     44px tall under coarse pointer, so flooring the picker costs no row height. */
+     header court switcher. The Score / ↑ / ↓ controls already force the queue
+     row to 44px tall under coarse pointer, so flooring the picker costs no
+     extra row height. */
   .score-edit-row__court--btn {
     min-height: 44px;
   }
@@ -6020,7 +6021,17 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 .league-matrix__win { color: #16a34a; }
 .league-matrix__loss { color: #dc2626; }
-.league-matrix__draw { color: var(--ink-2); }
+/* Draw must be distinguishable from win/loss WITHOUT colour (Principle 2):
+   the near-invisible 0.04-alpha cell tint can't carry the signal for a
+   colour-blind operator, so the draw letter (or "X") gets an underline —
+   a treatment, not a hue. Win/loss carry no underline, so the three states
+   are separable in greyscale. --ink-2 holds >4.5:1 on the faint draw bg. */
+.league-matrix__draw {
+  color: var(--ink-2);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
 
 .league-matrix__legend {
   display: flex;
@@ -6039,7 +6050,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 .league-matrix__legend-item--win { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
 .league-matrix__legend-item--loss { color: #dc2626; background: rgba(220, 38, 38, 0.08); }
-.league-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); }
+/* Mirror the cell's non-colour draw treatment (underline) so the legend key
+   matches what's rendered in the matrix. */
+.league-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); text-decoration: underline; text-decoration-thickness: 2px; text-underline-offset: 2px; }
 
 /* ---------- FoulCounter (Individual Scoring) ---------- */
 .sb-fouls {
@@ -7731,6 +7744,20 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 /* ↑/↓ reorder arrows: square, monospace-centred glyph so the arrow sits true. */
 .shiaijo-row__move { padding: 2px 7px; font-size: 12px; line-height: 1; min-width: 26px; text-align: center; }
 
+/* Touch devices: the Score / ↑ / ↓ controls must each meet the 44px target
+   (DESIGN.md §6 / Principle 4). The base .btn coarse rule already floors
+   height; we floor width too and widen the gap so three controls don't crowd
+   into a mis-tappable cluster. The actions grid column also widens to fit
+   them (see .shiaijo-row coarse override below). Desktop stays compact. */
+@media (pointer: coarse) {
+  .shiaijo-row__actions { gap: 10px; }
+  .shiaijo-row__pick,
+  .shiaijo-row__move {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
 /* Big sides block for the Up Next card */
 .shiaijo-sides { display: flex; align-items: center; gap: 12px; }
 .shiaijo-sides__side { flex: 1; min-width: 0; }
@@ -7744,6 +7771,11 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
    court-picker / Skip controls line up vertically across every queue row
    regardless of each row's content width. */
 .shiaijo-row { grid-template-columns: 52px 1fr 44px 84px; }
+/* Touch: widen the actions column so three 44px controls (Score ↑ ↓) plus
+   their gaps fit without crowding (DESIGN.md §6). Desktop keeps 84px. */
+@media (pointer: coarse) {
+  .shiaijo-row { grid-template-columns: 52px 1fr 44px 160px; }
+}
 /* Upcoming rows are informational (start via Up Next, manage via the row's
    own controls) — not openable in the scoring panel, so no button affordance. */
 .shiaijo-row--static { cursor: default; }
@@ -7764,10 +7796,14 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   border: 0;
 }
 
-.shiaijo-completed__toggle,
 .shiaijo-context__toggle {
   background: none; border: 0; cursor: pointer; width: 100%; text-align: left;
   display: flex; align-items: center; gap: 6px;
+}
+/* Inline "Show all N" / "Show fewer" toggle under the Completed list. */
+.shiaijo-completed__more {
+  margin-top: 8px;
+  font-size: 12px;
 }
 .shiaijo-count {
   display: inline-flex; align-items: center; justify-content: center;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4293,8 +4293,15 @@ button.pool-match-row {
   font-size: 14px;
   font-weight: 700;
   min-width: 44px;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
 }
+/* Symmetric foul gutters flanking the score (Shiro left, Aka right). Reserved
+   even when empty so the centred score never shifts as a hansoku ▲ appears. */
+.score-edit-row__foul { min-width: 0.85em; display: inline-flex; justify-content: center; }
+.score-edit-row__scoreval { text-align: center; }
 
 
 .score-edit-row__correction {

--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -24,6 +24,7 @@ import {
   teamResultLabel,
   isKoTieBlocked,
 } from '../admin_scoring_modal.jsx';
+import { makeSubmitDecision } from '../admin_scoring_shared.jsx';
 // teamEncounterHasResult is a module-internal helper of admin_scoring_team.jsx
 // (not part of the thin-entry consumer barrel), imported directly like the
 // resolveMatchLineup tests do.
@@ -1199,6 +1200,126 @@ describe('subBoutHasBeenPlayed (drops untouched kachinuki bouts)', () => {
   it('is false for null/undefined', () => {
     expect(subBoutHasBeenPlayed(null)).toBe(false);
     expect(subBoutHasBeenPlayed(undefined)).toBe(false);
+  });
+});
+
+// Item 7: hantei and fusenpai must route through onSubmitAndNext/onAfterDecision
+// so the next match on the same court is started without an extra operator tap.
+describe('item 7 — non-points decisions advance to next match', () => {
+  // submitHantei is component-internal, but the routing logic
+  //   `(!isComplete && onSubmitAndNext) ? onSubmitAndNext : onSubmit`
+  // is a pure predicate we can test directly.
+  it('routes hantei to onSubmitAndNext when provided and match is not a correction', () => {
+    const onSubmit = vi.fn();
+    const onSubmitAndNext = vi.fn();
+    const isComplete = false; // live match, not a correction
+    const submitFn = (!isComplete && onSubmitAndNext) ? onSubmitAndNext : onSubmit;
+    const patch = { winner: { id: 'p1', name: 'Hayashi' }, decidedByHantei: true, status: 'completed' };
+    submitFn(patch);
+    expect(onSubmitAndNext).toHaveBeenCalledWith(patch);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('routes hantei to onSubmit (not onSubmitAndNext) when correcting a completed match', () => {
+    const onSubmit = vi.fn();
+    const onSubmitAndNext = vi.fn();
+    const isComplete = true; // correction — do not auto-advance
+    const submitFn = (!isComplete && onSubmitAndNext) ? onSubmitAndNext : onSubmit;
+    const patch = { winner: { id: 'p1', name: 'Hayashi' }, decidedByHantei: true, status: 'completed' };
+    submitFn(patch);
+    expect(onSubmit).toHaveBeenCalledWith(patch);
+    expect(onSubmitAndNext).not.toHaveBeenCalled();
+  });
+
+  it('routes hantei to onSubmit when onSubmitAndNext is not provided', () => {
+    const onSubmit = vi.fn();
+    const onSubmitAndNext = undefined;
+    const isComplete = false;
+    const submitFn = (!isComplete && onSubmitAndNext) ? onSubmitAndNext : onSubmit;
+    const patch = { winner: { id: 'p2', name: 'Mori' }, decidedByHantei: true, status: 'completed' };
+    submitFn(patch);
+    expect(onSubmit).toHaveBeenCalledWith(patch);
+  });
+
+  // makeSubmitDecision: onAfterDecision is called for fusenpai when provided
+  // and the match is not complete.
+  describe('makeSubmitDecision with onAfterDecision', () => {
+    let savedAPI;
+    beforeEach(() => {
+      savedAPI = window.API;
+      window.API = {
+        recordDecision: vi.fn().mockResolvedValue({
+          winner: 'Shiro Fighter', sideA: 'Aka Fighter', sideB: 'Shiro Fighter',
+        }),
+      };
+    });
+    afterEach(() => { window.API = savedAPI; });
+
+    const makeMatch = (id) => ({
+      compId: 'c1', id,
+      sideA: { id: 'pa', name: 'Aka Fighter' },
+      sideB: { id: 'pb', name: 'Shiro Fighter' },
+    });
+    const makeSetters = () => ({
+      mountedRef: { current: true },
+      setDecisionSubmitting: vi.fn(),
+      setDecisionErr: vi.fn(),
+      setWithdrawnPlayer: vi.fn(),
+      setDecisionPromptKind: vi.fn(),
+    });
+
+    it('calls onAfterDecision for fusenpai when provided and match is not a correction', async () => {
+      const onAfterDecision = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+      const submit = makeSubmitDecision({
+        match: makeMatch('m1'), enchoPeriodCount: 0, password: 'pw',
+        ...makeSetters(), onClose, onAfterDecision, isComplete: false,
+        entityLabel: 'competitors',
+      });
+      await submit('fusenpai', { decisionBy: 'aka', decisionReason: '' });
+      expect(onAfterDecision).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('falls back to onClose for fusenpai when onAfterDecision is not set', async () => {
+      const onClose = vi.fn();
+      const submit = makeSubmitDecision({
+        match: makeMatch('m2'), enchoPeriodCount: 0, password: 'pw',
+        ...makeSetters(), onClose, isComplete: false, entityLabel: 'competitors',
+      });
+      await submit('fusenpai', { decisionBy: 'aka', decisionReason: '' });
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('does NOT call onAfterDecision for a correction (isComplete=true)', async () => {
+      const onAfterDecision = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+      const submit = makeSubmitDecision({
+        match: makeMatch('m3'), enchoPeriodCount: 0, password: 'pw',
+        ...makeSetters(), onClose, onAfterDecision, isComplete: true,
+        entityLabel: 'competitors',
+      });
+      await submit('fusenpai', { decisionBy: 'aka', decisionReason: '' });
+      // Correction: must close rather than advance
+      expect(onClose).toHaveBeenCalled();
+      expect(onAfterDecision).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call onAfterDecision for a kiken decision (modal stays open for RemainingMatchesPanel)', async () => {
+      const onAfterDecision = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+      const setWithdrawnPlayer = vi.fn();
+      const submit = makeSubmitDecision({
+        match: makeMatch('m4'), enchoPeriodCount: 0, password: 'pw',
+        ...makeSetters(), setWithdrawnPlayer, onClose, onAfterDecision, isComplete: false,
+        entityLabel: 'competitors',
+      });
+      await submit('kiken-voluntary', { decisionBy: 'aka', decisionReason: '' });
+      // Kiken neither advances nor closes — it parks on RemainingMatchesPanel.
+      expect(onAfterDecision).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+      expect(setWithdrawnPlayer).toHaveBeenCalled();
+    });
   });
 });
 

--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { parsePath, pathFromState } from '../app.jsx';
-import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, addMinuteHHMM, deferTimeFor, isTeamMatch } from '../admin_shiaijo.jsx';
+import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, isTeamMatch } from '../admin_shiaijo.jsx';
 
 // A team encounter's score must never be shown as a bare number — it always
 // carries an IV (Individual Victories) label, since a raw figure could read as
@@ -167,52 +167,6 @@ describe('partitionShiaijoMatches', () => {
   });
 });
 
-describe('addMinuteHHMM', () => {
-  it('bumps a clock string by one minute', () => {
-    expect(addMinuteHHMM('09:10')).toBe('09:11');
-    expect(addMinuteHHMM('09:59')).toBe('10:00');
-  });
-  it('wraps past midnight', () => {
-    expect(addMinuteHHMM('23:59')).toBe('00:00');
-  });
-  it('returns null for an unusable time', () => {
-    expect(addMinuteHHMM('')).toBeNull();
-    expect(addMinuteHHMM(null)).toBeNull();
-    expect(addMinuteHHMM('—')).toBeNull();
-  });
-});
-
-describe('deferTimeFor — Defer means run the next match, then come right back', () => {
-  // Sorted, scheduled-only court queue (the shape partitionShiaijoMatches yields).
-  const queue = [
-    { compId: 'c', id: 'm1', scheduledAt: '09:05' },
-    { compId: 'c', id: 'm2', scheduledAt: '09:10' },
-    { compId: 'c', id: 'm3', scheduledAt: '09:15' },
-  ];
-
-  it('slots the Up Next match one minute after its successor (down exactly one)', () => {
-    // Defer m1: it must land at 09:11 — after m2 (09:10), before m3 (09:15) —
-    // so m2 runs next and m1 is Up Next again right after.
-    expect(deferTimeFor(queue[0], queue)).toBe('09:11');
-  });
-
-  it('moves a mid-queue match down one, not to the end', () => {
-    expect(deferTimeFor(queue[1], queue)).toBe('09:16'); // after m3 (09:15)
-  });
-
-  it('returns null for the last match (already at the back)', () => {
-    expect(deferTimeFor(queue[2], queue)).toBeNull();
-  });
-
-  it('returns null when the successor has no usable time', () => {
-    const q = [{ compId: 'c', id: 'm1', scheduledAt: '09:05' }, { compId: 'c', id: 'm2', scheduledAt: '' }];
-    expect(deferTimeFor(q[0], q)).toBeNull();
-  });
-
-  it('returns null when the match is not in the queue', () => {
-    expect(deferTimeFor({ compId: 'c', id: 'ghost' }, queue)).toBeNull();
-  });
-});
 
 describe('isTeamMatch — gates the "Enter lineup" affordance', () => {
   it('true for team encounters (by compKind or teamSize)', () => {

--- a/web-mobile/js/__tests__/score_display.test.jsx
+++ b/web-mobile/js/__tests__/score_display.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatIpponsScore, ipponsFromScore } from '../bracket.jsx';
+import { formatIpponsScore, ipponsFromScore, matchStateCell } from '../bracket.jsx';
 
 // Convention enforced across all match-list views:
 //   SHIRO (sideB) is always displayed on the LEFT.
@@ -47,8 +47,21 @@ describe('formatIpponsScore', () => {
       expect(formatIpponsScore([], [], null, 'hikiwake')).toBe('X');
     });
 
-    it('returns X for a draw even when scores were entered (canonical hikiwake glyph)', () => {
-      expect(formatIpponsScore(['M'], ['K'], { type: 'hikiwake' }, null)).toBe('X');
+    it('returns X for a scoreless draw (canonical hikiwake glyph, no ippons)', () => {
+      expect(formatIpponsScore([], [], { type: 'hikiwake' }, null)).toBe('X');
+      expect(formatIpponsScore([], [], null, 'hikiwake')).toBe('X');
+    });
+
+    it('returns the points for a scored equal draw (1–1), not bare X', () => {
+      // Item 6: operator entered M on one side, K on the other, then toggled
+      // hikiwake. The ippons are preserved on the server (the score.type is
+      // hikiwake but ipponsA/B are non-empty). Show the techniques so the
+      // viewer sees what was struck rather than losing that information.
+      expect(formatIpponsScore(['M'], ['K'], { type: 'hikiwake' }, null)).toBe('M–K');
+    });
+
+    it('shows scored draw with one empty side using the placeholder dot', () => {
+      expect(formatIpponsScore(['M'], [], { type: 'hikiwake' }, null)).toBe('M–·');
     });
 
     it('falls back to numeric score when ippons arrays are empty AND score has no ippon letters', () => {
@@ -120,11 +133,12 @@ describe('formatIpponsScore', () => {
       expect(formatIpponsScore(['M'], ['K'], null, null, { periodCount: 1 })).toBe('M–K (E)');
     });
 
-    it('appends (E) to a draw', () => {
-      expect(formatIpponsScore(['M'], ['K'], { type: 'hikiwake' }, null, { periodCount: 1 })).toBe('X (E)');
+    it('appends (E) to a scored draw (shows points, not X)', () => {
+      // Item 6: scored equal draw shows techniques + encho suffix, not bare X.
+      expect(formatIpponsScore(['M'], ['K'], { type: 'hikiwake' }, null, { periodCount: 1 })).toBe('M–K (E)');
     });
 
-    it('appends (E) to a no-score draw', () => {
+    it('appends (E) to a no-score draw (X is the scoreless-draw glyph)', () => {
       expect(formatIpponsScore([], [], null, 'hikiwake', { periodCount: 2 })).toBe('X (E)');
     });
 
@@ -166,6 +180,65 @@ describe('formatIpponsScore', () => {
       expect(formatIpponsScore(['M'], ['K'], { type: 'ippon', hantei: true }, null, { periodCount: 1 })).toBe('M–K (E)');
       expect(formatIpponsScore(['M'], ['K'], { type: 'ippon', hantei: true }, null, { periodCount: 1 }, true)).toBe('M–K (E) Ht');
     });
+  });
+});
+
+// Item 6 regression suite: scored-draw rendering (formatIpponsScore).
+// Pinned so future changes to the hikiwake branch can't silently revert
+// the display from "M–K" back to the bare-X glyph.
+describe('formatIpponsScore — hikiwake draw display (item 6)', () => {
+  it('0–0 hikiwake (score.type) → bare X', () => {
+    expect(formatIpponsScore([], [], { type: 'hikiwake' }, null)).toBe('X');
+  });
+
+  it('0–0 hikiwake (decision string) → bare X', () => {
+    expect(formatIpponsScore([], [], null, 'hikiwake')).toBe('X');
+  });
+
+  it('1–1 hikiwake (ipponsA=[M], ipponsB=[K]) → "M–K" (points shown, no X)', () => {
+    // Canonical scored-equal-draw case: both sides hit one ippon, operator
+    // toggled hikiwake. Server keeps ippons; display must show techniques.
+    expect(formatIpponsScore(['M'], ['K'], { type: 'hikiwake' }, null)).toBe('M–K');
+  });
+
+  it('1–1 hikiwake with encho (periodCount>0) → "M–K (E)"', () => {
+    // Encho suffix must survive the scored-draw path unchanged.
+    expect(formatIpponsScore(['M'], ['K'], { type: 'hikiwake' }, null, { periodCount: 1 })).toBe('M–K (E)');
+  });
+});
+
+// matchStateCell: the shared centre-cell lifecycle cue. completed → score
+// string (with "—" fallback), running → "vs" (the row highlight is the "now"
+// signal, NOT a centre dot), scheduled/other → "–".
+describe('matchStateCell — shared running-row centre cue', () => {
+  it('completed → the formatted ippon score (first arg = SHIRO/left)', () => {
+    // matchStateCell(m, ipponsB, ipponsA) → matchScoreStr → formatIpponsScore
+    // renders firstArg–secondArg, so ['M'],['K'] → "M–K".
+    expect(matchStateCell({ status: 'completed' }, ['M'], ['K'])).toBe('M–K');
+  });
+
+  it('completed with no derivable score → "—" fallback', () => {
+    // No ippons, no score, no decision → matchScoreStr returns "" → "—".
+    expect(matchStateCell({ status: 'completed' }, [], [])).toBe('—');
+  });
+
+  it('running → "vs" (no centre dot; the row highlight is the now signal)', () => {
+    expect(matchStateCell({ status: 'running' }, [], [])).toBe('vs');
+  });
+
+  it('scheduled → "–"', () => {
+    expect(matchStateCell({ status: 'scheduled' }, [], [])).toBe('–');
+  });
+
+  it('unknown/missing status → "–" (treated as not-yet-run)', () => {
+    expect(matchStateCell({ status: 'bye' }, [], [])).toBe('–');
+    expect(matchStateCell({}, [], [])).toBe('–');
+  });
+
+  it('never emits a bare "●" for any state', () => {
+    for (const status of ['completed', 'running', 'scheduled', 'bye', undefined]) {
+      expect(matchStateCell({ status }, [], [])).not.toContain('●');
+    }
   });
 });
 

--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -28,7 +28,7 @@ describe('PoolsViewer draw-order standings (mp-938b)', () => {
   let runtime;
   let PoolsViewer;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
 
   const baseComp = { kind: 'individual', teamSize: 0, format: 'mixed', poolWinners: 2 };
   const tweaks = { showDojo: false };
@@ -73,6 +73,11 @@ describe('PoolsViewer draw-order standings (mp-938b)', () => {
     global.window.matchScoreStr = (m, ippB, ippA) =>
       (global.window.teamIVScore(m)) ||
       global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
+    // Mirror the real matchStateCell (bracket.jsx): completed → score||"—",
+    // running → "vs", scheduled → "–".
+    global.window.matchStateCell = (m, ippB, ippA) =>
+      m?.status === 'completed' ? (global.window.matchScoreStr(m, ippB, ippA) || '—')
+      : m?.status === 'running' ? 'vs' : '–';
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;
@@ -308,7 +313,7 @@ describe('PoolsViewer league standings label (mp-mnwu)', () => {
   let runtime;
   let PoolsViewer;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
 
   const leagueComp = (status) => ({
     format: 'league',
@@ -344,6 +349,11 @@ describe('PoolsViewer league standings label (mp-mnwu)', () => {
     global.window.matchScoreStr = (m, ippB, ippA) =>
       (global.window.teamIVScore(m)) ||
       global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
+    // Mirror the real matchStateCell (bracket.jsx): completed → score||"—",
+    // running → "vs", scheduled → "–".
+    global.window.matchStateCell = (m, ippB, ippA) =>
+      m?.status === 'completed' ? (global.window.matchScoreStr(m, ippB, ippA) || '—')
+      : m?.status === 'running' ? 'vs' : '–';
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;
@@ -410,7 +420,7 @@ describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
   let runtime;
   let PoolNumberedMatchRow;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
 
   beforeEach(async () => {
     runtime = makeReactive();
@@ -428,6 +438,11 @@ describe('PoolNumberedMatchRow team IV score (mp-o4xl)', () => {
     global.window.matchScoreStr = (m, ippB, ippA) =>
       (global.window.teamIVScore(m)) ||
       global.window.formatIpponsScore(ippB, ippA, m?.score, m?.decision, m?.encho, m?.decidedByHantei);
+    // Mirror the real matchStateCell (bracket.jsx): completed → score||"—",
+    // running → "vs", scheduled → "–".
+    global.window.matchStateCell = (m, ippB, ippA) =>
+      m?.status === 'completed' ? (global.window.matchScoreStr(m, ippB, ippA) || '—')
+      : m?.status === 'running' ? 'vs' : '–';
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;

--- a/web-mobile/js/admin_schedule_page.jsx
+++ b/web-mobile/js/admin_schedule_page.jsx
@@ -82,10 +82,12 @@ const AdminTWMatch = React.memo(({ m, highlight, courts, onMove, onTimeChange })
       <div className="tw-match__players">
         <div className={`tw-match__name ${bWin ? "tw-match__name--w" : ""}`}>
           <span className="tw-match__badge tw-match__badge--shiro">S</span>
+          {m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}
           {m.sideB?.name || "TBD"}
         </div>
         <div className={`tw-match__name ${aWin ? "tw-match__name--w" : ""}`}>
           <span className="tw-match__badge tw-match__badge--aka">A</span>
+          {m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}
           {m.sideA?.name || "TBD"}
         </div>
         <div className="tw-match__comp">{m.compName}</div>

--- a/web-mobile/js/admin_schedule_page.jsx
+++ b/web-mobile/js/admin_schedule_page.jsx
@@ -109,7 +109,9 @@ const AdminTWMatch = React.memo(({ m, highlight, courts, onMove, onTimeChange })
           const tIpponsB = m.ipponsB || window.ipponsFromScore(m.scoreB);
           return <div style={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: 13 }}>{window.formatIpponsScore(tIpponsB, tIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}</div>;
         })()}
-        {m.status === "running" && <span className="bc-running">●</span>}
+        {/* No centre "●" dot: a running match is signalled by the row's
+            .tw-match--running highlight (accent border + ring). The labelled
+            "● NOW" / "● {count} now" badges elsewhere are a separate affordance. */}
         <CourtPicker
           value={m.court}
           courts={courts}

--- a/web-mobile/js/admin_schedule_score_editor.jsx
+++ b/web-mobile/js/admin_schedule_score_editor.jsx
@@ -178,19 +178,21 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
                   <div className={`score-edit-row__side ${bWin ? "score-edit-row__side--win" : ""}`} style={{ textAlign: "right" }}>
                     <div className="name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{m.sideB?.name}</div>
                     <div className="dojo">{m.sideB?.dojo}</div>
-                    {/* Foul ▲ rides the badge line, NOT the name line — keeping it off
-                        the name means a mid-bout foul never shifts the competitor's name. */}
-                    <span className="se-color-badge se-color-badge--shiro">SHIRO</span>{foulB && <span className="msb-hansoku" data-testid="foul-mark-b"> {foulB}</span>}
+                    <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
                   </div>
+                  {/* Foul ▲ flanks the SCORE (Shiro left, Aka right) — a hansoku is part of
+                      the scoreline, so it reads at the score's level. The slots are reserved
+                      symmetrically so the centred score never shifts when a foul appears. */}
                   <div className="score-edit-row__score">
-                    {showScore && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
-                    {m.status === "scheduled" && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>}
-                    {/* Running rows show the live ippon score above and are signalled by the
-                        score-edit-row--running / is-running row highlight — no centre dot, no
-                        redundant "● NOW" label (the highlight already says "now"). */}
+                    <span className="score-edit-row__foul">{foulB && <span className="msb-hansoku" data-testid="foul-mark-b">{foulB}</span>}</span>
+                    <span className="score-edit-row__scoreval">
+                      {showScore && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
+                      {m.status === "scheduled" && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>}
+                    </span>
+                    <span className="score-edit-row__foul">{foulA && <span className="msb-hansoku" data-testid="foul-mark-a">{foulA}</span>}</span>
                   </div>
                   <div className={`score-edit-row__side ${aWin ? "score-edit-row__side--win" : ""}`}>
-                    <span className="se-color-badge se-color-badge--aka">AKA</span>{foulA && <span className="msb-hansoku" data-testid="foul-mark-a"> {foulA}</span>}
+                    <span className="se-color-badge se-color-badge--aka">AKA</span>
                     <div className="name">{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</div>
                     <div className="dojo">{m.sideA?.dojo}</div>
                   </div>

--- a/web-mobile/js/admin_schedule_score_editor.jsx
+++ b/web-mobile/js/admin_schedule_score_editor.jsx
@@ -176,9 +176,11 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
               <ScoreEditCourtBtn m={m} courts={tournament.courts || []} onMoveCourt={onMoveCourt} />
               <div className="score-edit-row__sides">
                   <div className={`score-edit-row__side ${bWin ? "score-edit-row__side--win" : ""}`} style={{ textAlign: "right" }}>
-                    <div className="name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{m.sideB?.name}{foulB && <span className="msb-hansoku" data-testid="foul-mark-b"> {foulB}</span>}</div>
+                    <div className="name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{m.sideB?.name}</div>
                     <div className="dojo">{m.sideB?.dojo}</div>
-                    <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
+                    {/* Foul ▲ rides the badge line, NOT the name line — keeping it off
+                        the name means a mid-bout foul never shifts the competitor's name. */}
+                    <span className="se-color-badge se-color-badge--shiro">SHIRO</span>{foulB && <span className="msb-hansoku" data-testid="foul-mark-b"> {foulB}</span>}
                   </div>
                   <div className="score-edit-row__score">
                     {showScore && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
@@ -188,8 +190,8 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
                         redundant "● NOW" label (the highlight already says "now"). */}
                   </div>
                   <div className={`score-edit-row__side ${aWin ? "score-edit-row__side--win" : ""}`}>
-                    <span className="se-color-badge se-color-badge--aka">AKA</span>
-                    <div className="name">{foulA && <span className="msb-hansoku" data-testid="foul-mark-a">{foulA} </span>}{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</div>
+                    <span className="se-color-badge se-color-badge--aka">AKA</span>{foulA && <span className="msb-hansoku" data-testid="foul-mark-a"> {foulA}</span>}
+                    <div className="name">{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</div>
                     <div className="dojo">{m.sideA?.dojo}</div>
                   </div>
               </div>

--- a/web-mobile/js/admin_schedule_score_editor.jsx
+++ b/web-mobile/js/admin_schedule_score_editor.jsx
@@ -3,6 +3,7 @@
 
 import { allMatchesCompleted } from './admin_schedule_utils.jsx';
 import { MatchLineupPanel } from './admin_schedule_lineup.jsx';
+import { boutHansokuMark } from './match_scoreboard.jsx';
 
 const { useState: useStateA, useMemo: useMemoA, useEffect: useEffectA, useRef: useRefA } = React;
 
@@ -158,6 +159,14 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
           // Go's formatScore doesn't get split into bogus ippon letters.
           const seIpponsA = m.ipponsA || window.ipponsFromScore(m.scoreA);
           const seIpponsB = m.ipponsB || window.ipponsFromScore(m.scoreB);
+          // Outstanding single hansoku → red ▲ next to the offending side (same
+          // mark as the scoresheet). hansoku may live on the match or under
+          // score.fouls depending on the source; fall back across both.
+          const foulB = boutHansokuMark(m.hansokuB ?? m.score?.fouls?.b ?? 0);
+          const foulA = boutHansokuMark(m.hansokuA ?? m.score?.fouls?.a ?? 0);
+          // Show the live ippon score for a running bout too (not just completed)
+          // so the list reflects scoring in progress; "vs" only before it starts.
+          const showScore = m.status === "completed" || m.status === "running";
           return (
             <div key={`${m.compId}:${m.id}`} className={`score-edit-row ${m.status === "running" ? "score-edit-row--running is-running" : ""} ${m.status === "completed" ? "score-edit-row--complete" : ""}`}>
               <div>
@@ -167,25 +176,26 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
               <ScoreEditCourtBtn m={m} courts={tournament.courts || []} onMoveCourt={onMoveCourt} />
               <div className="score-edit-row__sides">
                   <div className={`score-edit-row__side ${bWin ? "score-edit-row__side--win" : ""}`} style={{ textAlign: "right" }}>
-                    <div className="name">{m.sideB?.name}</div>
+                    <div className="name">{m.sideB?.name}{foulB && <span className="msb-hansoku" data-testid="foul-mark-b"> {foulB}</span>}</div>
                     <div className="dojo">{m.sideB?.dojo}</div>
                     <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
                   </div>
                   <div className="score-edit-row__score">
-                    {m.status === "completed" && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
+                    {showScore && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
                     {m.status === "scheduled" && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>}
-                    {/* Running rows rely on the score-edit-row--running row highlight (accent
-                        border + background tint) — no centre dot needed here. The right-column
-                        "● NOW" label (below) is the operator's status cue for running bouts. */}
+                    {/* Running rows show the live ippon score above and are signalled by the
+                        score-edit-row--running / is-running row highlight — no centre dot, no
+                        redundant "● NOW" label (the highlight already says "now"). */}
                   </div>
                   <div className={`score-edit-row__side ${aWin ? "score-edit-row__side--win" : ""}`}>
                     <span className="se-color-badge se-color-badge--aka">AKA</span>
-                    <div className="name">{m.sideA?.name}</div>
+                    <div className="name">{foulA && <span className="msb-hansoku" data-testid="foul-mark-a">{foulA} </span>}{m.sideA?.name}</div>
                     <div className="dojo">{m.sideA?.dojo}</div>
                   </div>
               </div>
               <div>
-                {m.status === "running" && <span className="bc-running">● NOW</span>}
+                {/* Running: no "● NOW" label — the row highlight is the signal (removed as
+                    redundant). Completed keeps its Final / Corrected status. */}
                 {m.status === "completed" && <span style={{ fontSize: 10, color: "var(--ink-3)" }}>{isCorrection ? "Corrected" : "Final"}</span>}
               </div>
               <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/web-mobile/js/admin_schedule_score_editor.jsx
+++ b/web-mobile/js/admin_schedule_score_editor.jsx
@@ -176,7 +176,7 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
               <ScoreEditCourtBtn m={m} courts={tournament.courts || []} onMoveCourt={onMoveCourt} />
               <div className="score-edit-row__sides">
                   <div className={`score-edit-row__side ${bWin ? "score-edit-row__side--win" : ""}`} style={{ textAlign: "right" }}>
-                    <div className="name">{m.sideB?.name}{foulB && <span className="msb-hansoku" data-testid="foul-mark-b"> {foulB}</span>}</div>
+                    <div className="name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{m.sideB?.name}{foulB && <span className="msb-hansoku" data-testid="foul-mark-b"> {foulB}</span>}</div>
                     <div className="dojo">{m.sideB?.dojo}</div>
                     <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
                   </div>
@@ -189,7 +189,7 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
                   </div>
                   <div className={`score-edit-row__side ${aWin ? "score-edit-row__side--win" : ""}`}>
                     <span className="se-color-badge se-color-badge--aka">AKA</span>
-                    <div className="name">{foulA && <span className="msb-hansoku" data-testid="foul-mark-a">{foulA} </span>}{m.sideA?.name}</div>
+                    <div className="name">{foulA && <span className="msb-hansoku" data-testid="foul-mark-a">{foulA} </span>}{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</div>
                     <div className="dojo">{m.sideA?.dojo}</div>
                   </div>
               </div>

--- a/web-mobile/js/admin_schedule_score_editor.jsx
+++ b/web-mobile/js/admin_schedule_score_editor.jsx
@@ -167,6 +167,10 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
           // Show the live ippon score for a running bout too (not just completed)
           // so the list reflects scoring in progress; "vs" only before it starts.
           const showScore = m.status === "completed" || m.status === "running";
+          // A just-started running bout is 0–0, where formatIpponsScore returns "".
+          // Fall back so the cell is never blank: running 0–0 → "vs", a completed
+          // match with no recorded score → "—". Live techniques show once present.
+          const seScore = showScore ? window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei) : "";
           return (
             <div key={`${m.compId}:${m.id}`} className={`score-edit-row ${m.status === "running" ? "score-edit-row--running is-running" : ""} ${m.status === "completed" ? "score-edit-row--complete" : ""}`}>
               <div>
@@ -186,8 +190,9 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
                   <div className="score-edit-row__score">
                     <span className="score-edit-row__foul">{foulB && <span className="msb-hansoku" data-testid="foul-mark-b">{foulB}</span>}</span>
                     <span className="score-edit-row__scoreval">
-                      {showScore && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
-                      {m.status === "scheduled" && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>}
+                      {m.status === "scheduled"
+                        ? <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>
+                        : (seScore || <span style={{ fontSize: 11, color: "var(--ink-3)" }}>{m.status === "running" ? "vs" : "—"}</span>)}
                     </span>
                     <span className="score-edit-row__foul">{foulA && <span className="msb-hansoku" data-testid="foul-mark-a">{foulA}</span>}</span>
                   </div>

--- a/web-mobile/js/admin_schedule_score_editor.jsx
+++ b/web-mobile/js/admin_schedule_score_editor.jsx
@@ -159,7 +159,7 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
           const seIpponsA = m.ipponsA || window.ipponsFromScore(m.scoreA);
           const seIpponsB = m.ipponsB || window.ipponsFromScore(m.scoreB);
           return (
-            <div key={`${m.compId}:${m.id}`} className={`score-edit-row ${m.status === "running" ? "score-edit-row--running" : ""} ${m.status === "completed" ? "score-edit-row--complete" : ""}`}>
+            <div key={`${m.compId}:${m.id}`} className={`score-edit-row ${m.status === "running" ? "score-edit-row--running is-running" : ""} ${m.status === "completed" ? "score-edit-row--complete" : ""}`}>
               <div>
                 <div className="score-edit-row__time">{m.scheduledAt || "—"}</div>
                 <div style={{ fontSize: 10, color: "var(--ink-3)", marginTop: 2 }}>{m.compName}</div>
@@ -173,8 +173,10 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
                   </div>
                   <div className="score-edit-row__score">
                     {m.status === "completed" && window.formatIpponsScore(seIpponsB, seIpponsA, m.score, m.decision, m.encho, m.decidedByHantei)}
-                    {m.status === "running" && <span className="bc-running">●</span>}
                     {m.status === "scheduled" && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>}
+                    {/* Running rows rely on the score-edit-row--running row highlight (accent
+                        border + background tint) — no centre dot needed here. The right-column
+                        "● NOW" label (below) is the operator's status cue for running bouts. */}
                   </div>
                   <div className={`score-edit-row__side ${aWin ? "score-edit-row__side--win" : ""}`}>
                     <span className="se-color-badge se-color-badge--aka">AKA</span>
@@ -291,6 +293,18 @@ export function AdminScoreEditor({ t, c, onEditScore, onMoveCourt, restrictToCom
                   } catch (_startErr) { /* gate rejected the start; stay on the next match in pre-match */ }
                 }
               } catch (_err) { /* keep modal open on error */ }
+            } : null}
+            onAfterDecision={nextActiveMatch ? async () => {
+              // A kiken/fusenpai decision already persisted the bout via the
+              // /decision POST — no score PUT here. Mirror onSubmitAndNext's
+              // start-next so a fusenpai advances the operator to (and starts)
+              // the next same-court match.
+              if (nextActiveMatch.status === "scheduled") {
+                try {
+                  await onEditScore(nextActiveMatch.compId, nextActiveMatch.id, startPatch(), nextActiveMatch);
+                  if (mountedRef.current) setOpenMatch(nextActiveMatch);
+                } catch (_startErr) { /* gate rejected the start; leave the operator where they are */ }
+              }
             } : null}
             password={password}
           />

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -32,7 +32,7 @@ import { SyncStatusPill, useDebouncedRunningWrite } from './admin_scoring_autosa
 
 import { TeamScoreEditorModal } from './admin_scoring_team.jsx';
 
-export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, prevMatch, nextMatch, onPrev, onNext, password, selfReport, variant = "modal", canClose = true }) {
+export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, onAfterDecision, prevMatch, nextMatch, onPrev, onNext, password, selfReport, variant = "modal", canClose = true }) {
   const m = match;
   const isComplete = m.status === "completed";
   // Canonical team check (matches admin_pools.jsx and the lineup panel):
@@ -42,7 +42,7 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, pr
   // correctly stay on the individual editor.
   const isTeam = m.compKind === "team" || (m.teamSize || 0) > 0;
   const teamSize = m.teamSize || 5;
-  if (isTeam) return <TeamScoreEditorModal match={m} teamSize={teamSize} onClose={onClose} onSubmit={onSubmit} onSubmitAndNext={onSubmitAndNext} prevMatch={prevMatch} nextMatch={nextMatch} onPrev={onPrev} onNext={onNext} password={password} selfReport={selfReport} variant={variant} canClose={canClose} />;
+  if (isTeam) return <TeamScoreEditorModal match={m} teamSize={teamSize} onClose={onClose} onSubmit={onSubmit} onSubmitAndNext={onSubmitAndNext} onAfterDecision={onAfterDecision} prevMatch={prevMatch} nextMatch={nextMatch} onPrev={onPrev} onNext={onNext} password={password} selfReport={selfReport} variant={variant} canClose={canClose} />;
 
   const seedAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
   const seedBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
@@ -143,10 +143,15 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, pr
   //   operator to confirm and re-send with force=true.
   // Shared factory (admin_scoring_shared.jsx) — the individual + team modals had
   // byte-identical copies; "competitors" is the only per-modal wording.
+  // Item 7: a non-kiken decision (fusenpai) routes through onAfterDecision when
+  // the host page provides it (and this isn't a correction) so the court
+  // advances to the next match — mirroring the Finish + Start Next flow. Hantei
+  // advance is handled separately in submitHantei below. Kiken keeps the modal
+  // open for RemainingMatchesPanel regardless.
   const submitDecision = makeSubmitDecision({
     match: m, enchoPeriodCount, password, mountedRef,
     setDecisionSubmitting, setDecisionErr, setWithdrawnPlayer, setDecisionPromptKind,
-    onClose, entityLabel: "competitors",
+    onClose, onAfterDecision, isComplete, entityLabel: "competitors",
   });
 
   // Hansoku Hs are now physically present in the opponent's pts array
@@ -222,11 +227,15 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, pr
   // viewer/Excel renderers display under the hantei suffix), and the
   // decidedByHantei flag set. This is a dedicated affordance because the
   // regular flow assumes an ippon-derived win.
+  //
+  // Item 7: mirror the Finish button's isComplete ? onSubmit : onSubmitAndNext
+  // choice so a hantei finish also advances to the next match on the same
+  // court (when onSubmitAndNext is available and this isn't a correction).
   const submitHantei = (winnerSide) => {
     const winner = winnerSide === "a" ? m.sideA : m.sideB;
     const aFinal = aPts.filter(x => x !== "•").slice(0, MAX_IPPONS_PER_SIDE);
     const bFinal = bPts.filter(x => x !== "•").slice(0, MAX_IPPONS_PER_SIDE);
-    return doSubmit(() => onSubmit({
+    const patch = {
       winner,
       ipponsA: aFinal,
       ipponsB: bFinal,
@@ -235,7 +244,9 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, pr
       status: "completed",
       ...enchoBlock(),
       decidedByHantei: true,
-    }));
+    };
+    const submitFn = (!isComplete && onSubmitAndNext) ? onSubmitAndNext : onSubmit;
+    return doSubmit(() => submitFn(patch));
   };
 
   const doSubmit = async (fn) => {

--- a/web-mobile/js/admin_scoring_shared.jsx
+++ b/web-mobile/js/admin_scoring_shared.jsx
@@ -260,7 +260,12 @@ function submitDecisionRequest(compId, matchId, kind, decisionPayload, enchoPeri
 // copies of this (the only difference was the "competitors"/"teams" wording in
 // the decision_locked confirm), so it lives here once. The returned closure:
 //   - POSTs the decision, then on a kiken result resolves the loser side and
-//     opens the withdrawn-player panel; other kinds close the modal;
+//     opens the withdrawn-player panel for default-win chaining (kiken keeps
+//     the modal open — DO NOT route kiken through onAfterDecision, the
+//     operator must work through RemainingMatchesPanel first);
+//   - for fusenpai / other non-kiken decisions: calls onAfterDecision when
+//     provided and the match is not a correction (item 7: starts next match),
+//     else falls back to onClose;
 //   - on 409 decision_locked / max_encho_exceeded, confirms then retries with
 //     force (recursing into itself).
 // Call it fresh each render so it captures the current enchoPeriodCount/password.
@@ -274,6 +279,12 @@ function makeSubmitDecision({
   setWithdrawnPlayer,
   setDecisionPromptKind,
   onClose,
+  // item 7: optional zero-arg callback invoked after a non-kiken decision
+  // succeeds and the match is not a correction. The shiaijo page wires this
+  // to startMatch(next) so the operator advances without an extra tap.
+  // Kiken always keeps the modal open for RemainingMatchesPanel chaining.
+  onAfterDecision,
+  isComplete,       // item 7: corrections (isComplete=true) must not auto-advance
   entityLabel = 'competitors',
 }) {
   const submit = async (kind, { decisionBy, decisionReason }, opts = {}) => {
@@ -285,9 +296,9 @@ function makeSubmitDecision({
       );
       if (!mountedRef.current) return;
       if (window.isKikenDecision(kind)) {
-        // The loser is the side != Winner. SideA/SideB on MatchResult are names;
-        // resolve back to the normalized {id,name} via the original match for the
-        // remaining-matches lookup.
+        // Kiken keeps the modal open so the operator can walk through
+        // RemainingMatchesPanel and award default wins to each remaining
+        // scheduled match for the withdrawn player. Do NOT advance yet.
         const winnerName = (updated?.winner || '').trim();
         const loserName = winnerName === (updated?.sideA || '') ? (updated?.sideB || '') : (updated?.sideA || '');
         const loser =
@@ -296,6 +307,11 @@ function makeSubmitDecision({
           { id: '', name: loserName };
         setWithdrawnPlayer(loser);
         setDecisionPromptKind('');
+      } else if (!isComplete && onAfterDecision) {
+        // Item 7: fusenpai (and any future non-kiken decision) advances to the
+        // next match on the same court. The decision was already persisted via
+        // /decision POST so we do NOT issue another score PUT — just advance.
+        await onAfterDecision();
       } else {
         onClose();
       }

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -137,7 +137,7 @@ export function subBoutHasBeenPlayed(s) {
   return (s.aPts?.length > 0) || (s.bPts?.length > 0) || (s.aFouls > 0) || (s.bFouls > 0) || !!s.fusensho || !!s.draw;
 }
 
-export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndNext, prevMatch, nextMatch, onPrev, onNext, password, selfReport, variant = "modal", canClose = true }) {
+export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSubmitAndNext, onAfterDecision, prevMatch, nextMatch, onPrev, onNext, password, selfReport, variant = "modal", canClose = true }) {
   const m = match;
   const isComplete = m.status === "completed";
   // Kachinuki appends bouts beyond teamSize (engine assigns Position =
@@ -391,10 +391,12 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
 
   // Shared factory (admin_scoring_shared.jsx) — same handler as ScoreEditorModal;
   // "teams" is the only per-modal wording (in the decision_locked confirm).
+  // Item 7: fusenpai routes through onAfterDecision (host-supplied) to advance
+  // the court, same as ScoreEditorModal. Kiken keeps the modal open regardless.
   const submitDecision = makeSubmitDecision({
     match: m, enchoPeriodCount, password, mountedRef,
     setDecisionSubmitting, setDecisionErr, setWithdrawnPlayer, setDecisionPromptKind,
-    onClose, entityLabel: "teams",
+    onClose, onAfterDecision, isComplete, entityLabel: "teams",
   });
 
   const existingSub = m.subResults || [];

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -226,16 +226,24 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         }
     };
 
-    // scoringStarted — has the current running bout had any score entered? Used
-    // by pickMatch to decide whether switching away is safe. A bout with ippons
-    // or points already recorded must be finished or corrected before the
-    // operator can move to another match (you can't abandon a half-scored bout).
-    const scoringStarted = (mm) => !!mm && mm.status === "running" && (
-        (mm.ipponsA?.length || 0) > 0 ||
-        (mm.ipponsB?.length || 0) > 0 ||
-        (mm.score?.winnerPts || 0) > 0 ||
-        (mm.score?.loserPts || 0) > 0
-    );
+    // scoringStarted — has the current running bout had ANY score entered? Used
+    // by pickMatch to decide whether switching away is safe: a bout with any
+    // entered state must be finished or corrected first (you can't abandon a
+    // half-scored bout, and the defer/un-start path would discard it).
+    // Counts real ippons (ignoring "•" placeholder slots), points, FOULS
+    // (hansoku — top-level or score.fouls), and team sub-bout results, so a
+    // lone foul or a scored team sub-bout also locks the switch.
+    const scoringStarted = (mm) => {
+        if (!mm || mm.status !== "running") return false;
+        const realIppons = (arr) => (arr || []).filter((x) => x && x !== "•").length;
+        const fouls = (mm.hansokuA || 0) + (mm.hansokuB || 0) + (mm.score?.fouls?.a || 0) + (mm.score?.fouls?.b || 0);
+        return realIppons(mm.ipponsA) > 0 ||
+            realIppons(mm.ipponsB) > 0 ||
+            (mm.score?.winnerPts || 0) > 0 ||
+            (mm.score?.loserPts || 0) > 0 ||
+            fouls > 0 ||
+            (mm.subResults?.length || 0) > 0;
+    };
 
     // pickMatch — run an upcoming match out of order. Rules:
     //   • Completed matches are never picked (correct them in the comp admin).
@@ -261,8 +269,12 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
             // pick below would leave the court with two running bouts. The shape
             // mirrors buildPatch("scheduled") in the scoring modal. If the
             // defer write fails (surfaced via toast) we must NOT start the pick.
+            // Reset to scheduled. scoringStarted (above) guarantees this bout has
+            // no entered state, but clear every scoring field — ippons, fouls AND
+            // team subResults — so no partially-entered data can be stranded on the
+            // now-scheduled match.
             try {
-                await onEditScore(cur.compId, cur.id, { status: "scheduled", winner: null, score: null, ipponsA: [], ipponsB: [], hansokuA: 0, hansokuB: 0 }, cur);
+                await onEditScore(cur.compId, cur.id, { status: "scheduled", winner: null, score: null, ipponsA: [], ipponsB: [], hansokuA: 0, hansokuB: 0, subResults: [] }, cur);
             } catch (_e) {
                 return;
             }
@@ -299,8 +311,13 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 
     // moveMatch — reorder by swapping scheduledAt with the adjacent row.
     // direction: "up" (earlier) or "down" (later). Only scheduled matches
-    // can be reordered; running/completed are stable. Two updateMatchTime
-    // calls keep both rows' times consistent (persisted + broadcast).
+    // can be reordered; running/completed are stable.
+    //
+    // The swap is two separate updateMatchTime PUTs (no server-side swap API),
+    // so it is NOT atomic. If the second PUT fails we best-effort roll the first
+    // one back to its original time, so a partial failure doesn't leave both rows
+    // with the same/incorrect time. Times are sent as strings ("" for an unset
+    // time) — never null, which the Go handler's `scheduledAt string` rejects (400).
     const moveMatch = async (m, direction) => {
         if (!window.API || typeof window.API.updateMatchTime !== "function") return;
         if (m.status === "running" || m.status === "completed") return;
@@ -309,15 +326,20 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         const neighbour = direction === "up" ? scheduled[idx - 1] : scheduled[idx + 1];
         if (!neighbour) return; // already first/last
         const label = (m.sideB && m.sideB.name) || (m.sideA && m.sideA.name) || "Match";
-        const myTime = m.scheduledAt || null;
-        const neighbourTime = neighbour.scheduledAt || null;
+        const myTime = m.scheduledAt || "";
+        const neighbourTime = neighbour.scheduledAt || "";
+        let firstDone = false;
         try {
-            // Swap the two times atomically (sequential; second call only runs
-            // if first succeeds so state is never corrupted on partial failure).
             await window.API.updateMatchTime(m.compId, m.id, neighbourTime, password);
+            firstDone = true;
             await window.API.updateMatchTime(neighbour.compId, neighbour.id, myTime, password);
             if (showToast) showToast(`Moved ${label} ${direction === "up" ? "earlier" : "later"} in the queue`);
         } catch (e) {
+            // Roll back the first swap so the queue isn't left half-swapped.
+            if (firstDone) {
+                try { await window.API.updateMatchTime(m.compId, m.id, myTime, password); }
+                catch (_rb) { /* rollback also failed; the error toast below still fires */ }
+            }
             if (showToast) showToast((e && e.message) || "Could not reorder the match", "error");
         }
     };

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -53,6 +53,11 @@ export function partitionShiaijoMatches(matches) {
 
 const matchKey = (m) => `${m.compId}:${m.id}`;
 
+// How many of the most-recent completed bouts the Completed section shows
+// before the "Show all N" toggle. Keeps the live queue + standings above the
+// fold on a full-day court without hiding the recent record.
+const COMPLETED_PREVIEW = 8;
+
 // A team encounter (vs an individual bout) — team matches carry a lineup the
 // operator can set before the bout starts. Exported for unit tests (it gates
 // the "Enter lineup" affordance).
@@ -104,6 +109,11 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     const [startingKey, setStartingKey] = useStateSh(null);
     const [startError, setStartError] = useStateSh("");
     const [contextOpen, setContextOpen] = useStateSh(true);
+    // Completed list stays expanded (it's the operator's running record), but a
+    // full-day court accumulates many bouts that would bury the live queue on
+    // mobile. Show the most recent COMPLETED_PREVIEW by default; the rest fold
+    // behind an inline "Show all N" toggle. The recent ones are never hidden.
+    const [showAllCompleted, setShowAllCompleted] = useStateSh(false);
     // The match the operator has explicitly picked to score from the queue.
     // null = follow the running bout (running[0]). A picked match drives the
     // scoring panel instead; the find() in pickedMatch guards staleness, so a
@@ -449,14 +459,31 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                 <div className="shiaijo-completed">
                                     {/* Completed matches stay expanded — this is the operator's
                                         running record of what's been played on this court/pool today,
-                                        so it must not be hidden behind a collapse toggle. */}
+                                        so it must not be hidden behind a collapse toggle. To keep the
+                                        live queue above the fold on a full day, only the most recent
+                                        COMPLETED_PREVIEW show by default; "Show all N" reveals the rest.
+                                        completed is sorted ascending, so the most recent are the tail. */}
                                     <div className="section-title">
                                         Completed <span className="shiaijo-count" aria-label={`${completed.length} matches`}>{completed.length}</span>
                                     </div>
                                     <ShiaijoQueueGroup
-                                        matches={completed}
+                                        matches={(showAllCompleted || completed.length <= COMPLETED_PREVIEW)
+                                            ? completed
+                                            : completed.slice(-COMPLETED_PREVIEW)}
                                         courts={courts} onMoveCourt={requestMoveCourt}
                                     />
+                                    {completed.length > COMPLETED_PREVIEW && (
+                                        <button
+                                            type="button"
+                                            className="linklike shiaijo-completed__more"
+                                            aria-expanded={showAllCompleted}
+                                            onClick={() => setShowAllCompleted((v) => !v)}
+                                        >
+                                            {showAllCompleted
+                                                ? "Show fewer"
+                                                : `Show all ${completed.length}`}
+                                        </button>
+                                    )}
                                 </div>
                             )}
                         </div>

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -58,25 +58,9 @@ const matchKey = (m) => `${m.compId}:${m.id}`;
 // the "Enter lineup" affordance).
 export const isTeamMatch = (m) => !!m && (m.compKind === "team" || (m.teamSize || 0) > 0);
 
-// addMinuteHHMM — bump an "HH:MM" clock string by one minute, wrapping past
-// midnight. Used to slot a deferred match one tick after its successor.
-export function addMinuteHHMM(t) {
-    const m = /^(\d{1,2}):(\d{2})$/.exec(t || "");
-    if (!m) return null;
-    const total = (Number(m[1]) * 60 + Number(m[2]) + 1) % (24 * 60);
-    return `${String(Math.floor(total / 60)).padStart(2, "0")}:${String(total % 60).padStart(2, "0")}`;
-}
-
-// deferTimeFor — "Defer" means run the next match, then come right back: move
-// this match down exactly one slot in the court's scheduled queue. We place it
-// one minute after its immediate successor (only this match's time changes; the
-// next match keeps its advertised slot). Returns the new "HH:MM", or null when
-// there's no successor (already last) or the successor has no usable time.
-export function deferTimeFor(m, scheduled) {
-    const i = (scheduled || []).findIndex((x) => matchKey(x) === matchKey(m));
-    if (i < 0 || i >= scheduled.length - 1) return null;
-    return addMinuteHHMM(scheduled[i + 1].scheduledAt);
-}
+// (addMinuteHHMM and deferTimeFor removed — queue reordering now works by
+// swapping scheduledAt between adjacent rows via moveMatch, which calls
+// updateMatchTime for both the moved match and its neighbour.)
 
 // shiaijoScoreCell — decide what the queue row's middle score column shows.
 // Exported so the team-vs-individual routing is unit-testable. A team
@@ -119,8 +103,12 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     const [callingKey, setCallingKey] = useStateSh(null);
     const [startingKey, setStartingKey] = useStateSh(null);
     const [startError, setStartError] = useStateSh("");
-    const [completedOpen, setCompletedOpen] = useStateSh(false);
     const [contextOpen, setContextOpen] = useStateSh(true);
+    // The match the operator has explicitly picked to score from the queue.
+    // null = follow the running bout (running[0]). A picked match drives the
+    // scoring panel instead; the find() in pickedMatch guards staleness, so a
+    // pick that completes or vanishes falls back to running[0] automatically.
+    const [pickedKey, setPickedKey] = useStateSh(null);
     // Pending court reassignment, awaiting operator confirmation. Moving a match
     // off this shiaijo is disruptive (it leaves the court and joins another's
     // queue), so it's gated behind a confirm step. {compId, matchId, to, label, from}.
@@ -148,11 +136,21 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     const courts = tournament.courts || [];
     const courtKnown = courts.includes(court);
 
-    // The scoring panel always shows the running (NOW) match being officiated
-    // on this court — nothing else. You start the next match from the Up Next
-    // card, and fixing a finished score is done in the competition's own admin
-    // view, so the console never opens an upcoming or completed match here.
-    const selectedMatch = useMemoSh(() => running[0] || null, [running]);
+    // The scoring panel shows the match the operator is officiating. By default
+    // that's the running (NOW) bout, but the operator may pick any upcoming
+    // match to run out of order via its "Score" button (pickMatch). Picking is
+    // governed by two rules in pickMatch: it is BLOCKED while the current bout
+    // has scoring in progress (you must finish or correct it first), and an
+    // unscored current bout is DEFERRED one slot before the new pick starts.
+    // A completed pick (or one that disappears) falls back to running[0]: the
+    // find() filters out completed matches and the `pickedMatch || running[0]`
+    // expression covers the null case. Fixing a finished score is still done
+    // in the competition's own admin view, so completed matches aren't picked.
+    const pickedMatch = useMemoSh(
+        () => pickedKey ? sorted.find((x) => matchKey(x) === pickedKey && x.status !== "completed") || null : null,
+        [pickedKey, sorted]
+    );
+    const selectedMatch = useMemoSh(() => pickedMatch || running[0] || null, [pickedMatch, running]);
 
     // The standings/context panel follows the court's current focus — not
     // strictly the running match — so it stays visible (and updates) after a
@@ -197,20 +195,74 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         return window.startPatch();
     };
 
+    // Returns true when the start write succeeded, false otherwise — pickMatch
+    // relies on this so it only pins pickedKey for a match that actually started
+    // (a blocked-by-eligibility start must not steal the panel).
     const startMatch = async (m) => {
-        if (startingKey) return;
+        if (startingKey) return false;
         setStartError("");
         setStartingKey(matchKey(m));
         try {
             // Starting makes the match running; the scoring panel shows
             // running[0], so it picks the match up on the next refetch.
             await onEditScore(m.compId, m.id, startPatch(), m);
+            return true;
         } catch (e) {
             if (mountedRef.current) setStartError((e && e.message) || "Could not start the match — check eligibility and try again.");
             if (showToast) showToast((e && e.message) || "Could not start the match", "error");
+            return false;
         } finally {
             if (mountedRef.current) setStartingKey(null);
         }
+    };
+
+    // scoringStarted — has the current running bout had any score entered? Used
+    // by pickMatch to decide whether switching away is safe. A bout with ippons
+    // or points already recorded must be finished or corrected before the
+    // operator can move to another match (you can't abandon a half-scored bout).
+    const scoringStarted = (mm) => !!mm && mm.status === "running" && (
+        (mm.ipponsA?.length || 0) > 0 ||
+        (mm.ipponsB?.length || 0) > 0 ||
+        (mm.score?.winnerPts || 0) > 0 ||
+        (mm.score?.loserPts || 0) > 0
+    );
+
+    // pickMatch — run an upcoming match out of order. Rules:
+    //   • Completed matches are never picked (correct them in the comp admin).
+    //   • If a DIFFERENT bout is running with scoring already started, block —
+    //     finish or correct it first (can't abandon a half-scored bout).
+    //   • If a DIFFERENT bout is running but unscored, defer it: un-start it
+    //     (back to scheduled) so the court is never left with two running bouts.
+    //     The deferred bout returns to the queue and runs after the picked one.
+    //   • A scheduled pick is started (through the eligibility gate); a pick
+    //     that's already running just takes the panel.
+    const pickMatch = async (m) => {
+        if (!m || m.status === "completed") return;
+        const cur = running[0] || null;
+        const isSame = cur && matchKey(cur) === matchKey(m);
+        if (cur && !isSame) {
+            if (scoringStarted(cur)) {
+                if (showToast) showToast("Finish or correct the bout in progress first", "error");
+                return;
+            }
+            // Unscored current bout: un-start it back to scheduled. moveMatch
+            // only reorders scheduled rows (it no-ops on a running bout), so a
+            // real defer here means clearing the running status — otherwise the
+            // pick below would leave the court with two running bouts. The shape
+            // mirrors buildPatch("scheduled") in the scoring modal. If the
+            // defer write fails (surfaced via toast) we must NOT start the pick.
+            try {
+                await onEditScore(cur.compId, cur.id, { status: "scheduled", winner: null, score: null, ipponsA: [], ipponsB: [], hansokuA: 0, hansokuB: 0 }, cur);
+            } catch (_e) {
+                return;
+            }
+            if (!mountedRef.current) return;
+        }
+        if (m.status === "scheduled") {
+            const ok = await startMatch(m);
+            if (!ok || !mountedRef.current) return;
+        }
+        setPickedKey(matchKey(m));
     };
 
     // Call to court — optional. Broadcasts a tournament announcement so the
@@ -235,25 +287,28 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         }
     };
 
-    // Defer — run the next match, then come right back: move this match down one
-    // slot (its time is set one minute after its successor; backend
-    // updateMatchTime, persisted + broadcast). No-op on running/completed, or
-    // when it's already last in the queue. The match stays in Upcoming and
-    // returns to Up Next as soon as the one match ahead of it finishes.
-    const skipMatch = async (m) => {
+    // moveMatch — reorder by swapping scheduledAt with the adjacent row.
+    // direction: "up" (earlier) or "down" (later). Only scheduled matches
+    // can be reordered; running/completed are stable. Two updateMatchTime
+    // calls keep both rows' times consistent (persisted + broadcast).
+    const moveMatch = async (m, direction) => {
         if (!window.API || typeof window.API.updateMatchTime !== "function") return;
         if (m.status === "running" || m.status === "completed") return;
+        const idx = scheduled.findIndex((x) => matchKey(x) === matchKey(m));
+        if (idx < 0) return;
+        const neighbour = direction === "up" ? scheduled[idx - 1] : scheduled[idx + 1];
+        if (!neighbour) return; // already first/last
         const label = (m.sideB && m.sideB.name) || (m.sideA && m.sideA.name) || "Match";
-        const newTime = deferTimeFor(m, scheduled);
-        if (!newTime) {
-            if (showToast) showToast(`${label} is already last in the queue`);
-            return;
-        }
+        const myTime = m.scheduledAt || null;
+        const neighbourTime = neighbour.scheduledAt || null;
         try {
-            await window.API.updateMatchTime(m.compId, m.id, newTime, password);
-            if (showToast) showToast(`Deferred ${label} — it returns after the next match`);
+            // Swap the two times atomically (sequential; second call only runs
+            // if first succeeds so state is never corrupted on partial failure).
+            await window.API.updateMatchTime(m.compId, m.id, neighbourTime, password);
+            await window.API.updateMatchTime(neighbour.compId, neighbour.id, myTime, password);
+            if (showToast) showToast(`Moved ${label} ${direction === "up" ? "earlier" : "later"} in the queue`);
         } catch (e) {
-            if (showToast) showToast((e && e.message) || "Could not defer the match", "error");
+            if (showToast) showToast((e && e.message) || "Could not reorder the match", "error");
         }
     };
 
@@ -335,7 +390,12 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                         <div className="shiaijo-upnext__time">{upNext.scheduledAt || "—"} · {upNext.compName}</div>
                                         <MatchSides m={upNext} large />
                                         <div className="shiaijo-upnext__actions">
-                                            <button type="button" className="btn btn--primary" disabled={startingKey === matchKey(upNext)} onClick={() => startMatch(upNext)}>
+                                            {/* Route through pickMatch (not startMatch) so starting the
+                                                Up Next bout honours the same lock/defer rules as the
+                                                Upcoming "Score" buttons: blocked while a different bout is
+                                                being scored, and an unscored running bout is deferred first.
+                                                With no running bout it simply starts this one. */}
+                                            <button type="button" className="btn btn--primary" disabled={startingKey === matchKey(upNext)} onClick={() => pickMatch(upNext)}>
                                                 {startingKey === matchKey(upNext) ? "Starting…" : "Start match"}
                                             </button>
                                             {isTeamMatch(upNext) && (
@@ -357,8 +417,8 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                                     {callingKey === matchKey(upNext) ? "Calling…" : (calledKey === matchKey(upNext) ? "Call again" : "Call to court")}
                                                 </button>
                                             )}
-                                            {window.API && typeof window.API.updateMatchTime === "function" && (
-                                                <button type="button" className="btn btn--sm btn--ghost" onClick={() => skipMatch(upNext)} title="Run the next match first, then return here">Defer</button>
+                                            {window.API && typeof window.API.updateMatchTime === "function" && scheduled.length > 1 && (
+                                                <button type="button" className="btn btn--sm btn--ghost" aria-label="Move down" onClick={() => moveMatch(upNext, "down")} title="Move this match later in the queue">↓</button>
                                             )}
                                         </div>
                                         {startError && <div className="shiaijo-upnext__error" role="alert">{startError}</div>}
@@ -379,21 +439,24 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                 <ShiaijoQueueGroup
                                     label="Upcoming" matches={upNext ? scheduled.slice(1) : scheduled}
                                     courts={courts} onMoveCourt={requestMoveCourt}
-                                    onSkip={skipMatch} onEnterLineup={setLineupMatch}
+                                    onMove={moveMatch} onEnterLineup={setLineupMatch}
+                                    onPick={pickMatch}
+                                    scheduled={scheduled}
                                 />
                             )}
 
                             {completed.length > 0 && (
                                 <div className="shiaijo-completed">
-                                    <button type="button" className="section-title shiaijo-completed__toggle" aria-expanded={completedOpen} onClick={() => setCompletedOpen((v) => !v)}>
-                                        {completedOpen ? "−" : "+"} Completed <span className="shiaijo-count" aria-label={`${completed.length} matches`}>{completed.length}</span>
-                                    </button>
-                                    {completedOpen && (
-                                        <ShiaijoQueueGroup
-                                            matches={completed}
-                                            courts={courts} onMoveCourt={requestMoveCourt}
-                                        />
-                                    )}
+                                    {/* Completed matches stay expanded — this is the operator's
+                                        running record of what's been played on this court/pool today,
+                                        so it must not be hidden behind a collapse toggle. */}
+                                    <div className="section-title">
+                                        Completed <span className="shiaijo-count" aria-label={`${completed.length} matches`}>{completed.length}</span>
+                                    </div>
+                                    <ShiaijoQueueGroup
+                                        matches={completed}
+                                        courts={courts} onMoveCourt={requestMoveCourt}
+                                    />
                                 </div>
                             )}
                         </div>
@@ -446,6 +509,15 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                                 try { await onEditScore(next.compId, next.id, startPatch(), next); } catch (_s) { /* gate */ }
                                             }
                                         } catch (_e) { /* keep panel */ }
+                                    }}
+                                    onAfterDecision={async () => {
+                                        // A kiken/fusenpai decision already persisted the bout via
+                                        // the /decision POST — no score PUT here. Just start the next
+                                        // scheduled match so the panel advances (mirrors onSubmitAndNext).
+                                        const next = nextActiveAfter(selectedMatch);
+                                        if (next && next.status === "scheduled") {
+                                            try { await onEditScore(next.compId, next.id, startPatch(), next); } catch (_s) { /* gate */ }
+                                        }
                                     }}
                                     password={password}
                                 />
@@ -518,12 +590,16 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     );
 }
 
-// A queued match row: plain info (the court reassign and Skip controls still
+// A queued match row: plain info (the court reassign and reorder controls
 // work) but the row itself can't be opened in the scoring panel — you start a
 // match from the Up Next card, not by clicking it. The console never shows a
 // running match in these groups (the running bout is officiated in the scoring
 // panel on the right), so only scheduled/completed states render here.
-function ShiaijoQueueGroup({ label, matches, courts, onMoveCourt, onSkip, onEnterLineup }) {
+//
+// `scheduled` is the full court scheduled list (used to derive first/last
+// position for disabling the ↑/↓ buttons). `onMove(m, direction)` swaps
+// scheduledAt with the adjacent row via two updateMatchTime calls.
+function ShiaijoQueueGroup({ label, matches, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick }) {
     return (
         <div className="shiaijo-group">
             {label && <div className="section-title">{label}</div>}
@@ -531,7 +607,8 @@ function ShiaijoQueueGroup({ label, matches, courts, onMoveCourt, onSkip, onEnte
                 {matches.map((m) => (
                     <ShiaijoQueueRow
                         key={matchKey(m)} m={m}
-                        courts={courts} onMoveCourt={onMoveCourt} onSkip={onSkip} onEnterLineup={onEnterLineup}
+                        scheduled={scheduled}
+                        courts={courts} onMoveCourt={onMoveCourt} onMove={onMove} onEnterLineup={onEnterLineup} onPick={onPick}
                     />
                 ))}
             </div>
@@ -539,9 +616,15 @@ function ShiaijoQueueGroup({ label, matches, courts, onMoveCourt, onSkip, onEnte
     );
 }
 
-function ShiaijoQueueRow({ m, courts, onMoveCourt, onSkip, onEnterLineup }) {
+function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick }) {
     const isComplete = m.status === "completed";
     const scoreCell = shiaijoScoreCell(m);
+    // Derive position in the full scheduled list to know when to disable ↑/↓.
+    // `scheduled` is the court's complete scheduled array (including Up Next);
+    // the row may be in the Upcoming slice but we disable based on absolute pos.
+    const scheduledIdx = onMove ? (scheduled || []).findIndex((x) => matchKey(x) === matchKey(m)) : -1;
+    const isFirst = scheduledIdx === 0;
+    const isLast = scheduledIdx >= 0 && scheduledIdx === (scheduled || []).length - 1;
     return (
         <div className={`score-edit-row shiaijo-row shiaijo-row--static ${isComplete ? "score-edit-row--complete" : ""}`}>
             <div>
@@ -550,7 +633,10 @@ function ShiaijoQueueRow({ m, courts, onMoveCourt, onSkip, onEnterLineup }) {
             </div>
             <div className="score-edit-row__sides">
                 <div className="score-edit-row__side" style={{ textAlign: "right" }} aria-label={`Shiro: ${m.sideB?.name || ""}`}>
-                    <div className="name">{m.sideB?.name}</div>
+                    <div className="name">
+                        {m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}
+                        {m.sideB?.name}
+                    </div>
                     <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
                 </div>
                 <div className="score-edit-row__score">
@@ -560,7 +646,10 @@ function ShiaijoQueueRow({ m, courts, onMoveCourt, onSkip, onEnterLineup }) {
                 </div>
                 <div className="score-edit-row__side" aria-label={`Aka: ${m.sideA?.name || ""}`}>
                     <span className="se-color-badge se-color-badge--aka">AKA</span>
-                    <div className="name">{m.sideA?.name}</div>
+                    <div className="name">
+                        {m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}
+                        {m.sideA?.name}
+                    </div>
                 </div>
             </div>
             <div className="shiaijo-row__status">
@@ -577,8 +666,14 @@ function ShiaijoQueueRow({ m, courts, onMoveCourt, onSkip, onEnterLineup }) {
                 {onEnterLineup && isTeamMatch(m) && m.status === "scheduled" && (
                     <button type="button" className="btn btn--ghost btn--sm" onClick={() => onEnterLineup(m)} title="Set the team lineup before starting">Lineup</button>
                 )}
-                {onSkip && m.status === "scheduled" && (
-                    <button type="button" className="btn btn--ghost btn--sm shiaijo-row__skip" onClick={() => onSkip(m)} title="Run the next match first, then return here">Defer</button>
+                {onPick && m.status === "scheduled" && (
+                    <button type="button" className="btn btn--sm shiaijo-row__pick" onClick={() => onPick(m)} title="Run this match now and score it">Score</button>
+                )}
+                {onMove && m.status === "scheduled" && (
+                    <>
+                        <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move up" disabled={isFirst} onClick={() => onMove(m, "up")} title="Move earlier in the queue">↑</button>
+                        <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move down" disabled={isLast} onClick={() => onMove(m, "down")} title="Move later in the queue">↓</button>
+                    </>
                 )}
             </div>
         </div>
@@ -590,13 +685,19 @@ function MatchSides({ m, large }) {
         <div className={`shiaijo-sides ${large ? "shiaijo-sides--lg" : ""}`}>
             <div className="shiaijo-sides__side" aria-label={`Shiro: ${m.sideB?.name || ""}`}>
                 <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
-                <div className="name">{m.sideB?.name}</div>
+                <div className="name">
+                    {m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}
+                    {m.sideB?.name}
+                </div>
                 <div className="dojo">{m.sideB?.dojo}</div>
             </div>
             <div className="shiaijo-sides__vs">vs</div>
             <div className="shiaijo-sides__side" style={{ textAlign: "right" }} aria-label={`Aka: ${m.sideA?.name || ""}`}>
                 <span className="se-color-badge se-color-badge--aka">AKA</span>
-                <div className="name">{m.sideA?.name}</div>
+                <div className="name">
+                    {m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}
+                    {m.sideA?.name}
+                </div>
                 <div className="dojo">{m.sideA?.dojo}</div>
             </div>
         </div>

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -652,57 +652,56 @@ function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLin
     const scheduledIdx = onMove ? (scheduled || []).findIndex((x) => matchKey(x) === matchKey(m)) : -1;
     const isFirst = scheduledIdx === 0;
     const isLast = scheduledIdx >= 0 && scheduledIdx === (scheduled || []).length - 1;
+    // Stacked card layout (not the wide score-editor grid): the matchup gets a
+    // full-width line so names stay READABLE in the narrow queue column; the
+    // controls live on their own line below so they never crowd the names.
+    const showActions = m.status === "scheduled" && (
+        (onMoveCourt && courts.length > 1) ||
+        (onEnterLineup && isTeamMatch(m)) || onPick || onMove
+    );
     return (
-        <div className={`score-edit-row shiaijo-row shiaijo-row--static ${isComplete ? "score-edit-row--complete" : ""}`}>
-            <div>
-                <div className="score-edit-row__time">{m.scheduledAt || "—"}</div>
-                <div className="shiaijo-row__comp">{m.compName}</div>
-            </div>
-            <div className="score-edit-row__sides">
-                <div className="score-edit-row__side" style={{ textAlign: "right" }} aria-label={`Shiro: ${m.sideB?.name || ""}`}>
-                    <div className="name">
-                        {m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}
-                        {m.sideB?.name}
-                    </div>
-                    <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
-                </div>
-                <div className="score-edit-row__score">
+        <div className={`shiaijo-qrow ${isComplete ? "shiaijo-qrow--complete" : ""}`}>
+            <div className="shiaijo-qrow__top">
+                <span className="shiaijo-qrow__time">{m.scheduledAt || "—"} · {m.compName}</span>
+                <span className="shiaijo-qrow__state">
                     {scoreCell.kind === "team" && <span className="shiaijo-row__teamscore"><abbr className="shiaijo-row__iv" title="Individual Victories">IV</abbr>{scoreCell.iv}</span>}
                     {scoreCell.kind === "ippon" && scoreCell.ippon}
-                    {scoreCell.kind === "vs" && <span style={{ fontSize: 11, color: "var(--ink-3)" }}>vs</span>}
+                    {isComplete && <span className="shiaijo-qrow__final">Final</span>}
+                </span>
+            </div>
+            <div className="shiaijo-qrow__match">
+                <div className="shiaijo-qrow__side" aria-label={`Shiro: ${m.sideB?.name || ""}`}>
+                    <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
+                    <span className="shiaijo-qrow__name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{m.sideB?.name}</span>
                 </div>
-                <div className="score-edit-row__side" aria-label={`Aka: ${m.sideA?.name || ""}`}>
+                <span className="shiaijo-qrow__vs">vs</span>
+                <div className="shiaijo-qrow__side shiaijo-qrow__side--aka" aria-label={`Aka: ${m.sideA?.name || ""}`}>
                     <span className="se-color-badge se-color-badge--aka">AKA</span>
-                    <div className="name">
-                        {m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}
-                        {m.sideA?.name}
-                    </div>
+                    <span className="shiaijo-qrow__name">{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</span>
                 </div>
             </div>
-            <div className="shiaijo-row__status">
-                {isComplete && <span style={{ fontSize: 10, color: "var(--ink-3)" }}>Final</span>}
-            </div>
-            <div className="shiaijo-row__actions" onClick={(e) => e.stopPropagation()}>
-                {onMoveCourt && courts.length > 1 && !isComplete && (
-                    <CourtPicker
-                        value={m.court} courts={courts}
-                        onChange={(cc) => onMoveCourt(m.compId, m.id, cc)}
-                        btnClassName="score-edit-row__court score-edit-row__court--btn"
-                    />
-                )}
-                {onEnterLineup && isTeamMatch(m) && m.status === "scheduled" && (
-                    <button type="button" className="btn btn--ghost btn--sm" onClick={() => onEnterLineup(m)} title="Set the team lineup before starting">Lineup</button>
-                )}
-                {onPick && m.status === "scheduled" && (
-                    <button type="button" className="btn btn--sm shiaijo-row__pick" onClick={() => onPick(m)} title="Run this match now and score it">Score</button>
-                )}
-                {onMove && m.status === "scheduled" && (
-                    <>
-                        <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move up" disabled={isFirst} onClick={() => onMove(m, "up")} title="Move earlier in the queue">↑</button>
-                        <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move down" disabled={isLast} onClick={() => onMove(m, "down")} title="Move later in the queue">↓</button>
-                    </>
-                )}
-            </div>
+            {showActions && (
+                <div className="shiaijo-qrow__actions" onClick={(e) => e.stopPropagation()}>
+                    {onMoveCourt && courts.length > 1 && (
+                        <CourtPicker
+                            value={m.court} courts={courts}
+                            onChange={(cc) => onMoveCourt(m.compId, m.id, cc)}
+                            btnClassName="score-edit-row__court score-edit-row__court--btn"
+                        />
+                    )}
+                    {onEnterLineup && isTeamMatch(m) && (
+                        <button type="button" className="btn btn--ghost btn--sm" onClick={() => onEnterLineup(m)} title="Set the team lineup before starting">Lineup</button>
+                    )}
+                    {onMove && (
+                        <>
+                            <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move up" disabled={isFirst} onClick={() => onMove(m, "up")} title="Move earlier in the queue">↑</button>
+                            <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move down" disabled={isLast} onClick={() => onMove(m, "down")} title="Move later in the queue">↓</button>
+                        </>
+                    )}
+                    {/* Score is the primary per-row action — pushed to the end (the "go" slot). */}
+                    {onPick && <button type="button" className="btn btn--primary btn--sm shiaijo-row__pick" onClick={() => onPick(m)} title="Run this match now and score it">Score</button>}
+                </div>
+            )}
         </div>
     );
 }

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -451,6 +451,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                     courts={courts} onMoveCourt={requestMoveCourt}
                                     onMove={moveMatch} onEnterLineup={setLineupMatch}
                                     onPick={pickMatch}
+                                    onCall={callToCourt} callingKey={callingKey} calledKey={calledKey} startingKey={startingKey}
                                     scheduled={scheduled}
                                 />
                             )}
@@ -626,7 +627,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 // `scheduled` is the full court scheduled list (used to derive first/last
 // position for disabling the ↑/↓ buttons). `onMove(m, direction)` swaps
 // scheduledAt with the adjacent row via two updateMatchTime calls.
-function ShiaijoQueueGroup({ label, matches, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick }) {
+function ShiaijoQueueGroup({ label, matches, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCall, callingKey, calledKey, startingKey }) {
     return (
         <div className="shiaijo-group">
             {label && <div className="section-title">{label}</div>}
@@ -636,6 +637,7 @@ function ShiaijoQueueGroup({ label, matches, scheduled, courts, onMoveCourt, onM
                         key={matchKey(m)} m={m}
                         scheduled={scheduled}
                         courts={courts} onMoveCourt={onMoveCourt} onMove={onMove} onEnterLineup={onEnterLineup} onPick={onPick}
+                        onCall={onCall} callingKey={callingKey} calledKey={calledKey} startingKey={startingKey}
                     />
                 ))}
             </div>
@@ -643,7 +645,7 @@ function ShiaijoQueueGroup({ label, matches, scheduled, courts, onMoveCourt, onM
     );
 }
 
-function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick }) {
+function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCall, callingKey, calledKey, startingKey }) {
     const isComplete = m.status === "completed";
     const scoreCell = shiaijoScoreCell(m);
     // Derive position in the full scheduled list to know when to disable ↑/↓.
@@ -698,8 +700,17 @@ function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLin
                             <button type="button" className="btn btn--ghost btn--sm shiaijo-row__move" aria-label="Move down" disabled={isLast} onClick={() => onMove(m, "down")} title="Move later in the queue">↓</button>
                         </>
                     )}
-                    {/* Score is the primary per-row action — pushed to the end (the "go" slot). */}
-                    {onPick && <button type="button" className="btn btn--primary btn--sm shiaijo-row__pick" onClick={() => onPick(m)} title="Run this match now and score it">Score</button>}
+                    {/* Optional announce — mirrors the Up Next card so any queued match is a
+                        complete view: call it to the floor, or start it directly. */}
+                    {onCall && window.API && typeof window.API.sendAnnouncement === "function" && (
+                        <button type="button" className="btn btn--ghost btn--sm" disabled={callingKey === matchKey(m)} onClick={() => onCall(m)} title="Announce this match to spectators and competitors">
+                            {callingKey === matchKey(m) ? "Calling…" : (calledKey === matchKey(m) ? "Call again" : "Call to court")}
+                        </button>
+                    )}
+                    {/* Start match is the primary per-row action — pushed to the end (the "go" slot).
+                        Same pickMatch path as the Up Next card: defers an unscored running bout,
+                        blocks while one is being scored, then starts this match for scoring. */}
+                    {onPick && <button type="button" className="btn btn--primary btn--sm shiaijo-row__pick" disabled={startingKey === matchKey(m)} onClick={() => onPick(m)} title="Start this match now and begin scoring">{startingKey === matchKey(m) ? "Starting…" : "Start match"}</button>}
                 </div>
             )}
         </div>

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -242,6 +242,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
             (mm.score?.winnerPts || 0) > 0 ||
             (mm.score?.loserPts || 0) > 0 ||
             fouls > 0 ||
+            (mm.encho?.periodCount || 0) > 0 ||
             (mm.subResults?.length || 0) > 0;
     };
 

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -104,10 +104,15 @@ function formatIpponsScore(ipponsA, ipponsB, score, decision, encho, decidedByHa
   const bStr = (ipponsB || []).filter(x => x && x !== "•").join("");
   const isDraw = isHikiwakeBC(decision) || isHikiwakeBC(score?.type);
   if (isDraw) {
-    // A hikiwake is always X — scored or not — to match the canonical team
-    // scoresheet (X on the centre line). This is the draw glyph, not the
-    // hansoku marker: fouls render separately as the reserved red triangle.
-    return "X" + suffix;
+    if (!aStr && !bStr) {
+      // Scoreless draw (operator pressed X with no ippons entered) — canonical
+      // hikiwake glyph. This is the draw marker, not the hansoku triangle.
+      return "X" + suffix;
+    }
+    // Scored equal draw (e.g. 1–1 M–K hikiwake): show the actual points so
+    // the operator and viewer see what was struck, not a bare X. The hikiwake
+    // type is still recorded on the server — this is a display-only change.
+    return `${aStr || "·"}–${bStr || "·"}` + suffix;
   }
   if (!aStr && !bStr) {
     // Fall back when the per-side ippon arrays are absent but a score object
@@ -765,14 +770,26 @@ function matchScoreStr(m, ipponsB, ipponsA) {
     || formatIpponsScore(ipponsB, ipponsA, m.score, m.decision, m.encho, m.decidedByHantei);
 }
 
+// matchStateCell — the centre score-cell content for a compact match row, shared
+// so every list renders the SAME lifecycle cue: completed → score string,
+// running → "vs" (the row's .is-running highlight is the "now" signal, NOT a
+// centre dot), scheduled → "–". The labelled "● NOW" badge used in headers/
+// status columns is a separate affordance and is NOT produced here.
+function matchStateCell(m, ipponsB, ipponsA) {
+  if (m.status === "completed") return matchScoreStr(m, ipponsB, ipponsA) || "—";
+  if (m.status === "running") return "vs";
+  return "–";
+}
+
 window.BracketTree = BracketTree;
 window.MatchCard = MatchCard;
 window.roundLabel = roundLabel;
 window.formatIpponsScore = formatIpponsScore;
 window.teamIVScore = teamIVScore;
 window.matchScoreStr = matchScoreStr;
+window.matchStateCell = matchStateCell;
 window.decisionSuffix = decisionSuffix;
 window.sideLabel = sideLabel;
 window.ipponsFromScore = ipponsFromScore;
 
-export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore, matchScoreStr, buildDisplayModel, computeMetaTops };
+export { formatIpponsScore, decisionSuffix, sideLabel, roundLabel, ipponsFromScore, teamIVScore, matchScoreStr, matchStateCell, buildDisplayModel, computeMetaTops };

--- a/web-mobile/js/viewer_schedule.jsx
+++ b/web-mobile/js/viewer_schedule.jsx
@@ -274,7 +274,9 @@ export function TWMatch({ m, highlight, onClick }) {
       <div style={{ textAlign: "right", fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: 13 }}>
         {m.status === "completed" && scoreStr}
         {m.status === "completed" && m.score?.type === "bye" && <span style={{ fontSize: 10, color: "var(--ink-3)" }}>BYE</span>}
-        {m.status === "running" && <span className="bc-running">●</span>}
+        {/* No centre "●" dot: a running match is signalled by the row's
+            .tw-match--running highlight (accent ring). The labelled "● NOW"
+            badge elsewhere is a separate status affordance. */}
       </div>
     </Tag>
   );

--- a/web-mobile/js/viewer_standings.jsx
+++ b/web-mobile/js/viewer_standings.jsx
@@ -163,23 +163,19 @@ export const PoolMatchRow = React.memo(({ m, onClick }) => {
   const aWin = winnerName && winnerName === aRawName;
   const bWin = winnerName && winnerName === bRawName;
 
-  const scoreStr = m.status === "completed"
-    ? window.matchScoreStr(m, m.ipponsB, m.ipponsA)
-    : null;
-
   // Render a non-interactive <div> when there's no click handler (read-only
   // reuse, e.g. the operator console passes onClick=null) so we don't leave a
   // focusable button that does nothing for keyboard/screen-reader users.
   const Tag = onClick ? "button" : "div";
   const interactiveProps = onClick ? { type: "button", onClick } : {};
   return (
-    <Tag className="pool-match-row" {...interactiveProps}>
+    <Tag className={`pool-match-row${m.status === "running" ? " is-running" : ""}`} {...interactiveProps}>
       <div className={`pool-match-row__side pool-match-row__side--right ${bWin ? "pool-match-row__side--win" : ""}`}>
         <span className="pool-match-row__name">{bName}</span>
         <span className="pool-match-row__badge pool-match-row__badge--shiro">SHIRO</span>
       </div>
       <span className="pool-match-row__score">
-        {m.status === "completed" ? (scoreStr || "—") : m.status === "running" ? <span className="bc-running" style={{ fontSize: 10 }}>●</span> : "–"}
+        {window.matchStateCell(m, m.ipponsB, m.ipponsA)}
       </span>
       <div className={`pool-match-row__side ${aWin ? "pool-match-row__side--win" : ""}`}>
         <span className="pool-match-row__badge pool-match-row__badge--aka">AKA</span>
@@ -296,7 +292,7 @@ export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPla
 
                 if (m.status !== "completed") {
                   return <td key={`${pkey(colPlayer)}#${ci}`} title={cellTitle(rowPlayer, colPlayer, m.status === "running" ? "Now" : "Pending")} className={`league-matrix__cell league-matrix__cell--pending ${m.status === "running" ? "league-matrix__cell--running" : ""}${colMe}`} aria-label={cellLabel(rowPlayer, colPlayer, m.status === "running" ? "Now" : "Pending")} {...interactiveProps}>
-                    {m.status === "running" ? <span className="bc-running" style={{ fontSize: 9 }}>●</span> : "–"}
+                    {m.status === "running" ? "" : "–"}
                   </td>;
                 }
 
@@ -324,7 +320,13 @@ export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPla
                 let cellContent;
                 let resultLabel;
                 if (isDraw) {
-                  cellContent = <span className="league-matrix__draw">X</span>;
+                  // A scored draw shows the row player's own ippon letters
+                  // (M/K/D/T/H); the draw colour (league-matrix__cell--draw)
+                  // signals it was a tie, so we don't collapse a 1–1 to a bare
+                  // "X". A scoreless draw has no letters → fall back to the "X"
+                  // hikiwake glyph.
+                  const drawLetters = rowIppons.join("");
+                  cellContent = <span className="league-matrix__draw">{drawLetters || "X"}</span>;
                   resultLabel = "Draw";
                 } else if (rowWon) {
                   // Show the row player's ippon letters (M/K/D/T/H); the green
@@ -352,8 +354,8 @@ export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPla
       <div className="league-matrix__legend">
         <span className="league-matrix__legend-item league-matrix__legend-item--win">win</span>
         <span className="league-matrix__legend-item league-matrix__legend-item--loss">loss</span>
-        <span className="league-matrix__legend-item league-matrix__legend-item--draw">X = draw</span>
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H)</span>
+        <span className="league-matrix__legend-item league-matrix__legend-item--draw">draw</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H) · X = scoreless draw</span>
         <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row player's result vs column player"}</span>
       </div>
     </div>
@@ -380,15 +382,6 @@ export const PoolNumberedMatchRow = React.memo(({ m, num, onMatchClick }) => {
   const aName = typeof m.sideA === "object" ? withNumber(m.sideA) : m.sideA;
   const bName = typeof m.sideB === "object" ? withNumber(m.sideB) : m.sideB;
 
-  // scoreStr: non-null only for completed matches; the render span below
-  // handles the empty-string/null → "—" fallback in one place.
-  // For team matches, teamIVScore derives the IV aggregate from subResults (mp-o4xl);
-  // for individual matches it returns null and formatIpponsScore is used instead.
-  // ipponsB = Shiro (left), ipponsA = Aka (right) — same arg order as all other callers.
-  const scoreStr = m.status === "completed"
-    ? window.matchScoreStr(m, m.ipponsB, m.ipponsA)
-    : null;
-
   const handleClick = onMatchClick ? () => onMatchClick(m) : undefined;
 
   // Non-interactive <div> when there's no handler (read-only reuse) so the row
@@ -396,14 +389,17 @@ export const PoolNumberedMatchRow = React.memo(({ m, num, onMatchClick }) => {
   const Tag = handleClick ? "button" : "div";
   const interactiveProps = handleClick ? { type: "button", onClick: handleClick } : {};
   return (
-    <Tag className="pool-match-numbered-row" style={{ cursor: handleClick ? "pointer" : "default" }} {...interactiveProps}>
+    <Tag className={`pool-match-numbered-row${m.status === "running" ? " is-running" : ""}`} style={{ cursor: handleClick ? "pointer" : "default" }} {...interactiveProps}>
       <span className="pool-match-numbered-row__num">{num}</span>
       <div className="pool-match-numbered-row__side pool-match-numbered-row__side--shiro">
         <span className="sr-only">Shiro: </span>
         <span className="pool-match-numbered-row__name">{bName || "—"}</span>
       </div>
       <span className="pool-match-numbered-row__score">
-        {m.status === "completed" ? (scoreStr || "—") : m.status === "running" ? <span className="bc-running" style={{ fontSize: 10 }}>●</span> : "–"}
+        {/* Running matches are signalled by the row highlight (shared .is-running),
+            not a centre dot — matchStateCell shows "vs" for the live matchup,
+            a score when completed, "–" when scheduled. */}
+        {window.matchStateCell(m, m.ipponsB, m.ipponsA)}
       </span>
       <div className="pool-match-numbered-row__side pool-match-numbered-row__side--aka">
         <span className="sr-only">Aka: </span>


### PR DESCRIPTION
## Summary

Fixes eight operator-reported issues on the shiaijo scoring surfaces, plus refinements from review and an `/impeccable` critique pass.

- **Competitor-number prefix** (e.g. `A1`) now renders in the Shiaijo console.
- **Running matches are highlighted, never shown with a centre `●` dot.** Unified behind a shared `matchStateCell()` helper + an `is-running` CSS convention across all match-row surfaces. (`.league-matrix__cell--running` was referenced in JSX but had **no CSS** — the matrix highlight never rendered before.)
- **Scored equal draw (1–1) shows the points** (`M–K`), not a bare `X`; scoreless draw still shows `X`. In `formatIpponsScore` and the league matrix.
- **Operator can pick any Up Next / Upcoming match to score.** Picking blocks switching away from a bout already being scored; defers (un-starts) an unscored running bout before starting the pick.
- **Upcoming queue rows are complete actionable views.** Each row carries a "Start match" button (routes through the same pick/lock/defer gate) and a "Call to court" button (with "Calling…" / "Call again" states), so the operator can act on any queued match without scrolling to the scoring panel.
- **Hantei / kiken / fusenpai finishes advance to the next match.**
- **↑/↓ reorder arrows** replace "Defer".
- **Completed section** in the Shiaijo console is always expanded.
- Standings/bracket refresh after scoring (verified).

### Follow-up — `/impeccable` critique pass (score 34/40)

- **Touch targets (P1):** the new queue-row controls (Score / ↑ / ↓) now meet the ≥44px coarse-pointer target (DESIGN.md Principle 4) — `min 44×44` under `@media (pointer: coarse)`, wider gap, widened actions column. Desktop density unchanged.
- **Matrix draws:** the scored-draw cell shows neutral ippon letters (e.g. `K`/`M`) — the uncoloured odd-one-out vs green win / red loss. The earlier underline cue was removed: underline reads as a hyperlink on static data; the Matches list carries the authoritative `M–K`. The legend item likewise reverted to plain text.
- **Completed scale (P2):** the always-expanded Completed list shows the most recent 8 with a "Show all N" / "Show fewer" toggle so a full-day court doesn't bury the queue.

### Follow-up — Copilot review hardening (rounds 1–2, converged clean on round 3)

- **`moveMatch` sends `""` not `null`** for an empty `scheduledAt` — `null` caused a JSON unmarshal error (400) in the `/time` handler which expects a `string`. Added best-effort rollback: if the second `updateMatchTime` call fails, the code attempts to restore the first match's original time before surfacing the error toast.
- **`scoringStarted` now counts fouls, encho, and sub-results.** Previously only checked ippons; operators using hansoku (stored in `hansokuA`/`hansokuB` and `score.fouls.*`) or encho (`encho.periodCount`) or team sub-results could get the match silently swapped out. Ignores `"•"` placeholder strings.
- **Defer reset clears `subResults`.** The patch that un-starts a running bout back to `scheduled` now includes `subResults: []` so stale team sub-results don't survive the reset.
- **`.is-running` no longer overrides component border-radius.** The shared rule previously set `border-radius: 8px` unconditionally, clobbering the score-edit-row's `10px`. The hardcoded radius was removed; each host element keeps its own radius.
- **Score editor running 0–0 shows `vs` / completed-empty shows `—`.** After dropping the centre `●`, a completed match with no recorded score was rendering blank. The fallback chain now: running → `vs`, completed → `—`.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/bracket.jsx` | `formatIpponsScore` scored-draw → points; shared `matchStateCell()` helper |
| `web-mobile/js/admin_shiaijo.jsx` | number prefix; pick/lock/defer; ↑/↓ reorder; Upcoming "Start match" + "Call to court"; Completed always-expanded + "Show all N"; `is-running`; `moveMatch` null→"" + rollback; `scoringStarted` counts fouls/encho/subResults; defer reset clears subResults |
| `web-mobile/js/admin_scoring_individual.jsx` | hantei finish → `onSubmitAndNext` |
| `web-mobile/js/admin_scoring_shared.jsx` | `makeSubmitDecision` `onAfterDecision`/`isComplete` (fusenpai advances; kiken chains) |
| `web-mobile/js/admin_scoring_team.jsx` | wire `onAfterDecision`; team hantei via Finish path |
| `web-mobile/js/admin_schedule_score_editor.jsx` | drop centre dot → `is-running`; running 0–0 → `vs`, completed-empty → `—`; wire `onAfterDecision` |
| `web-mobile/js/viewer_standings.jsx` | matrix scored-draw → neutral ippons; `matchStateCell`/`is-running` |
| `web-mobile/js/admin_schedule_page.jsx`, `viewer_schedule.jsx` | drop bare centre dot (rows already carry `.tw-match--running`) |
| `web-mobile/css/styles.css` | `.is-running` (no longer hardcodes `border-radius`); `.league-matrix__cell--running`; matrix draw — underline removed; 44px coarse targets; Completed "more"; queue-row stacked layout |
| `web-mobile/js/__tests__/*.test.jsx` | `matchStateCell`, hantei/fusenpai advance, draw rendering |

## Screenshots

**Shiaijo console — running match highlighted (no dot), scored draw `M–K`, matrix scored-draw shows neutral ippons (M/K), standings, number prefixes:**

![shiaijo matrix + standings](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/301/matrix-underline.png)

**Touch targets — under coarse-pointer the Score / ↑ / ↓ controls are each 44×44px (measured):**

![44px touch targets](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/301/touch-targets.png)

**Score editor — running row highlighted (no dot, no "● NOW"), showing live points `M–·` and the outstanding-foul ▲; completed `M–K`:**

![score editor running highlight](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/301/score-editor.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages ≥85%
- [x] New/updated unit tests cover the change — vitest **1731/1731** (`matchStateCell` incl. "never emits ●" guard, hantei/fusenpai advance, scored/scoreless draw)
- [x] Manual browser verification — number prefixes; running highlight (no dot) in console, matrix, score editor; scored draw `M–K` + scoreless `X`; matrix scored-draw shows neutral ippons (computed `text-decoration:none`); standings; pick-to-score with lock toast + defer; ↑/↓ reorder; hantei/draw auto-advance; Completed always-expanded; **44×44 touch controls measured under coarse-pointer emulation**; Upcoming "Start match" + "Call to court" actions; `moveMatch` reorder smoke-tested (swap verified); running 0–0 shows `vs`. No console errors.
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-nwds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
