### PR TITLE
fix(admin): draw-workflow + dashboard UX fixes and schedule feature flag

### DIFF
--- a/cmd/create-pools.go
+++ b/cmd/create-pools.go
@@ -23,6 +23,7 @@ type poolOptions struct {
 	seedsPath       string
 	outputWriter    *bufio.Writer
 	roundRobin      bool
+	poolFormat      string // "" / "full" → legacy roundRobin switch; "partial" → path-graph
 	withZekkenName  bool
 	singleTree      bool
 	determined      bool
@@ -235,8 +236,13 @@ func (o *poolOptions) createPools(entries []string) error {
 	// divide the tree depending on the number of pages
 	subtrees := helper.SubdivideTree(tree, numPages)
 
-	// Create pool matches and get winners BEFORE creating tree sheets
-	if o.roundRobin {
+	// Create pool matches and get winners BEFORE creating tree sheets.
+	// Mirror the engine's authoritative PoolFormat × RoundRobin mapping
+	// (internal/engine/pools.go) so an exported partial-pool competition
+	// gets the path-graph match set, not full round-robin.
+	if o.poolFormat == "partial" {
+		helper.CreatePartialPoolMatches(pools)
+	} else if o.roundRobin {
 		helper.CreatePoolRoundRobinMatches(pools)
 	} else {
 		helper.CreatePoolMatches(pools)

--- a/cmd/create_handler.go
+++ b/cmd/create_handler.go
@@ -101,6 +101,7 @@ func createTournamentHandler(c *gin.Context) {
 	}
 
 	roundRobin := c.PostForm("roundRobin") == "on"
+	poolFormat := c.PostForm("poolFormat") // "partial" → path-graph; else legacy roundRobin switch
 	poolSizeMode := c.PostForm("poolSizeMode")
 
 	// Parse courts (number of Shiaijo)
@@ -154,6 +155,7 @@ func createTournamentHandler(c *gin.Context) {
 			determined:      determined,
 			teamMatches:     teamMatches,
 			roundRobin:      roundRobin,
+			poolFormat:      poolFormat,
 			numPlayers:      numPlayers,
 			maxPlayers:      maxPlayers,
 			poolWinners:     winnersPerPool,

--- a/cmd/create_handler_test.go
+++ b/cmd/create_handler_test.go
@@ -116,6 +116,48 @@ func TestCreateHandler_CommaInPlayerName_NotCorrupted(t *testing.T) {
 	require.True(t, found, "comma-containing player name was corrupted (split on the comma) in the data sheet")
 }
 
+// TestCreateHandler_PartialPoolFormat_FewerMatches verifies the /create
+// generator honours a competition's PoolFormat=partial (mp-x0u9 follow-up):
+// AdminExport posts poolFormat=partial, which must route to
+// CreatePartialPoolMatches (a path graph of N-1 matches) instead of the default
+// full round-robin (N*(N-1)/2). Each pool match writes a literal "vs" cell on
+// the Pool Matches sheet, so the match count is the number of "vs" cells.
+func TestCreateHandler_PartialPoolFormat_FewerMatches(t *testing.T) {
+	roster := "Alice, DA\nBob, DB\nCharlie, DC\nDave, DD\nEve, DE\nFrank, DF" // 1 pool of 6
+	// Match rows are formula cells (GetRows shows them empty), so count them by
+	// geometry: the block runs from the "White … vs … Red" header to the
+	// "Results" block, separated by one blank row. matches = resultsRow - headerRow - 2.
+	matchCount := func(f *excelize.File) int {
+		rows, err := f.GetRows("Pool Matches")
+		require.NoError(t, err)
+		headerRow, resultsRow := -1, -1
+		for i, row := range rows {
+			for _, cell := range row {
+				if cell == "vs" {
+					headerRow = i
+				}
+			}
+			if len(row) > 0 && row[0] == "Results" {
+				resultsRow = i
+				break
+			}
+		}
+		require.Positive(t, headerRow+1, "match header row not found")
+		require.Positive(t, resultsRow+1, "Results block not found")
+		return resultsRow - headerRow - 2
+	}
+
+	full := matchCount(postCreate(t, leagueForm(roster))) // round-robin → 6*5/2 = 15
+
+	partialForm := leagueForm(roster)
+	partialForm.Set("poolFormat", "partial")          // takes precedence over roundRobin
+	partial := matchCount(postCreate(t, partialForm)) // path graph → 6-1 = 5
+
+	require.Equal(t, 15, full, "round-robin pool of 6 should produce 15 matches")
+	require.Equal(t, 5, partial, "partial (path-graph) pool of 6 should produce 5 matches")
+	require.Less(t, partial, full, "partial pool format must generate fewer matches than round-robin")
+}
+
 // TestCreateHandler_CRLFRoster_Normalized guards the newline-normalization fix:
 // a CRLF roster (as a browser textarea / curl can send) must not leave a
 // trailing "\r" on the last field nor trip the exact-match duplicate check on a

--- a/cmd/create_handler_test.go
+++ b/cmd/create_handler_test.go
@@ -120,8 +120,9 @@ func TestCreateHandler_CommaInPlayerName_NotCorrupted(t *testing.T) {
 // generator honours a competition's PoolFormat=partial (mp-x0u9 follow-up):
 // AdminExport posts poolFormat=partial, which must route to
 // CreatePartialPoolMatches (a path graph of N-1 matches) instead of the default
-// full round-robin (N*(N-1)/2). Each pool match writes a literal "vs" cell on
-// the Pool Matches sheet, so the match count is the number of "vs" cells.
+// full round-robin (N*(N-1)/2). Match rows are mostly formula cells (empty in
+// GetRows) and "vs" is just the block header, so the match count is measured by
+// geometry: the rows between the "vs" header and the "Results" block.
 func TestCreateHandler_PartialPoolFormat_FewerMatches(t *testing.T) {
 	roster := "Alice, DA\nBob, DB\nCharlie, DC\nDave, DD\nEve, DE\nFrank, DF" // 1 pool of 6
 	// Match rows are formula cells (GetRows shows them empty), so count them by

--- a/cmd/mobile_app.go
+++ b/cmd/mobile_app.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +18,21 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 	"github.com/spf13/cobra"
 )
+
+// ScheduleEnabledEnv is the env var that enables the "Tournament schedule"
+// feature in the SPA admin UI. Truthy values: "1", "true", "yes", "on"
+// (case-insensitive). Anything else / unset = false (default OFF). mp-fwce.
+const ScheduleEnabledEnv = "ENABLE_TOURNAMENT_SCHEDULE"
+
+// parseScheduleEnabled returns true when the env var value is one of the
+// canonical truthy strings ("1", "true", "yes", "on"), case-insensitive.
+func parseScheduleEnabled(val string) bool {
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
 
 // Server tuning constants for the mobile-app HTTP listener. mp-663 Phase 2:
 // closes slowloris and never-drains-connection vectors that the default
@@ -168,7 +184,12 @@ func (o *mobileAppOptions) run(cmd *cobra.Command, args []string) error {
 	}
 	hub := mobileapp.NewHubWithLimits(mobileapp.DefaultHistorySize, maxClients)
 
-	r, _, apiLimiter := mobileapp.NewRouterWithHub(store, eng, GetResources(), verifier, hub)
+	// ENABLE_TOURNAMENT_SCHEDULE feature flag (mp-fwce). Default OFF;
+	// truthy values ("1", "true", "yes", "on") enable the admin schedule card.
+	scheduleEnabled := parseScheduleEnabled(os.Getenv(ScheduleEnabledEnv))
+	slog.Info("mobile-app: schedule feature flag", "scheduleEnabled", scheduleEnabled)
+
+	r, _, apiLimiter := mobileapp.NewRouterWithHub(store, eng, GetResources(), verifier, hub, scheduleEnabled)
 
 	// Mount the stateless tournament-generation endpoint (same handler the
 	// `serve` web app uses) so the in-app "Download .xlsx" button runs the

--- a/cmd/mobile_app_test.go
+++ b/cmd/mobile_app_test.go
@@ -176,3 +176,30 @@ func TestMobileAppOptions_LockPasswordEnvVarFormats(t *testing.T) {
 		})
 	}
 }
+
+func TestParseScheduleEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"1 is truthy", "1", true},
+		{"true is truthy", "true", true},
+		{"TRUE is truthy", "TRUE", true},
+		{"yes is truthy", "yes", true},
+		{"on is truthy", "on", true},
+		{"empty string is false", "", false},
+		{"0 is false", "0", false},
+		{"false is false", "false", false},
+		{"no is false", "no", false},
+		{"off is false", "off", false},
+		{"garbage is false", "garbage", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseScheduleEnabled(tt.input)
+			assert.Equal(t, tt.want, got,
+				"parseScheduleEnabled(%q) = %v; want %v", tt.input, got, tt.want)
+		})
+	}
+}

--- a/internal/engine/scheduler_slots.go
+++ b/internal/engine/scheduler_slots.go
@@ -31,8 +31,9 @@ const defaultLunchStartClock = "12:00"
 // match when a competition carries neither PoolMatchDuration nor
 // PlayoffMatchDuration nor a legacy MatchDuration (e.g. an
 // unconfigured comp loaded under ApplyCompetitionDefaults). 3 minutes
-// matches the FIK individual default and keeps the slot loop
-// progressing rather than collapsing to zero-duration steps.
+// is a reasonable nominal value that keeps the slot loop progressing
+// rather than collapsing to zero-duration steps; it is only an estimate
+// anchor, not a regulation match time.
 const defaultPerMatchClockMinutes = 3
 
 // perMatchElapsedMinutes returns the elapsed minutes a single match

--- a/internal/mobileapp/coverage_gap_test.go
+++ b/internal/mobileapp/coverage_gap_test.go
@@ -684,7 +684,7 @@ func TestNewRouterWithHub_NilVerifier(t *testing.T) {
 		"web-mobile/index.html": {Data: []byte("<html></html>")},
 	})
 	// nil verifier is allowed — falls back to NewFileVerifier(store)
