### PR TITLE
feat(mp-a5d6): status-aware competition admin overview

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3520,6 +3520,146 @@ button.pool-match-row {
   margin-top: 6px;
 }
 
+/* stat-box link variant — a button-reset that keeps the stat-box layout
+   but is clickable (e.g. "View podium →" in the completed stats strip). */
+.stat-box__link {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+
+/* Stat value at text scale: the default .stat-box .v is 22px display, sized
+   for short numbers. Long/textual values ("2 pools", "3h 10m", "View podium →")
+   read better one step down. Modifier instead of scattered inline font-size. */
+.stat-box .v--sm {
+  font-size: 16px;
+}
+
+/* Clickable action card (mp-a5d6): the overview's navigate-on-click cards
+   (Scores/Results, draw preview, export) need the same affordance as the
+   dashboard's .tcard so they read as interactive, not static. Mirrors
+   .tcard:hover for system consistency. */
+.card--action {
+  cursor: pointer;
+  transition: border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.card--action:hover {
+  border-color: var(--ink-4);
+  box-shadow: var(--shadow);
+  transform: translateY(-1px);
+}
+
+.card--action:active {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card--action {
+    transition: none;
+  }
+  .card--action:hover {
+    transform: none;
+  }
+}
+
+@media (hover: none) {
+  .card--action:hover {
+    transform: none;
+    box-shadow: none;
+  }
+}
+
+/* Next-steps checklist (mp-a5d6) — status-aware overview for setup state.
+   Composes existing tokens; no new color values. */
+.comp-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.comp-step {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line-2);
+}
+
+.comp-step:last-child {
+  border-bottom: none;
+}
+
+.comp-step__icon {
+  flex-shrink: 0;
+  width: 20px;
+  font-size: 14px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.comp-step--done .comp-step__icon {
+  color: var(--accent);
+}
+
+.comp-step--active .comp-step__icon {
+  color: var(--accent);
+}
+
+.comp-step--todo .comp-step__icon {
+  color: var(--ink-3);
+}
+
+.comp-step__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.comp-step__label {
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.comp-step--done .comp-step__label {
+  color: var(--ink-3);
+}
+
+.comp-step--active .comp-step__label {
+  color: var(--ink);
+}
+
+.comp-step--todo .comp-step__label {
+  color: var(--ink-3);
+}
+
+.comp-step__detail {
+  font-size: 12px;
+  color: var(--ink-3);
+  margin-top: 2px;
+}
+
+.comp-step--active .comp-step__detail {
+  color: var(--ink-2);
+}
+
+.comp-step__cta {
+  margin-top: 8px;
+  font-size: 12.5px;
+}
+
+.comp-steps__hint {
+  font-size: 12px;
+  color: var(--ink-3);
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line-2);
+}
+
 /* Sidebar (admin tournament) */
 .workspace {
   display: grid;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3310,8 +3310,11 @@ button.pool-match-row {
 
 .vlist-item__bar>div {
   height: 100%;
+  width: 100%;
   background: var(--accent);
-  transition: width 300ms;
+  transform-origin: left;
+  transform: scaleX(var(--bar-fill, 0));
+  transition: transform 300ms;
 }
 
 .vlist-item__pct {
@@ -5816,7 +5819,7 @@ button.pool-match-row {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
   z-index: 500;
   pointer-events: none;
-  animation: toast-in 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  animation: toast-in 300ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 @keyframes toast-in {
@@ -6789,7 +6792,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   margin-bottom: 12px;
   font-size: 12px;
   flex-wrap: wrap;
-  transition: padding 180ms var(--ease-out);
 }
 .encho-row__label {
   display: flex;
@@ -7896,9 +7898,9 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   flex-direction: column;
   gap: 2px;
   padding: 8px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--red);
   border-radius: var(--r-sm);
-  border-left: 3px solid var(--red);
+  background: var(--red-soft);
 }
 .start-all__failed-name { font-weight: 600; color: var(--ink-1); }
 .start-all__failed-reason { font-size: 12px; color: var(--ink-3); }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3537,6 +3537,12 @@ button.pool-match-row {
   font: inherit;
 }
 
+.stat-box__link:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: 4px;
+}
+
 /* Stat value at text scale: the default .stat-box .v is 22px display, sized
    for short numbers. Long/textual values ("2 pools", "3h 10m", "View podium →")
    read better one step down. Modifier instead of scattered inline font-size. */
@@ -3561,6 +3567,11 @@ button.pool-match-row {
 
 .card--action:active {
   transform: translateY(0);
+}
+
+.card--action:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow), var(--focus-ring);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/web-mobile/js/__tests__/admin_competition_overview.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition_overview.test.jsx
@@ -1,0 +1,303 @@
+// Tests for the pure competitionNextSteps helper (mp-a5d6).
+// The function is unit-testable without mounting any component — it takes
+// a plain competition object and returns a step array.
+import { describe, it, expect } from 'vitest';
+import { competitionNextSteps, overviewViewMode } from '../admin_competition_overview.jsx';
+
+// ---------------------------------------------------------------------------
+// overviewViewMode — status → render-mode mapping
+// ---------------------------------------------------------------------------
+// Regression guard (mp-a5d6): the active phases are "pools" and "playoffs",
+// NOT a literal "running". An earlier version checked `status === "running"`,
+// which is never true in production, so a running competition mis-rendered the
+// "completed" card. These assertions lock the mapping against that drift.
+describe('overviewViewMode — status mapping', () => {
+  it('maps setup-ish statuses to "setup"', () => {
+    expect(overviewViewMode('setup')).toBe('setup');
+    expect(overviewViewMode('')).toBe('setup');
+    expect(overviewViewMode(undefined)).toBe('setup');
+    expect(overviewViewMode(null)).toBe('setup');
+  });
+
+  it('maps "draw-ready" to "draw-ready"', () => {
+    expect(overviewViewMode('draw-ready')).toBe('draw-ready');
+  });
+
+  it('maps the running PHASES ("pools", "playoffs") to "running"', () => {
+    expect(overviewViewMode('pools')).toBe('running');
+    expect(overviewViewMode('playoffs')).toBe('running');
+  });
+
+  it('maps "completed" to "completed"', () => {
+    expect(overviewViewMode('completed')).toBe('completed');
+  });
+
+  it('treats "invalid" and any unknown/future phase as "running" (keeps progress + scores widgets)', () => {
+    expect(overviewViewMode('invalid')).toBe('running');
+    expect(overviewViewMode('some-future-phase')).toBe('running');
+  });
+
+  it('never returns "completed" for an active phase (the original bug)', () => {
+    expect(overviewViewMode('pools')).not.toBe('completed');
+    expect(overviewViewMode('playoffs')).not.toBe('completed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+function makeComp(overrides = {}) {
+  return {
+    id: 'comp-1',
+    name: 'Shodan Open',
+    status: 'setup',
+    kind: 'individual',
+    format: 'pools',
+    players: [],
+    courts: ['A'],
+    ...overrides,
+  };
+}
+
+function makePlayer(seed = null) {
+  return { id: `p-${Math.random()}`, name: 'Player', seed };
+}
+
+// ---------------------------------------------------------------------------
+// Basic shape
+// ---------------------------------------------------------------------------
+describe('competitionNextSteps — basic shape', () => {
+  it('returns an array of step objects', () => {
+    const steps = competitionNextSteps(makeComp());
+    expect(Array.isArray(steps)).toBe(true);
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  it('every step has id, label, detail, state, section, cta', () => {
+    const steps = competitionNextSteps(makeComp());
+    for (const step of steps) {
+      expect(typeof step.id).toBe('string');
+      expect(typeof step.label).toBe('string');
+      expect(typeof step.detail).toBe('string');
+      expect(['done', 'active', 'todo']).toContain(step.state);
+      // section is string or null
+      expect(step.section === null || typeof step.section === 'string').toBe(true);
+      // cta (active-step button label) is string or null
+      expect(step.cta === null || typeof step.cta === 'string').toBe(true);
+    }
+  });
+
+  it('every navigable step carries a cta label; non-navigable steps have cta null', () => {
+    // Use a team comp so the lineups step is included in the navigable set.
+    const steps = competitionNextSteps(makeComp({ kind: 'team', players: [] }));
+    for (const step of steps) {
+      if (step.section) {
+        expect(typeof step.cta).toBe('string');
+        expect(step.cta.endsWith('→')).toBe(true);
+        // No clumsy double-verb copy like "Go to Review seeds & settings".
+        expect(step.cta.startsWith('Go to ')).toBe(false);
+      } else {
+        expect(step.cta).toBeNull();
+      }
+    }
+  });
+
+  it('first step (create) is always done', () => {
+    const steps = competitionNextSteps(makeComp());
+    expect(steps[0].id).toBe('create');
+    expect(steps[0].state).toBe('done');
+  });
+
+  it('last step (generate) is always todo or active, never done', () => {
+    const steps = competitionNextSteps(makeComp());
+    const last = steps[steps.length - 1];
+    expect(last.id).toBe('generate');
+    expect(last.state).not.toBe('done');
+  });
+
+  it('exactly one step is active', () => {
+    const steps = competitionNextSteps(makeComp());
+    const active = steps.filter(s => s.state === 'active');
+    expect(active.length).toBe(1);
+  });
+
+  it('no step after the active step is done', () => {
+    const steps = competitionNextSteps(makeComp());
+    const activeIdx = steps.findIndex(s => s.state === 'active');
+    for (let i = activeIdx + 1; i < steps.length; i++) {
+      expect(steps[i].state).toBe('todo');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Individual competition — setup states
+// ---------------------------------------------------------------------------
+describe('competitionNextSteps — individual, 0 players', () => {
+  it('participants step is active when 0 players', () => {
+    const steps = competitionNextSteps(makeComp({ players: [] }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.state).toBe('active');
+  });
+
+  it('participants step is active when 1 player', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer()] }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.state).toBe('active');
+  });
+
+  it('detail mentions need at least 2 when < 2 players', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer()] }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.detail).toMatch(/need at least 2/i);
+  });
+
+  it('participants step is done when >= 2 players', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer(), makePlayer()] }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.state).toBe('done');
+  });
+
+  it('settings step becomes active after participants done', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer(), makePlayer()] }));
+    const s = steps.find(s => s.id === 'settings');
+    expect(s.state).toBe('active');
+  });
+
+  it('settings step detail mentions seed count when seeds present', () => {
+    const players = [makePlayer(1), makePlayer(2), makePlayer()];
+    const steps = competitionNextSteps(makeComp({ players }));
+    const s = steps.find(st => st.id === 'settings');
+    expect(s.detail).toMatch(/2 seed/i);
+  });
+
+  it('generate step is todo when players < 2', () => {
+    const steps = competitionNextSteps(makeComp({ players: [] }));
+    const g = steps.find(s => s.id === 'generate');
+    expect(g.state).toBe('todo');
+  });
+
+  it('generate step detail mentions add participants when < 2 players', () => {
+    const steps = competitionNextSteps(makeComp({ players: [] }));
+    const g = steps.find(s => s.id === 'generate');
+    expect(g.detail).toMatch(/at least 2/i);
+  });
+
+  it('generate step detail mentions header button when >= 2 players', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer(), makePlayer()] }));
+    const g = steps.find(s => s.id === 'generate');
+    expect(g.detail).toMatch(/header/i);
+  });
+
+  it('no lineups step for individual comps', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'individual' }));
+    expect(steps.find(s => s.id === 'lineups')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Team competition
+// ---------------------------------------------------------------------------
+describe('competitionNextSteps — team competition', () => {
+  it('includes a lineups step for team comps', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'team' }));
+    expect(steps.find(s => s.id === 'lineups')).toBeDefined();
+  });
+
+  it('lineups step comes after settings and before generate', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'team' }));
+    const ids = steps.map(s => s.id);
+    const settingsIdx = ids.indexOf('settings');
+    const lineupsIdx = ids.indexOf('lineups');
+    const generateIdx = ids.indexOf('generate');
+    expect(settingsIdx).toBeGreaterThan(-1);
+    expect(lineupsIdx).toBeGreaterThan(settingsIdx);
+    expect(generateIdx).toBeGreaterThan(lineupsIdx);
+  });
+
+  it('lineups step points to "lineups" section', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'team' }));
+    const l = steps.find(s => s.id === 'lineups');
+    expect(l.section).toBe('lineups');
+  });
+
+  it('participants label says "teams" for team comps', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'team' }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.label).toMatch(/teams/i);
+  });
+
+  it('participants detail says "teams" for team comps when < 2', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'team', players: [] }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.detail).toMatch(/team/i);
+  });
+
+  it('exactly one active step for team comp with 0 players', () => {
+    const steps = competitionNextSteps(makeComp({ kind: 'team', players: [] }));
+    expect(steps.filter(s => s.state === 'active').length).toBe(1);
+  });
+
+  it('exactly one active step for team comp with >= 2 players', () => {
+    const steps = competitionNextSteps(makeComp({
+      kind: 'team',
+      players: [makePlayer(), makePlayer(), makePlayer()],
+    }));
+    expect(steps.filter(s => s.state === 'active').length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+describe('competitionNextSteps — edge cases', () => {
+  it('handles null/undefined comp gracefully (returns array)', () => {
+    // Should not throw — caller may pass a partially-loaded comp.
+    expect(() => competitionNextSteps(null)).not.toThrow();
+    expect(Array.isArray(competitionNextSteps(null))).toBe(true);
+  });
+
+  it('handles missing players array', () => {
+    const steps = competitionNextSteps({ id: 'c1', name: 'X', kind: 'individual' });
+    expect(Array.isArray(steps)).toBe(true);
+    const p = steps.find(s => s.id === 'participants');
+    expect(p).toBeDefined();
+  });
+
+  it('participants step detail mentions count', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer(), makePlayer(), makePlayer()] }));
+    const p = steps.find(s => s.id === 'participants');
+    expect(p.detail).toMatch(/3/);
+  });
+
+  it('all non-create steps have a section or are the generate step', () => {
+    const steps = competitionNextSteps(makeComp({ players: [makePlayer(), makePlayer()] }));
+    for (const step of steps) {
+      if (step.id === 'create') continue;
+      if (step.id === 'generate') {
+        // generate has no section (points at page-head button)
+        expect(step.section).toBeNull();
+      } else {
+        expect(typeof step.section).toBe('string');
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// draw-ready / running / completed: pure helper is only for setup state, but
+// it should still be callable with any comp without throwing.
+// ---------------------------------------------------------------------------
+describe('competitionNextSteps — non-setup statuses', () => {
+  it('does not throw for draw-ready status', () => {
+    expect(() => competitionNextSteps(makeComp({ status: 'draw-ready', players: [makePlayer(), makePlayer()] }))).not.toThrow();
+  });
+
+  it('does not throw for running status', () => {
+    expect(() => competitionNextSteps(makeComp({ status: 'running', players: [makePlayer(), makePlayer()] }))).not.toThrow();
+  });
+
+  it('does not throw for completed status', () => {
+    expect(() => competitionNextSteps(makeComp({ status: 'completed', players: [makePlayer(), makePlayer()] }))).not.toThrow();
+  });
+});

--- a/web-mobile/js/__tests__/admin_competition_overview.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition_overview.test.jsx
@@ -2,7 +2,30 @@
 // The function is unit-testable without mounting any component — it takes
 // a plain competition object and returns a step array.
 import { describe, it, expect } from 'vitest';
-import { competitionNextSteps, overviewViewMode } from '../admin_competition_overview.jsx';
+import { competitionNextSteps, overviewViewMode, overviewResultsSection } from '../admin_competition_overview.jsx';
+
+// ---------------------------------------------------------------------------
+// overviewResultsSection — format → results/standings section
+// ---------------------------------------------------------------------------
+// Regression guard (Copilot review on PR #312): swiss competitions have no
+// pools/bracket section, so a Results/podium CTA must route to "swiss", not the
+// pools/bracket default — otherwise the operator lands on an empty/hidden view.
+describe('overviewResultsSection — results routing', () => {
+  it('routes swiss competitions to the "swiss" section regardless of bracket presence', () => {
+    expect(overviewResultsSection('swiss', false)).toBe('swiss');
+    expect(overviewResultsSection('swiss', true)).toBe('swiss');
+  });
+
+  it('routes to "bracket" when a bracket exists (non-swiss)', () => {
+    expect(overviewResultsSection('playoffs', true)).toBe('bracket');
+    expect(overviewResultsSection('mixed', true)).toBe('bracket');
+  });
+
+  it('routes to "pools" when no bracket exists (non-swiss)', () => {
+    expect(overviewResultsSection('mixed', false)).toBe('pools');
+    expect(overviewResultsSection('league', false)).toBe('pools');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // overviewViewMode — status → render-mode mapping

--- a/web-mobile/js/__tests__/admin_competition_overview.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition_overview.test.jsx
@@ -82,8 +82,9 @@ function makeComp(overrides = {}) {
   };
 }
 
+let _playerSeq = 0;
 function makePlayer(seed = null) {
-  return { id: `p-${Math.random()}`, name: 'Player', seed };
+  return { id: `p-${++_playerSeq}`, name: 'Player', seed };
 }
 
 // ---------------------------------------------------------------------------

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -326,7 +326,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             )}
           </div>
           <div>
-            {section === "overview" && <AdminCompOverview c={c} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} password={password} />}
+            {section === "overview" && <AdminCompOverview c={c} tournament={t} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} password={password} />}
             {section === "participants" && <AdminParticipants c={c} tournament={t} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} />}
             {section === "lineups" && window.AdminTeamLineupsList && <window.AdminTeamLineupsList comp={c} password={password} showToast={showToast} />}
             {section === "settings" && <AdminSettings c={c} tournament={t} onUpdate={onUpdate} onBack={onBack} password={password} showToast={showToast} onStatusChange={setLocalStatus} />}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -326,7 +326,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             )}
           </div>
           <div>
