### PR TITLE
feat(mp-dm5e): highlight tied standings rows in amber (pools + league)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -326,6 +326,11 @@ The hatch on Shiro is load-bearing: pure white on a white card is invisible, and
 
 Auto-fill grid (320px min). Each pool is a card with `.pool__table` inside. `.pool--done` recolors the wrapper to `--accent-soft`.
 
+Row modifiers on `<tr>` inside `.pool__table`:
+- `tr.advancing` — light-green background + `▲` marker: player progressing to playoffs.
+- `tr.pool__row--me` — translucent navy tint (`rgba(29,53,87,0.07)`): the followed player (viewer).
+- `tr.pool__row--tied` — amber fill (`--warn-soft`) + 3px left inset border (`--warn-border`): two or more competitors tied on all ranking criteria. Appears only once the tie is observable (pool all-complete for pools format; emerging-tie trigger for league format). Clears automatically when the tie resolves. Uses amber tokens only — never `--red` (Aka/danger) or `--accent` (running state).
+
 ### Modals — `.modal-backdrop > .modal`
 
 `.modal--lg` widens to 720px (default 460). Always wire `useEscapeToClose(onClose)` from [ui.jsx#L133](web-mobile/js/ui.jsx#L133) — every modal in the app supports Escape, and operators rely on it.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -329,7 +329,7 @@ Auto-fill grid (320px min). Each pool is a card with `.pool__table` inside. `.po
 Row modifiers on `<tr>` inside `.pool__table`:
 - `tr.advancing` — light-green background + `▲` marker: player progressing to playoffs.
 - `tr.pool__row--me` — translucent navy tint (`rgba(29,53,87,0.07)`): the followed player (viewer).
-- `tr.pool__row--tied` — amber fill (`--warn-soft`) + 3px left inset border (`--warn-border`): two or more competitors tied on all ranking criteria. Appears only once the tie is observable (pool all-complete for pools format; emerging-tie trigger for league format). Clears automatically when the tie resolves. Uses amber tokens only — never `--red` (Aka/danger) or `--accent` (running state).
+- `tr.pool__row--tied` — amber fill (`--warn-soft`), background-only (same row-tint idiom as `pool__row--me`): two or more competitors tied on all ranking criteria. Scoped as `.pool__table tr.pool__row--tied` so the amber wins over `.advancing` (green) and `.pool__row--me` (navy). Appears only once the tie is observable (pool all-complete for pools format; emerging-tie trigger for league format). Clears automatically when the tie resolves. Uses amber tokens only — never `--red` (Aka/danger) or `--accent` (running state).
 
 ### Modals — `.modal-backdrop > .modal`
 

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -650,10 +650,139 @@ func (e *Engine) computeStandingsFrom(loader poolStandingsLoader, compId string)
 				}
 			}
 		}
+		markTiedStandings(comp, sorted, poolResults[p.PoolName])
 		allStandings[p.PoolName] = sorted
 	}
 
 	return allStandings, nil