-	r, _, limiter := NewRouterWithHub(store, eng, res, nil, hub)
+	r, _, limiter := NewRouterWithHub(store, eng, res, nil, hub, false)
 	t.Cleanup(limiter.Close)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/health", nil)

--- a/internal/mobileapp/handlers_auth_admin_test.go
+++ b/internal/mobileapp/handlers_auth_admin_test.go
@@ -27,7 +27,7 @@ func elevatedHandlerRouter(t *testing.T, store *state.Store, verifier PasswordVe
 	api := r.Group("/api")
 	RegisterTournamentHandlers(api, store, hub, verifier)
 	RegisterAdminPasswordHandler(api, store, ev)
-	RegisterAuthConfigHandlers(api, verifier, ev)
+	RegisterAuthConfigHandlers(api, verifier, ev, false)
 	return r, ev
 }
 

--- a/internal/mobileapp/handlers_auth_config.go
+++ b/internal/mobileapp/handlers_auth_config.go
@@ -36,6 +36,11 @@ type authConfigResponse struct {
 	ElevatedRequired   bool `json:"elevatedRequired"`
 	ElevatedConfigured bool `json:"elevatedConfigured"`
 	ElevatedEditable   bool `json:"elevatedEditable"`
+
+	// ScheduleEnabled controls whether the SPA renders the admin
+	// "Tournament schedule" card. Sourced from the ENABLE_TOURNAMENT_SCHEDULE
+	// env var (truthy: "1", "true", "yes", "on"). Default OFF — mp-fwce.
+	ScheduleEnabled bool `json:"scheduleEnabled"`
 }
 
 // RegisterAuthConfigHandlers wires GET /api/auth-config. The endpoint is
@@ -48,7 +53,11 @@ type authConfigResponse struct {
 // inferable from any 404 on /api/tournament/reset. Exposing it
 // explicitly lets the SPA branch up-front rather than relying on a
 // 404-probe race during form rendering.
-func RegisterAuthConfigHandlers(r *gin.RouterGroup, verifier PasswordVerifier, elevated ElevatedVerifier) {
+//
+// scheduleEnabled is sourced from ENABLE_TOURNAMENT_SCHEDULE in
+// cmd/mobile_app.go and threaded here so the env var is read once at
+// startup rather than on every request.
+func RegisterAuthConfigHandlers(r *gin.RouterGroup, verifier PasswordVerifier, elevated ElevatedVerifier, scheduleEnabled bool) {
 	r.GET("/auth-config", func(c *gin.Context) {
 		c.JSON(http.StatusOK, authConfigResponse{
 			Mode:               verifier.Mode(),
@@ -58,6 +67,7 @@ func RegisterAuthConfigHandlers(r *gin.RouterGroup, verifier PasswordVerifier, e
 			// Editable only in file mode — the locked-mode credential is the
 			// TOURNAMENT_ADMIN_PASSWORD_HASH env var, not settable via API.
 			ElevatedEditable: elevated.Mode() == "file",
+			ScheduleEnabled:  scheduleEnabled,
 		})
 	})
 }

--- a/internal/mobileapp/handlers_auth_config_test.go
+++ b/internal/mobileapp/handlers_auth_config_test.go
@@ -1,0 +1,52 @@
+package mobileapp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthConfigHandler_ScheduleEnabledFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		scheduleEnabled bool
+	}{
+		{"scheduleEnabled=true", true},
+		{"scheduleEnabled=false", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "auth-config-test-*")
+			require.NoError(t, err)
+			t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+			store, err := state.NewStore(tempDir)
+			require.NoError(t, err)
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			api := r.Group("/api")
+			verifier := NewFileVerifier(store)
+			elevated := NewFileElevatedVerifier(store)
+			RegisterAuthConfigHandlers(api, verifier, elevated, tc.scheduleEnabled)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/api/auth-config", nil)
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code,
+				"GET /api/auth-config must return 200: %s", w.Body.String())
+
+			var resp authConfigResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+			assert.Equal(t, tc.scheduleEnabled, resp.ScheduleEnabled,
+				"scheduleEnabled in response must match the flag passed to RegisterAuthConfigHandlers")
+		})
+	}
+}

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -847,19 +847,31 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				// applied below. This mirrors the participant/seed 409s in
 				// handlers_participants.go.
 				if current.Status == state.CompStatusDrawReady {
-					courtsChanged := len(comp.Courts) > 0 &&
-						strings.Join(comp.Courts, ",") != strings.Join(current.Courts, ",")
+					// Compare the EFFECTIVE (about-to-be-applied) values
+					// directly — no zero/empty sentinels. The settings merge
+					// below is a full replace, so a caller that sets an
+					// output-affecting field TO its zero/empty value (e.g.
+					// format:"" or poolFormat:"", both accepted by
+					// validateCompetitionFormat) would otherwise slip past a
+					// sentinel guard and corrupt the draw. The real client
+					// (admin_competition_settings.jsx finalNext) always PUTs
+					// the full config with current values for untouched fields,
+					// so a cosmetic-only edit never trips this. comp.Courts was
+					// already defaulted to >=1 court (tournament fallback) in the
+					// settings-validation block above. ApplyCompetitionDefaults
+					// touches only match-duration fields, so comparing here
+					// (pre-defaults) matches the merged result for these fields.
 					outputAffectingChanged :=
-						(comp.PoolSize != 0 && comp.PoolSize != current.PoolSize) ||
-							(comp.PoolWinners != 0 && comp.PoolWinners != current.PoolWinners) ||
-							(comp.PoolSizeMode != "" && comp.PoolSizeMode != current.PoolSizeMode) ||
-							courtsChanged ||
-							(comp.Format != "" && comp.Format != current.Format) ||
-							(comp.PoolFormat != "" && comp.PoolFormat != current.PoolFormat) ||
-							(comp.RoundRobin != current.RoundRobin) ||
-							(comp.Mirror != current.Mirror) ||
-							(comp.TeamSize != 0 && comp.TeamSize != current.TeamSize) ||
-							(comp.Kind != "" && comp.Kind != current.Kind)
+						comp.PoolSize != current.PoolSize ||
+							comp.PoolWinners != current.PoolWinners ||
+							comp.PoolSizeMode != current.PoolSizeMode ||
+							strings.Join(comp.Courts, ",") != strings.Join(current.Courts, ",") ||
+							comp.Format != current.Format ||
+							comp.PoolFormat != current.PoolFormat ||
+							comp.RoundRobin != current.RoundRobin ||
+							comp.Mirror != current.Mirror ||
+							comp.TeamSize != current.TeamSize ||
+							comp.Kind != current.Kind
 					if outputAffectingChanged {
 						drawReadyFlag = true
 						return nil, nil

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -956,7 +956,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		if drawReadyFlag {
-			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify output-affecting settings (format/courts/pool config/kind) while a draw is pending; discard the draw first"})
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify output-affecting settings (format, courts, pool size/winners/mode, pool format, round-robin, mirror, team size, kind) while a draw is pending; discard the draw first"})
 			return
 		}
 		if validationErr != nil {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -871,7 +871,13 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 							comp.RoundRobin != current.RoundRobin ||
 							comp.Mirror != current.Mirror ||
 							comp.TeamSize != current.TeamSize ||
-							comp.Kind != current.Kind
+							comp.Kind != current.Kind ||
+							// NumberPrefix and WithZekkenName reach the Excel generator
+							// (POST /create: numberPrefix → player numbers, withZekkenName
+							// → name columns), so changing them while draw-ready desyncs
+							// config from the generated output.
+							comp.NumberPrefix != current.NumberPrefix ||
+							comp.WithZekkenName != current.WithZekkenName
 					if outputAffectingChanged {
 						drawReadyFlag = true
 						return nil, nil
@@ -968,7 +974,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		if drawReadyFlag {
-			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify output-affecting settings (format, courts, pool size/winners/mode, pool format, round-robin, mirror, team size, kind) while a draw is pending; discard the draw first"})
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify output-affecting settings (format, courts, pool size/winners/mode, pool format, round-robin, mirror, team size, kind, number prefix, zekken display) while a draw is pending; discard the draw first"})
 			return
 		}
 		if validationErr != nil {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -837,14 +837,33 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				}
 
 				// Settings-only PUT (Players field absent in body).
-				// Block settings changes while a draw is pending — the
-				// draw artifacts (pools.csv / bracket.json) were generated
-				// from the current config; mutating PoolSize, Courts, or
-				// Format while draw-ready would leave config.md inconsistent
-				// with those artifacts when StartCompetition runs.
+				// Draw-ready gate: the draw artifacts (pools.csv /
+				// bracket.json) were generated from the current config.
+				// Mutating output-affecting fields while draw-ready would
+				// leave config.md inconsistent with those artifacts when
+				// StartCompetition runs. Cosmetic fields (Name, Date,
+				// StartTime, NumberPrefix, CheckInEnabled, Naginata,
+				// WithZekkenName) are still editable in draw-ready and are
+				// applied below. This mirrors the participant/seed 409s in
+				// handlers_participants.go.
 				if current.Status == state.CompStatusDrawReady {
-					drawReadyFlag = true
-					return nil, nil
+					courtsChanged := len(comp.Courts) > 0 &&
+						strings.Join(comp.Courts, ",") != strings.Join(current.Courts, ",")
+					outputAffectingChanged :=
+						(comp.PoolSize != 0 && comp.PoolSize != current.PoolSize) ||
+							(comp.PoolWinners != 0 && comp.PoolWinners != current.PoolWinners) ||
+							(comp.PoolSizeMode != "" && comp.PoolSizeMode != current.PoolSizeMode) ||
+							courtsChanged ||
+							(comp.Format != "" && comp.Format != current.Format) ||
+							(comp.PoolFormat != "" && comp.PoolFormat != current.PoolFormat) ||
+							(comp.RoundRobin != current.RoundRobin) ||
+							(comp.Mirror != current.Mirror) ||
+							(comp.TeamSize != 0 && comp.TeamSize != current.TeamSize) ||
+							(comp.Kind != "" && comp.Kind != current.Kind)
+					if outputAffectingChanged {
+						drawReadyFlag = true
+						return nil, nil
+					}
 				}
 				// Existence first, uniqueness second. Pre-fix order ran
 				// checkUniqueCompFields BEFORE the transform, so a PUT to
@@ -937,7 +956,7 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 		if drawReadyFlag {
-			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify competition while a draw is pending; discard the draw first"})
+			c.JSON(http.StatusConflict, gin.H{"error": "cannot modify output-affecting settings (format/courts/pool config/kind) while a draw is pending; discard the draw first"})
 			return
 		}
 		if validationErr != nil {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -841,11 +841,12 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				// bracket.json) were generated from the current config.
 				// Mutating output-affecting fields while draw-ready would
 				// leave config.md inconsistent with those artifacts when
-				// StartCompetition runs. Cosmetic fields (Name, Date,
-				// StartTime, NumberPrefix, CheckInEnabled, Naginata,
-				// WithZekkenName) are still editable in draw-ready and are
-				// applied below. This mirrors the participant/seed 409s in
-				// handlers_participants.go.
+				// StartCompetition runs. Fields that do NOT reach the Excel
+				// generator (Name, Date, StartTime, CheckInEnabled, Naginata)
+				// stay editable in draw-ready and are applied below. NOTE:
+				// NumberPrefix and WithZekkenName DO reach the generator
+				// (player numbers / name columns) and are gated below. This
+				// mirrors the participant/seed 409s in handlers_participants.go.
 				if current.Status == state.CompStatusDrawReady {
 					// Compare the EFFECTIVE (about-to-be-applied) values
 					// directly — no zero/empty sentinels. The settings merge

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -2410,6 +2410,42 @@ func TestPUTCompetition_DrawReadyOutputAffectingGate(t *testing.T) {
 		assert.Equal(t, state.CompStatusDrawReady, stored.Status)
 	})
 
+	// NumberPrefix and WithZekkenName reach the Excel generator (POST /create),
+	// so they are output-affecting and must be gated while draw-ready.
+	for _, tc := range []struct {
+		name  string
+		field string
+		value any
+	}{
+		{"REJECT numberPrefix change while draw-ready", "numberPrefix", "X"},
+		{"REJECT withZekkenName change while draw-ready", "withZekkenName", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]any{
+				"id":          cid,
+				"name":        "Draw Ready Gate",
+				"format":      state.CompFormatMixed,
+				"kind":        "individual",
+				"courts":      []string{"A"},
+				"poolSize":    4,
+				"poolWinners": 2,
+				"roundRobin":  false,
+				"mirror":      false,
+				tc.field:      tc.value, // the only output-affecting change
+			})
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			assert.Equalf(t, http.StatusConflict, w.Code,
+				"changing %s while draw-ready must return 409: %s", tc.field, w.Body.String())
+			stored, err := store.LoadCompetition(cid)
+			require.NoError(t, err)
+			assert.Equal(t, state.CompStatusDrawReady, stored.Status)
+		})
+	}
+
 	t.Run("ALLOW cosmetic Name rename while draw-ready", func(t *testing.T) {
 		// All output-affecting fields match the stored comp; only Name differs.
 		// The gate compares effective values directly (no sentinels): the real

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -2335,3 +2335,82 @@ func TestPUTCompetition_MixedPoolConfigPreserved(t *testing.T) {
 	assert.Equal(t, 4, stored.PoolSize, "mixed PoolSize must be preserved")
 	assert.Equal(t, 1, stored.PoolWinners, "mixed PoolWinners must be preserved")
 }
+
+func TestPUTCompetition_DrawReadyOutputAffectingGate(t *testing.T) {
+	r, store, _, _, _ := setupTestRouter(t)
+
+	const cid = "draw-ready-gate"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:          cid,
+		Name:        "Draw Ready Gate",
+		Format:      state.CompFormatMixed,
+		Kind:        "individual",
+		Courts:      []string{"A"},
+		PoolSize:    4,
+		PoolWinners: 2,
+		Status:      state.CompStatusDrawReady,
+	}))
+
+	t.Run("REJECT output-affecting PoolSize change while draw-ready", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{
+			"id":          cid,
+			"name":        "Draw Ready Gate",
+			"format":      state.CompFormatMixed,
+			"kind":        "individual",
+			"courts":      []string{"A"},
+			"poolSize":    5, // changed from stored 4 — output-affecting
+			"poolWinners": 2,
+			"roundRobin":  false,
+			"mirror":      false,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code,
+			"changing PoolSize while draw-ready must return 409: %s", w.Body.String())
+		assert.Contains(t, w.Body.String(), "discard",
+			"409 body must mention discarding the draw")
+
+		// Status must remain draw-ready — gate must not mutate state.
+		stored, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		assert.Equal(t, state.CompStatusDrawReady, stored.Status)
+	})
+
+	t.Run("ALLOW cosmetic Name rename while draw-ready", func(t *testing.T) {
+		// All output-affecting fields match the stored comp; only Name differs.
+		// RoundRobin and Mirror are sent explicitly — the gate has no non-zero
+		// sentinel for booleans, so their comparison is always against the stored
+		// value; sending them explicitly guards against future regressions where
+		// the stored values are non-zero.
+		body, _ := json.Marshal(map[string]any{
+			"id":          cid,
+			"name":        "Draw Ready Gate Renamed", // cosmetic change — allowed
+			"format":      state.CompFormatMixed,
+			"kind":        "individual",
+			"courts":      []string{"A"},
+			"poolSize":    4,     // same as stored
+			"poolWinners": 2,     // same as stored
+			"roundRobin":  false, // same as stored
+			"mirror":      false, // same as stored
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code,
+			"renaming while draw-ready must be allowed: %s", w.Body.String())
+
+		// Rename must have persisted.
+		stored, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		assert.Equal(t, "Draw Ready Gate Renamed", stored.Name,
+			"cosmetic Name change must persist through the draw-ready gate")
+		// Status must remain draw-ready — a rename does not discard the draw.
+		assert.Equal(t, state.CompStatusDrawReady, stored.Status)
+	})
+}

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -2379,12 +2379,43 @@ func TestPUTCompetition_DrawReadyOutputAffectingGate(t *testing.T) {
 		assert.Equal(t, state.CompStatusDrawReady, stored.Status)
 	})
 
