### PR TITLE
fix(mp-ebgz): reject poolSize<=0 instead of divide-by-zero panic

### DIFF
--- a/internal/engine/competition_test.go
+++ b/internal/engine/competition_test.go
@@ -227,6 +227,33 @@ func TestStartCompetition_SwissFormat(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "bracket.json must not be created for Swiss start")
 }
 
+// TestStartCompetition_PoolSizeZero pins mp-ebgz: starting a pool-based
+// competition with PoolSize=0 must fail as a ValidationError (HTTP 400),
+// not divide-by-zero panic deep inside helper.CreatePools (HTTP 500).
+func TestStartCompetition_PoolSizeZero(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "poolsize-zero"
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:        compID,
+		Name:      "Pool Size Zero Test",
+		Kind:      "individual",
+		Format:    state.CompFormatMixed,
+		PoolSize:  0, // unset — the bug trigger
+		Courts:    []string{"A", "B"},
+		StartTime: "09:00",
+		Status:    state.CompStatusSetup,
+	}))
+	saveTestParticipants(t, store, compID, []string{
+		"Alice", "Bob", "Charlie", "Dave", "Eve", "Frank", "Grace", "Heidi",
+	})
+
+	err := eng.StartCompetition(compID)
+	require.Error(t, err, "starting with PoolSize=0 must error, not panic")
+	var ve *ValidationError
+	assert.ErrorAs(t, err, &ve, "PoolSize=0 must surface as a ValidationError (→ HTTP 400)")
+}
+
 // TestStartCompetition_SwissRoundAlreadyGenerated verifies that StartCompetition
 // rejects the call when SwissCurrentRound != 0. This guards against
 // AdvanceSwissRound having partially run before start (matches written,

--- a/internal/engine/pools.go
+++ b/internal/engine/pools.go
@@ -11,6 +11,15 @@ import (
 )
 
 func (e *Engine) generatePools(comp *state.Competition, players []domain.Player, seeds []domain.SeedAssignment) error {
+	// PoolSize is the divisor in CreatePools (and is fed to PoolSeeding); a
+	// zero/negative value would otherwise reach helper.CreatePools and the
+	// guard there returns a plain error mapped to HTTP 500. Validate up front
+	// so a competition started with an unset PoolSize fails as a clean 400
+	// (validationErrorf → *ValidationError) with an actionable message. (mp-ebgz)
+	if comp.PoolSize <= 0 {
+		return validationErrorf("competition %s cannot start: pool size must be at least 1, got %d — set a pool size before starting", comp.ID, comp.PoolSize)
+	}
+
 	// helper.Player is a type alias for domain.Player (NFR-007); the
 	// Excel-coupled helpers accept domain values directly.
 	if len(seeds) > 0 {

--- a/internal/helper/tournament.go
+++ b/internal/helper/tournament.go
@@ -212,6 +212,14 @@ func SanitizeName(name string) string {
 }
 
 func CreatePools(players []Player, poolSize int, isMax bool) ([]Pool, error) {
+	// Guard before the division below: poolSize is the divisor in both the
+	// "max" and fixed-size branches, so a zero/negative value panics with an
+	// integer divide-by-zero. Reject it here — the lowest shared point — so
+	// every caller (engine draw, schedule estimator, CLI) is panic-proof
+	// regardless of how PoolSize reached it. (mp-ebgz)
+	if poolSize <= 0 {
+		return nil, fmt.Errorf("cannot create pools: pool size must be at least 1, got %d", poolSize)
+	}
 	var totalPools int
 	if isMax {
 		totalPools = (len(players) + poolSize - 1) / poolSize

--- a/internal/helper/tournament_test.go
+++ b/internal/helper/tournament_test.go
@@ -362,10 +362,18 @@ func TestCreatePools(t *testing.T) {
 			},
 		},
 		{
-			name:      "panics when pool size is zero",
-			players:   createPlayers(4, 4),
-			poolSize:  0,
-			wantPanic: true,
+			// mp-ebgz: poolSize=0 used to divide-by-zero panic; it now
+			// returns a clean error so every caller is panic-proof.
+			name:     "errors (no panic) when pool size is zero",
+			players:  createPlayers(4, 4),
+			poolSize: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "errors (no panic) when pool size is negative",
+			players:  createPlayers(4, 4),
+			poolSize: -1,
+			wantErr:  true,
 		},
 		{
 			name:     "errors when pool size larger than player count",


### PR DESCRIPTION
## Summary

- Starting a pool-based competition with `PoolSize=0` (or estimating its schedule) no longer crashes with `runtime error: integer divide by zero` → opaque HTTP 500. It now returns a clean **HTTP 400** with an actionable message.
- `PoolSize=0` is reachable today: `state.ApplyCompetitionDefaults` does not default it, so any `POST /api/competitions` body that omits `poolSize` persists a `0`, and `POST /api/competitions/:id/start` then panics.

## Why

Root cause: `helper.CreatePools` computes `totalPools = len(players) / poolSize` (both the `max` and fixed-size branches) **before** its only guard, so a zero divisor panics. The panic surfaces via `engine.generatePools` → `StartCompetition`, and Gin's Recovery middleware converts it to a 500. The same `CreatePools` call is also reached by the public schedule estimator (`helper.EstimateMatchCounts`).

Fix is two-layer: a guard at the lowest shared point (panic-proof for every caller) plus an explicit engine validation so the start path returns 400, not 500.

## Files changed

| File | What |
|---|---|
| `internal/helper/tournament.go` | `CreatePools` rejects `poolSize <= 0` up front (before the division), returning a plain error — makes all callers (engine, estimator, CLI) panic-proof |
| `internal/engine/pools.go` | `generatePools` validates `comp.PoolSize <= 0` first and returns a `*ValidationError` (→ HTTP 400) with an actionable message |
| `internal/helper/tournament_test.go` | The prior "panics when pool size is zero" case now expects a clean error; added a negative-poolSize case |
| `internal/engine/competition_test.go` | New `TestStartCompetition_PoolSizeZero` asserts the start path returns a `*ValidationError` |

## Notes

- `helper.PoolSeeding` was already guarded (`numPools <= 0` early return) — no change needed.
- The estimate-from-competition path (`engine.estimate_schedule.go`) already wraps `CreatePools` errors as `ValidationError` → 400, so it now degrades cleanly instead of panicking.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (`TestCreatePools` zero/negative cases; `TestStartCompetition_PoolSizeZero`)
- [x] No UI impact (backend-only) — Screenshots section intentionally omitted
- [x] No new console errors or warnings

Closes mp-ebgz