+}
+
+// markTiedStandings sets Tied=true on standings rows that are genuinely tied
+// (same Points on every criterion) and where the tie is visible/consequential
+// given the competition format and match-completion state.
+//
+// Gating rules by format:
+//
+//   - Pools (not league): mark tied groups only after ALL regular matches in
+//     that pool are complete. Regular = excludes TB ("-TB-") and DH ("-DH-")
+//     supplementary bouts. Pre-completion the rank is provisional, so no amber.
+//
+//   - League (comp.Format == state.CompFormatLeague), both team and individual:
+//     EMERGING-TIE trigger. Once ANY of the top-N competitors (N =
+//     effectiveTopN(comp), clamped to pool size) has completed ALL their own
+//     regular fights, mark Tied=true on every tied group whose MinPosition <=
+//     effectiveTopN AND that is not covered by the two-joint-3rd-places
+//     exemption (LeagueTwoThirdPlaces + MinPosition >= 3).
+//
+// matches contains only the regular+supplementary matches for this specific
+// pool (already filtered upstream by poolNameFromMatchID).
+func markTiedStandings(comp *state.Competition, sorted []state.PlayerStanding, matches []state.MatchResult) {
+	if len(sorted) == 0 {
+		return
+	}
+
+	// Separate regular matches (exclude supplementary TB/DH bouts).
+	var regularMatches []state.MatchResult
+	for _, m := range matches {
+		if !IsTiebreakerMatchID(m.ID) && !IsPoolDaihyosenMatchID(m.ID) {
+			regularMatches = append(regularMatches, m)
+		}
+	}
+
+	isLeague := comp != nil && comp.Format == state.CompFormatLeague
+
+	if isLeague {
+		markTiedStandingsLeague(comp, sorted, regularMatches)
+	} else {
+		markTiedStandingsPools(sorted, regularMatches)
+	}
+}
+
+// markTiedStandingsPools marks tied rows in a pools (non-league) competition.
+// Rows are only marked once ALL regular matches in the pool are complete.
+func markTiedStandingsPools(sorted []state.PlayerStanding, regularMatches []state.MatchResult) {
+	// Gate: there must be at least one regular match, and all must be completed.
+	// With no matches at all the pool hasn't started — everyone is tied at 0
+	// points, which must NOT surface as amber.
+	if len(regularMatches) == 0 {
+		return
+	}
+	for _, m := range regularMatches {
+		if m.Status != state.MatchStatusCompleted {
+			return // pool not yet finished — no amber
+		}
+	}
+
+	// Pool is complete; mark every tied group.
+	for _, positions := range detectPoolTies(sorted) {
+		for _, idx := range positions {
+			sorted[idx].Tied = true
+		}
+	}
+}
+
+// markTiedStandingsLeague marks tied rows in a league competition using the
+// emerging-tie trigger: once ANY top-N competitor has finished all their own
+// regular fights, mark consequential tied groups amber. Works for both team
+// and individual leagues.
+func markTiedStandingsLeague(comp *state.Competition, sorted []state.PlayerStanding, regularMatches []state.MatchResult) {
+	topN := min(effectiveTopN(comp), len(sorted))
+
+	// Build per-competitor regular match counts and completion status.
+	// A competitor is "done" when every regular match they appear in is Completed.
+	type compStatus struct {
+		total     int
+		completed int
+	}
+	status := make(map[string]*compStatus, len(sorted))
+	for _, s := range sorted {
+		status[s.Player.Name] = &compStatus{}
+	}
+	for _, m := range regularMatches {
+		if _, okA := status[m.SideA]; okA {
+			status[m.SideA].total++
+			if m.Status == state.MatchStatusCompleted {
+				status[m.SideA].completed++
+			}
+		}
+		if _, okB := status[m.SideB]; okB {
+			status[m.SideB].total++
+			if m.Status == state.MatchStatusCompleted {
+				status[m.SideB].completed++
+			}
+		}
+	}
+
+	// Check if ANY top-N competitor has completed all their own fights.
+	triggerFired := false
+	for i := range topN {
+		name := sorted[i].Player.Name
+		cs := status[name]
+		if cs != nil && cs.total > 0 && cs.completed == cs.total {
+			triggerFired = true
+			break
+		}
+	}
+	if !triggerFired {
+		return
+	}
+
+	// Trigger has fired: mark tied groups that intersect the top-N band and
+	// are not covered by the two-joint-3rd-places exemption.
+	for _, positions := range detectPoolTies(sorted) {
+		minPos := positions[0] + 1 // 1-based
+		g := TiedGroup{
+			Teams:       standingsAt(sorted, positions),
+			MinPosition: minPos,
+			MaxPosition: positions[len(positions)-1] + 1,
+		}
+		if !isConsequentialTie(g, comp) {
+			continue
+		}
+		for _, idx := range positions {
+			sorted[idx].Tied = true
+		}
+	}
 }
 
 // recordBracketMatchResult is the main bracket-side scoring path. It

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -622,6 +622,12 @@ func (e *Engine) computeStandingsFrom(loader poolStandingsLoader, compId string)
 			applyTiebreakSort(sorted, matches, IsPoolDaihyosenMatchID)
 		}
 