-            {section === "overview" && <AdminCompOverview c={c} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} />}
+            {section === "overview" && <AdminCompOverview c={c} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} password={password} />}
             {section === "participants" && <AdminParticipants c={c} tournament={t} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} />}
             {section === "lineups" && window.AdminTeamLineupsList && <window.AdminTeamLineupsList comp={c} password={password} showToast={showToast} />}
             {section === "settings" && <AdminSettings c={c} tournament={t} onUpdate={onUpdate} onBack={onBack} password={password} showToast={showToast} onStatusChange={setLocalStatus} />}

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -16,7 +16,7 @@ const compMatchStats = window.compMatchStats;
 // unit-testable without mounting any component.
 //
 // Shape:
-//   { id: string, label: string, detail: string,
+//   { id: string, label: string, detail: string, cta: string|null,
 //     state: 'done'|'active'|'todo', section: string|null }
 //
 // Rules:

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -222,13 +222,14 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
       });
     return () => controller.abort();
     // Re-fetch when config, participant count, or tournament-level timing changes.
-    // Tournament ceremony/timing fields are included so the estimate refreshes
-    // when the operator changes openingBlock, lunchBlock, closingBlock,
-    // clockToElapsedMultiplier, or slowestCourtBufferPct — mirroring AdminSettings.
+    // When check-in is enabled the backend counts only checked-in participants, so
+    // toggling check-in changes the effective count even if roster size stays fixed.
+    // Tournament ceremony/timing fields mirror AdminSettings' estimate effect deps.
   }, [c.id, c.format, c.kind, c.poolMatchDuration, c.playoffMatchDuration, c.courts,
     c.teamSize, c.poolSize, c.poolSizeMode, c.poolWinners, c.roundRobin, c.poolFormat,
     c.swissRounds, c.checkInEnabled, password,
     (c.players || []).length,
+    c.checkInEnabled ? (c.players || []).filter(p => p && p.checkedIn).length : 0,
     tournament?.openingBlock, tournament?.lunchBlock, tournament?.closingBlock,
     tournament?.clockToElapsedMultiplier, tournament?.slowestCourtBufferPct]);
 

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -21,14 +21,17 @@ const compMatchStats = window.compMatchStats;
 //
 // Rules:
 //   - "Create competition" is always done (the comp already exists).
