### PR TITLE
feat(mp-tidg): URL paths for viewer competition tabs

### DIFF
--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -52,6 +52,12 @@ describe('parsePath — /competition/:id/:tab', () => {
       mode: 'viewer', viewerCompId: 'abc', viewerTab: null,
     });
   });
+
+  it('normalizes an explicit /overview segment to null (canonical default)', () => {
+    expect(parsePath('/competition/abc/overview')).toEqual({
+      mode: 'viewer', viewerCompId: 'abc', viewerTab: null,
+    });
+  });
 });
 
 describe('pathFromState — viewer competition tab round-trip', () => {

--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -38,6 +38,56 @@ describe('shiaijoScoreCell — team numbers are never context-free', () => {
   });
 });
 
+// mp-tidg: viewer competition tab routing — /competition/:id/:tab gives
+// browser back/forward support across tabs (Overview / Pools / Bracket / etc).
+describe('parsePath — /competition/:id/:tab', () => {
+  it('parses a tab segment into viewerTab', () => {
+    expect(parsePath('/competition/abc/bracket')).toEqual({
+      mode: 'viewer', viewerCompId: 'abc', viewerTab: 'bracket',
+    });
+  });
+
+  it('returns viewerTab null when no tab segment is present', () => {
+    expect(parsePath('/competition/abc')).toEqual({
+      mode: 'viewer', viewerCompId: 'abc', viewerTab: null,
+    });
+  });
+});
+
+describe('pathFromState — viewer competition tab round-trip', () => {
+  it('emits bare /competition/:id for overview (default tab)', () => {
+    expect(pathFromState('viewer', undefined, 'abc', {}, 'overview')).toBe('/competition/abc');
+    expect(pathFromState('viewer', undefined, 'abc', {}, null)).toBe('/competition/abc');
+  });
+
+  it('appends the tab segment for non-overview tabs', () => {
+    expect(pathFromState('viewer', undefined, 'abc', {}, 'bracket')).toBe('/competition/abc/bracket');
+  });
+
+  it('round-trips bracket tab through parsePath', () => {
+    const url = pathFromState('viewer', undefined, 'abc', {}, 'bracket');
+    expect(parsePath(url)).toEqual({
+      mode: 'viewer', viewerCompId: 'abc', viewerTab: 'bracket',
+    });
+  });
+
+  it('register takes precedence over vcid — no tab suffix', () => {
+    expect(pathFromState('viewer', 'register', 'abc', {}, 'bracket')).toBe('/register/abc');
+  });
+
+  // mp-tidg: encode/decode symmetry — pathFromState encodeURIComponent's the
+  // tab and parsePath safeDecode's it, so a URL-special tab id round-trips.
+  // (Real tab ids are plain ASCII, so this is a defensive contract, not a
+  // behaviour change for current tabs.)
+  it('encodes a URL-special tab segment and round-trips it', () => {
+    const url = pathFromState('viewer', undefined, 'abc', {}, 'a b');
+    expect(url).toBe('/competition/abc/a%20b');
+    expect(parsePath(url)).toEqual({
+      mode: 'viewer', viewerCompId: 'abc', viewerTab: 'a b',
+    });
+  });
+});
+
 // Routing for the dedicated shiaijo operator view (mp-c2yr).
 describe('parsePath — /admin/shiaijo/:court', () => {
   it('maps a court segment to the shiaijo admin kind', () => {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -106,8 +106,13 @@ function parsePath(path) {
       return { mode: "display" };
     }
     if (path.startsWith("/competition/")) {
-      const id = path.split("/")[2];
-      return { mode: "viewer", viewerCompId: id };
+      const parts = path.split("/").filter(Boolean);
+      const id = parts[1];
+      // mp-tidg: the 3rd segment encodes the active tab so browser
+      // back/forward navigates across tabs. Decode defensively (same
+      // safeDecode pattern as the shiaijo court segment above).
+      const tab = parts[2] ? safeDecode(parts[2]) : null;
+      return { mode: "viewer", viewerCompId: id, viewerTab: tab };
     }
     if (path === "/schedule") {
       return { mode: "viewer", viewerScreen: "schedule" };
@@ -137,7 +142,10 @@ function parsePath(path) {
 }
 
 // Pure helper: render the App's view state back into a URL pathname.
-function pathFromState(m, vs, vcid, av) {
+// mp-tidg: `vt` is the viewer competition tab ("overview", "bracket", …).
+// overview is the default and is NOT emitted in the URL (clean root path).
+// register takes precedence over vcid alone and must NOT get a tab suffix.
+function pathFromState(m, vs, vcid, av, vt) {
     if (m === "admin") {
       if (av.kind === "dashboard") return "/admin";
       if (av.kind === "schedule") return "/admin/schedule";
@@ -154,7 +162,15 @@ function pathFromState(m, vs, vcid, av) {
       return "/admin";
     }
     if (vs === "register" && vcid) return `/register/${vcid}`;
-    if (vcid) return `/competition/${vcid}`;
+    if (vcid) {
+      // Omit the tab segment for overview (default) so the canonical URL
+      // stays clean and parsePath(pathFromState(…)) round-trips correctly.
+      // encodeURIComponent mirrors the safeDecode on the parse side (and the
+      // shiaijo-court segment above) so the encode/decode round-trip stays
+      // symmetric even if a future tab id carries a URL-special character.
+      if (vt && vt !== "overview") return `/competition/${vcid}/${encodeURIComponent(vt)}`;
+      return `/competition/${vcid}`;
+    }
     if (vs === "schedule") return "/schedule";
     if (vs === "glossary") return "/glossary";
     if (vs === "reset") return "/reset";
@@ -314,6 +330,10 @@ function App() {
   });
   const [authPrompt, setAuthPrompt] = useS(false);
   const [viewerCompId, setViewerCompId] = useS(initialRoute.viewerCompId || null);
+  // mp-tidg: tab is lifted here (not inside ViewerCompetition) so that
+  // browser back/forward across tabs works — each tab push/pop is a
+  // history entry owned by App, making this the single source of truth.
+  const [viewerTab, setViewerTab] = useS(initialRoute.viewerTab || null);
   const [viewerScreen, setViewerScreen] = useS(initialRoute.viewerScreen || "home"); // home | schedule | glossary | reset | results
   const [adminView, setAdminView] = useS(initialRoute.admin || { kind: "dashboard" });
   const [toast, setToast] = useS(null);
@@ -398,7 +418,7 @@ function App() {
     // on its own. Skip URL syncing here to avoid stripping the
     // query string (pathFromState only emits the path, not the query).
     if (mode === "display") return;
-    const url = pathFromState(mode, viewerScreen, viewerCompId, adminView);
+    const url = pathFromState(mode, viewerScreen, viewerCompId, adminView, viewerTab);
     if (window.location.pathname !== url) {
       if (AppRouter && AppRouter.route) {
         AppRouter.route(url);
@@ -406,7 +426,7 @@ function App() {
         history.pushState(null, "", url);
       }
     }
-  }, [mode, viewerScreen, viewerCompId, adminView]);
+  }, [mode, viewerScreen, viewerCompId, adminView, viewerTab]);
 
   // The popstate handler is preserved as a fallback for back/forward
   // navigation. preact-router would also fire its own listeners on
@@ -425,6 +445,7 @@ function App() {
       } else {
         setMode("viewer");
         setViewerCompId(route.viewerCompId || null);
+        setViewerTab(route.viewerTab || null);
         setViewerScreen(route.viewerScreen || "home");
       }
     };
@@ -889,11 +910,13 @@ function App() {
           poolMatches={selectedCompData.poolMatches}
           standings={selectedCompData.standings}
           bracket={selectedCompData.bracket}
-          onBack={() => setViewerCompId(null)}
+          onBack={() => { setViewerCompId(null); setViewerTab(null); }}
           onAdminClick={requestAdmin}
           authed={authed}
           onEditCompetition={(id) => { setMode("admin"); setAdminView({ kind: "competition", id, section: "settings" }); }}
           tweaks={THEME}
+          activeTab={viewerTab || "overview"}
+          onTabChange={setViewerTab}
         />
       ) : viewerScreen === "schedule" ? (
         <window.ViewerSchedule
@@ -934,6 +957,7 @@ function App() {
               onBack={() => {
                 setViewerScreen("home");
                 setViewerCompId(null);
+                setViewerTab(null);
               }}
             />
           : <window.LoadingSpinner text="Loading…" />
@@ -949,11 +973,12 @@ function App() {
       ) : (
         <window.ViewerHome
           tournament={tournament}
-          onSelectCompetition={setViewerCompId}
+          onSelectCompetition={(compId) => { setViewerCompId(compId); setViewerTab(null); }}
           onOpenSchedule={() => setViewerScreen("schedule")}
           onAdminClick={requestAdmin}
           onRegister={(compId) => {
             setViewerCompId(compId);
+            setViewerTab(null);
             setViewerScreen("register");
           }}
           onOpenResults={() => setViewerScreen("results")}
@@ -981,6 +1006,7 @@ function App() {
             // any other viewer route uses.
             if (mode === "admin") setMode("viewer");
             setViewerCompId(null);
+            setViewerTab(null);
             setViewerScreen("reset");
           }}
           onClose={() => {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -339,6 +339,36 @@ function App() {
   // browser back/forward across tabs works — each tab push/pop is a
   // history entry owned by App, making this the single source of truth.
   const [viewerTab, setViewerTab] = useS(initialRoute.viewerTab || null);
+  // When the next state→URL sync should replaceState instead of pushState.
+  // A correction (an invalid/non-canonical tab rewritten to its canonical
+  // path) must REPLACE the bad entry, otherwise Back returns to the invalid
+  // URL which re-corrects and re-pushes — a back/forward trap (PR #307
+  // review). It is armed for (a) a non-canonical landing URL — e.g.
+  // /competition/:id/overview, which parsePath normalizes to viewerTab=null
+  // so the initial sync rewrites to the bare path — and (b) the clamp in
+  // ViewerCompetition (via handleTabChange's replace arg). Genuine tab
+  // navigations leave it false and push normally. Consumed (reset to false)
+  // by the sync effect only when it actually rewrites the URL.
+  const replaceNextUrlSync = useR(
+    typeof window !== "undefined" &&
+      initialRoute.mode !== "display" &&
+      window.location.pathname !==
+        pathFromState(
+          initialRoute.mode || "viewer",
+          initialRoute.viewerScreen || "home",
+          initialRoute.viewerCompId || null,
+          initialRoute.admin || { kind: "dashboard" },
+          initialRoute.viewerTab || null,
+        ),
+  );
+  // Controlled-tab writer for ViewerCompetition. `replace` is true when the
+  // change is a correction (clamped invalid/unavailable tab) so the URL sync
+  // replaces rather than pushes; tab clicks pass false. Set explicitly on
+  // every call so the flag never leaks across navigations.
+  const handleTabChange = useC((tab, replace = false) => {
+    replaceNextUrlSync.current = replace;
+    setViewerTab(tab);
+  }, []);
   const [viewerScreen, setViewerScreen] = useS(initialRoute.viewerScreen || "home"); // home | schedule | glossary | reset | results
   const [adminView, setAdminView] = useS(initialRoute.admin || { kind: "dashboard" });
   const [toast, setToast] = useS(null);
@@ -425,8 +455,14 @@ function App() {
     if (mode === "display") return;
     const url = pathFromState(mode, viewerScreen, viewerCompId, adminView, viewerTab);
     if (window.location.pathname !== url) {
+      // Consume the replace flag only when we actually rewrite, so a no-op
+      // pass (e.g. the mount render before a clamp resolves) doesn't drop it.
+      const replace = replaceNextUrlSync.current;
+      replaceNextUrlSync.current = false;
       if (AppRouter && AppRouter.route) {
-        AppRouter.route(url);
+        AppRouter.route(url, replace);
+      } else if (replace) {
+        history.replaceState(null, "", url);
       } else {
         history.pushState(null, "", url);
       }
@@ -923,7 +959,7 @@ function App() {
           onEditCompetition={(id) => { setMode("admin"); setAdminView({ kind: "competition", id, section: "settings" }); }}
           tweaks={THEME}
           activeTab={viewerTab || "overview"}
-          onTabChange={setViewerTab}
+          onTabChange={handleTabChange}
         />
       ) : viewerScreen === "schedule" ? (
         <window.ViewerSchedule

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -110,8 +110,13 @@ function parsePath(path) {
       const id = parts[1];
       // mp-tidg: the 3rd segment encodes the active tab so browser
       // back/forward navigates across tabs. Decode defensively (same
-      // safeDecode pattern as the shiaijo court segment above).
-      const tab = parts[2] ? safeDecode(parts[2]) : null;
+      // safeDecode pattern as the shiaijo court segment above). Normalize
+      // the default tab to null — the rest of the app treats "overview" as
+      // the nullish default (selectTab/pathFromState), so /competition/:id
+      // and /competition/:id/overview must both parse to viewerTab=null and
+      // never carry two representations of the same state.
+      let tab = parts[2] ? safeDecode(parts[2]) : null;
+      if (tab === "overview") tab = null;
       return { mode: "viewer", viewerCompId: id, viewerTab: tab };
     }
     if (path === "/schedule") {
@@ -901,8 +906,10 @@ function App() {
       {selectedCompData && viewerScreen !== "register" ? (
         <window.ViewerCompetition
           // key on the competition id so switching comps remounts the
-          // component and resets per-comp UI state (active tab, open
-          // match modal, bracket scroll target).
+          // component and resets its internal per-comp UI state (open match
+          // modal, bracket scroll target). The active tab is NOT reset by the
+          // remount — it is controlled App state (viewerTab); the onBack /
+          // onSelectCompetition handlers clear it explicitly.
           key={selectedCompData.config.id}
           tournament={tournament}
           competition={selectedCompData.config}

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -168,7 +168,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
   // not "overview", for the default), and tolerates a missing handler via
   // optional chaining — some unit tests mount ViewerCompetition without an
   // onTabChange just to assert tab presence. (mp-tidg / PR #307 review)
-  const selectTab = (id) => onTabChange?.(id === "overview" ? null : id);
+  const selectTab = (id, replace = false) => onTabChange?.(id === "overview" ? null : id, replace);
 
   // mp-tidg: when the requested tab isn't available (deep-link to /bracket
   // before a draw, or a draw_discarded SSE while sitting on it) effectiveTab
@@ -179,7 +179,9 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
   // default/nullish state) there is nothing to correct — the URL is already
   // canonical.
   React.useEffect(() => {
-    if (activeTab && effectiveTab !== activeTab) selectTab(effectiveTab);
+    // replace=true: this is a correction, not a navigation — rewrite the
+    // invalid tab URL in place so Back doesn't return to it (PR #307 review).
+    if (activeTab && effectiveTab !== activeTab) selectTab(effectiveTab, true);
   }, [effectiveTab, activeTab, onTabChange]);
 
   const currentMatch = useMemo(() => {

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -18,8 +18,10 @@ const hasBothSides = (m) => window.hasBothSides(m);
 // Pool daihyosen matches carry '-DH-' in their id.
 const isPoolDaihyosenID = id => id.includes('-DH-');
 
-export function ViewerCompetition({ tournament, competition, pools, poolMatches, standings, bracket, onBack, authed, onEditCompetition, tweaks }) {
-  const [tab, setTab] = useState("overview");
+// mp-tidg: activeTab + onTabChange are controlled props — app.jsx owns the
+// tab state so browser back/forward across tabs works (each tab switch is a
+// history push in the URL-sync effect). Do not add internal tab state here.
+export function ViewerCompetition({ tournament, competition, pools, poolMatches, standings, bracket, onBack, authed, onEditCompetition, tweaks, activeTab, onTabChange }) {
   const c = competition;
 
   const allMatches = useMemo(() => {
@@ -156,6 +158,25 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     c.status === "completed" ? { id: "results", label: "Awards" } : null,
   ].filter(Boolean);
 
+  // Clamp the incoming activeTab to the set of tabs that are actually
+  // rendered for this competition — a tab that was valid on a previous
+  // comp (e.g. "bracket") may not exist yet on draw-ready or setup.
+  const effectiveTab = tabs.some(t => t.id === activeTab) ? activeTab : "overview";
+
+  // mp-tidg: when the requested tab isn't available (deep-link to /bracket
+  // before a draw, or a draw_discarded SSE while sitting on it) effectiveTab
+  // falls back to overview for display. Propagate that back to app state so
+  // the URL stops claiming a tab the user isn't actually on — otherwise a
+  // shared permalink would render Overview while still reading /…/bracket.
+  // null (not "overview") keeps the canonical bare /competition/:id path.
+  // Guard on a truthy activeTab: when no specific tab was requested (the
+  // default/nullish state) there is nothing to correct — the URL is already
+  // canonical — and skipping keeps the component renderable without an
+  // onTabChange handler (used by unit tests that only assert tab presence).
+  React.useEffect(() => {
+    if (activeTab && effectiveTab !== activeTab) onTabChange(effectiveTab === "overview" ? null : effectiveTab);
+  }, [effectiveTab, activeTab, onTabChange]);
+
   const currentMatch = useMemo(() => {
     if (runningMatches.length > 0) return runningMatches[0];
     return upcomingMatches[0] || null;
@@ -167,12 +188,12 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
   const [bracketOverflowRight, setBracketOverflowRight] = useState(false);
 
   React.useEffect(() => {
-    if (tab === "bracket" && currentMatch) {
+    if (effectiveTab === "bracket" && currentMatch) {
       setBracketScrollTarget(currentMatch.id + "::" + Date.now());
     }
-  }, [tab, currentMatch?.id]);
+  }, [effectiveTab, currentMatch?.id]);
 
-  const hasBracketEl = tab === "bracket" && !!derivedBracket;
+  const hasBracketEl = effectiveTab === "bracket" && !!derivedBracket;
   React.useEffect(() => {
     if (!hasBracketEl) return;
     const el = bracketScrollRef.current;
@@ -214,7 +235,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
         </div>
         <div className="viewer__tabs">
           {tabs.map((tb) => (
-            <button type="button" key={tb.id} className={`viewer__tab ${tab === tb.id ? "is-active" : ""}`} onClick={() => setTab(tb.id)}>
+            <button type="button" key={tb.id} className={`viewer__tab ${effectiveTab === tb.id ? "is-active" : ""}`} onClick={() => onTabChange(tb.id)}>
               {tb.label}
             </button>
           ))}
@@ -250,7 +271,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
           </div>
         )}
         <div className="viewer__body">
-          {tab === "overview" && (
+          {effectiveTab === "overview" && (
             <ViewerOverview
               c={c}
               myPlayer={myPlayer}
@@ -265,13 +286,13 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
               standings={standings}
               pools={pools}
               poolMatches={poolMatches}
-              onSwitchTab={setTab}
+              onSwitchTab={onTabChange}
               hasActiveFilter={hasActiveFilter}
               filterLabel={filterLabel}
               highlightPlayers={highlightPlayers}
             />
           )}
-          {tab === "bracket" && derivedBracket && (
+          {effectiveTab === "bracket" && derivedBracket && (
             <div className={`viewer-bracket-bleed${bracketOverflowRight ? " viewer-bracket-bleed--overflow-right" : ""}`}>
               <div ref={bracketScrollRef} className="bracket-canvas" style={{ borderRadius: 0, borderLeft: 0, borderRight: 0 }}>
                 <div className="bracket-canvas__inner" style={{ padding: 18 }}>
@@ -297,13 +318,13 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
               </div>
             </div>
           )}
-          {tab === "pools" && hasPools && (
+          {effectiveTab === "pools" && hasPools && (
             <PoolsViewer pools={pools} standings={standings} poolMatches={poolMatches} tweaks={tweaks} competition={c} onMatchClick={setSelectedMatch} highlightPlayers={highlightPlayers} />
           )}
-          {tab === "swiss" && isSwiss && (
+          {effectiveTab === "swiss" && isSwiss && (
             <SwissStandingsViewer competition={c} poolMatches={poolMatches} tweaks={tweaks} />
           )}
-          {tab === "results" && c.status === "completed" && (
+          {effectiveTab === "results" && c.status === "completed" && (
             // Pass the *real* server bracket (not derivedBracket) — the latter
             // is a TBD placeholder for visualization only and carries no
             // winner data. Using real server data ensures deriveAwards sees

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -163,18 +163,23 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
   // comp (e.g. "bracket") may not exist yet on draw-ready or setup.
   const effectiveTab = tabs.some(t => t.id === activeTab) ? activeTab : "overview";
 
+  // Controlled-tab writer. Maps the default tab to null so App keeps the
+  // canonical bare /competition/:id URL (the rest of the app stores null,
+  // not "overview", for the default), and tolerates a missing handler via
+  // optional chaining — some unit tests mount ViewerCompetition without an
+  // onTabChange just to assert tab presence. (mp-tidg / PR #307 review)
+  const selectTab = (id) => onTabChange?.(id === "overview" ? null : id);
+
   // mp-tidg: when the requested tab isn't available (deep-link to /bracket
   // before a draw, or a draw_discarded SSE while sitting on it) effectiveTab
   // falls back to overview for display. Propagate that back to app state so
   // the URL stops claiming a tab the user isn't actually on — otherwise a
   // shared permalink would render Overview while still reading /…/bracket.
-  // null (not "overview") keeps the canonical bare /competition/:id path.
   // Guard on a truthy activeTab: when no specific tab was requested (the
   // default/nullish state) there is nothing to correct — the URL is already
-  // canonical — and skipping keeps the component renderable without an
-  // onTabChange handler (used by unit tests that only assert tab presence).
+  // canonical.
   React.useEffect(() => {
-    if (activeTab && effectiveTab !== activeTab) onTabChange(effectiveTab === "overview" ? null : effectiveTab);
+    if (activeTab && effectiveTab !== activeTab) selectTab(effectiveTab);
   }, [effectiveTab, activeTab, onTabChange]);
 
   const currentMatch = useMemo(() => {
@@ -235,7 +240,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
         </div>
         <div className="viewer__tabs">
           {tabs.map((tb) => (
-            <button type="button" key={tb.id} className={`viewer__tab ${effectiveTab === tb.id ? "is-active" : ""}`} onClick={() => onTabChange(tb.id)}>
+            <button type="button" key={tb.id} className={`viewer__tab ${effectiveTab === tb.id ? "is-active" : ""}`} onClick={() => selectTab(tb.id)}>
               {tb.label}
             </button>
           ))}
@@ -286,7 +291,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
               standings={standings}
               pools={pools}
               poolMatches={poolMatches}
-              onSwitchTab={onTabChange}
+              onSwitchTab={selectTab}
               hasActiveFilter={hasActiveFilter}
               filterLabel={filterLabel}
               highlightPlayers={highlightPlayers}


### PR DESCRIPTION
## Summary

- The mobile-app viewer's within-competition tabs (Overview / Pools / Bracket / Standings / Awards) now have real URL paths — `/competition/:compId/:tab` — so a spectator can share a link straight to the Bracket or Pools view. Previously the active tab was local component state, invisible to the URL, so every shared link opened on Overview.
- Browser **back/forward** now navigates across tabs and the visible tab follows the URL (the tab was lifted into `App` as a controlled prop, the single source of truth).
- A deep-link to a tab that isn't available yet (e.g. `/competition/:id/bracket` before the draw exists) gracefully falls back to Overview **and rewrites the URL to canonical**, so a permalink never misrepresents the page.

## Why

Closes the "every page and tab has a shareable URL" gap (mp-tidg). The admin side (`/admin/competition/:id/:section`) and the display surfaces already had URLs; only the public viewer's competition tabs were missing them.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/app.jsx` | `parsePath`/`pathFromState` handle the `/competition/:id/:tab` segment (overview stays bare; tab `encodeURIComponent`'d to mirror the `safeDecode` on parse); new `viewerTab` state synced to the URL and restored on popstate; all `setViewerCompId` sites reset the tab |
| `web-mobile/js/viewer_competition.jsx` | Tab is now a controlled `activeTab`/`onTabChange` prop; `effectiveTab` clamps an unavailable/invalid tab to Overview and propagates that back so the URL stays canonical |
| `web-mobile/js/__tests__/admin_shiaijo.test.jsx` | Unit tests for the tab segment: parse, round-trip, register precedence, and encode/decode symmetry |

## Screenshots

Deep-linked viewer tabs (mobile viewport) — the active tab matches the URL path.

**Bracket tab** — `/competition/kendo-cup/bracket`

![Bracket tab deep-link](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/307/bracket.png)

**Pools tab** — `/competition/kendo-cup/pools`

![Pools tab deep-link](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/307/pools.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (`admin_shiaijo.test.jsx`; full JS suite: 1756 passed)
- [x] Manual browser verification — deep-linked `/competition/:id/bracket` and `/pools` land on the correct tab; clicking tabs updates the URL; back/forward moves the visible tab; an unavailable-tab deep-link (`/bracket` on a setup comp) falls back to Overview and rewrites the URL to `/competition/:id`
- [x] Screenshots added above (viewer Bracket and Pools tabs, deep-linked, mobile viewport)
- [x] No new console errors or warnings (verified via preview console — none)

Closes mp-tidg