+		// Detect ties before applying manual rank overrides. detectPoolTies walks
+		// adjacent elements, so it must run while the slice is still Points-sorted.
+		// Overrides only change the display order; the underlying scoring tie is real
+		// regardless of how the operator chose to resolve it.
+		markTiedStandings(comp, sorted, poolResults[p.PoolName])
+
 		// Apply manual rank overrides
 		overrides, _ := e.store.LoadOverrides(compId)
 		if overrides != nil && overrides.PoolRanks[p.PoolName] != nil {
@@ -650,7 +656,6 @@ func (e *Engine) computeStandingsFrom(loader poolStandingsLoader, compId string)
 				}
 			}
 		}
-		markTiedStandings(comp, sorted, poolResults[p.PoolName])
 		allStandings[p.PoolName] = sorted
 	}
 

--- a/internal/engine/tied_standings_test.go
+++ b/internal/engine/tied_standings_test.go
@@ -202,8 +202,9 @@ func TestMarkTiedStandings_AutoClear(t *testing.T) {
 	assert.Empty(t, tiedNames(resolved), "resolved tie must clear the highlight")
 }
 
-// TestMarkTiedStandings_NonLeagueNonMixed ensures the pools path also governs
-// playoffs-format pools (any non-league format routes through the pools gate).
+// TestMarkTiedStandings_EmptyStandings guards the empty-input path: an empty
+// standings slice must be a no-op (no panic, nothing marked), regardless of
+// format. League is used here as the non-trivial gating branch.
 func TestMarkTiedStandings_EmptyStandings(t *testing.T) {
 	comp := &state.Competition{Format: state.CompFormatLeague}
 	var sorted []state.PlayerStanding

--- a/internal/engine/tied_standings_test.go
+++ b/internal/engine/tied_standings_test.go
@@ -81,8 +81,9 @@ func TestMarkTiedStandings_Pools(t *testing.T) {
 	})
 }
 
