### PR TITLE
docs: refresh ARCHITECTURE.md and reduce staleness-prone content

### DIFF
--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -14,13 +14,13 @@ bracket-creator
 └── mobile-app         Web: live tournament management with real-time updates
 ```
 
-Hidden helper commands: `version`, `man` (man-page generation).
+Hidden / helper commands: `version`, `man` (man-page generation), `hash-password` (bcrypt hash for locked-mode auth), `print` (render a saved competition to PDF/Excel), and `diag` (runtime diagnostics).
 
 **CLI mode** reads a CSV participant list, generates bracket structures in memory, and writes an Excel workbook with formula-linked cells for bracket visualization.
 
 **Serve mode** is a full-featured web UI for Excel bracket generation. The SPA (`web/index.html`) provides tournament type selection (pools+playoffs or direct elimination), court configuration, CSV participant input with drag-and-drop and validation, a seeding modal, time estimation, and dark/light theming. Form values auto-save to localStorage. On submit, the backend generates the Excel workbook and returns it as a download. No server-side persistence.
 
-**Mobile-app mode** is a full tournament management platform: CRUD for tournaments/competitions, live match scoring, decision recording (kiken/fusenpai/daihyosen), team lineups, Swiss/Kachinuki formats, real-time push via SSE, and file-backed persistent state. The frontend is a Preact SPA embedded in the binary.
+**Mobile-app mode** is a full tournament management platform: CRUD for tournaments/competitions, live match scoring, decision recording (kiken/fusenpai/daihyosen), team lineups, Swiss/Kachinuki formats, league tie-breakers, mid-tournament participant replacement, self-service registration, public display surfaces (TV/lobby/streaming overlay), operator content (announcements, branding, sponsors), PDF/Excel print, real-time push via SSE, and file-backed persistent state. The frontend is a Preact SPA embedded in the binary.
 
 ## Layered View
 
@@ -53,6 +53,9 @@ main.go                          Entry point; embeds web/ and web-mobile/ via //
 │   ├── shared.go                Shared CLI helpers (processEntries, openOutputFile, etc.)
 │   ├── serve.go                 Stateless web server (form → Excel)
 │   ├── mobile_app.go            Live tournament server startup
+│   ├── hash_password.go         bcrypt hash generator for locked-mode auth
+│   ├── print.go                 Render a saved competition to PDF/Excel
+│   ├── diag_unix.go/_windows.go Runtime diagnostics (hidden)
 │   ├── version.go               Version display
 │   └── man.go                   Man-page generation (hidden)
 │
@@ -73,26 +76,28 @@ main.go                          Entry point; embeds web/ and web-mobile/ via //
 │   │   ├── csv.go               CSV parsing and validation
 │   │   ├── excel.go, excel_*.go Excel rendering (data, styles, tree, tags, kachinuki)
 │   │   ├── constants.go         Layout constants, sheet names, defaults
-│   │   ├── numbers.go, uuid.go, helper.go
-│   │   └── bracket/, csv/, pool/, seeding/   Small focused subpackages
+│   │   ├── numbers.go, uuid.go, helper.go, qr.go, rounds.go, dedup.go, reserved.go
+│   │   └── bracket/, csv/, seeding/   Small focused subpackages (ongoing extraction)
 │   │
 │   ├── excel/                   Excel file lifecycle
 │   │   ├── client.go            File open/save/close (Client)
 │   │   ├── error.go             Error handling utilities
 │   │   └── template.go          NewFileFromScratch — builds entire workbook
 │   │
-│   ├── engine/                  Business logic for live tournaments (15 files)
+│   ├── engine/                  Business logic for live tournaments (~23 source files)
 │   │   ├── engine.go            Engine struct (wraps state.Store)
 │   │   ├── scoring.go, scoring_tx.go   Match result recording (tx-aware variants)
-│   │   ├── pools.go, bracket.go        Pool round-robin + bracket advancement
-│   │   ├── ranking.go                  Standings, tie-breaking
+│   │   ├── pools.go, bracket.go, knockout.go   Pool round-robin + bracket advancement
+│   │   ├── ranking.go, tiebreaker.go, league_tiebreak.go   Standings, tie-breaking, league play-offs
 │   │   ├── competition.go              Lifecycle (start, invalidate, complete)
-│   │   ├── schedule.go, scheduler_slots.go   Court scheduling + estimator
+│   │   ├── replace_participant.go      Mid-tournament participant substitution
+│   │   ├── schedule.go, scheduler_slots.go, estimate_schedule.go   Court scheduling + estimator
+│   │   ├── court_validation.go         Court-count / labelling validation
 │   │   ├── eligibility.go              StartMatch gate (kiken/fusenpai)
 │   │   ├── kachinuki.go, kachinuki_export.go  Winner-stays-on bouts
 │   │   ├── daihyosen.go                Rep-bout flow
 │   │   ├── swiss.go                    Swiss-round format
-│   │   ├── export.go                   Excel export from live state
+│   │   ├── export.go, pdf_export.go    Excel / PDF export from live state
 │   │   └── errors.go                   Typed error definitions
 │   │
 │   ├── state/                   File-backed persistence with caching + WAL
@@ -105,6 +110,7 @@ main.go                          Entry point; embeds web/ and web-mobile/ via //
 │   │   ├── participants.go, seeds.go, pools.go, bracket.go, schedule.go
 │   │   ├── competitor_status.go Eligibility persistence
 │   │   ├── team_lineup.go       Team lineup persistence
+│   │   ├── announcement_store.go  Operator announcement persistence
 │   │   ├── overrides.go         Manual ranking overrides
 │   │   ├── match.go             DeriveQueuePositions (pure helper)
 │   │   └── ids.go               ID generation utilities
@@ -112,14 +118,25 @@ main.go                          Entry point; embeds web/ and web-mobile/ via //
 │   ├── mobileapp/               HTTP handlers and real-time events
 │   │   ├── server.go            Gin router setup, CORS, SPA fallback
 │   │   ├── middleware.go        Auth middleware (X-Tournament-Password)
+│   │   ├── auth_source.go, auth_admin.go   PasswordVerifier (file vs locked mode)
+│   │   ├── ratelimit.go         Per-IP token-bucket rate limiting
 │   │   ├── hub.go               SSE pub/sub hub (channel-based, non-blocking)
+│   │   ├── broadcast_coalescer.go  Coalesces bursty match_updated broadcasts (≤4/s/match)
+│   │   ├── viewer_singleflight.go  Dedupes concurrent viewer reads
+│   │   ├── public_projection.go    Read-only projection of state for public surfaces
+│   │   ├── safego.go            Panic-safe goroutine helper (see CLAUDE.md)
 │   │   ├── deps.go              Consumer-boundary interfaces (NFR-002)
 │   │   ├── validation.go        Shared request validation helpers
 │   │   ├── handlers_tournament.go, handlers_competition.go, handlers_participants.go
 │   │   ├── handlers_match.go, handlers_decision.go, handlers_daihyosen.go
 │   │   ├── handlers_eligibility.go, handlers_lineup.go, handlers_swiss.go
+│   │   ├── handlers_league_tiebreak.go   Operator-driven league play-offs
 │   │   ├── handlers_schedule.go Stateless schedule estimator (also wired into `serve`)
-│   │   ├── handlers_import.go   Tournament import
+│   │   ├── handlers_import.go, handlers_print.go   Tournament import + PDF/Excel print
+│   │   ├── handlers_registration.go      Self-service participant registration
+│   │   ├── handlers_announcement.go, handlers_branding.go, handlers_sponsors.go   Operator content
+│   │   ├── handlers_auth_admin.go, handlers_auth_config.go, handlers_reset.go   Auth + password reset
+│   │   ├── handlers_version.go  Build/version endpoint
 │   │   ├── handlers_display.go  Public TV/lobby/overlay surfaces
 │   │   └── handlers_viewer.go   Public (unauthenticated) endpoints
 │   │
@@ -133,20 +150,25 @@ main.go                          Entry point; embeds web/ and web-mobile/ via //
 │
 ├── web-mobile/                  Preact SPA (embedded, served by `mobile-app`)
 │   ├── index.html               SPA shell
-│   ├── js/
+│   ├── js/                      ~60 modules (split by feature as the SPA grew)
 │   │   ├── app.jsx              Root component, SSE listener, auth, view state
 │   │   ├── router.jsx           preact-router wrapper, useQuery()
 │   │   ├── api_client.jsx       HTTP client (auth, retry, error mapping)
 │   │   ├── api_serializers.jsx  JSON ↔ camelCase normalization
-│   │   ├── data.jsx             State hooks, data normalization
-│   │   ├── patch.jsx            Patch-merge for SSE updates
-│   │   ├── ui.jsx, bracket.jsx, glossary.jsx, glossary_data.js
-│   │   ├── viewer.jsx, display.jsx          Public surfaces
-│   │   ├── admin.jsx, admin_shell.jsx       Admin container + chrome
-│   │   ├── admin_setup.jsx, admin_competition.jsx, admin_participants.jsx
-│   │   ├── admin_pools.jsx, admin_schedule.jsx, admin_scoring_modal.jsx
-│   │   ├── admin_lineup.jsx, admin_helpers.jsx
-│   │   └── __tests__/           22 Vitest spec files
+│   │   ├── data.jsx, patch.jsx  State hooks, normalization, SSE patch-merge
+│   │   ├── ui.jsx, bracket.jsx, glossary.jsx, glossary_data.js, qr.jsx
+│   │   ├── viewer*.jsx          Public viewer (home, competition, schedule, standings,
+│   │   │                          match, awards, alerts, notifications, watchlist)
+│   │   ├── display*.jsx, streaming_overlay.jsx, match_scoreboard.jsx  TV/lobby/overlay
+│   │   ├── registration.jsx, reset.jsx, sponsor_strip.jsx   Public self-service surfaces
+│   │   ├── admin.jsx, admin_shell.jsx, admin_setup.jsx, admin_helpers.jsx   Container + chrome
+│   │   ├── admin_competition*.jsx   Overview, settings, bracket, swiss sub-tabs
+│   │   ├── admin_participants.jsx, admin_pools.jsx, admin_lineup.jsx
+│   │   ├── admin_schedule*.jsx       Schedule page, score editor, pacing, export, lineup
+│   │   ├── admin_scoring_*.jsx       Scoring modal (individual, team, autosave, shared)
+│   │   ├── admin_shiaijo.jsx         Per-court "now playing / up next" operator board
+│   │   ├── admin_announcement.jsx, admin_branding.jsx, admin_sponsors.jsx   Operator content
+│   │   └── __tests__/           ~79 Vitest spec files (incl. render/ DOM tests)
 │   ├── css/styles.css
 │   └── dist/                    esbuild output (pre-compiled JSX)
 │
@@ -262,6 +284,8 @@ Admin Client ──→ POST /api/competitions/:id/matches/:mid/score
 tournament-data/
 ├── tournament.md                       YAML front-matter: name, date, venue, courts, password
 ├── wal/                                Pending multi-file transactions (replayed on startup)
+├── branding/                           Uploaded logo (logo.png|jpg) for display surfaces
+├── sponsors/                           Uploaded sponsor images
 └── competitions/
     └── {compID}/
         ├── config.md                   YAML front-matter: format, pool size, courts, etc.
@@ -309,12 +333,17 @@ The `Hub` broadcasts the following event types over `GET /api/events`:
 
 | Event | Triggered by |
 |---|---|
-| `match_updated` | score / decision / status change |
+| `match_updated` | score / decision / status change (coalesced ≤4/s per match) |
 | `competition_started` | `POST /competitions/:id/start` |
 | `competition_completed` | final match resolved |
 | `tournament_updated` | tournament-level CRUD |
 | `schedule_updated` | court/time edits, schedule regenerated |
 | `competitor_status_updated` | eligibility change (new kiken/fusenpai) |
+| `participants_updated` | participant add/edit/remove/import |
+| `lineup_updated` | team lineup freeze/change |
+| `draw_generated` / `draw_discarded` | pool/bracket draw created or rolled back |
+| `announcement` | operator posts/clears an announcement |
+| `password_reset` | tournament password changed via reset flow |
 
 ## Frontend Architecture
 
@@ -339,18 +368,24 @@ The SPA discovers the active mode via the public `GET /api/auth-config` endpoint
 App (app.jsx)
 ├── Viewer mode (public)
 │   ├── TournamentHome
-│   ├── CompetitionViewer (pools, bracket, results)
-│   └── ScheduleView
+│   ├── CompetitionViewer (pools, bracket, standings, results, awards)
+│   ├── ScheduleView, MatchView
+│   └── Notifications / Alerts / Watchlist
 │
-├── Display mode (/display — TV/lobby/overlay, public, query-param driven)
+├── Display mode (/display — TV/lobby/scoreboard/streaming overlay, public, query-param driven)
+│
+├── Registration / Reset (public self-service surfaces)
 │
 └── Admin mode (password-protected)
     └── AdminShell
         ├── AdminDashboard
-        ├── AdminTournament
-        ├── AdminCompetition (overview, participants, schedule, scoring, seeding)
+        ├── AdminTournament (+ branding, sponsors, announcements)
+        ├── AdminCompetition (overview, settings, bracket, swiss)
+        ├── AdminParticipants
         ├── AdminPools
         ├── AdminSchedule (score editor with chained court-scoped navigation)
+        ├── AdminShiaijo (per-court now-playing / up-next board)
+        ├── AdminScoring (individual / team modal with autosave)
         ├── AdminLineup (team lineup composer)
         └── ImportTournament
 ```