-//   - "Add participants" is active when players < 2; done otherwise.
-//   - Team comps get an extra "Set team lineups" step (→ "lineups") between
-//     participants and Generate, following the existing sidebar ordering.
-//   - "Review seeds & settings" is done once players >= 2 and we have seeds
-//     OR the user has navigated there (we can't know that, so treat it as
-//     "todo" after participants are added — same behaviour as before).
-//   - "Generate the draw" is always todo (the button is in the page-head).
-//   - The FIRST non-done step is "active"; all subsequent are "todo".
+//   - "Add participants" is done when players >= 2, else active.
+//   - "Review seeds & settings" is always emitted as a non-done step: there is
+//     no reliable "seeds reviewed" signal, so it never auto-completes (its
+//     detail line reflects the current seed count, but its state stays
+//     todo/active and is resolved by the active-step pass below).
+//   - Team comps get an extra "Set team lineups" step (→ "lineups") inserted
+//     AFTER "Review seeds & settings" and before "Generate the draw". (This is
+//     the checklist's logical setup order; it intentionally differs from the
+//     sidebar, which groups lineups before settings.)
+//   - "Generate the draw" is always non-done (the button is in the page-head).
+//   - The FIRST non-done step is promoted to "active"; the rest stay "todo".
 //
 // Exported on window.competitionNextSteps AND in the ES export block below.
 function competitionNextSteps(c) {
@@ -138,6 +141,20 @@ function overviewViewMode(status) {
 }
 
 // ---------------------------------------------------------------------------
+// Pure helper: overviewResultsSection
+// ---------------------------------------------------------------------------
+// The section that holds standings/results for a given competition format.
+// Swiss competitions have no pools/bracket section — their results live in the
+// dedicated "swiss" section — so a Results/podium CTA that defaulted to
+// pools/bracket would strand the operator on an empty/hidden view. Route swiss
+// to "swiss"; otherwise prefer the bracket when one exists, else pools.
+// Pure + exported so the swiss routing is unit-tested (Copilot review #312).
+function overviewResultsSection(format, hasBracket) {
+  if (format === "swiss") return "swiss";
+  return hasBracket ? "bracket" : "pools";
+}
+
+// ---------------------------------------------------------------------------
 // AdminCompOverview — status-aware overview component
 // ---------------------------------------------------------------------------
 function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password }) {
@@ -233,6 +250,9 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
   // or textual values ("2 pools", "3h 10m") step down to 16px via .v--sm so
   // they don't crowd the box. The em-dash placeholder keeps the display size.
   const vClass = (val) => (val === "—" ? "v" : "v v--sm");
+
+  // Standings/results target for this competition's format (see helper above).
+  const resultsSection = overviewResultsSection(c.format, !!effectiveBracket);
 
   // ---------------------------------------------------------------------------
   // Render helpers
@@ -331,7 +351,7 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
           <button
             type="button"
             className="stat-box__link"
-            onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}
+            onClick={() => onSection(resultsSection)}
           >
             <div className="v v--sm" style={{ color: "var(--accent)" }}>View podium →</div>
             <div className="l">Standings</div>
@@ -473,7 +493,7 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
               type="button"
               className="card card--action"
               style={{ textAlign: "left" }}
-              onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}
+              onClick={() => onSection(resultsSection)}
             >
               <div className="card__title" style={{ marginBottom: 6 }}>Results →</div>
               <div className="card__sub">Visual bracket / pool standings</div>
@@ -498,7 +518,7 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
               type="button"
               className="card card--sm card--action"
               style={{ textAlign: "left" }}
-              onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}
+              onClick={() => onSection(resultsSection)}
               data-testid="completed-results-btn"
             >
               <div className="card__title" style={{ marginBottom: 4 }}>Results →</div>
@@ -699,6 +719,7 @@ if (typeof window !== "undefined") {
   window.FightingSpiritAwardsEditor = FightingSpiritAwardsEditor;
   window.competitionNextSteps = competitionNextSteps;
   window.overviewViewMode = overviewViewMode;
+  window.overviewResultsSection = overviewResultsSection;
 }
 
-export { competitionNextSteps, overviewViewMode };
+export { competitionNextSteps, overviewViewMode, overviewResultsSection };

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -8,54 +8,578 @@ const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
 
 const compMatchStats = window.compMatchStats;
 