-// leagueMatchesAllDoneFor builds a round-robin among `names` where every
-// listed competitor's matches are completed. Used to fire the emerging trigger.
+// leagueRoundRobin builds a round-robin among `names` where every
+// listed competitor's matches are either all completed or all scheduled.
+// Used to fire (or not) the emerging-tie trigger.
 func leagueRoundRobin(names []string, completed bool) []state.MatchResult {
 	var out []state.MatchResult
 	idx := 0

--- a/internal/engine/tied_standings_test.go
+++ b/internal/engine/tied_standings_test.go
@@ -1,0 +1,212 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+)
+
+// tiedStanding builds a standing with an explicit name and Points value.
+// markTiedStandings only reads Player.Name and Points, so the packed-points
+// chain is irrelevant here — equal Points means tied, by construction.
+func tiedStanding(name string, points int) state.PlayerStanding {
+	return state.PlayerStanding{Player: domain.Player{Name: name}, Points: points}
+}
+
+// completedMatch / scheduledMatch build regular pool matches (ID "Pool A-N")
+// between two named competitors with the given completion status.
+func completedMatch(idx int, a, b string) state.MatchResult {
+	return state.MatchResult{ID: fmt.Sprintf("Pool A-%d", idx), SideA: a, SideB: b, Status: state.MatchStatusCompleted}
+}
+
+func scheduledMatch(idx int, a, b string) state.MatchResult {
+	return state.MatchResult{ID: fmt.Sprintf("Pool A-%d", idx), SideA: a, SideB: b, Status: state.MatchStatusScheduled}
+}
+
+// tiedNames returns the set of names flagged Tied, for order-independent asserts.
+func tiedNames(sorted []state.PlayerStanding) map[string]bool {
+	out := map[string]bool{}
+	for _, s := range sorted {
+		if s.Tied {
+			out[s.Player.Name] = true
+		}
+	}
+	return out
+}
+
+// TestMarkTiedStandings_Pools covers the pools (non-league) gate: amber appears
+// only once every regular match in the pool is complete.
+func TestMarkTiedStandings_Pools(t *testing.T) {
+	comp := &state.Competition{Format: state.CompFormatMixed}
+
+	t.Run("no matches yet → no amber even when all tied at 0", func(t *testing.T) {
+		sorted := []state.PlayerStanding{tiedStanding("A", 0), tiedStanding("B", 0), tiedStanding("C", 0)}
+		markTiedStandings(comp, sorted, nil)
+		assert.Empty(t, tiedNames(sorted), "pre-start pool must not surface amber")
+	})
+
+	t.Run("pool complete with a tie → tied rows marked", func(t *testing.T) {
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 100), tiedStanding("C", 50)}
+		matches := []state.MatchResult{completedMatch(0, "A", "B"), completedMatch(1, "A", "C"), completedMatch(2, "B", "C")}
+		markTiedStandings(comp, sorted, matches)
+		assert.Equal(t, map[string]bool{"A": true, "B": true}, tiedNames(sorted))
+	})
+
+	t.Run("pool incomplete → no amber even if currently tied", func(t *testing.T) {
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 100), tiedStanding("C", 50)}
+		matches := []state.MatchResult{completedMatch(0, "A", "B"), scheduledMatch(1, "A", "C")}
+		markTiedStandings(comp, sorted, matches)
+		assert.Empty(t, tiedNames(sorted), "an unscored match must suppress amber")
+	})
+
+	t.Run("pool complete, no tie → nothing marked", func(t *testing.T) {
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 60), tiedStanding("C", 50)}
+		matches := []state.MatchResult{completedMatch(0, "A", "B"), completedMatch(1, "A", "C"), completedMatch(2, "B", "C")}
+		markTiedStandings(comp, sorted, matches)
+		assert.Empty(t, tiedNames(sorted))
+	})
+
+	t.Run("supplementary TB/DH bouts don't block the all-complete gate", func(t *testing.T) {
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 100), tiedStanding("C", 50)}
+		matches := []state.MatchResult{
+			completedMatch(0, "A", "B"), completedMatch(1, "A", "C"), completedMatch(2, "B", "C"),
+			{ID: "Pool A-TB-0", SideA: "A", SideB: "B", Status: state.MatchStatusScheduled},
+		}
+		markTiedStandings(comp, sorted, matches)
+		assert.Equal(t, map[string]bool{"A": true, "B": true}, tiedNames(sorted),
+			"a pending TB bout is supplementary and must not gate the highlight")
+	})
+}
+
+// leagueMatchesAllDoneFor builds a round-robin among `names` where every
+// listed competitor's matches are completed. Used to fire the emerging trigger.
+func leagueRoundRobin(names []string, completed bool) []state.MatchResult {
+	var out []state.MatchResult
+	idx := 0
+	st := state.MatchStatusScheduled
+	if completed {
+		st = state.MatchStatusCompleted
+	}
+	for i := range names {
+		for j := i + 1; j < len(names); j++ {
+			out = append(out, state.MatchResult{
+				ID: fmt.Sprintf("Pool A-%d", idx), SideA: names[i], SideB: names[j], Status: st,
+			})
+			idx++
+		}
+	}
+	return out
+}
+
+// TestMarkTiedStandings_League covers the emerging-tie trigger for league
+// format, for both team and individual leagues.
+func TestMarkTiedStandings_League(t *testing.T) {
+	// Team and individual leagues share the same trigger path; only TeamSize differs.
+	for _, tc := range []struct {
+		name     string
+		teamSize int
+	}{
+		{"individual league", 0},
+		{"team league", 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			comp := &state.Competition{Format: state.CompFormatLeague, TeamSize: tc.teamSize}
+
+			t.Run("trigger not fired (no top-N competitor finished) → no amber", func(t *testing.T) {
+				sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 100), tiedStanding("C", 50), tiedStanding("D", 40)}
+				// All matches scheduled → nobody has finished their fixtures.
+				matches := leagueRoundRobin([]string{"A", "B", "C", "D"}, false)
+				markTiedStandings(comp, sorted, matches)
+				assert.Empty(t, tiedNames(sorted))
+			})
+
+			t.Run("a top-N competitor finished all fights → consequential tie marked", func(t *testing.T) {
+				sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 100), tiedStanding("C", 50), tiedStanding("D", 40)}
+				// A (rank 1, within top-3) has completed every fixture; B still has one pending.
+				matches := []state.MatchResult{
+					completedMatch(0, "A", "B"), completedMatch(1, "A", "C"), completedMatch(2, "A", "D"),
+					scheduledMatch(3, "B", "C"), scheduledMatch(4, "B", "D"), scheduledMatch(5, "C", "D"),
+				}
+				markTiedStandings(comp, sorted, matches)
+				assert.Equal(t, map[string]bool{"A": true, "B": true}, tiedNames(sorted),
+					"emerging trigger fires once a top-N competitor is done, even though B isn't")
+			})
+
+			t.Run("tie outside the top-N band → not marked", func(t *testing.T) {
+				// effectiveTopN defaults to 3. Tie sits at positions 4-5 (MinPosition 4 > 3).
+				sorted := []state.PlayerStanding{
+					tiedStanding("A", 100), tiedStanding("B", 90), tiedStanding("C", 80),
+					tiedStanding("D", 50), tiedStanding("E", 50),
+				}
+				matches := leagueRoundRobin([]string{"A", "B", "C", "D", "E"}, true)
+				markTiedStandings(comp, sorted, matches)
+				assert.Empty(t, tiedNames(sorted), "a tie below the top-N band is not consequential")
+			})
+
+			t.Run("no tie → nothing marked even after trigger", func(t *testing.T) {
+				sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 90), tiedStanding("C", 80)}
+				matches := leagueRoundRobin([]string{"A", "B", "C"}, true)
+				markTiedStandings(comp, sorted, matches)
+				assert.Empty(t, tiedNames(sorted))
+			})
+		})
+	}
+}
+
+// TestMarkTiedStandings_TwoThirdPlacesExemption verifies the two-joint-3rd
+// exemption: a tie sitting entirely at positions >= 3 is not marked when
+// LeagueTwoThirdPlaces is enabled (both teams share bronze, no decider needed).
+func TestMarkTiedStandings_TwoThirdPlacesExemption(t *testing.T) {
+	matches := leagueRoundRobin([]string{"A", "B", "C", "D"}, true)
+
+	t.Run("exemption on → pure 3rd/4th tie not marked", func(t *testing.T) {
+		comp := &state.Competition{Format: state.CompFormatLeague, LeagueTiebreakTopN: 4, LeagueTwoThirdPlaces: true}
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 90), tiedStanding("C", 50), tiedStanding("D", 50)}
+		markTiedStandings(comp, sorted, matches)
+		assert.Empty(t, tiedNames(sorted), "joint-3rd tie needs no decider when two-third-places is enabled")
+	})
+
+	t.Run("exemption off → same 3rd/4th tie IS marked", func(t *testing.T) {
+		comp := &state.Competition{Format: state.CompFormatLeague, LeagueTiebreakTopN: 4, LeagueTwoThirdPlaces: false}
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 90), tiedStanding("C", 50), tiedStanding("D", 50)}
+		markTiedStandings(comp, sorted, matches)
+		assert.Equal(t, map[string]bool{"C": true, "D": true}, tiedNames(sorted))
+	})
+
+	t.Run("exemption on but tie straddles 2nd/3rd → still marked", func(t *testing.T) {
+		comp := &state.Competition{Format: state.CompFormatLeague, LeagueTiebreakTopN: 3, LeagueTwoThirdPlaces: true}
+		// Tie at positions 2-3 (MinPosition 2 < 3): a decider IS needed for 2nd.
+		sorted := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 80), tiedStanding("C", 80), tiedStanding("D", 40)}
+		markTiedStandings(comp, sorted, matches)
+		assert.Equal(t, map[string]bool{"B": true, "C": true}, tiedNames(sorted))
+	})
+}
+
+// TestMarkTiedStandings_AutoClear confirms that once a tie resolves (Points
+// differ), the rows are no longer flagged — the highlight clears on its own.
+func TestMarkTiedStandings_AutoClear(t *testing.T) {
+	comp := &state.Competition{Format: state.CompFormatMixed}
+	matches := []state.MatchResult{completedMatch(0, "A", "B"), completedMatch(1, "A", "C"), completedMatch(2, "B", "C")}
+
+	// Tied first.
+	tied := []state.PlayerStanding{tiedStanding("A", 100), tiedStanding("B", 100), tiedStanding("C", 50)}
+	markTiedStandings(comp, tied, matches)
+	assert.Equal(t, map[string]bool{"A": true, "B": true}, tiedNames(tied))
+
+	// A later result separates A and B → no rows flagged.
+	resolved := []state.PlayerStanding{tiedStanding("A", 110), tiedStanding("B", 100), tiedStanding("C", 50)}
+	markTiedStandings(comp, resolved, matches)
+	assert.Empty(t, tiedNames(resolved), "resolved tie must clear the highlight")
+}
+
+// TestMarkTiedStandings_NonLeagueNonMixed ensures the pools path also governs
+// playoffs-format pools (any non-league format routes through the pools gate).
+func TestMarkTiedStandings_EmptyStandings(t *testing.T) {
+	comp := &state.Competition{Format: state.CompFormatLeague}
+	var sorted []state.PlayerStanding
+	markTiedStandings(comp, sorted, nil) // must not panic
+	assert.Empty(t, tiedNames(sorted))
+}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -725,6 +725,7 @@ type PlayerStanding struct {
 	IndividualDraws  int           `json:"individualDraws,omitempty"`
 	PointsWon        int           `json:"pointsWon,omitempty"`
 	PointsLost       int           `json:"pointsLost,omitempty"`
+	Tied             bool          `json:"tied,omitempty"`
 }
 
 type BracketMatch struct {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7422,8 +7422,14 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   .sponsor-strip { gap: 12px; padding: 12px 8px; }
 }
 