@@ -365,15 +400,17 @@ App (app.jsx)
 
 **Tie-breaking**: Multi-criteria cascade — wins → losses → draws → points scored → points lost (individual). Team tournaments add team-level criteria before individual criteria. See CLAUDE.md for the full precedence.
 
-**Decision types** (`internal/domain/decision.go`): 8 canonical wire values — `""`, `fought`, `hikiwake`, `kiken`, `fusenpai`, `fusensho`, `daihyosen`, `kachinuki-exhaustion`. Legacy YAML `decision: true` migrates to `hikiwake`, `false` to `fought` (Decision.UnmarshalYAML).
+**Decision types** (`internal/domain/decision.go`): 11 canonical wire values — `""`, `fought`, `hikiwake`, `kiken` (legacy), `kiken-voluntary` (FIK Art. 31, permanent), `kiken-injury` (FIK Art. 30, reinstateable), `fusenpai`, `fusensho`, `daihyosen`, `kachinuki-exhaustion`, `ippon-shobu`. Use `domain.IsKikenDecision`/`IsKikenDecisionStr` to match any kiken variant. Legacy YAML `decision: true` migrates to `hikiwake`, `false` to `fought`, and `kiken` to `kiken-voluntary` (Decision.UnmarshalYAML).
 
-**Competitor eligibility** (`engine/eligibility.go`, `state/competitor_status.go`): a kiken/fusenpai decision auto-writes `CompetitorStatus{Eligible: false}` for the loser. `engine.StartMatchTx` is the FR-035 pre-flight gate — returns `*IneligibleCompetitorError` (matches `errors.Is(err, ErrIneligibleCompetitor)`), mapped to HTTP 409 by the score handler. Re-scoring a match that itself created the ineligibility is permitted (undo path).
+**Competitor eligibility** (`engine/eligibility.go`, `state/competitor_status.go`): a kiken/fusenpai decision auto-writes `CompetitorStatus{Eligible: false}` for the loser. `engine.StartMatchTx` is the FR-035 pre-flight gate — returns `*IneligibleCompetitorError` (matches `errors.Is(err, ErrIneligibleCompetitor)`), mapped to HTTP 409 by the score handler. Re-scoring a match that itself created the ineligibility is permitted (undo path). Kiken-injury (FIK Art. 30) sets `Reinstateable: true`; an admin can restore eligibility via `POST /competitions/:cid/competitors/:pid/reinstate`. Kiken-voluntary (Art. 31) and fusenpai are not reinstateable.
 
 **Team lineups & kachinuki** (`domain/team_lineup.go`, `engine/kachinuki.go`): TeamLineup pins position → player for a round. FIK 5-person rule: Senpo + Taisho mandatory; 1 vacancy must be Jiho, 2 must be Jiho+Fukusho, 3+ disqualifies. Kachinuki ("winner-stays-on") dynamically appends bouts via `engine.AdvanceKachinuki` until one team is exhausted (`DecisionKachinukiExhaustion`).
 
 **Schedule estimator** (`engine/schedule.go`): `EstimateSchedule(EstimateInput) ScheduleEstimate` returns total/per-court minutes from match duration × multiplier × slowest-court buffer. Exposed via stateless `GET /api/schedule/estimate` on both the CLI web server (`serve`) and the mobile app.
 
 **Swiss format** (`engine/swiss.go`): pairings + round advancement for Swiss-style competitions.