+	t.Run("REJECT zero-value bypass: format set to empty while draw-ready", func(t *testing.T) {
+		// Regression for the Copilot finding: the gate must compare effective
+		// values directly (no zero/empty sentinels), else a caller can set an
+		// output-affecting field TO its empty value to slip past the gate and
+		// corrupt the draw. format:"" is accepted by validateCompetitionFormat.
+		body, _ := json.Marshal(map[string]any{
+			"id":          cid,
+			"name":        "Draw Ready Gate",
+			"format":      "", // changed from stored "mixed" TO empty — must still 409
+			"kind":        "individual",
+			"courts":      []string{"A"},
+			"poolSize":    4,
+			"poolWinners": 2,
+			"roundRobin":  false,
+			"mirror":      false,
+		})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/competitions/"+cid, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code,
+			"setting format to empty while draw-ready must return 409 (no zero-value bypass): %s", w.Body.String())
+
+		stored, err := store.LoadCompetition(cid)
+		require.NoError(t, err)
+		assert.Equal(t, state.CompFormatMixed, stored.Format,
+			"format must be unchanged after a rejected zero-value PUT")
+		assert.Equal(t, state.CompStatusDrawReady, stored.Status)
+	})
+
 	t.Run("ALLOW cosmetic Name rename while draw-ready", func(t *testing.T) {
 		// All output-affecting fields match the stored comp; only Name differs.
-		// RoundRobin and Mirror are sent explicitly — the gate has no non-zero
-		// sentinel for booleans, so their comparison is always against the stored
-		// value; sending them explicitly guards against future regressions where
-		// the stored values are non-zero.
+		// The gate compares effective values directly (no sentinels): the real
+		// client always PUTs the full config, and the omitted fields here
+		// (poolSizeMode/poolFormat/teamSize) match the stored zero values, so no
+		// output-affecting change is detected and the rename is allowed.
 		body, _ := json.Marshal(map[string]any{
 			"id":          cid,
 			"name":        "Draw Ready Gate Renamed", // cosmetic change — allowed

--- a/internal/mobileapp/handlers_reset_test.go
+++ b/internal/mobileapp/handlers_reset_test.go
@@ -37,7 +37,7 @@ func setupResetTest(t *testing.T, verifier PasswordVerifier) (*state.Store, *gin
 	r := gin.New()
 	api := r.Group("/api")
 	RegisterResetHandlers(api, store, verifier, hub)
-	RegisterAuthConfigHandlers(api, verifier, defaultElevatedVerifier(verifier, store))
+	RegisterAuthConfigHandlers(api, verifier, defaultElevatedVerifier(verifier, store), false)
 
 	return store, r, hub
 }

--- a/internal/mobileapp/middleware_selfrun_test.go
+++ b/internal/mobileapp/middleware_selfrun_test.go
@@ -42,7 +42,7 @@ func setupSelfRunRouter(t *testing.T, store *state.Store, verifier PasswordVerif
 		"web-mobile/index.html": {Data: []byte("<html>test</html>")},
 	}
 	res := resources.NewResources(nil, mockFS)
-	r, _, limiter := NewRouterWithHub(store, eng, res, verifier, NewHub())
+	r, _, limiter := NewRouterWithHub(store, eng, res, verifier, NewHub(), false)
 	t.Cleanup(limiter.Close)
 	return r
 }

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -48,14 +48,16 @@ func defaultElevatedVerifier(verifier PasswordVerifier, store *state.Store) Elev
 // the long-lived SSE goroutines. The returned *APIRateLimiter should
 // also be closed on shutdown to stop the per-IP cleanup goroutine.
 func NewRouter(store *state.Store, eng *engine.Engine, res *resources.Resources, verifier PasswordVerifier) (*gin.Engine, *Hub, *APIRateLimiter) {
-	return NewRouterWithHub(store, eng, res, verifier, NewHub())
+	return NewRouterWithHub(store, eng, res, verifier, NewHub(), false)
 }
 
 // NewRouterWithHub is the testable / configurable variant — pass a
 // pre-built Hub (e.g. one with NewHubWithLimits) instead of constructing
 // the default. cmd/mobile_app.go uses this to apply the SSE_MAX_CLIENTS
 // override; tests use it to inject a small-capacity hub.
-func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Resources, verifier PasswordVerifier, hub *Hub) (*gin.Engine, *Hub, *APIRateLimiter) {
+// scheduleEnabled is sourced from ENABLE_TOURNAMENT_SCHEDULE (mp-fwce) and
+// forwarded to RegisterAuthConfigHandlers.
+func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Resources, verifier PasswordVerifier, hub *Hub, scheduleEnabled bool) (*gin.Engine, *Hub, *APIRateLimiter) {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 
@@ -164,7 +166,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	// inert payloads when locked mode is active — see handlers_reset.go
 	// and handlers_auth_config.go.
 	RegisterResetHandlers(api, store, verifier, hub)
-	RegisterAuthConfigHandlers(api, verifier, elevated)
+	RegisterAuthConfigHandlers(api, verifier, elevated, scheduleEnabled)
 
 	// Admin API endpoints (protected). Split into three sub-groups by
 	// expected body size so the body cap fires BEFORE AuthMiddleware at

--- a/internal/pdf/generate_unit_test.go
+++ b/internal/pdf/generate_unit_test.go
@@ -1,6 +1,7 @@
 package pdf
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,14 +105,14 @@ func TestGenerateGroups_UnknownType(t *testing.T) {
 	// validation path via a direct call on a zero-value Generator. The
 	// function returns before touching the converter.
 	g := &Generator{}
-	_, err := g.GenerateGroups(nil, []string{"nonexistent-type"}, nil, "") //nolint:staticcheck
+	_, err := g.GenerateGroups(context.TODO(), []string{"nonexistent-type"}, nil, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown PDF type")
 }
 
 func TestGenerate_NoSources(t *testing.T) {
 	g := &Generator{}
-	_, err := g.generate(nil, nil, nil, t.TempDir()) //nolint:staticcheck
+	_, err := g.generate(context.TODO(), nil, nil, t.TempDir())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no source workbooks")
 }

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -492,6 +492,13 @@ paths:
                       Whether the destructive-ops password can be set via
                       PUT /api/auth/admin-password. True in file mode; false in locked
                       mode (the credential is the TOURNAMENT_ADMIN_PASSWORD_HASH env var).
+                  scheduleEnabled:
+                    type: boolean
+                    description: |
+                      Whether the admin tournament-schedule view is enabled. Controlled
+                      by the ENABLE_TOURNAMENT_SCHEDULE env var on the mobile-app server
+                      (default false). When false, the SPA hides the dashboard's
+                      "Tournament schedule" entry.
 
   /api/auth/admin-password:
     put:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -975,11 +975,11 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           description: |
-            Conflict. Either a duplicate competition name/number-prefix was
-            detected, or output-affecting settings (format, courts, pool
+            Conflict. Output-affecting settings (format, courts, pool
             size/winners/mode, pool format, round-robin, mirror, team size,
             kind, number prefix, zekken display) were changed while the
             competition is in `draw-ready` state — discard the draw first.
+            Duplicate name/number-prefix violations are returned as 400.
           content:
             application/json:
               schema:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -973,6 +973,17 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: |
+            Conflict. Either a duplicate competition name/number-prefix was
+            detected, or output-affecting settings (format, courts, pool
+            size/winners/mode, pool format, round-robin, mirror, team size,
+            kind, number prefix, zekken display) were changed while the
+            competition is in `draw-ready` state — discard the draw first.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalError'
     delete:

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -453,6 +453,9 @@ describe('AdminSettings.saveNow payload whitelist', () => {
     // the backend PUT allowlist ignores unknown fields.
     'leagueTiebreakTopN',
     'leagueTwoThirdPlaces',
+    // Round-tripped (no UI control) to avoid clobbering a kachinuki
+    // competition's value to "" on a settings save.
+    'teamMatchType',
   ]);
   // Fields that MUST NOT appear in the PUT body — pinning the
   // negative invariant explicitly so a careless re-add is caught.

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -543,6 +543,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
         onViewerMode={onViewerMode}
         onUpdate={onUpdate}
         showToast={showToast}
+        authConfig={authConfig}
       />
       {announceOpen && <window.AnnouncementModal
         password={password}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -121,7 +121,15 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
       if (!mountedRef.current) return;
       onRefreshCompetition?.();
       showToast(`Draw discarded for ${c.name}`);
-      onSection("overview");
+      // After discard the status reverts to "setup", so draw-only/preview nav
+      // items (pools, bracket, swiss) disappear. If the operator is on one of
+      // those sections, fall back to participants — a sensible landing point
+      // after discarding. Otherwise leave them exactly where they are.
+      // (This fallback set mirrors the draw-only items gated on isDrawReady /
+      // draw artifacts in the sections array above.)
+      if (["pools", "bracket", "swiss"].includes(section)) {
+        onSection("participants");
+      }
     } catch (e) {
       console.error("Discard draw failed:", e);
       if (mountedRef.current) showToast(e.message, "error");
@@ -255,11 +263,11 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {(!c.status || c.status === "setup") && c.players.length >= 2 && (
               <>
                 <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                  <button type="button" className="btn btn--ghost" onClick={generateDraw} disabled={!isDateValid(c.date) || generating || starting}>
+                  <button type="button" className="btn btn--primary" onClick={generateDraw} disabled={!isDateValid(c.date) || generating || starting}>
                     {generating && <span className="spinner" />}
-                    {generating ? "Generating…" : "Preview draw"}
+                    {generating ? "Generating…" : "Generate draw"}
                   </button>
-                  <button type="button" className="btn btn--primary" onClick={start} disabled={!isDateValid(c.date) || starting || generating}>
+                  <button type="button" className="btn btn--ghost" onClick={start} disabled={!isDateValid(c.date) || starting || generating}>
                     {starting && <span className="spinner" />}
                     {starting ? "Starting…" : "Start competition →"}
                   </button>
@@ -311,12 +319,14 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 ))}
               </div>
             ))}
-            <div>
-              <div className="side-nav__sec">Other competitions</div>
-              {t.competitions.filter((cc) => cc.id !== c.id).map((cc) => (
-                <button type="button" key={cc.id} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
-              ))}
-            </div>
+            {t.competitions.filter((cc) => cc.id !== c.id).length > 0 && (
+              <div style={{ marginTop: 16, paddingTop: 12, borderTop: "1px solid var(--line)" }}>
+                <div className="side-nav__sec" style={{ opacity: 0.6 }}>Other competitions</div>
+                {t.competitions.filter((cc) => cc.id !== c.id).map((cc) => (
+                  <button type="button" key={cc.id} style={{ opacity: 0.75 }} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
+                ))}
+              </div>
+            )}
           </div>
           <div>
             {section === "overview" && <AdminCompOverview c={c} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} />}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -208,6 +208,9 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   // the in-flight transition changes which sections are valid and discardDraw's
   // fallback uses the section captured at call time (see the side-nav below).
   const navBusy = generating || starting || discarding;
+  // Compute the other-competitions list once (used for both the render guard
+  // and the map below).
+  const otherComps = t.competitions.filter((cc) => cc.id !== c.id);
   const sections = [
     {
       sec: "Preparation", items: [
@@ -335,10 +338,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 </div>
               ))}
             </div>
-            {t.competitions.filter((cc) => cc.id !== c.id).length > 0 && (
+            {otherComps.length > 0 && (
               <div className="side-nav" style={{ position: "static" }}>
                 <div className="side-nav__sec">Other competitions</div>
-                {t.competitions.filter((cc) => cc.id !== c.id).map((cc) => (
+                {otherComps.map((cc) => (
                   <button type="button" key={cc.id} disabled={navBusy} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
                 ))}
               </div>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -310,20 +310,26 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         </div>
 
         <div className="workspace">
-          <div className="side-nav">
-            {sections.map((sec) => (
-              <div key={sec.sec}>
-                <div className="side-nav__sec">{sec.sec}</div>
-                {sec.items.map((it) => (
-                  <button type="button" key={it.id} className={section === it.id ? "is-active" : ""} onClick={() => onSection(it.id)}>{it.label}</button>
-                ))}
-              </div>
-            ))}
+          {/* Left column stacks the per-competition nav and, as a SEPARATE
+              card below it, the switcher to other competitions (mp-xsc1).
+              The Other-competitions card is position:static so it doesn't
+              fight the sticky nav above it. */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div className="side-nav">
+              {sections.map((sec) => (
+                <div key={sec.sec}>
+                  <div className="side-nav__sec">{sec.sec}</div>
+                  {sec.items.map((it) => (
+                    <button type="button" key={it.id} className={section === it.id ? "is-active" : ""} onClick={() => onSection(it.id)}>{it.label}</button>
+                  ))}
+                </div>
+              ))}
+            </div>
             {t.competitions.filter((cc) => cc.id !== c.id).length > 0 && (
-              <div style={{ marginTop: 16, paddingTop: 12, borderTop: "1px solid var(--line)" }}>
-                <div className="side-nav__sec" style={{ opacity: 0.6 }}>Other competitions</div>
+              <div className="side-nav" style={{ position: "static" }}>
+                <div className="side-nav__sec">Other competitions</div>
                 {t.competitions.filter((cc) => cc.id !== c.id).map((cc) => (
-                  <button type="button" key={cc.id} style={{ opacity: 0.75 }} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
+                  <button type="button" key={cc.id} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
                 ))}
               </div>
             )}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -272,11 +272,15 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {isDrawReady && (
               <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
                 <div style={{ display: "flex", gap: 8 }}>
-                  <button type="button" className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting}>
+                  {/* navBusy (generating||starting||discarding) covers the brief
+                      window where generateDraw has flipped status to draw-ready
+                      but its setGenerating(false) hasn't run yet — without it
+                      these buttons would be momentarily clickable mid-generate. */}
+                  <button type="button" className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={navBusy}>
                     {discarding && <span className="spinner" />}
                     {discarding ? "Discarding…" : "Discard draw"}
                   </button>
-                  <button type="button" className="btn btn--primary" onClick={start} disabled={starting || discarding}>
+                  <button type="button" className="btn btn--primary" onClick={start} disabled={navBusy}>
                     {starting && <span className="spinner" />}
                     {starting ? "Starting…" : "Start competition →"}
                   </button>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -112,7 +112,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const discardDraw = async () => {
-    if (!(await window.confirmDialog({ message: `Discard the generated draw for "${c.name}"? The pools/bracket will be removed and you can regenerate.`, confirmLabel: "Discard draw", danger: true }))) return;
+    if (!(await window.confirmDialog({ message: `Discard the generated draw for "${c.name}"? The pools/bracket will be removed so you can edit participants and settings, then generate a new draw.`, confirmLabel: "Discard draw", danger: true }))) return;
     const admin = await window.promptAdminPassword();
     if (admin === null) return;
     setDiscarding(true);
@@ -138,34 +138,12 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
     }
   };
 
-  const regenerateDraw = async () => {
-    if (!(await confirmCheckInExclusion())) return;
-    // Regenerate discards the existing draw first (DELETE /draw is gated),
-    // so collect the elevated password up front before any work begins.
-    const admin = await window.promptAdminPassword();
-    if (admin === null) return;
-    setGenerating(true);
-    try {
-      await window.API.discardDraw(c.id, password, admin);
-      if (!mountedRef.current) return;
-      // Refresh after discard so the UI reflects setup status immediately;
-      // if generateDraw then fails the UI is consistent with the server.
-      onRefreshCompetition?.();
-      await window.API.generateDraw(c.id, password);
-      if (!mountedRef.current) return;
-      onRefreshCompetition?.();
-      showToast(`Draw regenerated for ${c.name}`);
-      onSection(c.format === "playoffs" ? "bracket" : c.format === "swiss" ? "overview" : "pools");
-    } catch (e) {
-      console.error("Regenerate draw failed:", e);
-      if (mountedRef.current) {
-        onRefreshCompetition?.();
-        showToast(e.message, "error");
-      }
-    } finally {
-      if (mountedRef.current) setGenerating(false);
-    }
-  };
+  // NOTE: there is intentionally no "regenerate draw" action. The draw is
+  // deterministic on its stored inputs (no RNG in helper seeding/pools/tree;
+  // Swiss round 1 uses a comp-id-seeded shuffle), so regenerating without
+  // changing inputs would reproduce the identical draw. To get a different
+  // draw the operator discards (which unlocks editing), changes inputs
+  // (e.g. Shuffle unseeded / seeds / settings), then generates again.
 
   const start = async () => {
     // draw-ready → running does not regenerate the draw; skip the confirmation
@@ -294,20 +272,16 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {isDrawReady && (
               <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 8 }}>
                 <div style={{ display: "flex", gap: 8 }}>
-                  <button type="button" className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting || generating}>
+                  <button type="button" className="btn btn--ghost btn--danger" onClick={discardDraw} disabled={discarding || starting}>
                     {discarding && <span className="spinner" />}
                     {discarding ? "Discarding…" : "Discard draw"}
                   </button>
-                  <button type="button" className="btn btn--ghost" onClick={regenerateDraw} disabled={generating || starting || discarding}>
-                    {generating && <span className="spinner" />}
-                    {generating ? "Regenerating…" : "Regenerate draw"}
-                  </button>
-                  <button type="button" className="btn btn--primary" onClick={start} disabled={starting || generating || discarding}>
+                  <button type="button" className="btn btn--primary" onClick={start} disabled={starting || discarding}>
                     {starting && <span className="spinner" />}
                     {starting ? "Starting…" : "Start competition →"}
                   </button>
                 </div>
-                <div style={{ fontSize: 11, color: "var(--ink-3)" }}>Draw generated — preview below, then start when ready</div>
+                <div style={{ fontSize: 11, color: "var(--ink-3)" }}>Draw generated — preview below, then start. To change it, discard and edit first.</div>
               </div>
             )}
             {c.format === "league" && c.status !== "setup" && c.status !== "draw-ready" && (

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -204,6 +204,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   };
 
   const isDrawReady = c.status === "draw-ready";
+  // Block section/competition navigation while a draw mutation is in-flight —
+  // the in-flight transition changes which sections are valid and discardDraw's
+  // fallback uses the section captured at call time (see the side-nav below).
+  const navBusy = generating || starting || discarding;
   const sections = [
     {
       sec: "Preparation", items: [
@@ -320,7 +324,13 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 <div key={sec.sec}>
                   <div className="side-nav__sec">{sec.sec}</div>
                   {sec.items.map((it) => (
-                    <button type="button" key={it.id} className={section === it.id ? "is-active" : ""} onClick={() => onSection(it.id)}>{it.label}</button>
+                    /* Disable nav while a draw mutation is in-flight: a
+                       discard/generate/start changes status and which sections
+                       are valid, and discardDraw's post-resolve fallback reads
+                       the `section` captured when it started. Navigating
+                       mid-flight could strand the UI on a section that
+                       disappears once status changes. */
+                    <button type="button" key={it.id} className={section === it.id ? "is-active" : ""} disabled={navBusy} onClick={() => onSection(it.id)}>{it.label}</button>
                   ))}
                 </div>
               ))}
@@ -329,7 +339,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
               <div className="side-nav" style={{ position: "static" }}>
                 <div className="side-nav__sec">Other competitions</div>
                 {t.competitions.filter((cc) => cc.id !== c.id).map((cc) => (
-                  <button type="button" key={cc.id} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
+                  <button type="button" key={cc.id} disabled={navBusy} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
                 ))}
               </div>
             )}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -188,7 +188,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
   const navBusy = generating || starting || discarding;
   // Compute the other-competitions list once (used for both the render guard
   // and the map below).
-  const otherComps = t.competitions.filter((cc) => cc.id !== c.id);
+  const otherComps = (t.competitions || []).filter((cc) => cc.id !== c.id);
   const sections = [
     {
       sec: "Preparation", items: [

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -7,8 +7,8 @@ const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
 
 // Default on-clock minutes per match when a duration field is left blank.
 // Mirrors defaultPerMatchClockMinutes in internal/engine/scheduler_slots.go
-// (3 min = the FIK individual default). Surfaced in the duration inputs so the
-// operator knows what "blank" resolves to.
+// (a nominal estimate anchor, not a regulation match time). Surfaced in the
+// duration inputs so the operator knows what "blank" resolves to.
 const DEFAULT_MATCH_MINUTES = 3;
 
 const dmyToIso = window.dmyToIso;

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -121,7 +121,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       });
       return next;
     });
-  }, [c.id, c.name, c.date, c.startTime, c.poolSize, c.poolWinners, c.poolSizeMode, c.courts, c.roundRobin, c.withZekkenName, c.teamSize, c.numberPrefix, c.format, c.kind, c.mirror, c.status, c.poolFormat, c.poolMatchDuration, c.playoffMatchDuration, c.swissRounds, c.swissCurrentRound, c.naginata, c.checkInEnabled, c.leagueTiebreakTopN, c.leagueTwoThirdPlaces]);
+  }, [c.id, c.name, c.date, c.startTime, c.poolSize, c.poolWinners, c.poolSizeMode, c.courts, c.roundRobin, c.withZekkenName, c.teamSize, c.numberPrefix, c.format, c.kind, c.mirror, c.status, c.poolFormat, c.poolMatchDuration, c.playoffMatchDuration, c.swissRounds, c.swissCurrentRound, c.naginata, c.checkInEnabled, c.leagueTiebreakTopN, c.leagueTwoThirdPlaces, c.teamMatchType]);
 
   const saveNow = () => {
     // Build `effective` from the LATEST server-known state (cRef.current)
@@ -282,6 +282,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       // the backend's PUT allowlist ignores unknown fields.
       leagueTiebreakTopN: safeInt(effective.leagueTiebreakTopN, latestC.leagueTiebreakTopN || 0),
       leagueTwoThirdPlaces: !!effective.leagueTwoThirdPlaces,
+      // teamMatchType has no editable control in this form, but the settings
+      // merge is a full replace — omitting it would clobber a kachinuki
+      // competition's value to "" (fixed) on any save. Round-trip it like
+      // `mirror` above to preserve the stored value.
+      teamMatchType: effective.teamMatchType || latestC.teamMatchType || "",
     };
     // Capture the snapshot of edited fields we're about to persist. On
     // success we clear ONLY those fields from the edited set — preserving
@@ -630,14 +635,14 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       )}
       <div className="field">
         <label className="field__label">Player number prefix <span style={{ fontWeight: 400, color: "var(--ink-3)" }}>(optional)</span></label>