-/* mp-dm5e: tied standings row — amber caution highlight */
-.pool__row--tied { background: var(--warn-soft); box-shadow: inset 3px 0 0 var(--warn-border); }
+/* mp-dm5e: tied standings row — amber caution highlight. Background-only,
+   matching the `.pool__row--me` row-tint idiom (no side accent).
+   Scoped to `.pool__table tr` so the amber fill wins over both `.pool__table
+   tr.advancing` (green, higher specificity) and `.pool__row--me` (navy, same
+   base specificity but defined later): a tie that needs breaking is the more
+   urgent signal, so it must not be masked for advancing qualifiers or the
+   followed player. */
+.pool__table tr.pool__row--tied { background: var(--warn-soft); }
 
 /* mp-wvkh: followed-player highlights */
 .pool__row--me { background: rgba(29,53,87,0.07); }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7422,6 +7422,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   .sponsor-strip { gap: 12px; padding: 12px 8px; }
 }
 
+/* mp-dm5e: tied standings row — amber caution highlight */
+.pool__row--tied { background: var(--warn-soft); box-shadow: inset 3px 0 0 var(--warn-border); }
+
 /* mp-wvkh: followed-player highlights */
 .pool__row--me { background: rgba(29,53,87,0.07); }
 /* Matrix row: top inset shadow on every cell so the highlight shows through win/loss/draw backgrounds */

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -520,7 +520,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
               {(poolStandings || selectedPool.players.map((p) => ({ player: p, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 }))).map((s, i) => {
                 const isTeamComp = c.kind === "team" || c.teamSize > 0;
                 return (
-                  <tr key={s.player.name}>
+                  <tr key={s.player.name} className={s.tied ? "pool__row--tied" : undefined}>
                     <td style={{ width: 60 }}>
                       <RankInput
                         initial={s.rank || i + 1}
@@ -676,7 +676,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
                   {(poolStandings || pool.players.map((p) => ({ player: p, wins: 0, losses: 0, draws: 0, ipponsGiven: 0, ipponsTaken: 0 }))).map((s, i) => {
                     const isTeamComp = c.kind === "team" || c.teamSize > 0;
                     return (
-                      <tr key={s.player.name}>
+                      <tr key={s.player.name} className={s.tied ? "pool__row--tied" : undefined}>
                         <td style={{ color: "var(--ink-3)", fontFamily: "var(--font-mono)" }}>
                           <RankInput
                             initial={s.rank || i + 1}

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -437,7 +437,7 @@ export function ViewerOverview({ c, myPlayer, myUpcoming, currentMatch, runningM
             </thead>
             <tbody>
               {leagueStandings.slice(0, 5).map((s, i) => (
-                <tr key={s.player?.id || s.player?.name || i}>
+                <tr key={s.player?.id || s.player?.name || i} className={s.tied ? "pool__row--tied" : undefined}>
                   {/* Rank-ordered summary: "#" is the authoritative standing rank
                       (s.rank), not the row index — DRY with the full standings and
                       the backend tiebreak/override logic. */}

--- a/web-mobile/js/viewer_standings.jsx
+++ b/web-mobile/js/viewer_standings.jsx
@@ -513,6 +513,7 @@ export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition
                   const rowClasses = [
                     isPlayerWatched(p, highlightPlayers) ? "pool__row--me" : "",
                     isAdvancing ? "advancing" : "",
+                    s && s.tied ? "pool__row--tied" : "",
                   ].filter(Boolean).join(" ");
 
                   return (


### PR DESCRIPTION
## Summary

- Tied standings rows are now highlighted **amber** so operators get a glanceable flag that a tie-break may be needed.
- A new `Tied` flag on `PlayerStanding` is computed server-side (single source of truth) and drives a `.pool__row--tied` highlight on every standings table.
- **Pools format:** rows highlight only once *every* regular match in that pool is complete (never on a pre-start/empty pool).
- **League format (team + individual):** *emerging-tie* trigger — once any top-N competitor (`effectiveTopN`, default 3, operator-configurable) has finished all their own regular fights, tied groups within the band are flagged, honoring the two-joint-3rd-places exemption. The highlight clears automatically as ties resolve.
- Tie detection reuses the existing `detectPoolTies` / `effectiveTopN` / `isConsequentialTie` — no second definition of "tied".

## Why

Closes mp-dm5e. Operators previously had no visual cue that competitors were tied on the full ranking chain; ties only surfaced via the (team-league-only, all-complete) tie-break banner. This adds an earlier, format-aware visual signal across all standings surfaces, including individual leagues.

## Files changed

| File | What |
|---|---|
| `internal/state/models.go` | Add `Tied bool` (`json:"tied,omitempty"`) to `PlayerStanding` |
| `internal/engine/scoring.go` | `markTiedStandings` (+ pools/league helpers) run per-pool in the standings pass; emerging-tie trigger + empty-pool guard |
| `internal/engine/tied_standings_test.go` | New table-driven tests: pools gate, league trigger (team + individual), out-of-band tie, two-thirds exemption, auto-clear |
| `web-mobile/js/viewer_standings.jsx` | Apply `pool__row--tied` in `PoolsViewer` (League tab) |
| `web-mobile/js/viewer_competition.jsx` | Apply `pool__row--tied` in the `ViewerOverview` league summary table |
| `web-mobile/js/admin_pools.jsx` | Apply `pool__row--tied` in both admin standings tables |
| `web-mobile/css/styles.css` | `.pool__row--tied` — `--warn-soft` fill + `--warn-border` inset (amber only) |
| `DESIGN.md` | Document the `tr.pool__row--tied` row modifier |

## Screenshots

Individual league, 3-way tie at the top (Akira / Bjorn / Carlos all 2–1); 4th place (0–3) correctly un-highlighted.

**Viewer — Overview league summary**
![viewer overview](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-dm5e/viewer-overview.png)

**Viewer — League tab (PoolsViewer)**
![viewer league](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-dm5e/viewer-league.png)

**Admin — Pools / League table**
![admin pools](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-dm5e/admin.png)

**Admin — Shiaijo operator console (standings panel)**
![shiaijo console](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-dm5e/shiaijo.png)

_The shiaijo console reuses the shared `PoolsViewer`, so the same amber highlight appears there with no extra code. The standings panel is **open by default** (`useState(true)`) — the operator sees the tie warning without any interaction._

## Test plan

- [x] `make go/test` passes (lint + security scan + tests; engine 85.9%, state 87.9% — both above the 85% gate)
- [x] New/updated unit tests cover the change (`tied_standings_test.go`)
- [x] Manual browser verification — seeded an individual league with a scored 3-way tie; confirmed amber rows (bg `#fffbeb`) on viewer Overview, viewer League tab, admin Pools, and the shiaijo operator console; 4th place un-highlighted
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-dm5e