+
+**League tie-breaker** (`engine/league_tiebreak.go`, `engine/tiebreaker.go`): operator-driven play-off bouts to resolve tied standings in league/pool formats when the automatic multi-criteria cascade cannot separate competitors.
 
 ## Design Patterns & Principles
 
@@ -399,18 +436,20 @@ Docker images available via `Dockerfile` and `Dockerfile.mobile`.
 
 ## Codebase Size
 
+Approximate, top-level package only (subpackages excluded); refresh with the `wc -l` sweep over `*.go` / `*_test.go`.
+
 | Package | Source LOC | Test LOC | Ratio |
 |---|---|---|---|
-| engine | 4,942 | 7,360 | 1.5× |
-| helper | 4,582 | 9,245 | 2.0× |
-| state | 4,192 | 6,336 | 1.5× |
-| mobileapp | 5,333 | 8,205 | 1.5× |
-| cmd | 1,216 | 2,055 | 1.7× |
-| domain | 860 | 913 | 1.1× |
+| mobileapp | 11,478 | 21,880 | 1.9× |
+| engine | 8,453 | 15,571 | 1.8× |
+| helper | 5,572 | 10,836 | 1.9× |
+| state | 5,509 | 8,245 | 1.5× |
+| cmd | 1,831 | 3,111 | 1.7× |
+| domain | 807 | 944 | 1.2× |
 | excel | 391 | 135 | 0.3× |
-| service / resources / test | 120 | 157 | — |
-| **Go total** | **~21,600** | **~34,400** | **1.6×** |
-| **Frontend (JSX/JS)** | **12,970** | **6,047** | **0.5×** |
+| service / resources / test | 121 | 175 | — |
+| **Go total** (incl. subpackages) | **~35,500** | **~62,100** | **1.7×** |
+| **Frontend (JSX/JS)** | **~27,300** | **~22,400** | **0.8×** |
 
 ## Known Architectural Observations
 
@@ -421,15 +460,14 @@ Docker images available via `Dockerfile` and `Dockerfile.mobile`.
 - **Single-binary deployment**: all assets embedded at compile time.
 - **Fine-grained concurrency**: per-competition + per-file locking avoids global contention; non-reentrant mutex caught misuse via `StoreTx`.
 - **Multi-file atomicity**: WAL-backed `Store.WithTransaction` lets the score handler commit several files (match result + eligibility + lineup) atomically across a crash.
-- **Real-time push**: SSE hub with non-blocking broadcast handles stalled clients gracefully.
+- **Real-time push**: SSE hub with non-blocking broadcast handles stalled clients gracefully, with a broadcast coalescer (≤4 `match_updated`/s per match) and per-IP rate limiting bounding fan-out cost.
 - **Consumer-boundary interfaces** in `mobileapp/deps.go` keep handler tests light.
 
 ### Areas to Watch
 