-        <input className="input" placeholder="e.g. A" maxLength="3" value={local.numberPrefix || ""} onChange={(e) => update("numberPrefix", e.target.value.substring(0, 3))} style={{ maxWidth: 80 }} />
+        <input className="input" placeholder="e.g. A" maxLength="3" value={local.numberPrefix || ""} onChange={(e) => update("numberPrefix", e.target.value.substring(0, 3))} disabled={isDrawReady} style={{ maxWidth: 80 }} />
         <div className="field__hint">Single letter prefix for participant numbers (A1, B1…). Keeps numbers unique across competitions.</div>
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {/* draw-ready lock: roundRobin is output-affecting. */}
         <label className="checkbox"><input type="checkbox" checked={local.roundRobin} onChange={(e) => updateNow("roundRobin", e.target.checked)} disabled={isDrawReady} /> Round-robin in pools</label>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label className="checkbox"><input type="checkbox" checked={local.withZekkenName} onChange={(e) => updateNow("withZekkenName", e.target.checked)} disabled={local.kind === "team"} /> Use Zekken display name</label>
+          <label className="checkbox"><input type="checkbox" checked={local.withZekkenName} onChange={(e) => updateNow("withZekkenName", e.target.checked)} disabled={isDrawReady || local.kind === "team"} /> Use Zekken display name</label>
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>{local.kind === "team" ? "(Only applicable for individual competitions)" : "When enabled, participant CSV uses three columns: Name, Zekken, Dojo."}</div>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -378,10 +378,12 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     if (nextCourts.length) updateNow("courts", nextCourts);
   };
 