-function AdminCompOverview({ c, pools, poolMatches, bracket, onSection }) {
+// ---------------------------------------------------------------------------
+// Pure helper: competitionNextSteps
+// ---------------------------------------------------------------------------
+// Returns an ordered array of step descriptors for the "Next steps" checklist
+// shown in the setup state. Each step is a plain object so the function is
+// unit-testable without mounting any component.
+//
+// Shape:
+//   { id: string, label: string, detail: string,
+//     state: 'done'|'active'|'todo', section: string|null }
+//
+// Rules:
+//   - "Create competition" is always done (the comp already exists).
+//   - "Add participants" is active when players < 2; done otherwise.
+//   - Team comps get an extra "Set team lineups" step (→ "lineups") between
+//     participants and Generate, following the existing sidebar ordering.
+//   - "Review seeds & settings" is done once players >= 2 and we have seeds
+//     OR the user has navigated there (we can't know that, so treat it as
+//     "todo" after participants are added — same behaviour as before).
+//   - "Generate the draw" is always todo (the button is in the page-head).
+//   - The FIRST non-done step is "active"; all subsequent are "todo".
+//
+// Exported on window.competitionNextSteps AND in the ES export block below.
+function competitionNextSteps(c) {
+  const players = (c && c.players) || [];
+  const numPlayers = players.length;
+  const isTeam = c && c.kind === "team";
+  const hasEnoughPlayers = numPlayers >= 2;
+  const seededCount = players.filter(p => p && p.seed).length;
+
+  const steps = [];
+
+  // Step 1 — always done.
+  steps.push({
+    id: "create",
+    label: "Create competition",
+    detail: `${c && c.name ? `"${c.name}" created` : "Competition created"}`,
+    state: "done",
+    section: null,
+    cta: null,
+  });
+
+  // Step 2 — participants.
+  const participantDetail = hasEnoughPlayers
+    ? `${numPlayers} ${isTeam ? "teams" : "participants"} added${seededCount > 0 ? `, ${seededCount} seeded` : ""}`
+    : `${numPlayers} ${isTeam ? "team" : "participant"}${numPlayers !== 1 ? "s" : ""} added — need at least 2`;
+  steps.push({
+    id: "participants",
+    label: `Add ${isTeam ? "teams" : "participants"}`,
+    detail: participantDetail,
+    state: hasEnoughPlayers ? "done" : "active",
+    section: "participants",
+    // `cta` is the button label shown only when this step is active. Authored
+    // here (not in JSX) so the copy is centralised and unit-testable; null for
+    // steps with no navigable action (the generate step lives in the header).
+    cta: `Add ${isTeam ? "teams" : "participants"} →`,
+  });
+
+  // Step 3 — seeds & settings (becomes active once participants done).
+  steps.push({
+    id: "settings",
+    label: "Review seeds & settings",
+    detail: seededCount > 0
+      ? `${seededCount} seed${seededCount !== 1 ? "s" : ""} assigned`
+      : "Optionally assign seeds and adjust format",
+    state: "todo",
+    section: "participants",
+    cta: "Review seeds & settings →",
+  });
+
+  // Step 3b (team only) — lineups, after settings.
+  if (isTeam) {
+    steps.push({
+      id: "lineups",
+      label: "Set team lineups",
+      detail: "Assign positions (Senpo, Jiho, …) before the draw",
+      state: "todo",
+      section: "lineups",
+      cta: "Set lineups →",
+    });
+  }
+
+  // Final step — generate draw (button is in the page-head; no section nav).
+  steps.push({
+    id: "generate",
+    label: "Generate the draw",
+    detail: hasEnoughPlayers
+      ? "Use the \"Generate draw\" button in the header above"
+      : "Add at least 2 participants first",
+    state: "todo",
+    section: null,
+    cta: null,
+  });
+
+  // Resolve active/todo: the first non-done step is active; the rest are todo.
+  let foundActive = false;
+  for (const step of steps) {
+    if (step.state === "done") continue;
+    if (!foundActive) {
+      step.state = "active";
+      foundActive = true;
+    }
+    // else stays "todo"
+  }
+
+  return steps;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: overviewViewMode
+// ---------------------------------------------------------------------------
+// Maps a CompetitionStatus wire value to the overview's render mode. The wire
+// values (internal/state/models.go:441-446) are:
+//   "setup" → "draw-ready" → "pools" / "playoffs" (the two RUNNING phases) →
+//   "completed", plus "invalid". There is NO literal "running" status — an
+//   active competition reports its phase ("pools" or "playoffs"). Anything that
+//   is not setup/draw-ready/completed (including "pools", "playoffs", "invalid",
+//   or any future phase) maps to "running", so an active competition keeps the
+//   progress + scores/results widgets instead of mis-rendering the "completed"
+//   card. Extracted as a pure function so this mapping is unit-tested and the
+//   regression (treating only the non-existent "running" string as active)
+//   cannot silently return. Exported on window + ES.
+function overviewViewMode(status) {
+  if (!status || status === "setup") return "setup";
+  if (status === "draw-ready") return "draw-ready";
+  if (status === "completed") return "completed";
+  return "running";
+}
+
+// ---------------------------------------------------------------------------
+// AdminCompOverview — status-aware overview component
+// ---------------------------------------------------------------------------
+function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password }) {
   // Prefer the props passed from the detail fetch, but fall back to whatever
   // is already on `c` when the detail hasn't loaded yet (or errored). Using ??
   // avoids overwriting non-null fields on `c` with undefined prop values.
-  const statsSource = { ...c, pools: pools ?? c.pools, poolMatches: poolMatches ?? c.poolMatches, bracket: bracket ?? c.bracket };
+  const statsSource = {
+    ...c,
+    pools: pools ?? c.pools,
+    poolMatches: poolMatches ?? c.poolMatches,
+    bracket: bracket ?? c.bracket,
+  };
   const { total, done, running: runningCount } = compMatchStats(statsSource);
-  const pct = total ? Math.round((done / total) * 100) : 0;
   const effectiveBracket = bracket ?? c.bracket;
+
   // Honour the OS reduced-motion preference for the progress-bar animation.
   const prefersReducedMotion = typeof window !== "undefined" && window.matchMedia
     ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
     : false;
-  return (
-    <div>
+
+  // ---------------------------------------------------------------------------
+  // Status derivation (single source of truth, derived once)
+  // ---------------------------------------------------------------------------
+  // CompetitionStatus wire values (internal/state/models.go:441-446):
+  //   "setup" → "draw-ready" → "pools"/"playoffs" (running phases) → "completed",
+  //   plus "invalid". There is NO literal "running" status — an active
+  //   competition is in its phase status ("pools" or "playoffs"). isRunning is
+  //   therefore the catch-all for any status that is not setup/draw-ready/
+  //   completed, which also lets an "invalid" competition keep the progress +
+  //   scores/results widgets (matching the pre-redesign always-on behaviour)
+  //   rather than mis-rendering the "Competition complete" card.
+  // viewMode ∈ { setup, draw-ready, running, completed }. The render helpers
+  // branch on isSetup/isDrawReady/isRunning and treat the remaining case
+  // (completed) as the trailing else, so no separate isCompleted flag is needed.
+  const viewMode = overviewViewMode(c.status);
+  const isSetup = viewMode === "setup";
+  const isDrawReady = viewMode === "draw-ready";
+  const isRunning = viewMode === "running";
+
+  // ---------------------------------------------------------------------------
+  // Schedule estimate fetch — same AbortController pattern as AdminSettings.
+  // Never blocks render: estimate starts as null and fills in asynchronously.
+  // ---------------------------------------------------------------------------
+  const [estimate, setEstimate] = useStateA(null);
+  const [estimateLoading, setEstimateLoading] = useStateA(false);
+  const [estimateErr, setEstimateErr] = useStateA(null);
+
+  useEffectA(() => {
+    if (!c.id) return;
+    const controller = new AbortController();
+    setEstimateLoading(true);
+    setEstimateErr(null);
+    window.API.estimateCompetitionSchedule(c.id, password, controller.signal)
+      .then(res => {
+        setEstimate(res);
+        setEstimateLoading(false);
+      })
+      .catch(e => {
+        if (!controller.signal.aborted) {
+          setEstimateErr(e.message || "Failed to estimate");
+          setEstimateLoading(false);
+        }
+      });
+    return () => controller.abort();
+    // Re-fetch whenever the saved competition config changes (same deps as AdminSettings).
+  }, [c.id, c.format, c.kind, c.poolMatchDuration, c.playoffMatchDuration, c.courts,
+    c.teamSize, c.poolSize, c.poolSizeMode, c.poolWinners, c.roundRobin, c.poolFormat,
+    c.swissRounds, c.checkInEnabled, password]);
+
+  // ---------------------------------------------------------------------------
+  // Derived stat values
+  // ---------------------------------------------------------------------------
+  const participantLabel = c.kind === "team" ? "Teams" : "Participants";
+  const numPlayers = (c.players || []).length;
+  const seededCount = (c.players || []).filter(p => p && p.seed).length;
+  const numCourts = (typeof window !== "undefined" && window.courtCount)
+    ? window.courtCount(c.courts)
+    : (Array.isArray(c.courts) ? c.courts.length : 0) || 1;
+
+  const formatCompMinutes = (typeof window !== "undefined" && window.formatCompMinutes)
+    ? window.formatCompMinutes
+    : (m) => (Number.isFinite(m) && m > 0 ? `${m}m` : null);
+
+  const estDuration = formatCompMinutes(estimate && estimate.totalDurationMinutes) || "—";
+
+  // draw-ready: pool count vs bracket size
+  const poolCount = (Array.isArray(pools) && pools.length > 0) ? pools.length : (c.pools ? c.pools.length : null);
+  const bracketRounds = effectiveBracket && effectiveBracket.rounds ? effectiveBracket.rounds.length : null;
+
+  const pct = total ? Math.round((done / total) * 100) : 0;
+
+  // Stat values that are short numbers use the default 22px display size; long
+  // or textual values ("2 pools", "3h 10m") step down to 16px via .v--sm so
+  // they don't crowd the box. The em-dash placeholder keeps the display size.
+  const vClass = (val) => (val === "—" ? "v" : "v v--sm");
+
+  // ---------------------------------------------------------------------------
+  // Render helpers
+  // ---------------------------------------------------------------------------
+
+  // Stats strip — 4 boxes, varies by state.
+  function renderStatsStrip() {
+    if (isSetup) {
+      return (
+        <div className="stats-strip">
+          <div className="stat-box">
+            <div className="v">{numPlayers}</div>
+            <div className="l">{participantLabel}</div>
+          </div>
+          <div className="stat-box">
+            <div className="v">{seededCount}</div>
+            <div className="l">Seeded</div>
+          </div>
+          <div className="stat-box">
+            <div className="v">{numCourts}</div>
+            <div className="l">{numCourts === 1 ? "Court" : "Courts"}</div>
+          </div>
+          <div className="stat-box">
+            <div className={vClass(estDuration)}>{estDuration}</div>
+            <div className="l">Est. duration{estimateLoading ? " …" : ""}</div>
+          </div>
+        </div>
+      );
+    }
+
+    if (isDrawReady) {
+      const drawSizeVal = c.format === "playoffs" || (!poolCount && bracketRounds)
+        ? (bracketRounds ? `${Math.pow(2, bracketRounds - 1) * 2} max` : "—")
+        : (poolCount ? `${poolCount} pool${poolCount !== 1 ? "s" : ""}` : "—");
+      const drawSizeLabel = c.format === "playoffs" ? "Bracket size" : "Pools";
+      return (
+        <div className="stats-strip">
+          <div className="stat-box">
+            <div className="v">{numPlayers}</div>
+            <div className="l">{participantLabel}</div>
+          </div>
+          <div className="stat-box">
+            <div className="v">{seededCount}</div>
+            <div className="l">Seeded</div>
+          </div>
+          <div className="stat-box">
+            <div className="v v--sm">{drawSizeVal}</div>
+            <div className="l">{drawSizeLabel}</div>
+          </div>
+          <div className="stat-box">
+            <div className={vClass(estDuration)}>{estDuration}</div>
+            <div className="l">Est. duration{estimateLoading ? " …" : ""}</div>
+          </div>
+        </div>
+      );
+    }
+
+    if (isRunning) {
+      return (
+        <div className="stats-strip">
+          <div className="stat-box">
+            <div className="v">{numPlayers}</div>
+            <div className="l">{participantLabel}</div>
+          </div>
+          <div className="stat-box">
+            <div className="v">{done}/{total}</div>
+            <div className="l">Matches done</div>
+          </div>
+          <div className="stat-box">
+            <div className="v" style={{ color: runningCount > 0 ? "var(--red)" : "inherit" }}>
+              {runningCount}
+            </div>
+            <div className="l">Now</div>
+          </div>
+          <div className="stat-box">
+            <div className={vClass(estDuration)}>{estDuration}</div>
+            <div className="l">Est. duration{estimateLoading ? " …" : ""}</div>
+          </div>
+        </div>
+      );
+    }
+
+    // completed
+    const totalDuration = formatCompMinutes(estimate && estimate.totalDurationMinutes) || "—";
+    return (
       <div className="stats-strip">
-        <div className="stat-box"><div className="v">{c.players.length}</div><div className="l">{c.kind === "team" ? "Teams" : "Participants"}</div></div>
-        <div className="stat-box"><div className="v">{c.players.filter((p) => p.seed).length}</div><div className="l">Seeded</div></div>
-        <div className="stat-box"><div className="v">{done}/{total}</div><div className="l">Matches done</div></div>
-        <div className="stat-box"><div className="v" style={{ color: runningCount > 0 ? "var(--red)" : "inherit" }}>{runningCount}</div><div className="l">Now</div></div>
-      </div>
-      <div className="card" style={{ marginBottom: 16 }}>
-        <div className="card__head"><div className="card__title">Progress</div><div className="card__sub">{pct}%</div></div>
-        {/* Animate via transform: scaleX (compositor-only) rather than width,
-            which forced a layout/paint each frame. The inner bar is full-width
-            and scaled from the left edge; the rounded track clips it so the
-            visual is equivalent. Transition is dropped under
-            prefers-reduced-motion. */}
-        <div style={{ height: 8, background: "var(--line-2)", borderRadius: 999, overflow: "hidden" }} role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100}>
-          <div style={{
-            height: "100%",
-            width: "100%",
-            background: "var(--accent)",
-            transformOrigin: "left center",
-            transform: `scaleX(${pct / 100})`,
-            transition: prefersReducedMotion ? "none" : "transform 300ms",
-          }}></div>
+        <div className="stat-box">
+          <div className="v">{numPlayers}</div>
+          <div className="l">{participantLabel}</div>
+        </div>
+        <div className="stat-box">
+          <div className="v">{done}</div>
+          <div className="l">Matches played</div>
+        </div>
+        <div className="stat-box">
+          <button
+            type="button"
+            className="stat-box__link"
+            onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}
+          >
+            <div className="v v--sm" style={{ color: "var(--accent)" }}>View podium →</div>
+            <div className="l">Standings</div>
+          </button>
+        </div>
+        <div className="stat-box">
+          <div className={vClass(totalDuration)}>{totalDuration}</div>
+          <div className="l">Total duration</div>
         </div>
       </div>
-      <div className="row">
-        <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection("scores")}>
-          <div className="card__title" style={{ marginBottom: 6 }}>Scores →</div>
-          <div className="card__sub">Update or correct match results</div>
-        </button>
-        <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}>
-          <div className="card__title" style={{ marginBottom: 6 }}>Results →</div>
-          <div className="card__sub">Visual bracket / pool standings</div>
-        </button>
+    );
+  }
+
+  // Primary content — branched by state.
+  function renderPrimaryContent() {
+    // --- setup ---
+    if (isSetup) {
+      const steps = competitionNextSteps(c);
+      return (
+        <div className="card" style={{ marginBottom: 16 }} data-testid="next-steps-card">
+          <div className="card__head">
+            <div className="card__title">Next steps</div>
+          </div>
+          <div className="comp-steps">
+            {steps.map(step => (
+              <div
+                key={step.id}
+                className={`comp-step comp-step--${step.state}`}
+                data-testid={`step-${step.id}`}
+              >
+                <div className="comp-step__icon" aria-hidden="true">
+                  {step.state === "done" ? "✓" : step.state === "active" ? "●" : "○"}
+                </div>
+                <div className="comp-step__body">
+                  <div className="comp-step__label">{step.label}</div>
+                  <div className="comp-step__detail">{step.detail}</div>
+                  {step.state === "active" && step.section && step.cta && (
+                    <button
+                      type="button"
+                      className="btn btn--primary comp-step__cta"
+                      onClick={() => onSection(step.section)}
+                      data-testid={`step-${step.id}-cta`}
+                    >
+                      {step.cta}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+          {numPlayers < 2 && (
+            <div className="comp-steps__hint" data-testid="participants-hint">
+              Need at least 2 {c.kind === "team" ? "teams" : "participants"} to generate a draw.
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // --- draw-ready ---
+    if (isDrawReady) {
+      const previewSection = c.format === "playoffs" ? "bracket" : "pools";
+      const previewLabel = c.format === "playoffs" ? "bracket" : "pools";
+      return (
+        <div className="card" style={{ marginBottom: 16 }} data-testid="draw-ready-card">
+          <div className="card__head">
+            <div className="card__title">Draw ready</div>
+            <div className="card__sub">{numPlayers} {participantLabel} · {seededCount > 0 ? `${seededCount} seeded` : "no seeds"}</div>
+          </div>
+          <div style={{ fontSize: 13.5, color: "var(--ink-2)", marginBottom: 14 }}>
+            The draw has been generated. Preview it below, then use the <strong>Start competition →</strong> button in the header to begin.
+          </div>
+          <div className="row">
+            <button
+              type="button"
+              className="card card--sm card--action"
+              style={{ textAlign: "left" }}
+              onClick={() => onSection(previewSection)}
+              data-testid="draw-ready-preview-btn"
+            >
+              <div className="card__title" style={{ marginBottom: 4 }}>
+                Preview {previewLabel} →
+              </div>
+              <div className="card__sub">Check placements before starting</div>
+            </button>
+            <div className="card card--sm" style={{ background: "var(--bg)" }}>
+              <div className="card__title" style={{ marginBottom: 4, color: "var(--ink-2)" }}>To start</div>
+              <div className="card__sub">
+                Use the <strong>Start competition →</strong> button above. To change the draw, use <strong>Discard draw</strong> first.
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // --- running ---
+    if (isRunning) {
+      return (
+        <div>
+          <div className="card" style={{ marginBottom: 16 }}>
+            <div className="card__head">
+              <div className="card__title">Progress</div>
+              <div className="card__sub">{pct}%</div>
+            </div>
+            {/* Animate via transform: scaleX (compositor-only) rather than width,
+                which forced a layout/paint each frame. The inner bar is full-width
+                and scaled from the left edge; the rounded track clips it so the
+                visual is equivalent. Transition is dropped under
+                prefers-reduced-motion. */}
+            <div
+              style={{ height: 8, background: "var(--line-2)", borderRadius: 999, overflow: "hidden" }}
+              role="progressbar"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div style={{
+                height: "100%",
+                width: "100%",
+                background: "var(--accent)",
+                transformOrigin: "left center",
+                transform: `scaleX(${pct / 100})`,
+                transition: prefersReducedMotion ? "none" : "transform 300ms",
+              }}></div>
+            </div>
+          </div>
+          <div className="row">
+            <button
+              type="button"
+              className="card card--action"
+              style={{ textAlign: "left" }}
+              onClick={() => onSection("scores")}
+            >
+              <div className="card__title" style={{ marginBottom: 6 }}>Scores →</div>
+              <div className="card__sub">Update or correct match results</div>
+            </button>
+            <button
+              type="button"
+              className="card card--action"
+              style={{ textAlign: "left" }}
+              onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}
+            >
+              <div className="card__title" style={{ marginBottom: 6 }}>Results →</div>
+              <div className="card__sub">Visual bracket / pool standings</div>
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    // --- completed ---
+    return (
+      <div>
+        <div className="card" style={{ marginBottom: 16 }} data-testid="completed-card">
+          <div className="card__head">
+            <div className="card__title">Competition complete</div>
+          </div>
+          <div style={{ fontSize: 13.5, color: "var(--ink-2)", marginBottom: 14 }}>
+            All matches have been played. View final standings or export results.
+          </div>
+          <div className="row">
+            <button
+              type="button"
+              className="card card--sm card--action"
+              style={{ textAlign: "left" }}
+              onClick={() => onSection(effectiveBracket ? "bracket" : "pools")}
+              data-testid="completed-results-btn"
+            >
+              <div className="card__title" style={{ marginBottom: 4 }}>Results →</div>
+              <div className="card__sub">View final standings &amp; podium</div>
+            </button>
+            <button
+              type="button"
+              className="card card--sm card--action"
+              style={{ textAlign: "left" }}
+              onClick={() => onSection("export")}
+              data-testid="completed-export-btn"
+            >
+              <div className="card__title" style={{ marginBottom: 4 }}>Export →</div>
+              <div className="card__sub">Print brackets &amp; certificates</div>
+            </button>
+          </div>
+        </div>
       </div>
+    );
+  }
+
+  // Footer: schedule estimate strip — shown whenever estimate resolves.
+  function renderEstimateFooter() {
+    if (!estimate && !estimateLoading && !estimateErr) return null;
+    const total = formatCompMinutes(estimate && estimate.totalDurationMinutes);
+    const perCourt = estimate ? (estimate.perCourtMinutes || []).map(m => formatCompMinutes(m) || "0m") : [];
+    const ceremony = formatCompMinutes(estimate && estimate.ceremonyMinutes);
+    return (
+      <div style={{
+        padding: "10px 12px",
+        borderRadius: 6,
+        background: "var(--accent-soft)",
+        border: "1px solid var(--accent)",
+        marginTop: 16,
+      }}>
+        <div style={{ fontSize: 12.5, fontWeight: 600, color: "var(--ink-2)", marginBottom: 4 }}>
+          Schedule estimate
+          {estimateLoading && <span className="spinner" style={{ marginLeft: 6, verticalAlign: "middle" }} />}
+        </div>
+        {estimateErr && (
+          <div style={{ fontSize: 12, color: "var(--red)" }}>{estimateErr}</div>
+        )}
+        {estimate && !estimateErr && (() => {
+          if (!total) {
+            return (
+              <div style={{ fontSize: 12, color: "var(--ink-3)" }}>
+                No estimate yet — add participants and configure duration to see a projection.
+              </div>
+            );
+          }
+          return (
+            <div style={{ fontSize: 12.5, color: "var(--ink)" }}>
+              <div><strong>Total:</strong> {total}</div>
+              {perCourt.length > 1 && (
+                <div style={{ marginTop: 2 }}>
+                  <strong>Per court:</strong>{" "}
+                  {perCourt.map((t, i) => `Court ${(c.courts && c.courts[i]) || String.fromCharCode(65 + i)}: ${t}`).join(" · ")}
+                </div>
+              )}
+              {perCourt.length === 1 && (
+                <div style={{ marginTop: 2 }}>
+                  <strong>Per court:</strong> {perCourt[0]}
+                </div>
+              )}
+              {ceremony && (
+                <div style={{ marginTop: 2 }}>
+                  <strong>Ceremony blocks:</strong> {ceremony}
+                </div>
+              )}
+            </div>
+          );
+        })()}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {renderStatsStrip()}
+      {renderPrimaryContent()}
+      {renderEstimateFooter()}
     </div>
   );
 }
@@ -170,6 +694,11 @@ function FightingSpiritAwardsEditor({ c, password, showToast }) {
   );
 }
 
+if (typeof window !== "undefined") {
+  window.AdminCompOverview = AdminCompOverview;
+  window.FightingSpiritAwardsEditor = FightingSpiritAwardsEditor;
+  window.competitionNextSteps = competitionNextSteps;
+  window.overviewViewMode = overviewViewMode;
+}
 
-window.AdminCompOverview = AdminCompOverview;
-window.FightingSpiritAwardsEditor = FightingSpiritAwardsEditor;
+export { competitionNextSteps, overviewViewMode };

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -25,11 +25,13 @@ const compMatchStats = window.compMatchStats;
 //   - "Review seeds & settings" is always emitted as a non-done step: there is
 //     no reliable "seeds reviewed" signal, so it never auto-completes (its
 //     detail line reflects the current seed count, but its state stays
-//     todo/active and is resolved by the active-step pass below).
+//     todo/active and is resolved by the active-step pass below). Its CTA
+//     navigates to the "settings" section (format, courts, duration); seeds
+//     are accessible from the seeding card on the "participants" page.
 //   - Team comps get an extra "Set team lineups" step (→ "lineups") inserted
-//     AFTER "Review seeds & settings" and before "Generate the draw". (This is
-//     the checklist's logical setup order; it intentionally differs from the
-//     sidebar, which groups lineups before settings.)
+//     AFTER "Review seeds & settings" and before "Generate the draw". This is
+//     the checklist's logical setup order; the sidebar lists lineups after
+//     participants but before settings, which differs from this ordering.
 //   - "Generate the draw" is always non-done (the button is in the page-head).
 //   - The FIRST non-done step is promoted to "active"; the rest stay "todo".
 //
@@ -77,8 +79,8 @@ function competitionNextSteps(c) {
       ? `${seededCount} seed${seededCount !== 1 ? "s" : ""} assigned`
       : "Optionally assign seeds and adjust format",
     state: "todo",
-    section: "participants",
-    cta: "Review seeds & settings →",
+    section: "settings",
+    cta: "Review settings →",
   });
 
   // Step 3b (team only) — lineups, after settings.
@@ -219,10 +221,12 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
         }
       });
     return () => controller.abort();
-    // Re-fetch whenever the saved competition config changes (same deps as AdminSettings).
+    // Re-fetch when config or participant count changes (participant count affects
+    // total match count, so the estimate becomes stale when roster changes).
   }, [c.id, c.format, c.kind, c.poolMatchDuration, c.playoffMatchDuration, c.courts,
     c.teamSize, c.poolSize, c.poolSizeMode, c.poolWinners, c.roundRobin, c.poolFormat,
-    c.swissRounds, c.checkInEnabled, password]);
+    c.swissRounds, c.checkInEnabled, password,
+    (c.players || []).length]);
 
   // ---------------------------------------------------------------------------
   // Derived stat values
@@ -413,6 +417,10 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
 
     // --- draw-ready ---
     if (isDrawReady) {
+      // Swiss rounds are generated dynamically on start; there is no static
+      // pools/bracket preview to show. Only non-swiss formats expose a preview
+      // section in the nav at this stage.
+      const isSwiss = c.format === "swiss";
       const previewSection = c.format === "playoffs" ? "bracket" : "pools";
       const previewLabel = c.format === "playoffs" ? "bracket" : "pools";
       return (
@@ -422,21 +430,25 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
             <div className="card__sub">{numPlayers} {participantLabel} · {seededCount > 0 ? `${seededCount} seeded` : "no seeds"}</div>
           </div>
           <div style={{ fontSize: 13.5, color: "var(--ink-2)", marginBottom: 14 }}>
-            The draw has been generated. Preview it below, then use the <strong>Start competition →</strong> button in the header to begin.
+            {isSwiss
+              ? <>Participants are set. Use the <strong>Start competition →</strong> button in the header to begin the first round.</>
+              : <>The draw has been generated. Preview it below, then use the <strong>Start competition →</strong> button in the header to begin.</>}
           </div>
           <div className="row">
-            <button
-              type="button"
-              className="card card--sm card--action"
-              style={{ textAlign: "left" }}
-              onClick={() => onSection(previewSection)}
-              data-testid="draw-ready-preview-btn"
-            >
-              <div className="card__title" style={{ marginBottom: 4 }}>
-                Preview {previewLabel} →
-              </div>
-              <div className="card__sub">Check placements before starting</div>
-            </button>
+            {!isSwiss && (
+              <button
+                type="button"
+                className="card card--sm card--action"
+                style={{ textAlign: "left" }}
+                onClick={() => onSection(previewSection)}
+                data-testid="draw-ready-preview-btn"
+              >
+                <div className="card__title" style={{ marginBottom: 4 }}>
+                  Preview {previewLabel} →
+                </div>
+                <div className="card__sub">Check placements before starting</div>
+              </button>
+            )}
             <div className="card card--sm" style={{ background: "var(--bg)" }}>
               <div className="card__title" style={{ marginBottom: 4, color: "var(--ink-2)" }}>To start</div>
               <div className="card__sub">

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -255,9 +255,9 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
 
   const pct = total ? Math.round((done / total) * 100) : 0;
 
-  // Stat values that are short numbers use the default 22px display size; long
-  // or textual values ("2 pools", "3h 10m") step down to 16px via .v--sm so
-  // they don't crowd the box. The em-dash placeholder keeps the display size.
+  // Stat values step down to 16px via .v--sm unless they are the em-dash
+  // placeholder "—" (which keeps the 22px display size). vClass is only called
+  // for boxes that hold textual or formatted values ("2 pools", "3h 10m").
   const vClass = (val) => (val === "—" ? "v" : "v v--sm");
 
   // Standings/results target for this competition's format (see helper above).
@@ -368,7 +368,7 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
         </div>
         <div className="stat-box">
           <div className={vClass(totalDuration)}>{totalDuration}</div>
-          <div className="l">Total duration</div>
+          <div className="l">Est. duration</div>
         </div>
       </div>
     );

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -296,7 +296,7 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
       const drawSizeVal = c.format === "playoffs" || (!poolCount && bracketRounds)
         ? (bracketRounds ? `${Math.pow(2, bracketRounds - 1) * 2} max` : "—")
         : (poolCount ? `${poolCount} pool${poolCount !== 1 ? "s" : ""}` : "—");
-      const drawSizeLabel = c.format === "playoffs" ? "Bracket size" : "Pools";
+      const drawSizeLabel = c.format === "playoffs" ? "Bracket size" : c.format === "league" ? "League" : "Pools";
       return (
         <div className="stats-strip">
           <div className="stat-box">
@@ -427,7 +427,7 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
       // section in the nav at this stage.
       const isSwiss = c.format === "swiss";
       const previewSection = c.format === "playoffs" ? "bracket" : "pools";
-      const previewLabel = c.format === "playoffs" ? "bracket" : "pools";
+      const previewLabel = c.format === "playoffs" ? "bracket" : c.format === "league" ? "league" : "pools";
       return (
         <div className="card" style={{ marginBottom: 16 }} data-testid="draw-ready-card">
           <div className="card__head">

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -159,7 +159,7 @@ function overviewResultsSection(format, hasBracket) {
 // ---------------------------------------------------------------------------
 // AdminCompOverview — status-aware overview component
 // ---------------------------------------------------------------------------
-function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password }) {
+function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSection, password }) {
   // Prefer the props passed from the detail fetch, but fall back to whatever
   // is already on `c` when the detail hasn't loaded yet (or errored). Using ??
   // avoids overwriting non-null fields on `c` with undefined prop values.
@@ -221,12 +221,16 @@ function AdminCompOverview({ c, pools, poolMatches, bracket, onSection, password
         }
       });
     return () => controller.abort();
-    // Re-fetch when config or participant count changes (participant count affects
-    // total match count, so the estimate becomes stale when roster changes).
+    // Re-fetch when config, participant count, or tournament-level timing changes.
+    // Tournament ceremony/timing fields are included so the estimate refreshes
+    // when the operator changes openingBlock, lunchBlock, closingBlock,
+    // clockToElapsedMultiplier, or slowestCourtBufferPct — mirroring AdminSettings.
   }, [c.id, c.format, c.kind, c.poolMatchDuration, c.playoffMatchDuration, c.courts,
     c.teamSize, c.poolSize, c.poolSizeMode, c.poolWinners, c.roundRobin, c.poolFormat,
     c.swissRounds, c.checkInEnabled, password,
-    (c.players || []).length]);
+    (c.players || []).length,
+    tournament?.openingBlock, tournament?.lunchBlock, tournament?.closingBlock,
+    tournament?.clockToElapsedMultiplier, tournament?.slowestCourtBufferPct]);
 
   // ---------------------------------------------------------------------------
   // Derived stat values

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -761,3 +761,4 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
 
 
 window.AdminSettings = AdminSettings;
