### PR TITLE
fix(mp-og2g): surface Admin entry on viewer when no competition configured

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3106,14 +3106,41 @@ button.pool-match-row {
   background: var(--accent-fg);
   border-color: var(--accent-fg);
   color: var(--accent);
-  font-weight: 600;
-  font-size: 11px;
-  padding: 5px 12px;
+  font-weight: 700;
+  font-size: 12px;
+  padding: 7px 14px;
+  letter-spacing: 0.02em;
+  /* Lift the white pill off the navy hero so it reads as a raised, pressable
+     control, then a slow white ring pulse draws the eye — the loud "set this
+     up" signal while the tournament has zero competitions. White ring (not the
+     navy running-pulse of §3) so the two motion languages never collide. */
+  box-shadow: 0 2px 10px -2px rgba(0, 0, 0, 0.35);
+  animation: admin-pill-pulse 2s var(--ease-out) infinite;
 }
 
 .viewer__head--hero .viewer__admin-pill--prominent:hover {
   background: var(--accent-soft);
   color: var(--accent);
+  /* Intent shown — settle the pulse so it doesn't nag during interaction. */
+  animation: none;
+}
+
+@keyframes admin-pill-pulse {
+  0% {
+    box-shadow: 0 2px 10px -2px rgba(0, 0, 0, 0.35),
+                0 0 0 0 color-mix(in srgb, var(--accent-fg) 55%, transparent);
+  }
+  70%,
+  100% {
+    box-shadow: 0 2px 10px -2px rgba(0, 0, 0, 0.35),
+                0 0 0 7px color-mix(in srgb, var(--accent-fg) 0%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .viewer__head--hero .viewer__admin-pill--prominent {
+    animation: none;
+  }
 }
 
 .viewer__logo {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3344,6 +3344,21 @@ button.pool-match-row {
   background: var(--accent-soft);
 }
 
+/* No competitions yet — promote the "Add competition" tile from a quiet dashed
+   placeholder to the page's primary action: solid accent frame, soft-navy fill,
+   and elevation so the operator's first step is unmistakable. Reverts to the
+   plain dashed tile once any competition exists (class is conditional). */
+.tcard--add.tcard--add-cta {
+  border-style: solid;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  box-shadow: var(--shadow);
+}
+
+.tcard--add.tcard--add-cta:hover {
+  box-shadow: var(--shadow-lg);
+}
+
 /* Inline tabs/sections */
 .section-title {
   font-size: 12px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3098,6 +3098,24 @@ button.pool-match-row {
   color: white;
 }
 
+/* Prominent admin pill — only while the tournament has zero competitions, so
+   the operator setting up a fresh tournament isn't left hunting for the entry
+   point. Solid white fill + navy text reads as the primary action on the navy
+   hero; reverts to the quiet pill above once any competition exists. */
+.viewer__head--hero .viewer__admin-pill--prominent {
+  background: var(--accent-fg);
+  border-color: var(--accent-fg);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 11px;
+  padding: 5px 12px;
+}
+
+.viewer__head--hero .viewer__admin-pill--prominent:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
 .viewer__logo {
   border: 1px solid rgba(255, 255, 255, 0.2);
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3552,6 +3552,12 @@ button.pool-match-row {
   margin: 0 0 4px;
 }
 
+/* Primary CTA inside an empty state (e.g. "Open admin" when no competitions
+   exist) — deliberate rhythm between the hint and the action, then a tighter
+   gap to its sub-note. */
+.empty__cta { margin-top: 16px; }
+.empty__cta-note { margin-top: 8px; }
+
 /* Inline seed list */
 .seed-list {
   display: flex;

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1287,6 +1287,125 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
 });
 
 // -----------------------------------------------------------------------
+// ViewerHome empty-state discoverability tests (mp-og2g)
+// -----------------------------------------------------------------------
+describe('ViewerHome empty-state discoverability (mp-og2g)', () => {
+  const realReact = global.React;
+  let runtime;
+  let ViewerHomeComp;
+  let originalLocalStorageDescriptor;
+  const STUBBED = [
+    'StatusBadge', 'formatDate', 'formatLabel', 'formatViewerHeaderEyebrow',
+    'pluralize', 'hasBothSides', 'compareDmy', 'queueLabelCompact',
+    'roundLabel', 'matchScoreStr', 'ipponsFromScore',
+  ];
+  const savedGlobals = {};
+
+  function findNode(node, pred) {
+    if (!node || typeof node !== 'object') return null;
+    if (Array.isArray(node)) {
+      for (const k of node) { const f = findNode(k, pred); if (f) return f; }
+      return null;
+    }
+    if (pred(node)) return node;
+    const kids = node.children || node.props?.children || [];
+    for (const k of [].concat(kids)) { const f = findNode(k, pred); if (f) return f; }
+    return null;
+  }
+
+  const emptyTournament = { name: 'T', date: '10-06-2026', competitions: [] };
+  const withCompTournament = {
+    name: 'T', date: '10-06-2026',
+    competitions: [{ id: 'c1', name: 'Open', status: 'setup', players: [], poolMatches: [] }],
+  };
+  const NOOP = () => {};
+
+  beforeEach(async () => {
+    originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    const store = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (k) => (k in store ? store[k] : null),
+        setItem: (k, v) => { store[k] = String(v); },
+        removeItem: (k) => { delete store[k]; },
+        clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+      },
+      writable: true,
+      configurable: true,
+    });
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    STUBBED.forEach(k => {
+      savedGlobals[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+        ? { had: true, val: global.window[k] } : { had: false };
+    });
+    global.window.StatusBadge = vi.fn(() => null);
+    global.window.formatDate = (d) => d || '';
+    global.window.formatLabel = (l) => l || '';
+    global.window.formatViewerHeaderEyebrow = () => '';
+    global.window.pluralize = (n, s) => `${n} ${s}`;
+    global.window.hasBothSides = () => true;
+    global.window.compareDmy = () => 0;
+    global.window.queueLabelCompact = null;
+    global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.matchScoreStr = () => '';
+    global.window.ipponsFromScore = () => [];
+    vi.resetModules();
+    ({ ViewerHome: ViewerHomeComp } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorageDescriptor);
+    }
+    runtime.unmount();
+    global.React = realReact;
+    STUBBED.forEach(k => {
+      if (savedGlobals[k]?.had) global.window[k] = savedGlobals[k].val;
+      else delete global.window[k];
+    });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('adds viewer__admin-pill--prominent class to admin pill when no competitions exist', () => {
+    const tree = runtime.mount(ViewerHomeComp, {
+      tournament: emptyTournament,
+      sseConnected: true, onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP,
+    });
+    const pill = findNode(tree, n => n.type === 'button' && String(n.props?.className || '').includes('viewer__admin-pill'));
+    expect(pill).toBeTruthy();
+    expect(pill.props.className).toContain('viewer__admin-pill--prominent');
+  });
+
+  it('does NOT add viewer__admin-pill--prominent when competitions exist', () => {
+    const tree = runtime.mount(ViewerHomeComp, {
+      tournament: withCompTournament,
+      sseConnected: true, onSelectCompetition: NOOP, onAdminClick: NOOP,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP,
+    });
+    const pill = findNode(tree, n => n.type === 'button' && String(n.props?.className || '').includes('viewer__admin-pill'));
+    expect(pill).toBeTruthy();
+    expect(pill.props.className).not.toContain('viewer__admin-pill--prominent');
+  });
+
+  it('renders empty-state "Open admin" CTA wired to onAdminClick when no competitions exist', () => {
+    const spy = vi.fn();
+    const tree = runtime.mount(ViewerHomeComp, {
+      tournament: emptyTournament,
+      sseConnected: true, onSelectCompetition: NOOP, onAdminClick: spy,
+      onOpenSchedule: NOOP, onRegister: NOOP, onOpenResults: NOOP,
+    });
+    const cta = findNode(tree, n => n.type === 'button' && String(n.props?.className || '').includes('empty__cta'));
+    expect(cta).toBeTruthy();
+    cta.props.onClick();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// -----------------------------------------------------------------------
 // ViewerHome globalRunning de-dup render test (mp-42rg)
 // -----------------------------------------------------------------------
 describe('ViewerHome globalRunning de-dup (mp-42rg)', () => {

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -393,6 +393,9 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
   }, [comps]);
 
   const running = comps.filter((c) => c.status === "pools" || c.status === "playoffs");
+  // No competitions yet: the "Add competition" tile is the operator's primary
+  // next step, so it's promoted from a quiet dashed placeholder to a loud CTA.
+  const noComps = comps.length === 0;
 
   // Derive the tournament-level status from competition activity instead of
   // trusting t.status, which can read "Pending" (setup) even while competitions
@@ -482,10 +485,10 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
         <div className="section-title">All competitions</div>
         <div className="tlist">
           {comps.map((c) => <CompCard key={c.id} c={c} onOpen={() => onOpenCompetition(c.id, initialSectionFor(c.status))} onStart={() => onStartCompetition(c.id)} tournament={t} showToast={showToast} />)}
-          <button type="button" className="tcard tcard--add" onClick={onCreateCompetition}>
-            <div style={{ fontSize: 28, color: "var(--ink-3)" }}>+</div>
-            <div style={{ fontWeight: 600, marginTop: 4 }}>Add competition</div>
-            <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>Individual or Team</div>
+          <button type="button" className={`tcard tcard--add${noComps ? " tcard--add-cta" : ""}`} onClick={onCreateCompetition}>
+            <div style={{ fontSize: 28, color: noComps ? "var(--accent)" : "var(--ink-3)" }}>+</div>
+            <div style={{ fontWeight: noComps ? 700 : 600, marginTop: 4, color: noComps ? "var(--accent)" : undefined }}>Add competition</div>
+            <div style={{ fontSize: 12, color: noComps ? "var(--ink-2)" : "var(--ink-3)", marginTop: 2 }}>Individual or Team</div>
           </button>
           <button type="button" className="tcard tcard--add" onClick={onOpenImport}>
             <div style={{ color: "var(--ink-3)" }}><Icon name="folder" size={28} /></div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -426,8 +426,8 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             </div>
           </div>
           <div className="page-head__actions">
-            <button type="button" className="btn" onClick={onAnnounce}><Icon name="megaphone" />Announce</button>
-            <button type="button" className="btn" onClick={() => setExportPdfOpen(true)}><Icon name="printer" />Export PDFs</button>
+            <button type="button" className="btn" onClick={onAnnounce} disabled={noComps} title={noComps ? "Add a competition first" : undefined}><Icon name="megaphone" />Announce</button>
+            <button type="button" className="btn" onClick={() => setExportPdfOpen(true)} disabled={noComps} title={noComps ? "Add a competition first" : undefined}><Icon name="printer" />Export PDFs</button>
             {comps.some(c => c.status === "completed") && (
               <button type="button" className="btn" onClick={() => setAllWinnersOpen(true)}><Icon name="trophy" />All winners</button>
             )}
@@ -451,7 +451,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="calendar" size={18} />Tournament schedule →</div>
             <div className="card__sub">All matches across courts. Move matches between shiaijo, filter by player.</div>
           </button>
-          <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenScoreEditor}>
+          <button type="button" className="card" style={{ textAlign: "left", cursor: noComps ? "not-allowed" : "pointer", opacity: noComps ? 0.6 : 1, border: "1px solid var(--line)" }} onClick={onOpenScoreEditor} disabled={noComps} title={noComps ? "Add a competition first" : undefined}>
             <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="pencil" size={18} />Score editor →</div>
             <div className="card__sub">Update results or correct past matches across the tournament.</div>
           </button>

--- a/web-mobile/js/viewer_home.jsx
+++ b/web-mobile/js/viewer_home.jsx
@@ -345,12 +345,13 @@ export function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOp
               <div className="section-title">Competitions</div>
               <div className="vlist">
                 <div className="empty">
-                  <div className="icon">⏳</div>
+                  <div className="icon">⚙️</div>
                   <h3>No competitions yet</h3>
                   <div className="hint--md">Head to Admin to set up the first competition.</div>
                   <button type="button" className="btn btn--primary empty__cta" onClick={onAdminClick}>
                     Open admin
                   </button>
+                  <div className="hint--sm empty__cta-note">Requires the admin password.</div>
                 </div>
               </div>
             </>

--- a/web-mobile/js/viewer_home.jsx
+++ b/web-mobile/js/viewer_home.jsx
@@ -242,7 +242,7 @@ export function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOp
             </div>
             <div className="viewer__title viewer__title--lg">{t.name}</div>
           </div>
-          <button type="button" className="viewer__admin-pill" onClick={onAdminClick}>
+          <button type="button" className={`viewer__admin-pill${comps.length === 0 ? " viewer__admin-pill--prominent" : ""}`} onClick={onAdminClick}>
             <svg width="10" height="12" viewBox="0 0 10 12" fill="none" aria-hidden="true">
               <rect x="1" y="5" width="8" height="7" rx="1.5" fill="currentColor"/>
               <path d="M3 5V3.5a2 2 0 0 1 4 0V5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
@@ -347,7 +347,10 @@ export function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOp
                 <div className="empty">
                   <div className="icon">⏳</div>
                   <h3>No competitions yet</h3>
-                  <div className="hint--md">Check back soon for the tournament schedule and updates.</div>
+                  <div className="hint--md">Head to Admin to set up the first competition.</div>
+                  <button type="button" className="btn btn--primary empty__cta" onClick={onAdminClick}>
+                    Open admin
+                  </button>
                 </div>
               </div>
             </>


### PR DESCRIPTION
## Summary

Make the **Admin / setup entry points loud and obvious when a tournament has no competitions configured** — so the operator (almost always the one viewing an unconfigured tournament) isn't stranded — while leaving populated, spectator-facing views untouched.

- **Viewer empty state** ([viewer_home.jsx](web-mobile/js/viewer_home.jsx)): operator-first copy ("Head to Admin to set up the first competition."), a navy `.btn--primary` **"Open admin"** CTA, a ⚙️ setup glyph, and a muted "Requires the admin password." note. Was spectator copy ("Check back soon…") with no admin path.
- **Viewer hero pill**: when `comps.length === 0` it becomes a loud raised white pill (700 weight, elevation) with a slow **white ring pulse**; settles on hover; full `prefers-reduced-motion` fallback keeps the loud static treatment. White ring — not the navy running-pulse of DESIGN §3 — so the motion languages never collide. Reverts to the quiet pill once any competition exists.
- **Admin overview** ([admin_shell.jsx](web-mobile/js/admin_shell.jsx)):
  - The **"Add competition"** tile is promoted from a quiet dashed placeholder to the primary action (solid accent frame, soft-navy fill, accent "+"/title, elevation); "Import competitions" stays quiet.
  - **Competition-dependent actions are disabled** with an "Add a competition first" tooltip: **Announce**, **Export PDFs**, and the **Score editor** card. Each re-enables the moment any competition exists.
  - Both behaviours revert once a competition exists.
- No auth change — admin stays password-gated; this only affects discoverability.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer_home.jsx` | Empty-state operator copy + "Open admin" CTA + ⚙️ glyph + password note; conditional `viewer__admin-pill--prominent` when `comps.length === 0` |
| `web-mobile/js/admin_shell.jsx` | Conditional `tcard--add-cta` on the "Add competition" tile; disable Announce / Export PDFs / Score editor when no competitions (`disabled={noComps}` + tooltip) |
| `web-mobile/css/styles.css` | `.viewer__admin-pill--prominent` (white fill, elevation, `admin-pill-pulse` + reduced-motion guard); `.empty__cta`/`.empty__cta-note` spacing; `.tcard--add-cta` promoted-tile styles |

## Screenshots

**Viewer — no competition configured** (mobile 390×844): prominent pulsing white Admin pill + "Open admin" CTA card.

![viewer empty state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/303/empty-state.png)

**Viewer — one competition exists**: Admin pill reverts to the quiet outline, CTA card gone.

![viewer with competition](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/303/with-comp.png)

**Admin overview — no competitions** (desktop 1280): "Add competition" tile promoted to the primary action; Announce / Export PDFs / Score editor disabled.

![admin no competitions](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/303/admin-add-competition.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages green, ≥85% coverage (re-run after a `main` merge/rebase)
- [x] New/updated unit tests cover the change — frontend copy/CSS/conditional-class/disabled-state change; full JS suite (1720) green; no existing test asserted the old copy
- [x] Manual browser verification — viewer (0 / 1 competition) mobile + admin overview (0 / 1 competition) desktop, headless Chromium; loud treatments + disabled actions appear with 0 and revert with ≥1 (asserted `disabled` flips True→False); reduced-motion verified (pill `animationName: none`, static loud fallback)
- [x] Screenshots added above (viewer both states + admin)
- [x] No new console errors or warnings

Closes mp-og2g