-- **`helper/` is the largest package** (4.6K LOC) mixing tree algorithms, CSV parsing, Excel rendering, seeding, and utility functions. The newer `helper/{bracket,csv,pool,seeding}/` subpackages signal an ongoing extraction; `helper/` proper has not shrunk yet.
-- **`engine/` has grown rapidly** — 15 files, ~5K LOC — and now spans scoring, eligibility, kachinuki, daihyosen, Swiss, and scheduling. Further sub-splitting may be warranted.
-- **`mobileapp/` is approaching `helper/` in size** (5.3K LOC) due to the new handler families (decision, eligibility, lineup, daihyosen, Swiss, display).
+- **`mobileapp/` is now the largest package** (~11.5K LOC, ~35 source files) after the new handler families landed (decision, eligibility, lineup, daihyosen, Swiss, display, league tie-breaker, registration, announcement, branding, sponsors, print). It now carries supporting infra too (rate limiting, broadcast coalescer, viewer single-flight). Further grouping into subpackages may be warranted.
+- **`engine/` has grown rapidly** — ~23 source files, ~8.5K LOC — spanning scoring, eligibility, kachinuki, daihyosen, Swiss, scheduling, league tie-breaks, participant replacement, and PDF export. Further sub-splitting may be warranted.
+- **`helper/` mixes concerns** (~5.6K LOC): tree algorithms, CSV parsing, Excel rendering, seeding, and utilities. The `helper/{bracket,csv,seeding}/` subpackages signal an ongoing extraction (the earlier `pool/` subpackage was folded back to `pool_partial.go`); `helper/` proper has not shrunk yet.
 - **`excel/` has minimal test coverage** (0.3× ratio) despite Excel output being the primary CLI deliverable. Most Excel test coverage lives in `helper/*_test.go` instead.
-- **`schedule_updated` SSE event is broadcast but the frontend does not consume it** — admin schedule view doesn't auto-refresh after court/time moves (see memory `project_schedule_updated_gap`).
-- **`domain/` is now substantially larger** (860 LOC, 8 files) but most business logic in `helper/` still uses `helper.Player` directly rather than domain types — the migration is partial.
+- **`domain/` is still partially adopted** (~800 LOC, 9 files): most business logic in `helper/` uses `helper.Player` directly rather than domain types — the migration is incomplete.
 - **No Go interfaces** for `state.Store` or `engine.Engine` at the top level — interface adoption is happening incrementally via `mobileapp/deps.go`, but engine-to-state and helper-to-engine calls still go through concrete types.

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ bracket-creator
 └── mobile-app         Web: live tournament management with real-time updates
 ```
 
-Hidden / helper commands: `version`, `man` (man-page generation), `hash-password` (bcrypt hash for locked-mode auth), `print` (render a saved competition to PDF/Excel), and `diag` (runtime diagnostics).
+Additional commands: `version`, `hash-password` (bcrypt hash for locked-mode auth), and `print` (render bracket XLSX workbooks to print-ready PDFs via LibreOffice). `man` (man-page generation) is the only hidden command. Folder-diagnostic helpers live in `cmd/diag_*.go` but are not a subcommand.
 
 **CLI mode** reads a CSV participant list, generates bracket structures in memory, and writes an Excel workbook with formula-linked cells for bracket visualization.
 
@@ -54,7 +54,7 @@ web-mobile/    Preact SPA for the live tournament app (embedded, served by mobil
 
 | Package | Owns | Start here |
 |---|---|---|
-| `cmd/` | Cobra CLI commands — one options struct + `run()` per subcommand; `serve`/`mobile_app` boot the web servers. Shared CLI logic in `shared.go`. | `root.go`, `shared.go`, `serve.go`, `mobile_app.go` |
+| `cmd/` | Cobra CLI commands — the larger ones (e.g. `create-pools`) use an options struct + `run()`; small ones (`version`, `man`) are plain `cobra.Command`. `serve`/`mobile_app` boot the web servers; shared CLI logic in `shared.go`. | `root.go`, `shared.go`, `serve.go`, `mobile_app.go` |
 | `internal/domain/` | Pure domain models with **zero internal dependencies** — Player, Pool, Match, Tournament, Seed, Decision, CompetitorStatus, TeamLineup, plus the UI glossary. | `decision.go`, `team_lineup.go` |
 | `internal/helper/` | Core algorithms + all Excel rendering (the historical catch-all). Bracket trees, seeding, pool creation, CSV parsing, `excel_*.go` renderers. Subpackages `bracket/`, `csv/`, `seeding/` are an in-progress extraction. | `tree.go`, `seed.go`, `tournament.go`, `constants.go` |
 | `internal/excel/` | Excel file lifecycle (`Client`) and full-workbook construction. | `template.go` (`NewFileFromScratch`) |

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ Admin Client ──→ POST /api/competitions/:id/matches/:mid/score
 ```
 tournament-data/
 ├── tournament.md                       YAML front-matter: name, date, venue, courts, password
-├── wal/                                Pending multi-file transactions (replayed on startup)
+├── .wal/                               Pending multi-file transactions (replayed on startup)
 ├── branding/                           Uploaded logo (logo.png|jpg) for display surfaces
 ├── sponsors/                           Uploaded sponsor images
 └── competitions/
@@ -226,7 +226,7 @@ The `Hub` broadcasts the following event types over `GET /api/events`:
 | Event | Triggered by |
 |---|---|
 | `match_updated` | score / decision / status change (coalesced ≤4/s per match) |
-| `competition_started` | `POST /competitions/:id/start` |
+| `competition_started` | `POST /api/competitions/:id/start` |
 | `competition_completed` | final match resolved |
 | `tournament_updated` | tournament-level CRUD |
 | `schedule_updated` | court/time edits, schedule regenerated |
@@ -294,7 +294,7 @@ App (app.jsx)
 
 **Decision types** (`internal/domain/decision.go` is the source of truth): the canonical wire values include `""`, `fought`, `hikiwake`, `kiken` (legacy), `kiken-voluntary` (FIK Art. 31, permanent), `kiken-injury` (FIK Art. 30, reinstateable), `fusenpai`, `fusensho`, `daihyosen`, `kachinuki-exhaustion`, `ippon-shobu`. Use `domain.IsKikenDecision`/`IsKikenDecisionStr` to match any kiken variant. Legacy YAML `decision: true` migrates to `hikiwake`, `false` to `fought`, and `kiken` to `kiken-voluntary` (Decision.UnmarshalYAML).
 
-**Competitor eligibility** (`engine/eligibility.go`, `state/competitor_status.go`): a kiken/fusenpai decision auto-writes `CompetitorStatus{Eligible: false}` for the loser. `engine.StartMatchTx` is the FR-035 pre-flight gate — returns `*IneligibleCompetitorError` (matches `errors.Is(err, ErrIneligibleCompetitor)`), mapped to HTTP 409 by the score handler. Re-scoring a match that itself created the ineligibility is permitted (undo path). Kiken-injury (FIK Art. 30) sets `Reinstateable: true`; an admin can restore eligibility via `POST /competitions/:cid/competitors/:pid/reinstate`. Kiken-voluntary (Art. 31) and fusenpai are not reinstateable.
+**Competitor eligibility** (`engine/eligibility.go`, `state/competitor_status.go`): a kiken/fusenpai decision auto-writes `CompetitorStatus{Eligible: false}` for the loser. `engine.StartMatchTx` is the FR-035 pre-flight gate — returns `*IneligibleCompetitorError` (matches `errors.Is(err, ErrIneligibleCompetitor)`), mapped to HTTP 409 by the score handler. Re-scoring a match that itself created the ineligibility is permitted (undo path). Kiken-injury (FIK Art. 30) sets `Reinstateable: true`; an admin can restore eligibility via `POST /api/competitions/:id/competitors/:pid/reinstate`. Kiken-voluntary (Art. 31) and fusenpai are not reinstateable.
 
 **Team lineups & kachinuki** (`domain/team_lineup.go`, `engine/kachinuki.go`): TeamLineup pins position → player for a round. FIK 5-person rule: Senpo + Taisho mandatory; 1 vacancy must be Jiho, 2 must be Jiho+Fukusho, 3+ disqualifies. Kachinuki ("winner-stays-on") dynamically appends bouts via `engine.AdvanceKachinuki` until one team is exhausted (`DecisionKachinukiExhaustion`).
 

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -436,27 +436,21 @@ Docker images available via `Dockerfile` and `Dockerfile.mobile`.
 
 ## Codebase Size
 