-  // draw-ready lock: output-affecting fields (pools, courts, format, kind, team
-  // size, mirror) are disabled while a draw exists. Cosmetic fields (name,
-  // date, startTime, numberPrefix, checkInEnabled, naginata, withZekkenName)
-  // remain editable. Discard the draw from the competition header to unlock.
+  // draw-ready lock: output-affecting fields — those that reach the Excel
+  // generator (pools, courts, format, kind, team size, mirror, numberPrefix,
+  // withZekkenName) — are disabled while a draw exists. Fields that do NOT
+  // affect the generated workbook (name, date, startTime, checkInEnabled,
+  // naginata) remain editable. Discard the draw from the competition header to
+  // unlock everything.
   const isDrawReady = local.status === "draw-ready";
 
   return (

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -373,6 +373,12 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     if (nextCourts.length) updateNow("courts", nextCourts);
   };
 
+  // draw-ready lock: output-affecting fields (pools, courts, format, kind, team
+  // size, mirror) are disabled while a draw exists. Cosmetic fields (name,
+  // date, startTime, numberPrefix, checkInEnabled, naginata, withZekkenName)
+  // remain editable. Discard the draw from the competition header to unlock.
+  const isDrawReady = local.status === "draw-ready";
+
   return (
     <div className="card">
       <div className="card__head">
@@ -449,6 +455,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           {/* Render NaN as "" so clearing the input stays empty instead of */}
           {/* collapsing to "0"; updateNumber gates the debounced save so a */}
           {/* cleared/invalid value never lands on the backend as 0. */}
+          {/* draw-ready lock: teamSize is output-affecting. */}
           <input
             className="input"
             type="number"
@@ -456,14 +463,21 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
             max={MAX_TEAM_SIZE}
             value={Number.isFinite(local.teamSize) ? local.teamSize : ""}
             onChange={(e) => updateNumber("teamSize", e.target.value, 1)}
+            disabled={isDrawReady}
           />
         </div>
       )}
       <div className="field">
         <label className="field__label">Assigned shiaijo (courts)</label>