+window.formatCompMinutes = formatCompMinutes;

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -206,6 +206,16 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     return p.danGrade ? `${base}, ${p.danGrade}` : base;
   }).join("\n");
 
+  // Fill the roster textarea with a generated sample roster of `count`
+  // competitors. This lives in the Participants view (not the create form)
+  // so a sample is a starting point you review and edit before clicking
+  // "Apply changes" — it reuses the whole parse/validate/save path. The
+  // generated ids are placeholders; apply() mints real UUIDs from the text.
+  const fillSample = (count) => {
+    const sample = window.makeCompetitors(count, c.kind, c.id, 0, c.gender || "M");
+    setText(generateText(sample));
+  };
+
   useEffectA(() => {
     if (!textFocusRef.current) {
       setText(generateText(c.players || []));
@@ -1066,6 +1076,22 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               <input ref={fileRef} type="file" accept=".csv,.txt,text/csv,text/plain" style={{ display: "none" }} onChange={(e) => handleFile(e.target.files[0])} />
             </div>
           </div>
+
+          {/* Sample roster: only offered while the box is empty so it can't
+              clobber an in-progress list. Fills the textarea for review; the
+              operator still clicks "Apply changes" to save. */}
+          {!isDrawReady && lines.length === 0 && (
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+              <span className="field__hint" style={{ margin: 0 }}>
+                No list yet? Fill with a sample {c.kind === "team" ? "team " : ""}roster:
+              </span>
+              <div className="radio-group" style={{ gap: 6 }}>
+                <button type="button" className="radio-pill" onClick={() => fillSample(8)}>Small (8)</button>
+                <button type="button" className="radio-pill" onClick={() => fillSample(16)}>Medium (16)</button>
+                <button type="button" className="radio-pill" onClick={() => fillSample(32)}>Large (32)</button>
+              </div>
+            </div>
+          )}
 
           {importSummary && (
             <div className="alert alert--success" style={{ marginBottom: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -211,7 +211,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   // competitors. This lives in the Participants view (not the create form)
   // so a sample is a starting point you review and edit before clicking
   // "Apply changes" — it reuses the whole parse/validate/save path. The
-  // generated ids are placeholders; apply() mints real UUIDs from the text.
+  // generated ids are placeholders; apply() assigns `${compId}-pN` ids.
   const fillSample = (count) => {
     const sample = window.makeCompetitors(count, c.kind, c.id, 0, c.gender || "M");
     setText(generateText(sample));

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -330,6 +330,10 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   const trimmedSearch = useMemoA(() => searchQuery.trim(), [searchQuery]);
   const lines = useMemoA(() => text.split("\n").filter((l) => l.trim()), [text]);
   const players = useMemoA(() => c.players || [], [c.players]);
+  // First-run: with no participants yet there is nothing to seed or check in,
+  // so the seeding panel is premature. Collapse it and let the roster-input
+  // panel fill the width — adding names is the only task at this point.
+  const emptyRoster = players.length === 0;
 
   // Provisional competitor numbers for the pre-draw check-in list (mp-1tk).
   // The draw assigns the final, pool-interleaved numbers (player.number);
@@ -734,7 +738,27 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
           <button type="button" className="btn btn--primary" onClick={() => onSection("scores")}>Go to Scoring →</button>
         </div>
       )}
-      <div className="row" style={{ alignItems: "start" }}>
+      {/* Setup next-step cue: connects this landing page to the rest of the
+          preparation flow. Adding the roster here doesn't tell the operator
+          what comes next (the Generate draw button lives in the page header,
+          the full checklist on Overview), so state it explicitly. */}
+      {isSetup && (
+        <div className="card" style={{ marginBottom: 16, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div className="card__title" style={{ marginBottom: 2 }}>
+              {players.length >= 2 ? "Roster ready" : "Add your roster to begin"}
+            </div>
+            <div className="card__sub">
+              {players.length >= 2
+                ? `${players.length} ${c.kind === "team" ? "teams" : "participants"} added. Assign seeds (optional), then use “Generate draw” in the header to build the bracket.`
+                : `Add at least 2 ${c.kind === "team" ? "teams" : "participants"}, then you can generate the draw.`}
+            </div>
+          </div>
+          <button type="button" className="btn" onClick={() => onSection("overview")}>View setup steps →</button>
+        </div>
+      )}
+      <div className="row" style={{ alignItems: "start", ...(emptyRoster ? { gridTemplateColumns: "1fr" } : {}) }}>
+        {!emptyRoster && (
         <div className="card">
           <div className="card__head">
             <div>
@@ -998,6 +1022,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
             </div>
           )}
         </div>
+        )}
         <div className="card">
           <div className="card__head">
             <div>

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -762,25 +762,29 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
         <div className="card">
           <div className="card__head">
             <div>
-              <div className="card__title">Check-in & Seeding</div>
+              <div className="card__title">{c.checkInEnabled ? "Check-in & Seeding" : "Seeding"}</div>
               <div className="card__sub">
                 {c.checkInEnabled && `${players.filter(p => p.checkedIn).length} / ${players.length} checked in · `}{players.filter((p) => p.seed).length} seeded
               </div>
             </div>
-            <div style={{ display: "flex", gap: 6 }}>
+            <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+              {/* Attendance cluster: only present when check-in tracking is on. */}
               {c.checkInEnabled && (
-                <button className={`btn btn--sm ${showOnlyUnchecked ? "btn--primary" : ""}`} type="button" onClick={() => setShowOnlyUnchecked(!showOnlyUnchecked)}>
+                <button className={`btn btn--sm ${showOnlyUnchecked ? "btn--primary" : ""}`} type="button" aria-pressed={showOnlyUnchecked} onClick={() => setShowOnlyUnchecked(!showOnlyUnchecked)}>
                   {showOnlyUnchecked ? "Show all" : "Show unchecked"}
                 </button>
               )}
               {c.checkInEnabled && (
                 <button className="btn btn--sm" type="button" onClick={bulkCheckInAll} disabled={players.length === 0} title="Mark all as checked in">Check in all</button>
               )}
-              {/* draw-ready lock: seed mutations disabled until the draw is discarded */}
+              {/* Divider between the attendance and seeding clusters. */}
+              {c.checkInEnabled && <span aria-hidden="true" style={{ width: 1, alignSelf: "stretch", background: "var(--line)", margin: "0 2px" }} />}
+              {/* Seeding cluster. draw-ready lock: seed mutations disabled until the draw is discarded. */}
               <button className="btn btn--sm" type="button" onClick={shuffleUnseeded} disabled={players.length === 0 || isDrawReady} title={isDrawReady ? "Discard the draw to shuffle seeds" : "Shuffle unseeded players"}>Shuffle unseeded</button>
-              <button className="btn btn--sm" type="button" onClick={() => seedFileRef.current?.click()} disabled={players.length === 0 || isDrawReady} title={isDrawReady ? "Discard the draw to import seeds" : players.length === 0 ? "Add participants first" : undefined}>Import Seeds CSV</button>
+              <button className="btn btn--sm" type="button" onClick={() => seedFileRef.current?.click()} disabled={players.length === 0 || isDrawReady} title={isDrawReady ? "Discard the draw to import seeds" : players.length === 0 ? "Add participants first" : undefined}>Import seeds (CSV)</button>
               <input ref={seedFileRef} type="file" accept=".csv,.txt,text/csv,text/plain" style={{ display: "none" }} onChange={(e) => handleSeedFile(e.target.files[0])} />
-              <button className="btn btn--sm" type="button" onClick={clearAllSeeds} disabled={isDrawReady} title={isDrawReady ? "Discard the draw to clear seeds" : undefined}>Clear seeds</button>
+              {/* Lone destructive action: ghost-danger, set apart from the constructive seeding buttons. */}
+              <button className="btn btn--sm btn--ghost btn--danger" type="button" onClick={clearAllSeeds} disabled={isDrawReady} title={isDrawReady ? "Discard the draw to clear seeds" : "Remove all seed ranks"}>Clear seeds</button>
             </div>
           </div>
           <div className="card__body" style={{ paddingTop: 0, paddingBottom: 8 }}>
@@ -836,9 +840,9 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
           )}
           {allTags.length > 0 && (
             <div style={{ padding: "0 16px 10px", display: "flex", gap: 6, flexWrap: "wrap" }}>
-              <button type="button" className={`radio-pill ${!tagFilter ? "is-active" : ""}`} onClick={() => setTagFilter(null)}>All</button>
+              <button type="button" aria-pressed={!tagFilter} className={`radio-pill ${!tagFilter ? "is-active" : ""}`} onClick={() => setTagFilter(null)}>All</button>
               {allTags.map(t => (
-                <button type="button" key={t} className={`radio-pill ${tagFilter === t ? "is-active" : ""}`} onClick={() => setTagFilter(tagFilter === t ? null : t)}>{t}</button>
+                <button type="button" key={t} aria-pressed={tagFilter === t} className={`radio-pill ${tagFilter === t ? "is-active" : ""}`} onClick={() => setTagFilter(tagFilter === t ? null : t)}>{t}</button>
               ))}
             </div>
           )}

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -646,8 +646,6 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   // (neighbour-only) is the new option for league-sized fields where a
   // full round-robin would not fit in the day's schedule.
   const [poolFormat, setPoolFormat] = useStateA("full");
-  const [useSample, setUseSample] = useStateA(false);
-  const [sampleSize, setSampleSize] = useStateA("medium");
   const [poolMode, setPoolMode] = useStateA("max");
   const [poolSize, setPoolSize] = useStateA(3);
   const [winners, setWinners] = useStateA(2);
@@ -761,7 +759,9 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
       name: finalName,
       kind, gender,
       format,
-      sampleRoster: useSample ? sampleSize : null,
+      // New competitions start with an empty roster — participants (or a
+      // sample roster) are added in the Participants view, not here.
+      sampleRoster: null,
       seedCount: 0, status: "setup",
       startTime,
       date: normDate,
@@ -926,21 +926,6 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
               <div className="field__hint">Typical: 4 rounds for 16 players, 5 for 32, 6 for 64 (≈ log₂ of field size).</div>
             </div>
           )}
-
-          <div className="field">
-            <label className="checkbox field__label" style={{ display: "inline-flex" }}>
-              <input type="checkbox" checked={useSample} onChange={(e) => setUseSample(e.target.checked)} />
-              Pre-fill with sample roster
-            </label>
-            {useSample && (
-              <div className="radio-group" style={{ marginTop: 8 }}>
-                <button className={`radio-pill ${sampleSize === "small" ? "is-active" : ""}`} type="button" onClick={() => setSampleSize("small")}>Small (8)</button>
-                <button className={`radio-pill ${sampleSize === "medium" ? "is-active" : ""}`} type="button" onClick={() => setSampleSize("medium")}>Medium (16)</button>
-                <button className={`radio-pill ${sampleSize === "large" ? "is-active" : ""}`} type="button" onClick={() => setSampleSize("large")}>Large (32)</button>
-              </div>
-            )}
-            <div className="field__hint">Leave off to add real participants in the next step.</div>
-          </div>
 
           <div className="field">
             <label className="field__label">Assigned shiaijo (courts)</label>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -436,10 +436,33 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             {comps.some(c => c.status === "setup" && (c.players || []).length >= 2) && (
               <button type="button" className="btn btn--danger" onClick={onStartAll}>Start all</button>
             )}
-            <button type="button" className="btn btn--primary" onClick={onCreateCompetition}>+ Add competition</button>
+            {/* When the tournament is empty the first-run empty state below carries
+                the single primary "Add competition" CTA, so we drop the duplicate
+                header button to keep one clear call to action on the first screen. */}
+            {!noComps && (
+              <button type="button" className="btn btn--primary" onClick={onCreateCompetition}>+ Add competition</button>
+            )}
           </div>
         </div>
 
+        {/* First-run: an empty tournament has no matches, so the match-count
+            stat strip ("Matches done 0/0", "Now 0"), the tournament-wide score
+            editor, and the per-shiaijo operator views are all dead widgets. Show
+            a single oriented empty state instead and skip the rest of the
+            dashboard until the first competition exists. */}
+        {noComps ? (
+          <div className="empty" style={{ padding: "48px 24px", marginBottom: 24 }}>
+            <div className="icon" aria-hidden="true">🥋</div>
+            <h3>Add your first competition</h3>
+            <div style={{ fontSize: 13, color: "var(--ink-2)", maxWidth: 460, margin: "0 auto", lineHeight: 1.5 }}>
+              A competition is one event within {t.name} — like Men's Individual or Women's Teams. Add one to enter participants, build the draw, and run matches.
+            </div>
+            <div className="empty__cta" style={{ display: "flex", gap: 8, justifyContent: "center", flexWrap: "wrap" }}>
+              <button type="button" className="btn btn--primary" onClick={onCreateCompetition}>+ Add competition</button>
+              <button type="button" className="btn" onClick={onOpenImport}>Import from folder</button>
+            </div>
+          </div>
+        ) : (<>
         <div className="stats-strip">
           <div className="stat-box"><div className="v">{comps.length}</div><div className="l">Competitions</div></div>
           <div className="stat-box"><div className="v">{totalParticipants}</div><div className="l">Participants</div></div>
@@ -488,10 +511,13 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
         <div className="section-title">All competitions</div>
         <div className="tlist">
           {comps.map((c) => <CompCard key={c.id} c={c} onOpen={() => onOpenCompetition(c.id, initialSectionFor(c.status))} onStart={() => onStartCompetition(c.id)} tournament={t} showToast={showToast} />)}
-          <button type="button" className={`tcard tcard--add${noComps ? " tcard--add-cta" : ""}`} onClick={onCreateCompetition}>
-            <div style={{ fontSize: 28, color: noComps ? "var(--accent)" : "var(--ink-3)" }}>+</div>
-            <div style={{ fontWeight: noComps ? 700 : 600, marginTop: 4, color: noComps ? "var(--accent)" : undefined }}>Add competition</div>
-            <div style={{ fontSize: 12, color: noComps ? "var(--ink-2)" : "var(--ink-3)", marginTop: 2 }}>Individual or Team</div>
+          {/* This section only renders when competitions exist (the empty-tournament
+              case is handled by the first-run empty state above), so the dashed
+              tile stays a quiet "add another", not the promoted first-run CTA. */}
+          <button type="button" className="tcard tcard--add" onClick={onCreateCompetition}>
+            <div style={{ fontSize: 28, color: "var(--ink-3)" }}>+</div>
+            <div style={{ fontWeight: 600, marginTop: 4 }}>Add competition</div>
+            <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>Individual or Team</div>
           </button>
           <button type="button" className="tcard tcard--add" onClick={onOpenImport}>
             <div style={{ color: "var(--ink-3)" }}><Icon name="folder" size={28} /></div>
@@ -499,6 +525,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
             <div style={{ fontSize: 12, color: "var(--ink-3)", marginTop: 2 }}>From folder with manifest.yaml</div>
           </button>
         </div>
+        </>)}
         {window.VersionFooter && <window.VersionFooter />}
       </div>
       {exportPdfOpen && (

--- a/web-mobile/js/viewer_home.jsx
+++ b/web-mobile/js/viewer_home.jsx
@@ -381,7 +381,7 @@ export function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOp
                         </div>
                         {c.status && c.status !== "setup" && c.status !== "draw-ready" && total > 0 && (
                           <div className="vlist-item__progress">
-                            <div className="vlist-item__bar"><div style={{ width: pct + "%" }}></div></div>
+                            <div className="vlist-item__bar"><div style={{ '--bar-fill': pct / 100 }}></div></div>
                             <div className="vlist-item__pct">
                               {runningCount > 0 ? <span className="bc-running-count">● {runningCount} now</span> : pluralize(done, "match", "matches") + " / " + total}
                             </div>


### PR DESCRIPTION
## Summary

This PR makes the kendo admin **status-aware across the whole setup journey** — the competition overview, the empty-tournament dashboard, and the participants landing.

**Competition overview** (original scope):
- Redesigns the competition admin **Overview** into a status-aware launchpad. Previously it always rendered running-competition widgets, so a freshly created competition (status `setup`, no draw) showed `Matches done 0/0`, `Now 0`, a 0% progress bar, and Scores/Results quick actions that were dead links.
- The Overview now adapts to `c.status`: **setup** shows a guided next-steps checklist; **draw-ready** shows a draw summary that points at the header Start button; **running** keeps the existing progress bar + Scores/Results; **completed** shows a podium link + Results/Export shortcuts.
- Surfaces **Est. duration** as a headline stat (and a per-court footer breakdown) in every state, reusing the existing `estimateCompetitionSchedule` endpoint + `formatCompMinutes` already used in Settings — no new backend.

**Onboarding pass** (added after an `/impeccable critique` of the setup flow):
- **Empty-tournament dashboard:** a brand-new tournament showed the same status-blind widgets (a `Matches done 0/0` / `Now 0` stat strip, a disabled tournament-wide score editor, premature per-shiaijo operator views) — the literal first screen of onboarding. When there are no competitions, it now shows a single oriented first-run empty state (what a competition is + Add / Import CTAs) and drops the duplicate header "+ Add competition" button.
- **Participants landing:** the post-create page led with a "Check-in & Seeding" panel before any participant existed, pushing the actual task (pasting the roster) to the far column. The seeding panel is now hidden until ≥1 participant and the roster-input panel fills the width.
- **Next-step cue:** the participants page never said what comes after adding names. A setup-only cue ("Add your roster to begin" → "Roster ready") now points at the header Generate-draw action and links to the Overview setup steps.
- **Sample roster moved to where you add participants:** the "Pre-fill with sample roster" toggle was on the Add-competition form (a config-time decision about roster content). It now lives in the Participants view as a "No list yet? Fill with a sample roster: Small/Medium/Large" control, shown only while the box is empty; it fills the textarea for review and the operator clicks Apply to save.

Routing after creation is unchanged (still lands on Participants); the Overview is reached via the sidebar and is the default when reopening a competition.

## Why

The admin was built for a *running* tournament and was a dead end for a fresh one — zero-value match widgets, no call-to-action, no "what next" — at three different levels. This PR applies one consistent status-aware pattern at each.

During browser verification a real bug was caught and fixed: there is **no literal `running` status** — the active phases are `pools` and `playoffs` (`internal/state/models.go:441-446`). An initial `isRunning = status === "running"` was always false, so a live competition mis-rendered the "Competition complete" card. Fixed via a pure, unit-tested `overviewViewMode(status)` helper (anything not setup/draw-ready/completed → running, covering pools/playoffs/invalid/future phases).

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_competition_overview.jsx` | Rewrote `AdminCompOverview` to branch on `c.status`; added pure helpers `overviewViewMode` + `competitionNextSteps` (with per-step CTA copy); schedule-estimate fetch; `vClass` stat sizing |
| `web-mobile/js/admin_shell.jsx` | Empty-tournament dashboard shows a first-run empty state instead of zero-value match widgets; drops the duplicate header Add button when empty |
| `web-mobile/js/admin_participants.jsx` | Hide the seeding panel until ≥1 participant (roster-input fills width); add a setup next-step cue linking to Generate-draw / Overview; honest "Seeding" title + grouped toolbar + `aria-pressed` (design-critique); sample-roster fill control |
| `web-mobile/js/admin_setup.jsx` | Remove the "Pre-fill with sample roster" toggle from the Add-competition form (moved to Participants); new competitions start with an empty roster |
| `web-mobile/js/admin_competition.jsx` | Pass `password` to `<AdminCompOverview>` so it can fetch the estimate |
| `web-mobile/js/admin_competition_settings.jsx` | Expose `window.formatCompMinutes` for reuse by the overview |
| `web-mobile/js/viewer_home.jsx` | Progress bar markup uses `--bar-fill` CSS custom property + `scaleX` transform (compositor-safe animation) instead of `width %` |
| `web-mobile/css/styles.css` | Next-steps checklist styles; `.card--action` hover modifier; `.v--sm` stat modifier; `.stat-box__link:focus-visible` + `.card--action:focus-visible` focus rings; `.start-all__list--failed li` full border+bg (side-stripe ban); toast expo-out easing (no bounce); removed layout-property transition from `.encho-row--expanded`; `.vlist-item__bar > div` scaleX compositor-safe animation |
| `web-mobile/js/__tests__/admin_competition_overview.test.jsx` | Unit tests for `competitionNextSteps` (all states, individual vs team, CTA copy) and `overviewViewMode` (status→mode mapping, regression guard) |

## Screenshots

### Competition overview (status-aware)

**Setup** — guided next-steps checklist + Est. duration headline stat

![Overview, setup state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/overview-setup.png)

**Draw ready** — pool/bracket summary, points at the header Start button

![Overview, draw-ready state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/overview-drawready.png)

**Running** (pools) — progress bar + Scores/Results retained

![Overview, running state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/overview-running.png)

**Completed** — podium link + Results/Export shortcuts

![Overview, completed state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/overview-completed.png)

### Onboarding / setup

**Empty tournament dashboard** — single first-run empty state, no zero-value match widgets

![Empty tournament dashboard](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/onboarding-dashboard-empty.png)

**Participants (empty roster)** — seeding panel hidden, roster-input full width, setup cue

![Participants, empty roster](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/onboarding-participants-empty.png)

**Participants (roster added)** — seeding panel returns, cue flips to "Roster ready"

![Participants, roster added](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/onboarding-participants-ready.png)

### Seeding card refinements (design-critique follow-ups)

**Check-in enabled** — title reads "Check-in & Seeding"; toolbar split into attendance | seeding clusters by a thin divider; "Clear seeds" is the lone ghost-danger action; "Import seeds (CSV)" casing

![Check-in & Seeding card, check-in on](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/seed-checkin-on.png)

**Check-in disabled** — title correctly reads "Seeding" (no longer promises absent check-in); divider suppressed; sub-line drops the check-in count

![Seeding card, check-in off](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/seed-checkin-off.png)

### Sample roster (moved to Participants view)

**Empty roster** — "No list yet? Fill with a sample roster" sits under the CSV dropzone; the Add-competition form no longer carries this toggle

![Participants, sample roster control](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/sample-empty.png)

**After Medium (16)** — the textarea is filled for review (preview table populated); the control hides so it can't clobber an edited list; operator clicks "Apply changes" to save

![Participants, sample roster filled](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/sample-filled.png)

### CSS accessibility & polish fixes

**Admin overview — running** — `.stat-box__link:focus-visible` + `.card--action:focus-visible` focus rings; `scaleX`-based progress bar

![Admin overview, running (Shodan Open in pools)](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/01_overview_running.png)

**Admin overview — completed** — `View podium →` link + Results/Export `card--action` cards

![Admin overview, completed (Nidan Cup)](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/02_overview_completed.png)

**`stat-box__link` focus ring** — keyboard focus on "View podium →" (`stat-box__link:focus-visible`)

![stat-box__link focus ring](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/02b_stat_box_link_focused.png)

**`card--action` focus ring** — keyboard focus on "Results →" card (`.card--action:focus-visible`)

![card--action focus ring](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/04_card_action_focused.png)

**Viewer home — progress bars** — `.vlist-item__bar` using compositor-safe `scaleX` transform (replaces `width %`)

![Viewer home, progress bars (mobile viewport)](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/03_viewer_home_bars.png)

**Start-all failed item** — `border: 1px solid var(--red)` + `background: var(--red-soft)` replacing left-stripe-only styling

![Start-all failed list styling](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/06_start_all_failed.png)

**Toast notification** — expo-out easing `cubic-bezier(0.16, 1, 0.3, 1)` (no bounce)

![Toast notification](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/312/07_toast.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — JS: 80 files / 1797 tests; Go coverage ≥85% maintained
- [x] New/updated unit tests cover the change — 37 tests in the overview suite incl. the `overviewViewMode` regression guard
- [x] Manual browser verification — overview: all four states (`setup` with 0 and 6 participants, `draw-ready`, `running`/pools, `completed`); onboarding: empty dashboard, populated dashboard, participants empty-roster and ≥2 roster; seeding card: title flips "Check-in & Seeding"↔"Seeding" with check-in on/off, divider geometry (1×26px), `aria-pressed` toggles false→true; sample roster: control present on empty Participants box, "Medium (16)" fills 16 lines, control hides after fill, Apply persists 16 participants, and the Add-competition form no longer shows the toggle. Verified via the `mobile-app` server in a real browser; only benign favicon/logo 404s, no JS errors
- [x] Screenshots added above (REQUIRED for any UI-affecting change) — CSS changes verified via Playwright captures for all 7 affected surfaces
- [x] No new console errors or warnings

Closes mp-a5d6