-Approximate, top-level package only (subpackages excluded); refresh with the `wc -l` sweep over `*.go` / `*_test.go`.
+Relative sizing only — exact line counts go stale immediately and aren't worth hand-maintaining. Re-derive with a `wc -l` / `gocloc` sweep when you need numbers.
 
-| Package | Source LOC | Test LOC | Ratio |
-|---|---|---|---|
-| mobileapp | 11,478 | 21,880 | 1.9× |
-| engine | 8,453 | 15,571 | 1.8× |
-| helper | 5,572 | 10,836 | 1.9× |
-| state | 5,509 | 8,245 | 1.5× |
-| cmd | 1,831 | 3,111 | 1.7× |
-| domain | 807 | 944 | 1.2× |
-| excel | 391 | 135 | 0.3× |
-| service / resources / test | 121 | 175 | — |
-| **Go total** (incl. subpackages) | **~35,500** | **~62,100** | **1.7×** |
-| **Frontend (JSX/JS)** | **~27,300** | **~22,400** | **0.8×** |
+**Package mass** (largest → smallest): `mobileapp` ≫ `engine` ≳ `helper` ≈ `state` ≫ `cmd` ≫ `domain` ≫ `excel`. The Go backend and the JSX frontend are roughly comparable in size.
+
+**Test investment** (test LOC ÷ source LOC): most packages sit around 1.5–1.9× — substantial, algorithm-heavy test bodies. Two outliers:
+
+- `excel` ≈ 0.3× — thinly tested directly; most Excel coverage lives in `helper/*_test.go` instead.
+- Frontend ≈ 0.8× — lighter than the Go side, though still ~79 Vitest spec files.
 
 ## Known Architectural Observations
 
 ### Strengths
 
 - **Clean layering**: presentation → engine → state → filesystem with no circular dependencies.
-- **Strong algorithmic test coverage**: helper (2.0×), engine (1.5×), state (1.5×), and mobileapp (1.5×) all carry substantial test bodies.
+- **Strong algorithmic test coverage**: helper, engine, state, and mobileapp all carry substantial test bodies (roughly 1.5–1.9× source).
 - **Single-binary deployment**: all assets embedded at compile time.
 - **Fine-grained concurrency**: per-competition + per-file locking avoids global contention; non-reentrant mutex caught misuse via `StoreTx`.
 - **Multi-file atomicity**: WAL-backed `Store.WithTransaction` lets the score handler commit several files (match result + eligibility + lineup) atomically across a crash.