+        {/* draw-ready lock: courts is output-affecting — discard the draw to reassign. */}
+        {isDrawReady && (
+          <div className="field__hint" style={{ marginBottom: 6, color: "var(--ink-2)", fontWeight: 500 }}>
+            Discard the draw to change pools, courts, or format.
+          </div>
+        )}
         <div className="radio-group">
           {tournament.courts.map((cc) => (
-            <button key={cc} className={`radio-pill ${local.courts.includes(cc) ? "is-active" : ""}`} type="button" onClick={() => toggleCourt(cc)}>Shiaijo (court) {cc}</button>
+            <button key={cc} className={`radio-pill ${local.courts.includes(cc) ? "is-active" : ""}`} type="button" onClick={() => toggleCourt(cc)} disabled={isDrawReady}>Shiaijo (court) {cc}</button>
           ))}
         </div>
         {(local.format === "league" || local.poolFormat === "partial") ? (() => {
@@ -485,9 +499,10 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
         <>
           <div className="field">
             <label className="field__label">Pool size is a</label>
+            {/* draw-ready lock: poolSizeMode, poolSize, poolWinners are output-affecting. */}
             <div className="radio-group">
-              <button className={`radio-pill ${local.poolSizeMode === "max" ? "is-active" : ""}`} type="button" onClick={() => updateNow("poolSizeMode", "max")}>maximum</button>
-              <button className={`radio-pill ${local.poolSizeMode === "min" ? "is-active" : ""}`} type="button" onClick={() => updateNow("poolSizeMode", "min")}>minimum</button>
+              <button className={`radio-pill ${local.poolSizeMode === "max" ? "is-active" : ""}`} type="button" onClick={() => updateNow("poolSizeMode", "max")} disabled={isDrawReady}>maximum</button>
+              <button className={`radio-pill ${local.poolSizeMode === "min" ? "is-active" : ""}`} type="button" onClick={() => updateNow("poolSizeMode", "min")} disabled={isDrawReady}>minimum</button>
             </div>
           </div>
           <div className="row">
@@ -500,6 +515,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
               min="3"
               value={Number.isFinite(local.poolSize) ? local.poolSize : ""}
               onChange={(e) => updateNumber("poolSize", e.target.value, 3)}
+              disabled={isDrawReady}
             /></div>
             <div className="field"><label className="field__label">Winners per pool</label><input
               className="input"
@@ -507,6 +523,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
               min="1"
               value={Number.isFinite(local.poolWinners) ? local.poolWinners : ""}
               onChange={(e) => updateNumber("poolWinners", e.target.value, 1)}
+              disabled={isDrawReady}
             /></div>
           </div>
         </>
@@ -617,7 +634,8 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
         <div className="field__hint">Single letter prefix for participant numbers (A1, B1…). Keeps numbers unique across competitions.</div>
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <label className="checkbox"><input type="checkbox" checked={local.roundRobin} onChange={(e) => updateNow("roundRobin", e.target.checked)} /> Round-robin in pools</label>
+        {/* draw-ready lock: roundRobin is output-affecting. */}
+        <label className="checkbox"><input type="checkbox" checked={local.roundRobin} onChange={(e) => updateNow("roundRobin", e.target.checked)} disabled={isDrawReady} /> Round-robin in pools</label>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <label className="checkbox"><input type="checkbox" checked={local.withZekkenName} onChange={(e) => updateNow("withZekkenName", e.target.checked)} disabled={local.kind === "team"} /> Use Zekken display name</label>
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>{local.kind === "team" ? "(Only applicable for individual competitions)" : "When enabled, participant CSV uses three columns: Name, Zekken, Dojo."}</div>

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -5,6 +5,12 @@
 
 const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
 
+// Default on-clock minutes per match when a duration field is left blank.
+// Mirrors defaultPerMatchClockMinutes in internal/engine/scheduler_slots.go
+// (3 min = the FIK individual default). Surfaced in the duration inputs so the
+// operator knows what "blank" resolves to.
+const DEFAULT_MATCH_MINUTES = 3;
+
 const dmyToIso = window.dmyToIso;
 const isoToDmy = window.isoToDmy;
 const validateAndNormalizeDate = window.validateAndNormalizeDate;
@@ -549,9 +555,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
                 step="1"
                 value={Number.isFinite(local.poolMatchDuration) && local.poolMatchDuration > 0 ? local.poolMatchDuration : ""}
                 onChange={(e) => updateNumber("poolMatchDuration", e.target.value, 0)}
-                placeholder="default"
+                placeholder={`default: ${DEFAULT_MATCH_MINUTES}`}
               />
-              <div className="field__hint">{local.format === "swiss" ? "Estimated minutes per Swiss-round match. Leave blank for default." : "Estimated minutes per pool match. Leave blank for default."}</div>
+              <div className="field__hint">{local.format === "swiss" ? `Estimated minutes per Swiss-round match. Leave blank for the default (${DEFAULT_MATCH_MINUTES} min).` : `Estimated minutes per pool match. Leave blank for the default (${DEFAULT_MATCH_MINUTES} min).`}</div>
             </div>
           )}
           {(local.format === "playoffs" || local.format === "mixed") && (
@@ -564,9 +570,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
                 step="1"
                 value={Number.isFinite(local.playoffMatchDuration) && local.playoffMatchDuration > 0 ? local.playoffMatchDuration : ""}
                 onChange={(e) => updateNumber("playoffMatchDuration", e.target.value, 0)}
-                placeholder="default"
+                placeholder={`default: ${DEFAULT_MATCH_MINUTES}`}
               />
-              <div className="field__hint">Estimated minutes per playoff/knockout match. Leave blank for default.</div>
+              <div className="field__hint">{`Estimated minutes per playoff/knockout match. Leave blank for the default (${DEFAULT_MATCH_MINUTES} min).`}</div>
             </div>
           )}
         </div>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -726,7 +726,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     <>
       {isDrawReady && (
         <div className="alert alert--warn" style={{ marginBottom: 12 }}>
-          Draw generated — participants and seeds are locked. Discard the draw (from the competition header) to change them.
+          Draw generated — the roster and seeds are locked. Discard the draw (from the competition header) to change them. Check-in stays available.
         </div>
       )}
       {isStarted && (

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -923,11 +923,11 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                     onDragOver={(e) => { if (reorderDisabled) return; e.preventDefault(); setDragOverIdx(i); }}
                     onDragLeave={() => { if (dragOverIdx === i) setDragOverIdx(null); }}
                     onDrop={() => {
-                      // Clear the drop-target highlight even when disabled — if
-                      // the row went disabled mid-drag (e.g. draw-ready via SSE)
-                      // an early return would leave dragOverIdx stranded.
-                      if (reorderDisabled) { setDragOverIdx(null); return; }
-                      moveSeedRow(dragIdxRef.current, i);
+                      // Clear both refs on disabled path — if the row went
+                      // disabled mid-drag (e.g. draw-ready via SSE) a stale
+                      // dragIdxRef would corrupt the next legitimate drop.
+                      if (reorderDisabled) { dragIdxRef.current = null; setDragOverIdx(null); return; }
+                      if (dragIdxRef.current !== null) moveSeedRow(dragIdxRef.current, i);
                       dragIdxRef.current = null;
                       setDragOverIdx(null);
                     }}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -725,8 +725,8 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   return (
     <>
       {isDrawReady && (
-        <div className="notice notice--info" style={{ marginBottom: 12 }}>
-          Draw pending — edits will update the draw in place.
+        <div className="alert alert--warn" style={{ marginBottom: 12 }}>
+          Draw generated — participants and seeds are locked. Discard the draw (from the competition header) to change them.
         </div>
       )}
       {isStarted && (
@@ -752,10 +752,11 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               {c.checkInEnabled && (
                 <button className="btn btn--sm" type="button" onClick={bulkCheckInAll} disabled={players.length === 0} title="Mark all as checked in">Check in all</button>
               )}
-              <button className="btn btn--sm" type="button" onClick={shuffleUnseeded} disabled={players.length === 0} title="Shuffle unseeded players">Shuffle unseeded</button>
-              <button className="btn btn--sm" type="button" onClick={() => seedFileRef.current?.click()} disabled={players.length === 0} title={players.length === 0 ? "Add participants first" : undefined}>Import Seeds CSV</button>
+              {/* draw-ready lock: seed mutations disabled until the draw is discarded */}
+              <button className="btn btn--sm" type="button" onClick={shuffleUnseeded} disabled={players.length === 0 || isDrawReady} title={isDrawReady ? "Discard the draw to shuffle seeds" : "Shuffle unseeded players"}>Shuffle unseeded</button>
+              <button className="btn btn--sm" type="button" onClick={() => seedFileRef.current?.click()} disabled={players.length === 0 || isDrawReady} title={isDrawReady ? "Discard the draw to import seeds" : players.length === 0 ? "Add participants first" : undefined}>Import Seeds CSV</button>
               <input ref={seedFileRef} type="file" accept=".csv,.txt,text/csv,text/plain" style={{ display: "none" }} onChange={(e) => handleSeedFile(e.target.files[0])} />
-              <button className="btn btn--sm" type="button" onClick={clearAllSeeds}>Clear seeds</button>
+              <button className="btn btn--sm" type="button" onClick={clearAllSeeds} disabled={isDrawReady} title={isDrawReady ? "Discard the draw to clear seeds" : undefined}>Clear seeds</button>
             </div>
           </div>
           <div className="card__body" style={{ paddingTop: 0, paddingBottom: 8 }}>
@@ -910,13 +911,15 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               )}
               {visiblePlayers.map((p) => {
                 const i = players.indexOf(p);
-                const reorderDisabled = !!tagFilter || showOnlyUnchecked || !!trimmedSearch;
+                // draw-ready lock: reordering (and all seed mutations) disabled until the draw is discarded.
+                // Filter-active check is kept separate so both reasons can coexist.
+                const reorderDisabled = !!tagFilter || showOnlyUnchecked || !!trimmedSearch || isDrawReady;
                 return (
                   <div
                     key={p.id ?? p.name}
                     className={`seed-row ${p.seed ? "has-seed" : ""} ${p.checkedIn ? "is-checked-in" : ""} ${dragOverIdx === i ? "seed-row--drop-target" : ""}`}
                     draggable={!reorderDisabled}
-                    onDragStart={() => { dragIdxRef.current = i; }}
+                    onDragStart={() => { if (reorderDisabled) return; dragIdxRef.current = i; }}
                     onDragOver={(e) => { if (reorderDisabled) return; e.preventDefault(); setDragOverIdx(i); }}
                     onDragLeave={() => { if (dragOverIdx === i) setDragOverIdx(null); }}
                     onDrop={() => {
@@ -971,7 +974,8 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                       <button type="button" className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i - 1)} disabled={i === 0 || reorderDisabled} aria-label="Move up">↑</button>
                       <button type="button" className="btn btn--sm btn--icon-sm" onClick={() => moveSeedRow(i, i + 1)} disabled={i === players.length - 1 || reorderDisabled} aria-label="Move down">↓</button>
-                      {(isSetup || isDrawReady) && (
+                      {/* draw-ready lock: edit is setup-only; editing participants requires discarding the draw first */}
+                      {isSetup && (
                         <button type="button" className="btn btn--sm btn--icon-sm" style={{ fontSize: 11 }} title={`Edit ${p.name}`} onClick={() => { setReplaceTarget(p); setReplaceName(p.name); setReplaceDojo(p.dojo); setReplaceDanGrade(p.danGrade || ""); setReplaceZekken(c.withZekkenName ? (p.displayName || "") : ""); }} aria-label={`Edit ${p.name}`}>✎</button>
                       )}
                     </div>
@@ -982,6 +986,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                         value={p.seed || ""}
                         onChange={(val) => updateSeed(i, val)}
                         autoSelect={false}
+                        disabled={isDrawReady}
                       />
                   </div>
                 );
@@ -1003,20 +1008,21 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                 <br /><button type="button" className="btn--link" style={{ padding: 0, fontSize: 11, fontWeight: 600 }} onClick={downloadTemplate}>Download CSV template</button>
               </div>
             </div>
+            {/* draw-ready lock: roster mutations (paste, apply, CSV import) disabled until the draw is discarded */}
             <div style={{ display: "flex", gap: 6 }}>
-              <button className="btn btn--sm" type="button" onClick={pasteFromExcel} title="Reads clipboard and converts tab-separated values (e.g. from Excel) to CSV">Paste clipboard</button>
-              <button className="btn btn--sm btn--primary" type="button" onClick={apply} disabled={hasGaps}>Apply changes</button>
+              <button className="btn btn--sm" type="button" onClick={pasteFromExcel} disabled={isDrawReady} title={isDrawReady ? "Discard the draw to edit participants" : "Reads clipboard and converts tab-separated values (e.g. from Excel) to CSV"}>Paste clipboard</button>
+              <button className="btn btn--sm btn--primary" type="button" onClick={apply} disabled={hasGaps || isDrawReady} title={isDrawReady ? "Discard the draw to apply roster changes" : undefined}>Apply changes</button>
             </div>
           </div>
 
           <div style={{ display: "flex", gap: 10, marginBottom: 12 }}>
             <div
-              className={`dropzone ${dragOver ? "dropzone--active" : ""}`}
-              onClick={() => fileRef.current?.click()}
-              onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+              className={`dropzone ${dragOver ? "dropzone--active" : ""} ${isDrawReady ? "dropzone--disabled" : ""}`}
+              onClick={() => { if (!isDrawReady) fileRef.current?.click(); }}
+              onDragOver={(e) => { if (isDrawReady) return; e.preventDefault(); setDragOver(true); }}
               onDragLeave={() => setDragOver(false)}
-              onDrop={onDrop}
-              style={{ flex: 1, height: 80, minHeight: 80 }}
+              onDrop={(e) => { if (isDrawReady) { e.preventDefault(); return; } onDrop(e); }}
+              style={{ flex: 1, height: 80, minHeight: 80, cursor: isDrawReady ? "not-allowed" : undefined, opacity: isDrawReady ? 0.5 : undefined }}
             >
               <div className="dropzone__icon">📥</div>
               <div>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -923,7 +923,10 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                     onDragOver={(e) => { if (reorderDisabled) return; e.preventDefault(); setDragOverIdx(i); }}
                     onDragLeave={() => { if (dragOverIdx === i) setDragOverIdx(null); }}
                     onDrop={() => {
-                      if (reorderDisabled) return;
+                      // Clear the drop-target highlight even when disabled — if
+                      // the row went disabled mid-drag (e.g. draw-ready via SSE)
+                      // an early return would leave dragOverIdx stranded.
+                      if (reorderDisabled) { setDragOverIdx(null); return; }
                       moveSeedRow(dragIdxRef.current, i);
                       dragIdxRef.current = null;
                       setDragOverIdx(null);
@@ -1021,7 +1024,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               onClick={() => { if (!isDrawReady) fileRef.current?.click(); }}
               onDragOver={(e) => { if (isDrawReady) return; e.preventDefault(); setDragOver(true); }}
               onDragLeave={() => setDragOver(false)}
-              onDrop={(e) => { if (isDrawReady) { e.preventDefault(); return; } onDrop(e); }}
+              onDrop={(e) => { if (isDrawReady) { e.preventDefault(); setDragOver(false); return; } onDrop(e); }}
               style={{ flex: 1, height: 80, minHeight: 80, cursor: isDrawReady ? "not-allowed" : undefined, opacity: isDrawReady ? 0.5 : undefined }}
             >
               <div className="dropzone__icon">📥</div>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -947,7 +947,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                         />
                       </div>
                     )}
-                    <span className="seed-row__handle" title={reorderDisabled ? "Clear all filters to reorder" : "Drag to reorder"}>⠿</span>
+                    <span className="seed-row__handle" title={isDrawReady ? "Discard the draw to reorder" : reorderDisabled ? "Clear filters/search to reorder" : "Drag to reorder"}>⠿</span>
                     <span className="seed-row__rank">{p.seed ? `#${p.seed}` : ""}</span>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ display: "flex", alignItems: "center", minWidth: 0 }}>

--- a/web-mobile/js/admin_schedule_export.jsx
+++ b/web-mobile/js/admin_schedule_export.jsx
@@ -66,6 +66,10 @@ export function AdminExport({ c, t }) {
         determined: "on", // preserve the registered participant order (no shuffle)
       });
       if (singlePool || cfg.roundRobin) body.set("roundRobin", "on");
+      // Honour the competition's pool format: "partial" → path-graph match set
+      // (the generator otherwise defaults to full round-robin). Mirrors the
+      // engine's PoolFormat switch (internal/engine/pools.go).
+      if (cfg.poolFormat === "partial") body.set("poolFormat", "partial");
       if (cfg.withZekkenName) body.set("withZekkenName", "on");
       if (seeded.length) body.set("seeds", JSON.stringify(seeded));
 

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -331,11 +331,12 @@ function AllWinnersModal({ comps, onClose }) {
   );
 }
 
-function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompetition, onEditTournament, onAnnounce, onOpenSchedule, onOpenScoreEditor, onOpenImport, onOpenShiaijo, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate, showToast }) {
+function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompetition, onEditTournament, onAnnounce, onOpenSchedule, onOpenScoreEditor, onOpenImport, onOpenShiaijo, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate, showToast, authConfig }) {
   const t = tournament;
   const comps = t.competitions || [];
   const [exportPdfOpen, setExportPdfOpen] = useStateA(false);
   const [allWinnersOpen, setAllWinnersOpen] = useStateA(false);
+  const scheduleEnabled = !!((authConfig ?? window.getCachedAuthConfig?.())?.scheduleEnabled);
 
   useEffectA(() => {
     // Coalesce bursts of events into a single dashboard refresh. On a busy
@@ -447,10 +448,12 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
         </div>
 
         <div className="row" style={{ marginBottom: 24 }}>
-          <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenSchedule}>
-            <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="calendar" size={18} />Tournament schedule →</div>
-            <div className="card__sub">All matches across courts. Move matches between shiaijo, filter by player.</div>
-          </button>
+          {scheduleEnabled && (
+            <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenSchedule}>
+              <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="calendar" size={18} />Tournament schedule →</div>
+              <div className="card__sub">All matches across courts. Move matches between shiaijo, filter by player.</div>
+            </button>
+          )}
           <button type="button" className="card" style={{ textAlign: "left", cursor: noComps ? "not-allowed" : "pointer", opacity: noComps ? 0.6 : 1, border: "1px solid var(--line)" }} onClick={onOpenScoreEditor} disabled={noComps} title={noComps ? "Add a competition first" : undefined}>
             <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="pencil" size={18} />Score editor →</div>
             <div className="card__sub">Update results or correct past matches across the tournament.</div>
@@ -714,6 +717,9 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
         <div className="tcard__actions">
           {c.status === "setup" && playerCount >= 2 && (
             <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
+          )}
+          {c.status === "draw-ready" && (
+            <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start competition →</button>
           )}
           {(c.status === "pools" || c.status === "playoffs") && (
             <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onOpen(); }}>Go to Scoring →</button>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -719,7 +719,7 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
             <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
           )}
           {c.status === "draw-ready" && (
-            <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start competition →</button>
+            <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
           )}
           {(c.status === "pools" || c.status === "playoffs") && (
             <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onOpen(); }}>Go to Scoring →</button>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -336,7 +336,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
   const comps = t.competitions || [];
   const [exportPdfOpen, setExportPdfOpen] = useStateA(false);
   const [allWinnersOpen, setAllWinnersOpen] = useStateA(false);
-  const scheduleEnabled = !!((authConfig ?? window.getCachedAuthConfig?.())?.scheduleEnabled);
+  const scheduleEnabled = !!(authConfig?.scheduleEnabled);
 
   useEffectA(() => {
     // Coalesce bursts of events into a single dashboard refresh. On a busy
@@ -715,10 +715,7 @@ function CompCard({ c, onOpen, onStart, tournament, showToast }) {
           {runningCount > 0 && <div className="tcard__stat"><div className="v" style={{ color: "var(--red)" }}>{runningCount}</div><div className="l">Now</div></div>}
         </div>
         <div className="tcard__actions">
-          {c.status === "setup" && playerCount >= 2 && (
-            <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
-          )}
-          {c.status === "draw-ready" && (
+          {(c.status === "draw-ready" || (c.status === "setup" && playerCount >= 2)) && (
             <button type="button" className="btn btn--primary btn--sm btn--full" onClick={(e) => { e.stopPropagation(); onStart(); }}>Start Competition →</button>
           )}
           {(c.status === "pools" || c.status === "playoffs") && (


### PR DESCRIPTION
## Summary

Six admin-view bug fixes bundled into one PR (all confirmed against the code first via `/critical-thinking`):

- **mp-c0bs** — The dashboard competition card showed **no action button** once a draw existed (`draw-ready` matched none of the setup/running/completed branches). Added a draw-ready branch rendering a primary **"Start competition →"** button.
- **mp-h7ca** — **Discard draw** hard-navigated to Overview, losing the operator's place. Now it **stays on the current section**, falling back to Participants only when the current section is a draw-only preview (pools/bracket/swiss) that disappears after discard.
- **mp-xsc1** — The **"Other competitions"** switcher was visually indistinguishable from the active competition's side-nav. It is now its **own separate card stacked below** the nav (`position:static` so it doesn't fight the sticky nav), and hidden when there are no other competitions.
- **mp-bofc (Phase 1)** — In setup state, **"Generate draw"** is now the primary CTA (relabelled from "Preview draw"); **Start competition** is demoted to ghost there. Also **removed the redundant "Regenerate draw"** action: the draw is deterministic on its (now-locked) inputs, so regenerating reproduced the identical draw — the flow to change a draw is Discard → edit → Generate. *(Phase 2 — "first scored match auto-starts the competition" — is intentionally out of scope.)*
- **mp-nixa** — Fixed a frontend/backend contradiction: the Participants tab promised *"edits update in place"* while the backend **409'd** them. Now **all output-affecting fields** (participants, seeds, pool size/winners/mode, courts, format, pool format, round-robin, mirror, team size, kind) are gated behind discard/regenerate while `draw-ready` — UI controls disabled with an honest hint, plus a server-side PUT-settings guard for parity. Cosmetic fields (name, date, start time, number prefix, check-in, naginata, zekken) remain editable.
- **mp-fwce** — The admin **Tournament-schedule** entry is now hidden behind a new `ENABLE_TOURNAMENT_SCHEDULE` env flag (**default OFF**), surfaced to the SPA via `GET /api/auth-config` (`scheduleEnabled`).

## Why

mp-nixa root cause: the draw (pools.csv / bracket.json) is generated from far more than participants — `PoolSeeding(players, PoolSize, len(Courts))`, `CreatePools(players, PoolSize, …)`, and the bracket builder consume courts, pool size/winners, format, mirror and round-robin. Changing any of those while a draw existed silently desynced the generated draw from config, and participants were already 409'd on the backend while the UI claimed in-place edits.

## Tri-review follow-up

A parallel multi-lens review (simplify + correctness + security, adversarially verified) surfaced a draw-ready gate gap, a data-loss bug, and an export-fidelity bug — all fixed here:

- **Gate widened to match the Excel generator** (`/create`): `NumberPrefix` + `WithZekkenName` reach the generator (player numbers / name columns), so they're now output-affecting (backend 409 + settings controls disabled). `StartTime` and `CheckInEnabled` were verified NOT to reach `/create` (no times in the generator; the export sends the full unfiltered roster) and stay editable.
- **HIGH data-loss fix:** `teamMatchType` was absent from the settings PUT body, so the full-replace merge clobbered a kachinuki competition to `fixed` on any cosmetic edit. Now round-tripped in `finalNext`.
- **Export-fidelity fix (mp-x0u9 follow-up):** the `/create` generator always produced full round-robin, silently losing `PoolFormat=partial`. It now honours partial (path-graph, N-1 matches), mirroring the engine.
- **Cleanups:** deduped the identical Start-Competition buttons; dropped a dead `getCachedAuthConfig` fallback; documented the PUT 409 in `specs/openapi.yaml`.

New tests: 409 on numberPrefix/withZekken change; `finalNext` allowlist includes teamMatchType; partial pool of 6 → 5 matches vs 15 round-robin.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_competition.jsx` | Generate-draw primary CTA + relabel; discard stays in current view; Other-competitions as its own card below the nav |
| `web-mobile/js/admin_shell.jsx` | Draw-ready Start button on CompCard; schedule card gated by `scheduleEnabled` |
| `web-mobile/js/admin.jsx` | Thread `authConfig` to AdminDashboard |
| `web-mobile/js/admin_participants.jsx` | Honest draw-ready notice; disable participant/seed editing while draw-ready |
| `web-mobile/js/admin_competition_settings.jsx` | Disable output-affecting settings while draw-ready + hint |
| `internal/mobileapp/handlers_competition.go` | PUT-settings draw-ready gate (409 on output-affecting change only) |
| `internal/mobileapp/handlers_auth_config.go` | Add `scheduleEnabled` to `/api/auth-config` |
| `internal/mobileapp/server.go` | Thread `scheduleEnabled` through router construction |
| `cmd/mobile_app.go` | `ENABLE_TOURNAMENT_SCHEDULE` env parsing (`parseScheduleEnabled`, default OFF) |
| `internal/pdf/generate_unit_test.go` | Pass `context.TODO()` instead of `nil`; drop SA1012 nolint |
| `internal/mobileapp/handlers_competition_test.go` | Draw-ready settings gate tests (409 / 200) |
| `internal/mobileapp/handlers_auth_config_test.go` | `scheduleEnabled` reflection test (new) |
| `cmd/mobile_app_test.go` | `parseScheduleEnabled` table test |
| `internal/mobileapp/{coverage_gap,handlers_auth_admin,handlers_reset,middleware_selfrun}_test.go` | Update callers for new `NewRouterWithHub` param |

## Screenshots

**Setup state — "Generate draw" is the primary CTA (mp-bofc) + "Other competitions" as its own card below the nav (mp-xsc1):**
![comp setup](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/01-comp-setup.png)

**Draw-ready header — just Discard draw + Start competition (Regenerate removed, mp-bofc):**
![draw-ready header](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/02-drawready-header.png)

**Participants tab in draw-ready — honest "locked" notice + disabled controls (mp-nixa):**
![participants locked](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/03-participants-locked.png)

**Settings tab in draw-ready — output-affecting controls disabled with hint; cosmetic fields editable (mp-nixa):**
![settings gated](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/04-settings-gated.png)

**Dashboard, flag OFF — draw-ready card shows "Start competition →" (mp-c0bs); NO Tournament-schedule card (mp-fwce):**
![dashboard flag off](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/05-dashboard-flagoff.png)

**Dashboard, flag ON — Tournament-schedule card present (mp-fwce):**
![dashboard flag on](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/06-dashboard-flagon.png)

**Discard draw keeps the operator on the current section (mp-h7ca) — still on Settings after discard:**
![discard stays on settings](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/305/07-discard-stays-settings.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — lint 0 issues, gosec 0, govulncheck clean, JS lint + 1746 JS tests, Go coverage ≥85% (mobileapp 85.7%, cmd 86.5%)
- [x] New/updated unit tests cover the change — draw-ready settings gate (409 output-affecting / 200 cosmetic), schedule flag env parsing, `/api/auth-config` flag reflection
- [x] Manual browser verification (for `web-mobile/` changes) — drove the real app (system Chrome): created a tournament + two competitions, generated/discarded a draw, exercised the setup/draw-ready headers, participants & settings gating, dashboard cards, and both schedule-flag states (see Screenshots)
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors or warnings — console checked clean during the browser pass

Closes mp-c0bs
Closes mp-h7ca
Closes mp-xsc1
Closes mp-bofc
Closes mp-nixa
Closes mp-fwce


