### PR TITLE
fix(mp-pt1v): reuse shared scoring editor in bracket winner-picker (+ match number/round, state-driven panel)

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2047,6 +2047,30 @@ a:hover {
   font-weight: 600;
   font-size: 16px;
 }
+/* Round suffix on the panel title ("Match M1 · Semifinals") — subordinate to
+   the match number so the eye lands on the identifier first. */
+.running-panel__round {
+  font-weight: 500;
+  color: var(--ink-3);
+}
+
+/* Completed-match result view: the shared read-only IndividualScore card, a
+   "winner advances" confirmation line, then the (confirmation-gated) edit
+   action. */
+.running-panel__result {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.running-panel__advances {
+  padding: 10px;
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  border-radius: 8px;
+  font-size: 12.5px;
+  color: #065f46;
+  text-align: center;
+}
 
 .running-panel__court {
   font-family: var(--font-mono);
@@ -2055,104 +2079,6 @@ a:hover {
   padding: 3px 10px;
   border: 1px solid var(--line);
   border-radius: 999px;
-}
-
-.score-card {
-  display: grid;
-  grid-template-columns: 1fr 60px 1fr;
-  align-items: stretch;
-  gap: 0;
-  border: 1px solid var(--line);
-  border-radius: var(--r);
-  overflow: hidden;
-}
-
-.score-side {
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  /* Aka/Shiro side treatment (DESIGN.md §4): a thick coloured top bar gives
-     each side real colour area so the two read apart at a glance, not just a
-     faint tint. The bar colour is the side identity. */
-  border-top: 5px solid var(--line);
-  /* Mirrored head-to-head: content is vertically centred and the two sides
-     face the central "vs" — Shiro (left) leans right-toward-centre, Aka
-     (right) leans left-toward-centre. Matches the live scoreboard. */
-  justify-content: center;
-}
-
-.score-side--white {
-  background: var(--white-side);
-  /* framed white: dark cool bar + 45° hatch so "white" reads as a side */
-  border-top-color: var(--shiro-edge);
-  background-image: repeating-linear-gradient(
-    -45deg, transparent 0 7px, var(--shiro-hatch) 7px 8px);
-}
-
-/* Aka is on the right: align its content to the outer (right) edge so the
-   two sides mirror each other — Shiro left-aligned, Aka right-aligned.
-   Both sides are vertically centred by the justify-content:center above. */
-.score-side--red {
-  align-items: flex-end;
-  text-align: right;
-}
-.score-side--red .score-side__buttons,
-.score-side--red .score-side__points {
-  justify-content: flex-end;
-}
-
-.score-side--red {
-  background: var(--red-soft);
-  border-top-color: var(--red);
-}
-
-.score-side__lbl {
-  align-self: flex-start;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 11px;
-  font-weight: 800;
-  font-family: var(--font-strong);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 4px 10px;
-  border-radius: 999px;
-}
-/* filled identity chip — the obvious cue, present before any winner is chosen */
-.score-side--white .score-side__lbl {
-  background: #fff;
-  color: var(--shiro-edge);
-  border: 1.5px solid var(--shiro-edge);
-}
-.score-side--red .score-side__lbl {
-  background: var(--red);
-  color: #fff;
-}
-
-.score-side__name {
-  font-size: 17px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.score-side__dojo {
-  font-size: 12px;
-  color: var(--ink-3);
-}
-
-.score-side__points {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-  margin-top: 4px;
-}
-
-.score-side__buttons {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
 }
 
 .ipt-btn {
@@ -2168,45 +2094,6 @@ a:hover {
 
 .ipt-btn:hover {
   border-color: var(--ink-4);
-}
-
-.score-vs {
-  display: grid;
-  place-items: center;
-  background: white;
-  border-left: 1px solid var(--line);
-  border-right: 1px solid var(--line);
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--ink-3);
-  font-family: var(--font-display);
-}
-
-/* Mode tabs */
-.mode-tabs {
-  display: flex;
-  gap: 4px;
-  padding: 4px;
-  background: var(--line-2);
-  border-radius: 10px;
-  margin-bottom: 16px;
-}
-
-.mode-tabs button {
-  flex: 1;
-  background: none;
-  border: none;
-  padding: 8px 12px;
-  border-radius: 7px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--ink-2);
-}
-
-.mode-tabs button.is-active {
-  background: var(--surface);
-  color: var(--ink);
-  box-shadow: var(--shadow-sm);
 }
 
 /* ---------- Viewer (mobile) ---------- */

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2055,6 +2055,14 @@ a:hover {
   font-weight: 600;
   font-size: 16px;
 }
+/* Centred content column: the panel card fills the row (so it aligns with the
+   bracket card), but the reused editor / result card are capped here so they
+   read as a comfortable scoreboard width instead of stretching edge-to-edge. */
+.running-panel__inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
 /* Completed-match result view: the shared MatchDetailCard (same as the viewer)
    followed by the confirmation-gated edit action. */
 .running-panel__result {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1996,6 +1996,39 @@ a:hover {
 }
 
 /* ---------- Running match panel (admin) ---------- */
+/* Bracket page layout: the tree and the winner-picker / scoring panel sit
+   side by side when there's room. The panel keeps a minimum width so the
+   reused inline scoring editor never squashes or clips; when the bracket and
+   that minimum can't both fit, the panel wraps to a full-width row BELOW the
+   bracket (flex line-break on basis 560 + 520 > available). */
+.bracket-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: flex-start;
+}
+.bracket-layout__bracket {
+  /* grows to fill; min-width:0 lets it shrink so .bracket-canvas scrolls
+     (overflow-x:auto) instead of forcing page overflow. */
+  flex: 1 1 560px;
+  min-width: 0;
+}
+.bracket-layout__panel {
+  flex: 1 1 520px;
+  min-width: 500px;
+  max-width: 680px;
+}
+/* Phones / small tablets: drop the minimum so the panel fills the single
+   column instead of overflowing; the editor's own coarse-pointer rules handle
+   compact sizing from here. */
+@media (max-width: 760px) {
+  .bracket-layout__panel {
+    flex-basis: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+}
+
 .running-panel {
   background: var(--surface);
   border: 1px solid var(--line);
@@ -2116,35 +2149,6 @@ a:hover {
   margin-top: 4px;
 }
 
-.score-pt {
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  display: grid;
-  place-items: center;
-  font-family: var(--font-mono);
-  font-weight: 700;
-  font-size: 12px;
-}
-
-.score-pt--filled {
-  background: var(--accent);
-  color: var(--accent-fg);
-  border-color: var(--accent);
-}
-
-.score-side--red .score-pt--filled {
-  background: var(--red);
-  border-color: var(--red);
-  color: white;
-}
-
-.score-pt--empty {
-  color: var(--ink-4);
-}
-
 .score-side__buttons {
   display: flex;
   gap: 6px;
@@ -2176,141 +2180,6 @@ a:hover {
   font-weight: 700;
   color: var(--ink-3);
   font-family: var(--font-display);
-}
-
-/* ---------- Scoreboard editor (Proposal C) ----------
-   4 columns: [Shiro button rail | Shiro who | Aka who | Aka button rail].
-   The Aka/Shiro colour runs continuously edge-to-edge (no neutral gap); the
-   two competitors meet at the centre facing a floating "vs". Side name is
-   stated ONCE, in the centre identity chip (rails are unlabelled — their
-   colour + position already say which side). DESIGN.md §4 Aka/Shiro. */
-.sc-board {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto 1fr 1fr auto;
-  align-items: stretch;
-  border: 1px solid var(--line);
-  border-radius: var(--r);
-  overflow: hidden;
-}
-.sc-board__rail,
-.sc-board__who {
-  border-top: 5px solid var(--line);
-}
-/* side fills — shared by rail + who so colour is continuous */
-.sc-board__shiro {
-  background: var(--white-side);
-  border-top-color: var(--accent);
-  background-image: repeating-linear-gradient(
-    -45deg, transparent 0 7px, var(--shiro-hatch) 7px 8px);
-}
-.sc-board__aka {
-  background: var(--red-soft);
-  border-top-color: var(--red);
-}
-.sc-board__rail {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 14px;
-}
-.sc-board__btnrow {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  justify-content: center;
-  max-width: 156px;
-}
-.sc-board__who {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  justify-content: center;
-  padding: 18px;
-}
-.sc-board__who--shiro { align-items: flex-end; text-align: right; padding-right: 32px; }
-.sc-board__who--aka { align-items: flex-start; text-align: left; padding-left: 32px; }
-.sc-board__lbl {
-  display: inline-flex;
-  align-items: center;
-  font: 800 11px/1 var(--font-strong);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 4px 10px;
-  border-radius: 999px;
-}
-.sc-board__who--shiro .sc-board__lbl {
-  background: #fff;
-  color: var(--accent);
-  border: 1.5px solid var(--accent);
-}
-.sc-board__who--aka .sc-board__lbl {
-  background: var(--red);
-  color: #fff;
-}
-.sc-board__nm {
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-.sc-board__tally { display: flex; gap: 6px; }
-/* the meeting line — a floating vs pill dead-centre */
-.sc-board__vs {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  font: 800 12px/1 var(--font-display);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--ink-4);
-  background: #fff;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 6px 9px;
-  z-index: 2;
-}
-/* Portrait phones/tablets: the 4-column side-by-side doesn't fit, so each side
-   becomes its own horizontal band — name + tally on the inner side, the score
-   buttons on the same line to the outer side. Landscape (incl. landscape
-   phones) keeps the side-by-side Proposal C above. Orientation-based per the
-   operator's request. The two shiro/aka DOM nodes (rail + who) are re-placed
-   into a 2×2 grid: [who | rail] per row. */
-@media (max-width: 600px) {
-  /* Narrow screens (true phones, portrait or landscape): a side-by-side rail
-     competes with the name for horizontal space and overflows. So each side
-     becomes a single full-width block — identity chip + name + tally, then the
-     score buttons full-width beneath, wrapping as needed. One column = can't
-     overflow at any width, every button keeps its 44px touch target. Wider
-     tablets (incl. portrait ≥600px) keep the side-by-side Proposal C above. */
-  .sc-board {
-    grid-template-columns: 1fr;
-    grid-template-rows: none;
-    grid-auto-flow: row;
-  }
-  /* re-order so each side's buttons sit directly under that side's name:
-     shiro who → shiro rail → aka who → aka rail */
-  .sc-board__who--shiro { order: 1; }
-  .sc-board__rail.sc-board__shiro { order: 2; }
-  .sc-board__who--aka { order: 3; }
-  .sc-board__rail.sc-board__aka { order: 4; }
-  .sc-board__who--shiro,
-  .sc-board__who--aka {
-    align-items: flex-start; text-align: left; padding: 14px 16px 8px;
-  }
-  /* rail no longer its own column — full width under the name, buttons left-aligned.
-     Its top border would double the divider, so drop it here. */
-  .sc-board__rail { border-top: none; padding: 0 16px 14px; justify-content: flex-start; }
-  .sc-board__btnrow { max-width: none; justify-content: flex-start; }
-  /* the floating centre "vs" is meaningless once stacked */
-  .sc-board__vs { display: none; }
-}
-
-.running-panel__actions {
-  display: flex;
-  gap: 8px;
-  margin-top: 16px;
-  flex-wrap: wrap;
 }
 
 /* Mode tabs */
@@ -3821,9 +3690,8 @@ button.pool-match-row {
     min-height: 44px;
     padding: 8px 10px;
   }
-  /* Scoring buttons are the operator's most-tapped control — meet the 44px
-     touch target on tablets/phones (DESIGN.md §6). The portrait sc-board
-     button rail is sized (max-width ~100px) so two 44px buttons fit per row. */
+  /* Scoring buttons (sb-points-grid) are the operator's most-tapped control —
+     meet the 44px touch target on tablets/phones (DESIGN.md §6). */
   .ipt-btn {
     min-width: 44px;
     min-height: 44px;
@@ -5520,25 +5388,6 @@ button.pool-match-row {
   color: var(--accent);
   border: 1px solid var(--accent);
   margin-left: 4px;
-}
-
-/* Aka ippon buttons in scoreboard */
-.ipt-btn--aka {
-  background: var(--red-soft);
-  border-color: var(--red);
-  color: var(--red);
-}
-
-.score-pt--aka.score-pt--filled {
-  background: var(--red);
-  border-color: var(--red);
-  color: white;
-}
-
-.score-pt--shiro.score-pt--filled {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: white;
 }
 
 /* Team header color label */

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2055,29 +2055,12 @@ a:hover {
   font-weight: 600;
   font-size: 16px;
 }
-/* Round suffix on the panel title ("Match M1 · Semifinals") — subordinate to
-   the match number so the eye lands on the identifier first. */
-.running-panel__round {
-  font-weight: 500;
-  color: var(--ink-3);
-}
-
-/* Completed-match result view: the shared read-only IndividualScore card, a
-   "winner advances" confirmation line, then the (confirmation-gated) edit
-   action. */
+/* Completed-match result view: the shared MatchDetailCard (same as the viewer)
+   followed by the confirmation-gated edit action. */
 .running-panel__result {
   display: flex;
   flex-direction: column;
   gap: 12px;
-}
-.running-panel__advances {
-  padding: 10px;
-  background: #ecfdf5;
-  border: 1px solid #a7f3d0;
-  border-radius: 8px;
-  font-size: 12.5px;
-  color: #065f46;
-  text-align: center;
 }
 
 .running-panel__court {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -2018,9 +2018,13 @@ a:hover {
   min-width: 0;
 }
 .bracket-layout__panel {
+  /* Grows to fill its flex line. When it wraps below the bracket (the common
+     case at desktop widths) it fills the whole row, so its card lines up edge-
+     to-edge with the bracket card above — no max-width cap that would leave a
+     ragged right edge. min-width keeps the inline editor from squashing when
+     it DOES sit beside the bracket. */
   flex: 1 1 520px;
   min-width: 500px;
-  max-width: 680px;
 }
 /* Phones / small tablets: drop the minimum so the panel fills the single
    column instead of overflowing; the editor's own coarse-pointer rules handle

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -345,7 +345,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
               />
             )}
             {section === "pools" && <AdminPools c={c} pools={pools} poolMatches={poolMatches} standings={standings} tweaks={tweaks} onEditScore={onEditScore} password={password} />}
-            {section === "bracket" && <AdminBracket c={c} t={t} bracket={bracket} onMoveCourt={onMoveCourt} onEditScore={onEditScore} tweaks={tweaks} password={password} showToast={showToast} />}
+            {section === "bracket" && <AdminBracket c={c} t={t} bracket={bracket} onMoveCourt={onMoveCourt} onEditScore={onEditScore} tweaks={tweaks} password={password} />}
             {section === "scores" && !isDrawReady && <AdminScoreEditor c={c} t={t} onEditScore={onEditScore} onMoveCourt={onMoveCourt} restrictToCompId={c.id} password={password} />}
             {section === "export" && <AdminExport c={c} t={t} />}
           </div>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -345,7 +345,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
               />
             )}
             {section === "pools" && <AdminPools c={c} pools={pools} poolMatches={poolMatches} standings={standings} tweaks={tweaks} onEditScore={onEditScore} password={password} />}
-            {section === "bracket" && <AdminBracket c={c} t={t} bracket={bracket} onMoveCourt={onMoveCourt} tweaks={tweaks} password={password} showToast={showToast} />}
+            {section === "bracket" && <AdminBracket c={c} t={t} bracket={bracket} onMoveCourt={onMoveCourt} onEditScore={onEditScore} tweaks={tweaks} password={password} showToast={showToast} />}
             {section === "scores" && !isDrawReady && <AdminScoreEditor c={c} t={t} onEditScore={onEditScore} onMoveCourt={onMoveCourt} restrictToCompId={c.id} password={password} />}
             {section === "export" && <AdminExport c={c} t={t} />}
           </div>

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -92,17 +92,22 @@ function loadScoreboardPoints(match) {
   };
 }
 
-const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundName, onMoveCourt, onEditScore, password }) => {
-  // Two shared components, both off the window bridge at render time so module
-  // load order never matters:
+const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundName, compName, onMoveCourt, onEditScore, password }) => {
+  // Reuse the shared components wholesale — both off the window bridge at render
+  // time so module load order never matters:
   //   ScoreEditorModal (variant="inline") — the ONE scoring editor the shiaijo /
-  //     pools / scores screens use (ippons, draws, hantei, fouls, encho,
-  //     kiken/fusenpai). It IS the manual-override path, so there's no separate
-  //     "force winner" affordance.
-  //   IndividualScore — the SAME read-only result card the viewer / TV show.
+  //     pools / scores screens use. We keep ITS header (it's the same in every
+  //     host), so the panel doesn't add a competing title.
+  //   MatchDetailCard — the SAME read-only result card the public viewer shows
+  //     for a completed match (names + winner highlight + FINAL + score marks),
+  //     instead of a stripped-down lookalike.
   const ScoreEditorModal = window.ScoreEditorModal;
-  const IndividualScore = window.IndividualScore;
+  const MatchDetailCard = window.MatchDetailCard;
   const isComplete = match.status === "completed";
+  // Bracket match objects don't carry round/compName, so the shared headers
+  // would render sparse (a lone "·" with an empty round). Feed them the round
+  // we already computed + the competition name so their own headers read fully.
+  const m = { ...match, round: match.round || roundName, compName: match.compName || compName };
   // A completed match shows its read-only result by default; re-opening the
   // editor to change a recorded result is gated behind a confirmation so it's
   // not changed by accident. An un-played match goes straight to the editor
@@ -113,28 +118,22 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
 
   return (
     <div className="running-panel">
+      {/* Slim header: only the bits the reused components' own headers DON'T
+          carry — the bracket match number and the move-court control. Comp /
+          shiaijo / round / time / status come from the embedded component. */}
       <div className="running-panel__head">
-        <div className="running-panel__title">
-          {matchNum != null
-            ? <>Match M{matchNum}{roundName ? <span className="running-panel__round"> · {roundName}</span> : null}</>
-            : <>{roundName || `Match · ${match.id.slice(-6)}`}</>}
-        </div>
-        <div className="running-panel__court">
-          {onMoveCourt && courts && courts.length ? (
-            <>
-              <CourtPicker
-                value={match.court}
-                courts={courts}
-                onChange={(cc) => onMoveCourt(compId, match.id, cc)}
-                btnClassName="running-panel__court-btn"
-                label="SHIAIJO "
-              />
-              <span> · {match.scheduledAt || "TBA"}</span>
-            </>
-          ) : (
-            <span>SHIAIJO {match.court} · {match.scheduledAt || "TBA"}</span>
-          )}
-        </div>
+        <div className="running-panel__title">{matchNum != null ? `Match M${matchNum}` : `Match · ${match.id.slice(-6)}`}</div>
+        {onMoveCourt && courts && courts.length ? (
+          <div className="running-panel__court">
+            <CourtPicker
+              value={match.court}
+              courts={courts}
+              onChange={(cc) => onMoveCourt(compId, match.id, cc)}
+              btnClassName="running-panel__court-btn"
+              label="SHIAIJO "
+            />
+          </div>
+        ) : null}
       </div>
 
       {showEditor ? (
@@ -142,7 +141,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
           <ScoreEditorModal
             key={`${match.id}:${match.status}`}
             variant="inline"
-            match={match}
+            match={m}
             // Offer "close" only when there's a result card to fall back to
             // (editing a completed match); an un-played match has nowhere to go.
             canClose={isComplete}
@@ -159,10 +158,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
         )
       ) : (
         <div className="running-panel__result">
-          {IndividualScore && <IndividualScore match={match} variant="card" showNames />}
-          {match.winner?.name && (
-            <div className="running-panel__advances">✓ {match.winner.name} advances</div>
-          )}
+          {MatchDetailCard && <MatchDetailCard match={m} escapeToClose={false} />}
           <button type="button" className="btn btn--sm btn--full" onClick={async () => {
             const ok = await window.confirmDialog({
               title: "Edit recorded result?",
@@ -282,6 +278,7 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
             courts={t?.courts || []}
             matchNum={matchMeta(selectedMatch.id).matchNum}
             roundName={matchMeta(selectedMatch.id).roundName}
+            compName={c.name}
             onMoveCourt={onMoveCourt}
             onEditScore={onEditScore}
             password={password}

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -92,22 +92,20 @@ function loadScoreboardPoints(match) {
   };
 }
 
-const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundName, compName, onMoveCourt, onEditScore, password }) => {
+const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, onMoveCourt, onEditScore, password }) => {
   // Reuse the shared components wholesale — both off the window bridge at render
   // time so module load order never matters:
   //   ScoreEditorModal (variant="inline") — the ONE scoring editor the shiaijo /
   //     pools / scores screens use. We keep ITS header (it's the same in every
-  //     host), so the panel doesn't add a competing title.
+  //     host), so the panel doesn't add a competing title. `match` is enriched
+  //     upstream with the comp metadata the editor needs (compId, compKind,
+  //     teamSize, phase, round) — see AdminBracket.scoringMatch.
   //   MatchDetailCard — the SAME read-only result card the public viewer shows
   //     for a completed match (names + winner highlight + FINAL + score marks),
   //     instead of a stripped-down lookalike.
   const ScoreEditorModal = window.ScoreEditorModal;
   const MatchDetailCard = window.MatchDetailCard;
   const isComplete = match.status === "completed";
-  // Bracket match objects don't carry round/compName, so the shared headers
-  // would render sparse (a lone "·" with an empty round). Feed them the round
-  // we already computed + the competition name so their own headers read fully.
-  const m = { ...match, round: match.round || roundName, compName: match.compName || compName };
   // A completed match shows its read-only result by default; re-opening the
   // editor to change a recorded result is gated behind a confirmation so it's
   // not changed by accident. An un-played match goes straight to the editor
@@ -143,9 +141,13 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
       {showEditor ? (
         ScoreEditorModal && (
           <ScoreEditorModal
-            key={`${match.id}:${match.status}`}
+            // Include subResults.length: the editor reads team sub-bouts into
+            // refs on mount, so an SSE update that adds/removes a daihyosen
+            // sub-bout from another surface must remount to avoid a stale board
+            // (mirrors the shiaijo inline embed's key — admin_shiaijo.jsx).
+            key={`${match.id}:${match.status}:${(match.subResults || []).length}`}
             variant="inline"
-            match={m}
+            match={match}
             // Offer "close" only when there's a result card to fall back to
             // (editing a completed match); an un-played match has nowhere to go.
             canClose={isComplete}
@@ -162,7 +164,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
         )
       ) : (
         <div className="running-panel__result">
-          {MatchDetailCard && <MatchDetailCard match={m} escapeToClose={false} />}
+          {MatchDetailCard && <MatchDetailCard match={match} escapeToClose={false} />}
           <button type="button" className="btn btn--sm btn--full" onClick={async () => {
             const ok = await window.confirmDialog({
               title: "Edit recorded result?",
@@ -238,6 +240,28 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
   // onEditScore (the same path pools / scores / shiaijo use), so the bespoke
   // recordScore / overrideBracketWinner entry points are gone from this panel.
   const selectedMatch = findSelectedMatch();
+  // Compute the match's number/round ONCE (one scan of the display model).
+  const selectedMeta = selectedMatch ? matchMeta(selectedMatch.id) : { matchNum: null, roundName: null };
+  // Enrich the bracket match with the competition metadata the shared scorer
+  // (ScoreEditorModal / MatchDetailCard) reads off the match object — the raw
+  // bracket.rounds entries carry none of it. Mirrors enrichPoolMatchWithComp:
+  //   compId      → decision endpoints + maxEncho/naginata fetch
+  //   compKind /  → individual vs team editor routing
+  //   teamSize
+  //   phase       → "bracket" makes isKnockoutPhase true: blocks hikiwake (no
+  //                 draws in elimination — decide by hantei after encho)
+  //   compFormat, round, matchNumber → header/label fields
+  const scoringMatch = selectedMatch && {
+    ...selectedMatch,
+    compId: selectedMatch.compId || c.id || "",
+    compName: selectedMatch.compName || c.name || "",
+    compFormat: selectedMatch.compFormat || c.format || "",
+    compKind: selectedMatch.compKind || c.kind || "",
+    teamSize: selectedMatch.teamSize ?? c.teamSize ?? 0,
+    phase: selectedMatch.phase || "bracket",
+    round: selectedMatch.round || selectedMeta.roundName,
+    matchNumber: selectedMatch.matchNumber || selectedMeta.matchNum || 0,
+  };
   // mp-turx: per-match playability — a bracket match is running iff hasBothSides()
   // returns true (both sides are resolved real participants, not “Winner of rX-mY”
   // feeders or pool-origin placeholders like “Pool A-1st”). The old bracket-wide
@@ -278,12 +302,10 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
       <div className="bracket-layout__panel">
         {hasBothSides(selectedMatch) ? (
           <RunningMatchPanel
-            match={selectedMatch}
+            match={scoringMatch}
             compId={c.id}
             courts={t?.courts || []}
-            matchNum={matchMeta(selectedMatch.id).matchNum}
-            roundName={matchMeta(selectedMatch.id).roundName}
-            compName={c.name}
+            matchNum={selectedMeta.matchNum}
             onMoveCourt={onMoveCourt}
             onEditScore={onEditScore}
             password={password}

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -91,21 +91,14 @@ function loadScoreboardPoints(match) {
   };
 }
 
-const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMoveCourt, onRecord, onOverride }) => {
+const RunningMatchPanel = React.memo(({ match, compId, courts, onMoveCourt, onRecord, onOverride, onEditScore, password }) => {
   const [mode, setMode] = useStateA("tap");
-  const [aPoints, setAPoints] = useStateA([]);
-  const [bPoints, setBPoints] = useStateA([]);
-  useEffectA(() => {
-    // Load both sides' letters from the canonical match.ipponsA /
-    // match.ipponsB fields so the read shape matches what
-    // buildRunningIpponResult writes — see loadScoreboardPoints above.
-    const { aPoints: a, bPoints: b } = loadScoreboardPoints(match);
-    setAPoints(a);
-    setBPoints(b);
-    // Include status + both sides' ippons in deps so an SSE update for
-    // the same match (e.g. an off-panel correction) doesn't leave the
-    // scoreboard view showing stale points.
-  }, [match.id, match.status, match.ipponsA?.join(","), match.ipponsB?.join(",")]);
+  // The "Scoreboard" tab embeds the ONE shared scoring editor
+  // (ScoreEditorModal, variant="inline") — the same component the shiaijo
+  // operator view and the pools/scores editors use — rather than a bespoke
+  // scoreboard. Pulled off the window bridge (admin_scoring_modal.jsx) at
+  // render time so load order with this module never matters.
+  const ScoreEditorModal = window.ScoreEditorModal;
   const a = match.sideA, b = match.sideB;
   const isComplete = match.status === "completed";
   return (
@@ -164,69 +157,25 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
           </div>
         </div>
       )}
-      {mode === "scoreboard" && (
-        // Proposal C layout (DESIGN.md §4 Aka/Shiro): SHIRO (sideB) on the
-        // LEFT, AKA (sideA) on the RIGHT. Colour runs edge-to-edge; the two
-        // competitors meet at the centre. Side name appears once, in the
-        // centre identity chip — the button rails are unlabelled (their colour
-        // + position already say which side). Source order is rail→who→who→rail
-        // so the phone single-column stack reads top-to-bottom per side.
-        <div className="sc-board">
-          <div className="sc-board__rail sc-board__shiro">
-            <div className="sc-board__btnrow">
-              {(isNaginata ? ["M", "K", "D", "T", "S"] : ["M", "K", "D", "T"]).map((cc) => (<button type="button" key={cc} className="ipt-btn" onClick={() => setBPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}
-              <button type="button" className="ipt-btn" onClick={() => setBPoints([])}>↺</button>
-            </div>
-          </div>
-          <div className="sc-board__who sc-board__who--shiro sc-board__shiro">
-            <span className="sc-board__lbl">Shiro (White)</span>
-            <span className="sc-board__nm">{b.name}</span>
-            <span className="sc-board__tally">{[0, 1].map((i) => (<span key={i} className={`score-pt score-pt--shiro ${bPoints[i] ? "score-pt--filled" : "score-pt--empty"}`}>{bPoints[i] || "·"}</span>))}</span>
-          </div>
-          <div className="sc-board__who sc-board__who--aka sc-board__aka">
-            <span className="sc-board__lbl">Aka (Red)</span>
-            <span className="sc-board__nm">{a.name}</span>
-            <span className="sc-board__tally">{[0, 1].map((i) => (<span key={i} className={`score-pt score-pt--aka ${aPoints[i] ? "score-pt--filled" : "score-pt--empty"}`}>{aPoints[i] || "·"}</span>))}</span>
-          </div>
-          <div className="sc-board__rail sc-board__aka">
-            <div className="sc-board__btnrow">
-              {(isNaginata ? ["M", "K", "D", "T", "S"] : ["M", "K", "D", "T"]).map((cc) => (<button type="button" key={cc} className="ipt-btn ipt-btn--aka" onClick={() => setAPoints((p) => p.length < 2 ? [...p, cc] : p)}>{cc}</button>))}
-              <button type="button" className="ipt-btn" onClick={() => setAPoints([])}>↺</button>
-            </div>
-          </div>
-          <div className="sc-board__vs">vs</div>
-        </div>
+      {mode === "scoreboard" && ScoreEditorModal && (
+        // Reuse the shared inline scoring editor — full FIK scoreboard with
+        // ippons, draws (hikiwake), hantei, fouls, encho and kiken/fusenpai
+        // decisions — instead of a bespoke board. onSubmit is wired exactly as
+        // the pools/shiaijo embeddings: onEditScore(compId, matchId, patch, match).
+        <ScoreEditorModal
+          key={`${match.id}:${match.status}`}
+          variant="inline"
+          match={match}
+          onClose={() => {}}
+          canClose={false}
+          onSubmit={async (patch) => {
+            try { await onEditScore(compId, match.id, patch, match); }
+            catch (_e) { /* surfaced via toast in the parent */ }
+          }}
+          onSubmitAndNext={null}
+          password={password}
+        />
       )}
-      {mode === "scoreboard" && (() => {
-        // Submit is only valid when one side strictly leads. Tied counts
-        // (e.g. 1–1) would otherwise silently get attributed to SHIRO via
-        // `aWins ? "a" : "b"`. For draws, use the full editor's hikiwake toggle.
-        const aWins = aPoints.length > bPoints.length;
-        const bWins = bPoints.length > aPoints.length;
-        const hasWinner = aWins || bWins;
-        const isTied = !hasWinner && (aPoints.length > 0 || bPoints.length > 0);
-        // Submit the FULL points arrays — pre-fix, only aPoints[0]/bPoints[0]
-        // (a single letter) was passed and recordWinner hardcoded winnerPts=1,
-        // so a 2-ippon win was silently truncated to 1 ippon. recordWinner now
-        // builds winnerPts / ipponsA / ipponsB from the array lengths via
-        // buildRunningIpponResult.
-        const winnerArr = aWins ? aPoints : bPoints;
-        const loserArr = aWins ? bPoints : aPoints;
-        return (
-          <div className="running-panel__actions">
-            <button type="button"
-              className="btn btn--primary btn--full"
-              disabled={!hasWinner}
-              onClick={() => onRecord(aWins ? "a" : "b", "ippon", winnerArr, loserArr)}
-            >Submit result</button>
-            {isTied && (
-              <div className="field__hint" style={{ textAlign: "center", marginTop: 6 }}>
-                Tied — open the full score editor to record a draw (hikiwake).
-              </div>
-            )}
-          </div>
-        );
-      })()}
       {isComplete && (
         <div style={{ marginTop: 12, padding: 10, background: "#ecfdf5", border: "1px solid #a7f3d0", borderRadius: 8, fontSize: 12.5, color: "#065f46" }}>
           ✓ Recorded — {match.winner?.name} advances
@@ -248,7 +197,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, isNaginata, onMov
   );
 });
 RunningMatchPanel.displayName = "RunningMatchPanel";
-function AdminBracket({ c, t, bracket, onMoveCourt, tweaks, password, showToast }) {
+function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, password, showToast }) {
   const [selected, setSelected] = useStateA(null);
   const scrollRef = useRefA(null);
   const [autoScrollId, setAutoScrollId] = useStateA(null);
@@ -322,8 +271,12 @@ function AdminBracket({ c, t, bracket, onMoveCourt, tweaks, password, showToast 
   // bye-containing brackets legitimately have.
   const hasUnseededPools = bracket.rounds.some(r => (r || []).some(m => hasPoolOriginPlaceholder(m)));
   return (
-    <div className="row" style={{ gridTemplateColumns: "1fr 360px", alignItems: "start" }}>
-      <div>
+    // Flex-wrap rather than a fixed 2-col grid (see .bracket-layout in
+    // styles.css): the scoring panel keeps a minimum width so the reused inline
+    // editor never squashes/clips, and when the bracket + that min width can't
+    // sit side by side, the panel wraps to a full-width row BELOW the bracket.
+    <div className="bracket-layout">
+      <div className="bracket-layout__bracket">
         {hasUnseededPools && (
           <div className="banner banner--info" style={{ marginBottom: 12, padding: "10px 14px", background: "var(--accent-soft)", border: "1px solid var(--accent)", borderRadius: 6, fontSize: 13 }}>
             <strong>Knockout filling in</strong> — this bracket fills in automatically as each pool finishes. Matches start once both sides are decided.
@@ -343,16 +296,17 @@ function AdminBracket({ c, t, bracket, onMoveCourt, tweaks, password, showToast 
           </div>
         </div>
       </div>
-      <div>
+      <div className="bracket-layout__panel">
         {hasBothSides(selectedMatch) ? (
           <RunningMatchPanel
             match={selectedMatch}
             compId={c.id}
             courts={t?.courts || []}
-            isNaginata={!!c.naginata}
             onMoveCourt={onMoveCourt}
             onRecord={recordWinner}
             onOverride={overrideWinner}
+            onEditScore={onEditScore}
+            password={password}
           />
         ) : selectedMatch ? (
           <div className="empty"><h3>Match not ready</h3><div style={{ fontSize: 13 }}>Waiting for upstream winners.</div></div>

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -91,20 +91,33 @@ function loadScoreboardPoints(match) {
   };
 }
 
-const RunningMatchPanel = React.memo(({ match, compId, courts, onMoveCourt, onRecord, onOverride, onEditScore, password }) => {
-  const [mode, setMode] = useStateA("tap");
-  // The "Scoreboard" tab embeds the ONE shared scoring editor
-  // (ScoreEditorModal, variant="inline") — the same component the shiaijo
-  // operator view and the pools/scores editors use — rather than a bespoke
-  // scoreboard. Pulled off the window bridge (admin_scoring_modal.jsx) at
-  // render time so load order with this module never matters.
+const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundName, onMoveCourt, onEditScore, password }) => {
+  // Two shared components, both off the window bridge at render time so module
+  // load order never matters:
+  //   ScoreEditorModal (variant="inline") — the ONE scoring editor the shiaijo /
+  //     pools / scores screens use (ippons, draws, hantei, fouls, encho,
+  //     kiken/fusenpai). It IS the manual-override path, so there's no separate
+  //     "force winner" affordance.
+  //   IndividualScore — the SAME read-only result card the viewer / TV show.
   const ScoreEditorModal = window.ScoreEditorModal;
-  const a = match.sideA, b = match.sideB;
+  const IndividualScore = window.IndividualScore;
   const isComplete = match.status === "completed";
+  // A completed match shows its read-only result by default; re-opening the
+  // editor to change a recorded result is gated behind a confirmation so it's
+  // not changed by accident. An un-played match goes straight to the editor
+  // (nothing to overwrite). Reset when switching matches.
+  const [editing, setEditing] = useStateA(false);
+  useEffectA(() => { setEditing(false); }, [match.id]);
+  const showEditor = !isComplete || editing;
+
   return (
     <div className="running-panel">
       <div className="running-panel__head">
-        <div className="running-panel__title">Match · {match.id.slice(-6)}</div>
+        <div className="running-panel__title">
+          {matchNum != null
+            ? <>Match M{matchNum}{roundName ? <span className="running-panel__round"> · {roundName}</span> : null}</>
+            : <>{roundName || `Match · ${match.id.slice(-6)}`}</>}
+        </div>
         <div className="running-panel__court">
           {onMoveCourt && courts && courts.length ? (
             <>
@@ -122,82 +135,48 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, onMoveCourt, onRe
           )}
         </div>
       </div>
-      <div className="mode-tabs">
-        <button type="button" className={mode === "tap" ? "is-active" : ""} onClick={() => setMode("tap")}>Tap winner</button>
-        <button type="button" className={mode === "card" ? "is-active" : ""} onClick={() => setMode("card")}>Match card</button>
-        <button type="button" className={mode === "scoreboard" ? "is-active" : ""} onClick={() => setMode("scoreboard")}>Scoreboard</button>
-      </div>
-      {mode === "tap" && (<>
-        {/* Layout convention: SHIRO (White, sideB) on the LEFT, AKA (Red, sideA) on the RIGHT. */}
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 10 }}>
-          <button type="button" className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === b.id ? "var(--accent)" : "var(--line)", background: match.winner?.id === b.id ? "var(--accent)" : "var(--surface)", color: match.winner?.id === b.id ? "white" : "inherit" }} onClick={() => onRecord("b", "ippon")}>
-            <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em" }}>SHIRO (WHITE)</div>
-            <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{b.name}</div>
-            <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{b.dojo}</div>
-          </button>
-          <button type="button" className="card" style={{ padding: 16, textAlign: "center", cursor: "pointer", borderColor: match.winner?.id === a.id ? "var(--red)" : "var(--line)", background: match.winner?.id === a.id ? "var(--red)" : "var(--surface)", color: match.winner?.id === a.id ? "white" : "inherit" }} onClick={() => onRecord("a", "ippon")}>
-            {/* Label tinted red when unselected (button is on white), inherits white when selected (button background is red) */}
-            <div style={{ fontSize: 10, fontWeight: 700, opacity: 0.7, letterSpacing: "0.1em", color: match.winner?.id === a.id ? "inherit" : "var(--red)" }}>AKA (RED)</div>
-            <div style={{ fontWeight: 600, fontSize: 15, marginTop: 6 }}>{a.name}</div>
-            <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>{a.dojo}</div>
-          </button>
-        </div>
-        <div className="field__hint" style={{ textAlign: "center" }}>Tap the winner. Use Match card or Scoreboard for detail.</div>
-      </>)}
-      {mode === "card" && (
-        <div className="score-card">
-          <div className="score-side score-side--white">
-            <div><div className="score-side__lbl">Shiro (White)</div><div className="score-side__name">{b.name}</div><div className="score-side__dojo">{b.dojo}</div></div>
-            <div className="score-side__buttons"><button type="button" className="btn btn--sm btn--primary" onClick={() => onRecord("b", "ippon", ["M"])}>Win (Ippon)</button></div>
-          </div>
-          <div className="score-vs">VS</div>
-          <div className="score-side score-side--red">
-            <div><div className="score-side__lbl">Aka (Red)</div><div className="score-side__name">{a.name}</div><div className="score-side__dojo">{a.dojo}</div></div>
-            <div className="score-side__buttons"><button type="button" className="btn btn--sm btn--danger" onClick={() => onRecord("a", "ippon", ["M"])}>Win (Ippon)</button></div>
-          </div>
-        </div>
-      )}
-      {mode === "scoreboard" && ScoreEditorModal && (
-        // Reuse the shared inline scoring editor — full FIK scoreboard with
-        // ippons, draws (hikiwake), hantei, fouls, encho and kiken/fusenpai
-        // decisions — instead of a bespoke board. onSubmit is wired exactly as
-        // the pools/shiaijo embeddings: onEditScore(compId, matchId, patch, match).
-        <ScoreEditorModal
-          key={`${match.id}:${match.status}`}
-          variant="inline"
-          match={match}
-          onClose={() => {}}
-          canClose={false}
-          onSubmit={async (patch) => {
-            try { await onEditScore(compId, match.id, patch, match); }
-            catch (_e) { /* surfaced via toast in the parent */ }
-          }}
-          onSubmitAndNext={null}
-          password={password}
-        />
-      )}
-      {isComplete && (
-        <div style={{ marginTop: 12, padding: 10, background: "#ecfdf5", border: "1px solid #a7f3d0", borderRadius: 8, fontSize: 12.5, color: "#065f46" }}>
-          ✓ Recorded — {match.winner?.name} advances
+
+      {showEditor ? (
+        ScoreEditorModal && (
+          <ScoreEditorModal
+            key={`${match.id}:${match.status}`}
+            variant="inline"
+            match={match}
+            // Offer "close" only when there's a result card to fall back to
+            // (editing a completed match); an un-played match has nowhere to go.
+            canClose={isComplete}
+            onClose={() => setEditing(false)}
+            onSubmit={async (patch) => {
+              try {
+                await onEditScore(compId, match.id, patch, match);
+                setEditing(false); // recorded → fall back to the result card
+              } catch (_e) { /* surfaced via toast in the parent */ }
+            }}
+            onSubmitAndNext={null}
+            password={password}
+          />
+        )
+      ) : (
+        <div className="running-panel__result">
+          {IndividualScore && <IndividualScore match={match} variant="card" showNames />}
+          {match.winner?.name && (
+            <div className="running-panel__advances">✓ {match.winner.name} advances</div>
+          )}
+          <button type="button" className="btn btn--sm btn--full" onClick={async () => {
+            const ok = await window.confirmDialog({
+              title: "Edit recorded result?",
+              message: `${matchNum != null ? `Match M${matchNum}` : "This match"} already has a result. Re-open scoring to change it?`,
+              confirmLabel: "Edit result",
+            });
+            if (ok) setEditing(true);
+          }}>Edit result</button>
         </div>
       )}
-      <div style={{ marginTop: 14, paddingTop: 14, borderTop: "1px dashed var(--line)" }}>
-        <button type="button" className="btn btn--sm btn--full" onClick={async () => {
-          // promptDialog returns null on empty/cancel and a string otherwise.
-          // A whitespace-only value would be truthy under `if (name)` and would
-          // persist a whitespace key as `m.Winner` on the backend (and then
-          // mismatch the canonical SideA / SideB names downstream). Trim
-          // defensively and only override when there's a real value to record.
-          const raw = await window.promptDialog({ title: "Override winner", message: "Enter the name of the winner to override:", defaultValue: match.winner?.name || match.sideA?.name });
-          const name = raw?.trim();
-          if (name) onOverride(name);
-        }}>Force winner (manual override)</button>
-      </div>
     </div>
   );
 });
 RunningMatchPanel.displayName = "RunningMatchPanel";
-function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, password, showToast }) {
+function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, password }) {
   const [selected, setSelected] = useStateA(null);
   const scrollRef = useRefA(null);
   const [autoScrollId, setAutoScrollId] = useStateA(null);
@@ -210,6 +189,28 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
   useEffectA(() => {
     if (runningMatchId) setAutoScrollId(runningMatchId + "::" + Date.now());
   }, [runningMatchId]);
+
+  // Label a selected match with the SAME number ("M1") and round the bracket
+  // tree shows — derived from the shared buildDisplayModel so the panel and the
+  // cards/columns can never disagree. Recomputed from bracket.rounds (not stored
+  // at click time) so it survives SSE topology refreshes. Hook stays above the
+  // early return below so the hook order is stable.
+  const displayModel = React.useMemo(
+    () => (bracket?.rounds && window.buildDisplayModel ? window.buildDisplayModel(bracket.rounds) : { hasMeta: false, matchNumById: null }),
+    [bracket]
+  );
+  const matchMeta = (matchId) => {
+    if (!matchId || !bracket?.rounds) return { matchNum: null, roundName: null };
+    const cols = displayModel.hasMeta ? displayModel.columns : bracket.rounds;
+    let ci = -1;
+    for (let i = 0; i < cols.length; i++) {
+      if ((cols[i] || []).some((m) => m && m.id === matchId)) { ci = i; break; }
+    }
+    return {
+      matchNum: displayModel.matchNumById ? displayModel.matchNumById[matchId] : null,
+      roundName: (ci >= 0 && window.roundLabel) ? window.roundLabel(ci, cols.length) : null,
+    };
+  };
 
   if (!bracket || !bracket.rounds) {
     const previewMode = c && c.status === "draw-ready";
@@ -231,33 +232,9 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
     }
     return null;
   };
-  // winnerIppons/loserIppons are arrays of letter codes. Tap mode (no
-  // detail) and card mode (single explicit letter) pass a single-element
-  // array; scoreboard mode passes the full points it accumulated for
-  // each side. See buildRunningIpponResult above for the schema rationale.
-  const recordWinner = (winnerSide, _mode = "ippon", winnerIppons = ["M"], loserIppons = []) => {
-    const m = findSelectedMatch();
-    if (!m) return;
-    const winner = winnerSide === "a" ? m.sideA : m.sideB;
-    if (!winner) return;
-
-    const result = buildRunningIpponResult(winnerSide, m.sideA, m.sideB, winnerIppons, loserIppons);
-
-    // Don't call onUpdate(c) on success — AdminApp's onUpdate is the
-    // competition-config PUT, which would overwrite server state with
-    // the (now-stale) c prop. SSE + patchCompetitionData in AdminApp
-    // already refreshes the bracket after a recordScore.
-    window.API.recordScore(c.id, m.id, result, password, m)
-      .catch(err => showToast(err.message, "error"));
-  };
-
-  const overrideWinner = (winnerName) => {
-    if (!selected) return;
-    // Same reason as recordWinner: rely on SSE to refresh, don't
-    // route the success path through the config-PUT callback.
-    window.API.overrideBracketWinner(c.id, selected.matchId, winnerName, password)
-      .catch(err => showToast(err.message, "error"));
-  };
+  // All bracket scoring now flows through the shared inline ScoreEditorModal →
+  // onEditScore (the same path pools / scores / shiaijo use), so the bespoke
+  // recordScore / overrideBracketWinner entry points are gone from this panel.
   const selectedMatch = findSelectedMatch();
   // mp-turx: per-match playability — a bracket match is running iff hasBothSides()
   // returns true (both sides are resolved real participants, not “Winner of rX-mY”
@@ -302,9 +279,9 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
             match={selectedMatch}
             compId={c.id}
             courts={t?.courts || []}
+            matchNum={matchMeta(selectedMatch.id).matchNum}
+            roundName={matchMeta(selectedMatch.id).roundName}
             onMoveCourt={onMoveCourt}
-            onRecord={recordWinner}
-            onOverride={overrideWinner}
             onEditScore={onEditScore}
             password={password}
           />

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -118,6 +118,10 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
 
   return (
     <div className="running-panel">
+      {/* The card fills the row to align with the bracket card above; this inner
+          column caps the content to a comfortable width and centres it so the
+          reused editor / result card aren't stretched edge-to-edge. */}
+      <div className="running-panel__inner">
       {/* Slim header: only the bits the reused components' own headers DON'T
           carry — the bracket match number and the move-court control. Comp /
           shiaijo / round / time / status come from the embedded component. */}
@@ -169,6 +173,7 @@ const RunningMatchPanel = React.memo(({ match, compId, courts, matchNum, roundNa
           }}>Edit result</button>
         </div>
       )}
+      </div>
     </div>
   );
 });

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -784,6 +784,9 @@ function matchStateCell(m, ipponsB, ipponsA) {
 window.BracketTree = BracketTree;
 window.MatchCard = MatchCard;
 window.roundLabel = roundLabel;
+// Exposed so the bracket winner-picker panel can label a selected match with
+// the SAME number ("M1") and round the tree shows on its cards/columns.
+window.buildDisplayModel = buildDisplayModel;
 window.formatIpponsScore = formatIpponsScore;
 window.teamIVScore = teamIVScore;
 window.matchScoreStr = matchScoreStr;

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -64,4 +64,7 @@ if (typeof window !== 'undefined') {
     window.TermV = TermV;
     window.VSchedItem = VSchedItem;
     window.WATCHLIST_MAX = WATCHLIST_MAX;
+    // The admin bracket panel reuses the SAME read-only result card the viewer
+    // shows for a completed match, instead of a stripped-down lookalike.
+    window.MatchDetailCard = MatchDetailCard;
 }


### PR DESCRIPTION
## Summary

The bracket page's match panel (winner-picker) is rebuilt around the **shared scoring + result components** instead of bespoke per-panel UI.

- **Fixes mp-pt1v**: the old "Scoreboard" tab rendered a bespoke `sc-board` whose only responsive breakpoint was viewport-based, so on desktop its wide grid crammed into the fixed side panel with each **score stacked _below_ the name**. Replaced with the shared inline `ScoreEditorModal` — the same editor the shiaijo / pools / scores screens use.
- **State-driven panel** (replaces the `Tap winner` / `Match card` / `Scoreboard` tabs and the `Force winner` button — redundant once the full editor is embedded):
  - **un-played match** → the inline scoring editor directly;
  - **completed match** → the viewer's own **`MatchDetailCard`** (comp · shiaijo · round · time header, `FINAL` badge, Shiro/Aka names with winner highlight, score marks), with **re-opening the editor gated behind a confirmation**.
- **No duplicate components**: the result view reuses the viewer's `MatchDetailCard` (not a stripped-down lookalike), and the editor keeps **its own header** (the same one it shows in shiaijo/pools/scores). Bracket matches lack `round`/`compName`, so the panel feeds those to the shared headers; the panel's own header shrinks to just the match number + move-court picker.
- **Layout**: the panel card fills the row to **line up edge-to-edge with the bracket card**, while the content is centred in a comfortable column so the scoreboard isn't stretched. The panel title (`Match M1`) matches the bracket's own vocabulary; the round is shown in the embedded component's header (editor eyebrow / `MatchDetailCard`), not duplicated in the title.

No scoring/result component was modified — `ScoreEditorModal` and `MatchDetailCard` are reused as-is (the latter newly exposed on `window`).

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_competition_bracket.jsx` | RunningMatchPanel rebuilt: embed `ScoreEditorModal` (un-played/editing) and `MatchDetailCard` (completed); confirm-gated edit; feed round/compName to the shared headers; slim panel header; responsive `.bracket-layout` + centred content column. |
| `web-mobile/js/viewer.jsx` | Expose `window.MatchDetailCard` so the admin panel reuses the viewer's result card. |
| `web-mobile/js/admin_competition.jsx` | Thread the existing `onEditScore` prop into AdminBracket. |
| `web-mobile/js/bracket.jsx` | Expose `window.buildDisplayModel` for the match number/round label. |
| `web-mobile/css/styles.css` | `.bracket-layout` + centred `.running-panel__inner`; removed the dead `.sc-board*`, `.score-pt*`, `.mode-tabs`, `.score-card`, `.score-side*`, `.score-vs`, `.running-panel__round/advances` rules. |

## Screenshots

**Un-played match → the shared inline scoring editor (centred), header reads fully**
![Un-played editor](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/313/pr_unplayed_editor.png)

**Completed match → the viewer's `MatchDetailCard` (FINAL + winner highlight), confirm-gated "Edit result"**
![Completed result card](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/313/pr_completed_card.png)

**"Edit result" → confirmation before re-opening the editor on a recorded result**
![Edit confirmation](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/313/pr_edit_confirm.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — green, all packages ≥85% coverage
- [x] New/updated unit tests cover the change — scoring/result logic is delegated to the already-tested shared `ScoreEditorModal` / `MatchDetailCard`; kept pure-helper tests + the AdminBracket suite stay green (1803 vitest cases)
- [x] Manual browser verification — `/admin/competition/:id/bracket`: un-played → editor (header "Demo Bracket · Semifinals", no orphan dot); scored a match (engine PUT 200, one-bout-per-court 409 enforced) → `MatchDetailCard` with FINAL + winner highlight; "Edit result" → confirm → editor reopens; cards align edge-to-edge, content centred, 0px horizontal overflow at 1280px
- [x] Screenshots added above
- [x] No new console errors or warnings

Closes mp-pt1v