@@ -465,9 +459,9 @@ Approximate, top-level package only (subpackages excluded); refresh with the `wc
 
 ### Areas to Watch
 
-- **`mobileapp/` is now the largest package** (~11.5K LOC, ~35 source files) after the new handler families landed (decision, eligibility, lineup, daihyosen, Swiss, display, league tie-breaker, registration, announcement, branding, sponsors, print). It now carries supporting infra too (rate limiting, broadcast coalescer, viewer single-flight). Further grouping into subpackages may be warranted.
-- **`engine/` has grown rapidly** — ~23 source files, ~8.5K LOC — spanning scoring, eligibility, kachinuki, daihyosen, Swiss, scheduling, league tie-breaks, participant replacement, and PDF export. Further sub-splitting may be warranted.
-- **`helper/` mixes concerns** (~5.6K LOC): tree algorithms, CSV parsing, Excel rendering, seeding, and utilities. The `helper/{bracket,csv,seeding}/` subpackages signal an ongoing extraction (the earlier `pool/` subpackage was folded back to `pool_partial.go`); `helper/` proper has not shrunk yet.
-- **`excel/` has minimal test coverage** (0.3× ratio) despite Excel output being the primary CLI deliverable. Most Excel test coverage lives in `helper/*_test.go` instead.
-- **`domain/` is still partially adopted** (~800 LOC, 9 files): most business logic in `helper/` uses `helper.Player` directly rather than domain types — the migration is incomplete.
+- **`mobileapp/` is now the largest package** after the new handler families landed (decision, eligibility, lineup, daihyosen, Swiss, display, league tie-breaker, registration, announcement, branding, sponsors, print). It now carries supporting infra too (rate limiting, broadcast coalescer, viewer single-flight). Further grouping into subpackages may be warranted.
+- **`engine/` has grown rapidly** — spanning scoring, eligibility, kachinuki, daihyosen, Swiss, scheduling, league tie-breaks, participant replacement, and PDF export. Further sub-splitting may be warranted.
+- **`helper/` mixes concerns**: tree algorithms, CSV parsing, Excel rendering, seeding, and utilities. The `helper/{bracket,csv,seeding}/` subpackages signal an ongoing extraction (the earlier `pool/` subpackage was folded back to `pool_partial.go`); `helper/` proper has not shrunk yet.
+- **`excel/` has minimal direct test coverage** despite Excel output being the primary CLI deliverable. Most Excel test coverage lives in `helper/*_test.go` instead.
+- **`domain/` is still partially adopted**: most business logic in `helper/` uses `helper.Player` directly rather than domain types — the migration is incomplete.
 - **No Go interfaces** for `state.Store` or `engine.Engine` at the top level — interface adoption is happening incrementally via `mobileapp/deps.go`, but engine-to-state and helper-to-engine calls still go through concrete types.

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -43,137 +43,29 @@ Presentation (cmd/, mobileapp/, web/, web-mobile/)
 
 ## Package Map
 
+This is a responsibility map at the package level, with a few representative anchor files per package — it is deliberately **not** a file-by-file inventory (those drift on every commit; let `go doc ./...` and a directory listing be the source of truth). Each entry describes what the package owns and where to start reading.
+
 ```
-main.go                          Entry point; embeds web/ and web-mobile/ via //go:embed
-│
-├── cmd/                         Cobra CLI commands
-│   ├── root.go                  Root command, flag registration
-│   ├── create-pools.go          Pool + playoff bracket generation
-│   ├── create-playoffs.go       Direct elimination bracket generation
-│   ├── shared.go                Shared CLI helpers (processEntries, openOutputFile, etc.)
-│   ├── serve.go                 Stateless web server (form → Excel)
-│   ├── mobile_app.go            Live tournament server startup
-│   ├── hash_password.go         bcrypt hash generator for locked-mode auth
-│   ├── print.go                 Render a saved competition to PDF/Excel
-│   ├── diag_unix.go/_windows.go Runtime diagnostics (hidden)
-│   ├── version.go               Version display
-│   └── man.go                   Man-page generation (hidden)
-│
-├── internal/
-│   ├── domain/                  Pure domain models (no internal dependencies)
-│   │   ├── player.go            Player, MatchWinner
-│   │   ├── seed.go              SeedAssignment
-│   │   ├── pool.go, match.go, tournament.go
-│   │   ├── decision.go          Decision wire values + UnmarshalYAML migration
-│   │   ├── competitor_status.go Eligibility record
-│   │   ├── team_lineup.go       Team-match lineup (Senpo..Taisho)
-│   │   └── glossary.go          Kendo-term glossary used by the UI
-│   │
-│   ├── helper/                  Core algorithms and Excel rendering (largest package)
-│   │   ├── tree.go              Binary bracket tree (Node, recursive subdivision)
-│   │   ├── seed.go              Seeding algorithms (StandardSeeding, PoolSeeding, ApplySeeds)
-│   │   ├── tournament.go        Pool creation (greedy, dojo-conflict avoidance)
-│   │   ├── csv.go               CSV parsing and validation
-│   │   ├── excel.go, excel_*.go Excel rendering (data, styles, tree, tags, kachinuki)
-│   │   ├── constants.go         Layout constants, sheet names, defaults
-│   │   ├── numbers.go, uuid.go, helper.go, qr.go, rounds.go, dedup.go, reserved.go
-│   │   └── bracket/, csv/, seeding/   Small focused subpackages (ongoing extraction)
-│   │
-│   ├── excel/                   Excel file lifecycle
-│   │   ├── client.go            File open/save/close (Client)
-│   │   ├── error.go             Error handling utilities
-│   │   └── template.go          NewFileFromScratch — builds entire workbook
-│   │
-│   ├── engine/                  Business logic for live tournaments (~23 source files)
-│   │   ├── engine.go            Engine struct (wraps state.Store)
-│   │   ├── scoring.go, scoring_tx.go   Match result recording (tx-aware variants)
-│   │   ├── pools.go, bracket.go, knockout.go   Pool round-robin + bracket advancement
-│   │   ├── ranking.go, tiebreaker.go, league_tiebreak.go   Standings, tie-breaking, league play-offs
-│   │   ├── competition.go              Lifecycle (start, invalidate, complete)
-│   │   ├── replace_participant.go      Mid-tournament participant substitution
-│   │   ├── schedule.go, scheduler_slots.go, estimate_schedule.go   Court scheduling + estimator
-│   │   ├── court_validation.go         Court-count / labelling validation
-│   │   ├── eligibility.go              StartMatch gate (kiken/fusenpai)
-│   │   ├── kachinuki.go, kachinuki_export.go  Winner-stays-on bouts
-│   │   ├── daihyosen.go                Rep-bout flow
-│   │   ├── swiss.go                    Swiss-round format
-│   │   ├── export.go, pdf_export.go    Excel / PDF export from live state
-│   │   └── errors.go                   Typed error definitions
-│   │
-│   ├── state/                   File-backed persistence with caching + WAL
-│   │   ├── store.go             Store struct, per-competition locking, mtime cache
-│   │   ├── transactions.go      WithTransaction / StoreTx (multi-file atomic commits)
-│   │   ├── atomic_write.go      Single-file durable write (tmp → fsync → rename)
-│   │   ├── wal/wal.go           Write-ahead log for multi-file transactions
-│   │   ├── models.go            Tournament, Competition, MatchResult, Bracket, etc.
-│   │   ├── tournament.go, competition.go   YAML-frontmatter Markdown read/write
-│   │   ├── participants.go, seeds.go, pools.go, bracket.go, schedule.go
-│   │   ├── competitor_status.go Eligibility persistence
-│   │   ├── team_lineup.go       Team lineup persistence
-│   │   ├── announcement_store.go  Operator announcement persistence
-│   │   ├── overrides.go         Manual ranking overrides
-│   │   ├── match.go             DeriveQueuePositions (pure helper)
-│   │   └── ids.go               ID generation utilities
-│   │
-│   ├── mobileapp/               HTTP handlers and real-time events
-│   │   ├── server.go            Gin router setup, CORS, SPA fallback
-│   │   ├── middleware.go        Auth middleware (X-Tournament-Password)
-│   │   ├── auth_source.go, auth_admin.go   PasswordVerifier (file vs locked mode)
-│   │   ├── ratelimit.go         Per-IP token-bucket rate limiting
-│   │   ├── hub.go               SSE pub/sub hub (channel-based, non-blocking)
-│   │   ├── broadcast_coalescer.go  Coalesces bursty match_updated broadcasts (≤4/s/match)
-│   │   ├── viewer_singleflight.go  Dedupes concurrent viewer reads
-│   │   ├── public_projection.go    Read-only projection of state for public surfaces
-│   │   ├── safego.go            Panic-safe goroutine helper (see CLAUDE.md)
-│   │   ├── deps.go              Consumer-boundary interfaces (NFR-002)
-│   │   ├── validation.go        Shared request validation helpers
-│   │   ├── handlers_tournament.go, handlers_competition.go, handlers_participants.go
-│   │   ├── handlers_match.go, handlers_decision.go, handlers_daihyosen.go
-│   │   ├── handlers_eligibility.go, handlers_lineup.go, handlers_swiss.go
-│   │   ├── handlers_league_tiebreak.go   Operator-driven league play-offs
-│   │   ├── handlers_schedule.go Stateless schedule estimator (also wired into `serve`)
-│   │   ├── handlers_import.go, handlers_print.go   Tournament import + PDF/Excel print
-│   │   ├── handlers_registration.go      Self-service participant registration
-│   │   ├── handlers_announcement.go, handlers_branding.go, handlers_sponsors.go   Operator content
-│   │   ├── handlers_auth_admin.go, handlers_auth_config.go, handlers_reset.go   Auth + password reset
-│   │   ├── handlers_version.go  Build/version endpoint
-│   │   ├── handlers_display.go  Public TV/lobby/overlay surfaces
-│   │   └── handlers_viewer.go   Public (unauthenticated) endpoints
-│   │
-│   ├── resources/               Embedded filesystem abstraction
-│   ├── service/                 Thin service layer (tournament_service.go)
-│   ├── cmd/version/             Build/version metadata helpers
-│   └── test/                    Shared test helpers and factories
-│
-├── web/                         Web UI for Excel bracket generation
-│   └── index.html               Full SPA: tournament config, CSV input, seeding, estimator
-│
-├── web-mobile/                  Preact SPA (embedded, served by `mobile-app`)
-│   ├── index.html               SPA shell
-│   ├── js/                      ~60 modules (split by feature as the SPA grew)
-│   │   ├── app.jsx              Root component, SSE listener, auth, view state
-│   │   ├── router.jsx           preact-router wrapper, useQuery()
-│   │   ├── api_client.jsx       HTTP client (auth, retry, error mapping)
-│   │   ├── api_serializers.jsx  JSON ↔ camelCase normalization
-│   │   ├── data.jsx, patch.jsx  State hooks, normalization, SSE patch-merge
-│   │   ├── ui.jsx, bracket.jsx, glossary.jsx, glossary_data.js, qr.jsx
-│   │   ├── viewer*.jsx          Public viewer (home, competition, schedule, standings,
-│   │   │                          match, awards, alerts, notifications, watchlist)
-│   │   ├── display*.jsx, streaming_overlay.jsx, match_scoreboard.jsx  TV/lobby/overlay
-│   │   ├── registration.jsx, reset.jsx, sponsor_strip.jsx   Public self-service surfaces
-│   │   ├── admin.jsx, admin_shell.jsx, admin_setup.jsx, admin_helpers.jsx   Container + chrome
-│   │   ├── admin_competition*.jsx   Overview, settings, bracket, swiss sub-tabs
-│   │   ├── admin_participants.jsx, admin_pools.jsx, admin_lineup.jsx
-│   │   ├── admin_schedule*.jsx       Schedule page, score editor, pacing, export, lineup
-│   │   ├── admin_scoring_*.jsx       Scoring modal (individual, team, autosave, shared)
-│   │   ├── admin_shiaijo.jsx         Per-court "now playing / up next" operator board
-│   │   ├── admin_announcement.jsx, admin_branding.jsx, admin_sponsors.jsx   Operator content
-│   │   └── __tests__/           ~79 Vitest spec files (incl. render/ DOM tests)
-│   ├── css/styles.css
-│   └── dist/                    esbuild output (pre-compiled JSX)
-│
-└── specs/                       OpenAPI spec, feature specs, this document
+main.go        Entry point; embeds web/ and web-mobile/ via //go:embed
+specs/         OpenAPI spec, feature specs, this document
+web/           index.html — full SPA for the stateless Excel generator (serve mode)
+web-mobile/    Preact SPA for the live tournament app (embedded, served by mobile-app)
 ```
+
+| Package | Owns | Start here |
+|---|---|---|
+| `cmd/` | Cobra CLI commands — one options struct + `run()` per subcommand; `serve`/`mobile_app` boot the web servers. Shared CLI logic in `shared.go`. | `root.go`, `shared.go`, `serve.go`, `mobile_app.go` |
+| `internal/domain/` | Pure domain models with **zero internal dependencies** — Player, Pool, Match, Tournament, Seed, Decision, CompetitorStatus, TeamLineup, plus the UI glossary. | `decision.go`, `team_lineup.go` |
+| `internal/helper/` | Core algorithms + all Excel rendering (the historical catch-all). Bracket trees, seeding, pool creation, CSV parsing, `excel_*.go` renderers. Subpackages `bracket/`, `csv/`, `seeding/` are an in-progress extraction. | `tree.go`, `seed.go`, `tournament.go`, `constants.go` |
+| `internal/excel/` | Excel file lifecycle (`Client`) and full-workbook construction. | `template.go` (`NewFileFromScratch`) |
+| `internal/engine/` | Business logic for live tournaments — scoring, pools/bracket advancement, ranking & tie-breaking, scheduling, eligibility, kachinuki, daihyosen, Swiss, participant replacement, Excel/PDF export. | `engine.go`, `scoring_tx.go`, `eligibility.go` |
+| `internal/state/` | File-backed persistence with mtime caching + WAL. Markdown/YAML and CSV/JSON readers per artifact; multi-file transactions. | `store.go`, `transactions.go`, `models.go`, `wal/wal.go` |
+| `internal/mobileapp/` | Gin HTTP handlers (`handlers_*.go`, grouped by feature), SSE hub, auth, and supporting infra (rate limiting, broadcast coalescing, viewer single-flight, `safeGo`). Handlers depend on `deps.go` interfaces. | `server.go`, `hub.go`, `deps.go`, `middleware.go` |
+| `internal/resources/` | Embedded-filesystem abstraction (`fs.FS`) over the bundled web assets. | — |
+| `internal/service/` | Thin service layer over helper logic. | `tournament_service.go` |
+| `internal/test/` | Shared test helpers and factories. | `helpers.go` |
+
+The `web-mobile/js/` SPA is organized by feature prefix rather than enumerated here: `app.jsx`/`router.jsx` (shell + routing), `api_*.jsx`/`data.jsx`/`patch.jsx` (transport + state), `viewer_*.jsx` (public viewer), `display_*.jsx`/`streaming_overlay.jsx` (TV/lobby/overlay), `admin_*.jsx` (operator surfaces — setup, competition, pools, schedule, scoring, lineup, shiaijo, content), and `registration.jsx`/`reset.jsx` (public self-service). Tests live in `js/__tests__/` (Vitest, including `render/` DOM tests); compiled output in `dist/`.
 
 ## Dependency Graph
 
@@ -400,7 +292,7 @@ App (app.jsx)
 
 **Tie-breaking**: Multi-criteria cascade — wins → losses → draws → points scored → points lost (individual). Team tournaments add team-level criteria before individual criteria. See CLAUDE.md for the full precedence.
 
-**Decision types** (`internal/domain/decision.go`): 11 canonical wire values — `""`, `fought`, `hikiwake`, `kiken` (legacy), `kiken-voluntary` (FIK Art. 31, permanent), `kiken-injury` (FIK Art. 30, reinstateable), `fusenpai`, `fusensho`, `daihyosen`, `kachinuki-exhaustion`, `ippon-shobu`. Use `domain.IsKikenDecision`/`IsKikenDecisionStr` to match any kiken variant. Legacy YAML `decision: true` migrates to `hikiwake`, `false` to `fought`, and `kiken` to `kiken-voluntary` (Decision.UnmarshalYAML).
+**Decision types** (`internal/domain/decision.go` is the source of truth): the canonical wire values include `""`, `fought`, `hikiwake`, `kiken` (legacy), `kiken-voluntary` (FIK Art. 31, permanent), `kiken-injury` (FIK Art. 30, reinstateable), `fusenpai`, `fusensho`, `daihyosen`, `kachinuki-exhaustion`, `ippon-shobu`. Use `domain.IsKikenDecision`/`IsKikenDecisionStr` to match any kiken variant. Legacy YAML `decision: true` migrates to `hikiwake`, `false` to `fought`, and `kiken` to `kiken-voluntary` (Decision.UnmarshalYAML).
 
 **Competitor eligibility** (`engine/eligibility.go`, `state/competitor_status.go`): a kiken/fusenpai decision auto-writes `CompetitorStatus{Eligible: false}` for the loser. `engine.StartMatchTx` is the FR-035 pre-flight gate — returns `*IneligibleCompetitorError` (matches `errors.Is(err, ErrIneligibleCompetitor)`), mapped to HTTP 409 by the score handler. Re-scoring a match that itself created the ineligibility is permitted (undo path). Kiken-injury (FIK Art. 30) sets `Reinstateable: true`; an admin can restore eligibility via `POST /competitions/:cid/competitors/:pid/reinstate`. Kiken-voluntary (Art. 31) and fusenpai are not reinstateable.
 
@@ -443,7 +335,7 @@ Relative sizing only — exact line counts go stale immediately and aren't worth
 **Test investment** (test LOC ÷ source LOC): most packages sit around 1.5–1.9× — substantial, algorithm-heavy test bodies. Two outliers:
 
 - `excel` ≈ 0.3× — thinly tested directly; most Excel coverage lives in `helper/*_test.go` instead.
-- Frontend ≈ 0.8× — lighter than the Go side, though still ~79 Vitest spec files.
+- Frontend ≈ 0.8× — lighter than the Go side, though still a substantial Vitest suite.
 
 ## Known Architectural Observations
 

--- a/specs/ARCHITECTURE.md
+++ b/specs/ARCHITECTURE.md
@@ -58,6 +58,7 @@ web-mobile/    Preact SPA for the live tournament app (embedded, served by mobil
 | `internal/domain/` | Pure domain models with **zero internal dependencies** — Player, Pool, Match, Tournament, Seed, Decision, CompetitorStatus, TeamLineup, plus the UI glossary. | `decision.go`, `team_lineup.go` |
 | `internal/helper/` | Core algorithms + all Excel rendering (the historical catch-all). Bracket trees, seeding, pool creation, CSV parsing, `excel_*.go` renderers. Subpackages `bracket/`, `csv/`, `seeding/` are an in-progress extraction. | `tree.go`, `seed.go`, `tournament.go`, `constants.go` |
 | `internal/excel/` | Excel file lifecycle (`Client`) and full-workbook construction. | `template.go` (`NewFileFromScratch`) |
+| `internal/pdf/` | Renders bracket XLSX workbooks to print-ready PDFs via LibreOffice (used by the `print` command and engine PDF export). | `generate.go`, `soffice.go` |
 | `internal/engine/` | Business logic for live tournaments — scoring, pools/bracket advancement, ranking & tie-breaking, scheduling, eligibility, kachinuki, daihyosen, Swiss, participant replacement, Excel/PDF export. | `engine.go`, `scoring_tx.go`, `eligibility.go` |
 | `internal/state/` | File-backed persistence with mtime caching + WAL. Markdown/YAML and CSV/JSON readers per artifact; multi-file transactions. | `store.go`, `transactions.go`, `models.go`, `wal/wal.go` |
 | `internal/mobileapp/` | Gin HTTP handlers (`handlers_*.go`, grouped by feature), SSE hub, auth, and supporting infra (rate limiting, broadcast coalescing, viewer single-flight, `safeGo`). Handlers depend on `deps.go` interfaces. | `server.go`, `hub.go`, `deps.go`, `middleware.go` |
@@ -330,7 +331,7 @@ Docker images available via `Dockerfile` and `Dockerfile.mobile`.
 
 Relative sizing only — exact line counts go stale immediately and aren't worth hand-maintaining. Re-derive with a `wc -l` / `gocloc` sweep when you need numbers.
 
-**Package mass** (largest → smallest): `mobileapp` ≫ `engine` ≳ `helper` ≈ `state` ≫ `cmd` ≫ `domain` ≫ `excel`. The Go backend and the JSX frontend are roughly comparable in size.
+**Package mass** (largest → smallest): `mobileapp` > `engine` > `helper` ≈ `state` ≫ `cmd` ≫ `domain` ≫ `excel`. The Go backend is somewhat larger than the JSX frontend, but they're the same order of magnitude.
 
 **Test investment** (test LOC ÷ source LOC): most packages sit around 1.5–1.9× — substantial, algorithm-heavy test bodies. Two outliers:
 


### PR DESCRIPTION
## Summary

- Bring `specs/ARCHITECTURE.md` back in sync with the current codebase — it had drifted on decision types, SSE events, file lists, frontend modules, and metrics.
- Restructure the most staleness-prone regions so the doc describes durable intent rather than mirroring code 1:1.

## Why

The document was last meaningfully revised before several feature families landed (league tie-breaker, shiaijo board, registration, sponsors/branding/announcements, PDF print, display surfaces). More importantly, large parts of it (the file-by-file tree, exact LOC counts, "N files" totals) tracked code structure 1:1 and went stale on ordinary commits — every LOC figure was wrong, sometimes by ~2×. This PR fixes the content **and** removes the categories of content that guarantee future rot.

Changes, in three commits:

1. **Refresh** — decision types 8→11 (incl. `kiken-voluntary`, `kiken-injury`, `ippon-shobu`) + reinstatement semantics; SSE events 6→12 with coalescing note; new `cmd`/`engine`/`mobileapp` files and infra (rate limiting, broadcast coalescer, single-flight); `helper` subpackages (dropped folded-back `pool/`); refreshed frontend map + component tree; added `branding/`+`sponsors/` to the on-disk layout; marked the `schedule_updated` frontend gap resolved.
2. **Relative sizing** — replaced the exact LOC table with relative package ordering + test-ratio bands; exact line counts aren't worth hand-maintaining.
3. **Trim** — replaced the exhaustive file tree and ~60-module js/ list with a package-level responsibility table (Owns / Start here) plus representative anchor files; pointed readers at `go doc ./...` as the source of truth; dropped remaining hard counts.

Protocol contracts (the SSE event table and decision-value list) were kept — they're reader-facing API surface — but stripped of embedded counts.

## Files changed

| File | What |
|---|---|
| `specs/ARCHITECTURE.md` | Refreshed to current code; replaced LOC table with relative sizing; trimmed the file-by-file Package Map to a package-level responsibility table |

## Screenshots

No UI impact — documentation-only change.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — N/A: documentation-only change, no code touched
- [x] New/updated unit tests cover the change — N/A: documentation-only
- [x] Manual browser verification (for `web-mobile/` or `web/` changes) — N/A: no UI change
- [x] Screenshots added above (REQUIRED for any UI-affecting change) — N/A: no UI change
- [x] No new console errors or warnings — N/A: no code change
- [x] Doc claims verified against the codebase (file lists, decision types, SSE events, auth modes, persistence paths) before editing

<!-- No bead associated with this docs task. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScX6wNW8ibDUuHUtucfL2)_