### PR TITLE
feat(mp-ulnb): shiaijo court console — competition selector, filtered queue, match numbers, switch nudge

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -41,6 +41,12 @@ When extending the design system, **mobile-app is the canonical surface**. The b
 1. **Clarity over decoration.** Operators run tournaments under time pressure; a glanceable card beats a beautiful one. No gratuitous animation, no decorative shadows.
 2. **Kendo first.** Red (Aka) and White (Shiro) are positional, never swapped. Web bracket cards put Aka first/top; the horizontal scoreboard and list rows put Shiro left / Aka right; Excel puts White in the left column. The two sides must be **distinguishable at a glance on every surface** — and the distinction is carried by *treatment*, not hue alone (so it survives glare, projectors, and color-blindness): Aka = solid/red-tinted fill, Shiro = framed white (cool border + diagonal hatch) so "white" never dissolves into the page. **Color area must scale with the surface.** A full-screen scoreboard can flood half the screen; a dense schedule row cannot rely on a 5px spine — give each side a tinted cell, a colored header, or a filled badge so the signal stays legible as the component shrinks. See [§4 Match cards](#match-cards--bc-match), [§4 Aka/Shiro side treatment](#akashiro-side-treatment), and [CLAUDE.md](CLAUDE.md) "Match Colors" for the full rule.
 3. **Running state is loud — but not red.** Anything currently happening on a court gets the **`--accent` (navy) treatment**: navy border, soft-navy ring, and a pulsing dot whose *motion* is the primary signal. Anything else stays neutral. Don't dilute it. **Red is reserved for Aka (side) and danger only** — running state must never use red, so the two never collide on the same card (a running match still shows its Aka side in red while the running ring stays navy).
+
+   **Pulse has exactly two sanctioned meanings, kept apart by hue — never by motion.** The *motion* always says "this needs your eyes"; the *color* says which kind:
+   - **Navy pulse (`--accent`)** = *happening now* — a live/running match on a court (the `.dot--running` dot, running ring/strip).
+   - **Amber pulse (`--warn`)** = *your expected next action* — a state where the operator should act but nothing is live yet, e.g. the court console nudging the operator to switch to the competition that now needs this court (active competition done/not-started while another has matches assignable here).
+
+   These two are mutually exclusive by hue so they can coexist on screen without ambiguity (navy = "watch this", amber = "do this next"). Do **not** add a third pulse meaning, and do **not** use red for either (red stays Aka/danger). A next-action pulse must clear itself the moment the action is no longer expected.
 4. **Touch-friendly dense surfaces.** Operators score on tablets; players check brackets on phones. The existing pattern bumps tap targets under `@media (pointer: coarse)` — see `.btn--icon-sm` at 44px in [styles.css#L2356](web-mobile/css/styles.css#L2356). Aim for ≥ 36px in shared surfaces, ≥ 44px under coarse pointers.
 5. **Status drives color, color doesn't drive meaning.** The pipeline `setup → pools → playoffs → completed` has its own palette; reuse the existing `.badge--*` rather than inventing local hues.
 6. **Domain coupling is allowed.** Class names like `.bc-tree`, `.pool__table`, `.podium-step` exist because they map 1:1 to bracket concepts. Don't generalize a `.match-card` into a `.list-row` — readability wins.
@@ -60,7 +66,7 @@ All tokens are defined in [styles.css#L3-L33](web-mobile/css/styles.css#L3). Ref
 | `--red-soft` | `#fde7e8` | Aka (Red) side tint (score editor, bracket, pool/schedule rows) |
 | `--danger` | `var(--red)` | **Semantic alias of `--red`** for error/destructive intent (error text/borders, the hansoku ▲, invalid-input outlines). Prefer `--danger` over `--red` when the meaning is "error", not "Aka side" — it reads at the call site and keeps the value single-sourced. Never use for running state. |
 | `--danger-soft` | `var(--red-soft)` | Soft danger tint — faint error backgrounds. Alias of `--red-soft`. |
-| `--warn` | `#b45309` | Warning text/icon (amber-700, >=4.5:1 on `--warn-soft`). Caution/attention, **never error** (use `--danger`) and **never running** (use `--accent`). Per Principle 3 amber is non-overlapping with red and navy. |
+| `--warn` | `#b45309` | Warning text/icon (amber-700, >=4.5:1 on `--warn-soft`). Caution/attention, **never error** (use `--danger`) and **never running** (use `--accent`). Per Principle 3 amber is non-overlapping with red and navy — and is the **one sanctioned colour for an "expected next action" pulse** (e.g. the court-console competition-switch nudge), distinct from the navy running pulse. |
 | `--warn-strong` | `#f59e0b` | Saturated amber-500 accent border for status pills (offline sync pill) |
 | `--warn-soft` | `#fffbeb` | Warning fill (amber-50) — `.alert--warn`, `.tag-badge--warn`, offline pill background |
 | `--warn-border` | `#fde68a` | Warning hairline border (amber-200) |
@@ -168,7 +174,7 @@ Durations remain literals (de facto tokens, fold new work toward these):
 | `300ms` | Progress bars, toast slide-in |
 
 Keyframes (find each `@keyframes` block in [styles.css](web-mobile/css/styles.css)):
-- `pulse` (1.6s infinite) — `.dot--running` only
+- `pulse` (1.6s infinite) — running state (`.dot--running`, navy `--accent`). The same motion is reused, tinted amber (`--warn`), for an **expected-next-action** nudge (see Principle 3); gate any next-action pulse behind `prefers-reduced-motion` and clear it when the action is no longer expected
 - `spin` (0.6s linear infinite) — loading spinners
 - `toast-in` (300ms) — toast entrance
 - `decision-prompt-in` (160ms, `var(--ease-out)`) — match-decision modal entrance

--- a/internal/engine/bracket.go
+++ b/internal/engine/bracket.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
@@ -246,7 +248,89 @@ func (e *Engine) buildBracketFromLeaves(comp *state.Competition, leaves []string
 	// recomputed after results resolve those placeholders into player names.
 	computeBracketDisplayMetadata(bracket)
 
+	// Assign sequential match numbers matching the Excel Tree sheet (AC8).
+	// Must run AFTER computeBracketDisplayMetadata sets Hidden so the skipping
+	// logic is identical to helper.AssignMatchNumbers (nil-node skip in Excel
+	// = Hidden or both-sides-empty in the web bracket).
+	assignBracketMatchNumbers(bracket)
+
 	return bracket, nil
+}
+
+// assignBracketMatchNumbers sets MatchNumber on every real (non-Hidden,
+// non-empty) bracket match. This is the web API's numbering implementation; the
+// Excel renderer has a SEPARATE one, helper.AssignMatchNumbers, which operates on
+// []*Node instead of *state.Bracket. The two are NOT a literally-shared function
+// (the types differ) — they are kept equal-by-contract so the on-screen "Match N"
+// always equals the printed Excel "Match N".
+//
+// Ordering — CRITICAL for byes: the Excel sheet numbers via eliminationMatchRounds,
+// which groups matches by DEPTH-FROM-ROOT (the unbalanced tree's deepest matches
+// come first), NOT by raw bracket.Rounds index. With a non-power-of-two roster the
+// pow2-padded bracket.Rounds order diverges from that depth grouping, so numbering
+// in raw Rounds order drifts (e.g. 5 entrants: the lone deep first-round bout must
+// be Match 1, not the shallow slot-0 bout). DisplayRound already encodes the Excel
+// depth grouping (verified by TestBracketDisplayMetadata_MatchesExcelRounds), so we
+// number by descending DisplayRound (deepest/earliest round first) then by the
+// 0-based position parsed from the match ID — identical to both the Excel
+// AssignMatchNumbers walk and the JS buildDisplayModel matchNumById ordering.
+//
+// Skip rule (matches the Excel nil-node skip): Hidden (structural-bye) matches and
+// both-sides-empty dead matches are excluded and do not consume a number.
+//
+// The printed Excel sheet is authoritative. The contract is enforced by
+// TestMatchNumberingParity_ExcelVsWeb (match_numbering_parity_test.go), which builds
+// both numberings from identical entrant sets — including bye-producing, non-power-
+// of-two sizes — and asserts the real-match numbers are identical bout-for-bout.
+// If they ever diverge, fix THIS path to match the Excel one.
+//
+// Must run AFTER computeBracketDisplayMetadata, which sets Hidden / DisplayRound.
+func assignBracketMatchNumbers(b *state.Bracket) {
+	type ref struct {
+		m   *state.BracketMatch
+		pos int
+	}
+	var real []ref
+	for ri := range b.Rounds {
+		for mi := range b.Rounds[ri] {
+			m := &b.Rounds[ri][mi]
+			if m.Hidden {
+				continue
+			}
+			if m.SideA == "" && m.SideB == "" {
+				continue
+			}
+			real = append(real, ref{m: m, pos: bracketMatchPosFromID(m.ID)})
+		}
+	}
+	// Descending DisplayRound (deepest/earliest round first), then ascending
+	// position — mirrors the Excel eliminationMatchRounds walk.
+	sort.SliceStable(real, func(i, j int) bool {
+		if real[i].m.DisplayRound != real[j].m.DisplayRound {
+			return real[i].m.DisplayRound > real[j].m.DisplayRound
+		}
+		return real[i].pos < real[j].pos
+	})
+	for i, r := range real {
+		r.m.MatchNumber = i + 1
+	}
+}
+
+// bracketMatchPosFromID extracts the 0-based within-round position from a bracket
+// match ID of the form "m-r{ROUND}-{POS}" (e.g. "m-r2-1" → 1). It is the same
+// position the JS buildDisplayModel reads from the id suffix when ordering match
+// numbers, keeping the Go and JS numbering tie-breaks identical. Returns 0 for any
+// unparseable ID (defensive; real IDs always carry a trailing integer).
+func bracketMatchPosFromID(id string) int {
+	idx := strings.LastIndex(id, "-")
+	if idx < 0 || idx == len(id)-1 {
+		return 0
+	}
+	pos, err := strconv.Atoi(id[idx+1:])
+	if err != nil {
+		return 0
+	}
+	return pos
 }
 
 // computeBracketDisplayMetadata fills DisplayRound / Hidden / Feeders on every

--- a/internal/engine/match_numbering_parity_test.go
+++ b/internal/engine/match_numbering_parity_test.go
@@ -1,0 +1,201 @@
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// matchSignature canonically identifies a bracket bout by the SORTED set of real
+// leaf (entrant) names that feed into it. The same bout has the same leaf set in
+// BOTH numbering paths even though the two paths walk different tree structures
+// (the Excel path uses the unbalanced CreateBalancedTree(names); the engine path
+// uses a power-of-two-padded tree). Comparing leaf sets — not positions — lets the
+// test assert "this physical bout got the same Match N in both paths", which is the
+// AC1 user-facing invariant (on-screen Match N == printed Excel Match N).
+func matchSignature(leaves []string) string {
+	cp := append([]string(nil), leaves...)
+	sort.Strings(cp)
+	return strings.Join(cp, "|")
+}
+
+// excelLeafNames returns every real leaf name beneath an unbalanced Excel tree
+// node (the matchup that node represents on the printed Tree sheet).
+func excelLeafNames(n *helper.Node) []string {
+	if n == nil {
+		return nil
+	}
+	if n.LeafNode {
+		if n.LeafVal == "" {
+			return nil
+		}
+		return []string{n.LeafVal}
+	}
+	return append(excelLeafNames(n.Left), excelLeafNames(n.Right)...)
+}
+
+// excelNumberBySignature reproduces the AUTHORITATIVE printed-sheet numbering:
+// build the unbalanced tree the Excel create-playoffs path builds, collect the
+// elimination rounds in the exact eliminationMatchRounds order, run the shared
+// helper.AssignMatchNumbers, then map each numbered node to its leaf-set signature.
+func excelNumberBySignature(players []domain.Player) map[string]int {
+	seeded := helper.StandardSeeding(players)
+	names := make([]string, len(seeded))
+	for i, p := range seeded {
+		names[i] = p.Name
+	}
+	tree := helper.CreateBalancedTree(names)
+	depth := helper.CalculateDepth(tree)
+
+	// Same construction as cmd/create-playoffs.go:
+	// eliminationMatchRounds[depth-i] = TraverseRounds(tree, 1, i-1).
+	rounds := make([][]*helper.Node, depth-1)
+	for i := depth; i > 1; i-- {
+		rounds[depth-i] = helper.TraverseRounds(tree, 1, i-1)
+	}
+
+	helper.AssignMatchNumbers(rounds)
+
+	out := map[string]int{}
+	for _, round := range rounds {
+		for _, node := range round {
+			if node == nil {
+				continue
+			}
+			num := node.MatchNum()
+			if num == 0 {
+				continue
+			}
+			out[matchSignature(excelLeafNames(node))] = int(num)
+		}
+	}
+	return out
+}
+
+// engineNumberBySignature returns the engine bracket's MatchNumber for each real
+// match, keyed by the same leaf-set signature. Leaf sets are computed bottom-up
+// over the validated Feeders graph: a real match's leaves are its resolved
+// (non-"Winner of") sides plus the leaves of each real feeder match.
+func engineNumberBySignature(t *testing.T, players []domain.Player) map[string]int {
+	t.Helper()
+	bracket := enginePlayoffsBracket(t, players)
+
+	byID := map[string]*state.BracketMatch{}
+	for r := range bracket.Rounds {
+		for i := range bracket.Rounds[r] {
+			m := &bracket.Rounds[r][i]
+			byID[m.ID] = m
+		}
+	}
+
+	// Memoized leaf-set resolver over the real feeder graph.
+	leafCache := map[string][]string{}
+	var leavesOf func(m *state.BracketMatch) []string
+	leavesOf = func(m *state.BracketMatch) []string {
+		if cached, ok := leafCache[m.ID]; ok {
+			return cached
+		}
+		var acc []string
+		// Direct resolved entrants (a side that is not a "Winner of" placeholder
+		// and not empty is a real leaf feeding this match directly).
+		for _, side := range []string{m.SideA, m.SideB} {
+			if side != "" && !strings.HasPrefix(side, "Winner of") {
+				acc = append(acc, side)
+			}
+		}
+		// Real feeders contribute their own leaf sets.
+		for _, fid := range m.Feeders {
+			if fid == "" {
+				continue
+			}
+			if f, ok := byID[fid]; ok {
+				acc = append(acc, leavesOf(f)...)
+			}
+		}
+		leafCache[m.ID] = acc
+		return acc
+	}
+
+	out := map[string]int{}
+	for r := range bracket.Rounds {
+		for i := range bracket.Rounds[r] {
+			m := &bracket.Rounds[r][i]
+			if m.Hidden {
+				continue
+			}
+			require.NotZerof(t, m.MatchNumber,
+				"real match %s must have a non-zero MatchNumber", m.ID)
+			out[matchSignature(leavesOf(m))] = m.MatchNumber
+		}
+	}
+	return out
+}
+
+// TestMatchNumberingParity_ExcelVsWeb is the equal-by-contract proof for AC1/AC8:
+// the web bracket's MatchNumber equals the printed Excel Tree sheet's "Match N"
+// for every real bout, INCLUDING bye-producing non-power-of-two sizes where the
+// Excel tree inserts shorter branches and the web bracket marks matches Hidden —
+// the very case where the two numbering schemes could drift.
+//
+// Both paths are exercised end-to-end (the engine path runs StartCompetition;
+// the Excel path runs the real CreateBalancedTree/TraverseRounds/AssignMatchNumbers
+// pipeline), then every bout is matched by its leaf-descendant set and the assigned
+// numbers are compared. If a future change drifts the web path, this test fails and
+// the web path must be corrected to match the authoritative Excel numbering.
+func TestMatchNumberingParity_ExcelVsWeb(t *testing.T) {
+	// Sizes chosen to span every bye topology: 3/5/6/7 give shallow byes,
+	// 11/13 give multi-level bye chains, 4/8/16 are clean powers of two
+	// (no byes — the easy baseline).
+	sizes := []int{3, 4, 5, 6, 7, 8, 11, 13, 16}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("%d entrants", n), func(t *testing.T) {
+			players := makePlayers(n)
+
+			excel := excelNumberBySignature(players)
+			web := engineNumberBySignature(t, players)
+
+			// N-1 real matches in single elimination.
+			assert.Equalf(t, n-1, len(excel),
+				"excel must have N-1 numbered matches (n=%d)", n)
+			assert.Equalf(t, n-1, len(web),
+				"web must have N-1 numbered matches (n=%d)", n)
+
+			// Numbers must be the contiguous range 1..N-1 in each path.
+			assertContiguous(t, excel, n-1, "excel")
+			assertContiguous(t, web, n-1, "web")
+
+			// Position-for-position: the same bout (leaf set) gets the same number.
+			require.Equal(t, len(excel), len(web),
+				"both paths must produce the same number of bouts")
+			for sig, excelNum := range excel {
+				webNum, ok := web[sig]
+				require.Truef(t, ok,
+					"bout %q numbered %d in Excel is missing from the web bracket",
+					sig, excelNum)
+				assert.Equalf(t, excelNum, webNum,
+					"bout %q: Excel Match %d but web Match %d — numbering drifted",
+					sig, excelNum, webNum)
+			}
+		})
+	}
+}
+
+// assertContiguous verifies the numbers in m form the set {1..count}.
+func assertContiguous(t *testing.T, m map[string]int, count int, label string) {
+	t.Helper()
+	seen := make([]bool, count+1)
+	for _, v := range m {
+		require.GreaterOrEqualf(t, v, 1, "%s: match number must be >= 1", label)
+		require.LessOrEqualf(t, v, count, "%s: match number must be <= %d", label, count)
+		require.Falsef(t, seen[v], "%s: duplicate match number %d", label, v)
+		seen[v] = true
+	}
+}

--- a/internal/helper/excel_tree.go
+++ b/internal/helper/excel_tree.go
@@ -137,18 +137,45 @@ func AddPoolsToTree(f *excelize.File, sheetName string, pools []Pool, poolCoords
 
 }
 
-func FillInMatches(f *excelize.File, eliminationMatchRounds [][]*Node) {
-	var matchNum = 1
+// AssignMatchNumbers assigns sequential match numbers to all non-nil nodes in
+// eliminationMatchRounds, in the same iteration order as the Excel FillInMatches
+// output (earliest/widest round first, within-round left-to-right). Each non-nil
+// node's matchNum field is set in-place.
+//
+// This is the authoritative numbering for the printed Excel Tree sheet. The web
+// API has a SEPARATE implementation, engine.assignBracketMatchNumbers, which
+// operates on *state.Bracket (a different type) instead of []*Node — the two are
+// NOT a literally-shared function. They are kept equal-by-contract: skip the same
+// positions (a nil node here == a Hidden-or-both-sides-empty match there) and
+// iterate the same round order, so the Nth real match gets the same number on both
+// paths. That contract is verified by TestMatchNumberingParity_ExcelVsWeb in
+// internal/engine, which builds both numberings from identical entrant sets
+// (including bye-producing, non-power-of-two sizes) and asserts the sequences match
+// position-for-position. The printed Excel sheet is authoritative; if they ever
+// diverge, the web path must be corrected to match this one.
+func AssignMatchNumbers(eliminationMatchRounds [][]*Node) {
+	var matchNum int64 = 1
 	for _, round := range eliminationMatchRounds {
 		for _, match := range round {
 			if match == nil {
 				continue
 			}
-			match.matchNum = int64(matchNum)
-			if match.SheetName != "" {
-				handleExcelError("SetCellInt", f.SetCellInt(match.SheetName, match.LeafVal, int64(matchNum)))
-			}
+			match.matchNum = matchNum
 			matchNum++
+		}
+	}
+}
+
+func FillInMatches(f *excelize.File, eliminationMatchRounds [][]*Node) {
+	AssignMatchNumbers(eliminationMatchRounds)
+	for _, round := range eliminationMatchRounds {
+		for _, match := range round {
+			if match == nil {
+				continue
+			}
+			if match.SheetName != "" {
+				handleExcelError("SetCellInt", f.SetCellInt(match.SheetName, match.LeafVal, match.matchNum))
+			}
 		}
 	}
 }

--- a/internal/helper/excel_tree_test.go
+++ b/internal/helper/excel_tree_test.go
@@ -107,3 +107,54 @@ func TestSetTreeSheetTitle(t *testing.T) {
 		})
 	}
 }
+
+// TestAssignMatchNumbers verifies that AssignMatchNumbers assigns sequential
+// numbers starting at 1, skips nil nodes, and does not re-number on subsequent
+// calls (i.e. each call is idempotent with a fresh counter — it overwrites).
+func TestAssignMatchNumbers(t *testing.T) {
+	t.Run("sequential numbering skips nil", func(t *testing.T) {
+		n1 := &Node{LeafNode: false}
+		n2 := &Node{LeafNode: false}
+		n3 := &Node{LeafNode: false}
+		n4 := &Node{LeafNode: false}
+
+		rounds := [][]*Node{
+			{n1, nil, n2}, // round 0: n1=1, nil skipped, n2=2
+			{n3, n4},      // round 1: n3=3, n4=4
+		}
+
+		AssignMatchNumbers(rounds)
+
+		assert.Equal(t, int64(1), n1.matchNum, "first non-nil node in round 0")
+		assert.Equal(t, int64(2), n2.matchNum, "second non-nil node in round 0 (nil skipped)")
+		assert.Equal(t, int64(3), n3.matchNum, "first node in round 1")
+		assert.Equal(t, int64(4), n4.matchNum, "second node in round 1")
+	})
+
+	t.Run("all nil round", func(t *testing.T) {
+		n1 := &Node{LeafNode: false}
+		rounds := [][]*Node{
+			{nil, nil},
+			{n1},
+		}
+
+		AssignMatchNumbers(rounds)
+
+		assert.Equal(t, int64(1), n1.matchNum, "first real node after all-nil round gets number 1")
+	})
+
+	t.Run("single match", func(t *testing.T) {
+		n := &Node{LeafNode: false}
+		rounds := [][]*Node{{n}}
+
+		AssignMatchNumbers(rounds)
+
+		assert.Equal(t, int64(1), n.matchNum)
+	})
+
+	t.Run("empty rounds", func(t *testing.T) {
+		// Must not panic
+		AssignMatchNumbers([][]*Node{})
+		AssignMatchNumbers(nil)
+	})
+}

--- a/internal/helper/excel_tree_test.go
+++ b/internal/helper/excel_tree_test.go
@@ -109,8 +109,8 @@ func TestSetTreeSheetTitle(t *testing.T) {
 }
 
 // TestAssignMatchNumbers verifies that AssignMatchNumbers assigns sequential
-// numbers starting at 1, skips nil nodes, and does not re-number on subsequent
-// calls (i.e. each call is idempotent with a fresh counter — it overwrites).
+// numbers starting at 1 and skips nil nodes. Each call restarts the counter
+// from 1, overwriting any numbers a previous call assigned (not preserved).
 func TestAssignMatchNumbers(t *testing.T) {
 	t.Run("sequential numbering skips nil", func(t *testing.T) {
 		n1 := &Node{LeafNode: false}

--- a/internal/helper/tree.go
+++ b/internal/helper/tree.go
@@ -25,6 +25,17 @@ type Node struct {
 	Right   *Node
 }
 
+// MatchNum returns the sequential match number assigned to this node by
+// AssignMatchNumbers (0 if not yet assigned). Exported so cross-package callers —
+// notably the engine-vs-Excel numbering-parity test — can read the authoritative
+// printed-sheet number without reaching into the unexported field.
+func (n *Node) MatchNum() int64 {
+	if n == nil {
+		return 0
+	}
+	return n.matchNum
+}
+
 func CreateBalancedTree(leafValues []string) *Node {
 	mid := len(leafValues) / 2
 	node := &Node{}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -741,6 +741,10 @@ type BracketMatch struct {
 	ScoreB        string `json:"scoreB"`
 	IsOverridden  bool   `json:"isOverridden"`
 	QueuePosition int    `json:"queuePosition,omitempty"`
+	// MatchNumber is the sequential bracket match number, matching the
+	// "Match N" label printed on the Excel tree sheet. 0 means unset
+	// (pool matches, bye placeholders, or legacy brackets).
+	MatchNumber int `json:"matchNumber,omitempty"`
 	// Decision-type metadata mirrors MatchResult so an elimination-stage
 	// kiken/fusenpai/encho is reconstructable from bracket.json alone
 	// (label rendering, Excel export, SSE replays).

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -742,8 +742,9 @@ type BracketMatch struct {
 	IsOverridden  bool   `json:"isOverridden"`
 	QueuePosition int    `json:"queuePosition,omitempty"`
 	// MatchNumber is the sequential bracket match number, matching the
-	// "Match N" label printed on the Excel tree sheet. 0 means unset
-	// (pool matches, bye placeholders, or legacy brackets).
+	// "Match N" label printed on the Excel tree sheet. 0 means unset — for a
+	// BracketMatch that is a hidden/bye placeholder, or a legacy bracket saved
+	// before numbering was assigned.
 	MatchNumber int `json:"matchNumber,omitempty"`
 	// Decision-type metadata mirrors MatchResult so an elimination-stage
 	// kiken/fusenpai/encho is reconstructable from bracket.json alone

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3597,6 +3597,20 @@ button.pool-match-row {
   font-size: 15px;
   margin: 0 0 4px;
 }
+/* Inline recovery control inside an empty state (e.g. the court picker shown
+   for an unknown shiaijo). */
+.empty__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.empty__action .input {
+  width: auto;
+  min-width: 130px;
+}
 .empty > div:not(.icon):not(.empty__cta-note) {
   font-size: 13px;
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6868,6 +6868,30 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   gap: 4px;
 }
 
+/* Centered overtime pill — sits below the foul boxes in the individual scorer
+   (the EnchoControl renders its own .encho-row child, which this centers). */
+.encho-center {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+/* Stacked decision place: a "Decision:" header, the judges'-decision (hantei)
+   affordance as the top row, then the withdrawal/forfeit controls as the
+   bottom row. Overrides the default inline-row .decision-controls layout. */
+.decision-controls--stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+.decision-controls--stacked .decision-controls__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
 /* ？ icon that carries the glossary tooltip for a decision button. */
 .glossary-hint .tw-term {
   border-bottom: none;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8040,6 +8040,68 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   color: var(--ink-2);
 }
 
+/* Competition selector in page-head (AC3) */
+.shiaijo-comp-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.shiaijo-comp-selector__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+.shiaijo-comp-selector__name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--accent);
+}
+.shiaijo-comp-select {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--accent);
+  min-width: 140px;
+  width: auto;
+}
+
+/* Amber nudge — composes the shared .alert--warn (amber `--warn-*` tokens only,
+   never red/danger or navy/running). It is an actionable control: clicking
+   switches the page-head competition selector to the competition that needs this
+   court, so the operator never has to hunt the dropdown. */
+.shiaijo-nudge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin-bottom: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+.shiaijo-nudge:hover {
+  background: var(--warn-border);
+}
+.shiaijo-nudge:focus-visible {
+  outline: 2px solid var(--warn-ink);
+  outline-offset: 2px;
+}
+.shiaijo-nudge__icon {
+  font-size: 15px;
+  flex-shrink: 0;
+  line-height: 1.4;
+}
+.shiaijo-nudge__text {
+  line-height: 1.4;
+  font-weight: 500;
+}
+.shiaijo-nudge__cta {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
 @media (max-width: 900px) {
   .shiaijo { grid-template-columns: 1fr; }
   /* Stack layout for tablet portrait mode (queue below scoring). */

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8096,29 +8096,23 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   border-radius: 4px;
 }
 
-/* Competition selector in page-head (AC3) */
-.shiaijo-comp-selector {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+/* Competition selector in page-head (AC3) — mirrors the Shiaijo title on the
+   right edge: the competition name gets the full display-title treatment (same
+   size/font as "Shiaijo A") plus the navy chevron chip, with an "Officiating"
+   caption beneath that lines up with the title's own sub-caption on the left. */
+.shiaijo-officiating {
+  text-align: right;
 }
-.shiaijo-comp-selector__label {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--ink-2);
-  white-space: nowrap;
-}
-.shiaijo-comp-selector__name {
-  font-size: 15px;
-  font-weight: 700;
+/* Navy so the changeable competition reads distinct from the fixed court name,
+   tying it to the navy chevron chip while keeping the identical title scale. */
+.shiaijo-officiating__name {
   color: var(--accent);
 }
-.shiaijo-comp-select {
-  font-size: 15px;
-  font-weight: 700;
-  color: var(--accent);
-  min-width: 140px;
-  width: auto;
+.shiaijo-officiating__sub {
+  text-align: right;
+}
+.shiaijo-title-select--right {
+  text-align: right;
 }
 
 /* Amber nudge — composes the shared .alert--warn (amber `--warn-*` tokens only,

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8040,6 +8040,55 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   color: var(--ink-2);
 }
 
+/* Page title doubles as the court switcher: the H1 shows a chevron and a
+   transparent native <select> overlays it (native picker + a11y, no duplicate
+   control). Only rendered when there is more than one court. */
+.shiaijo-title-select {
+  position: relative;
+  display: inline-block;
+}
+.shiaijo-title-select .page-head__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.shiaijo-title-select__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  font-size: 16px;
+  border-radius: 8px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  line-height: 1;
+  transition: background 150ms ease, color 150ms ease;
+}
+.shiaijo-title-select:hover .shiaijo-title-select__chevron {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.shiaijo-title-select__native {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.shiaijo-title-select:focus-within .page-head__title {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
 /* Competition selector in page-head (AC3) */
 .shiaijo-comp-selector {
   display: flex;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8024,6 +8024,30 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   background: var(--accent-soft); color: var(--accent); font-size: 11px; font-weight: 700;
 }
 
+/* Sub-group headers inside the Upcoming queue: pool name ("Pool A") or playoff
+   round ("Final"), so the operator knows which pool/round they'll be scoring.
+   Lighter than the .section-title above it — a secondary tier, not a peer. */
+.shiaijo-subgroup + .shiaijo-subgroup {
+  margin-top: 14px;
+}
+.shiaijo-subgroup__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  margin: 0 0 6px;
+}
+.shiaijo-subgroup__title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+}
+
 /* Context panel (collapsible) */
 .shiaijo-context { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
 .shiaijo-context__toggle { padding: 12px 14px; }

--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { parsePath, pathFromState } from '../app.jsx';
-import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, isTeamMatch } from '../admin_shiaijo.jsx';
+import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, isTeamMatch, groupQueueMatches } from '../admin_shiaijo.jsx';
 
 // A team encounter's score must never be shown as a bare number — it always
 // carries an IV (Individual Victories) label, since a raw figure could read as
@@ -220,6 +220,49 @@ describe('partitionShiaijoMatches', () => {
   it('returns empty groups for an empty input', () => {
     const out = partitionShiaijoMatches([]);
     expect(out).toEqual({ sorted: [], running: [], scheduled: [], completed: [] });
+  });
+});
+
+
+describe('groupQueueMatches — Upcoming queue grouping', () => {
+  const pool = (poolName, id) => ({ phase: 'pool', compFormat: 'mixed', poolName, id });
+  const bracket = (round, roundIndex, id) => ({ phase: 'bracket', compFormat: 'mixed', round, roundIndex, id });
+
+  it('returns null (flat) for a league competition — no grouping', () => {
+    const matches = [
+      { phase: 'pool', compFormat: 'league', poolName: 'League table', id: 'l1' },
+      { phase: 'pool', compFormat: 'league', poolName: 'League table', id: 'l2' },
+    ];
+    expect(groupQueueMatches(matches)).toBeNull();
+  });
+
+  it('returns null for an empty list', () => {
+    expect(groupQueueMatches([])).toBeNull();
+  });
+
+  it('groups pool matches by pool name in first-appearance order', () => {
+    const groups = groupQueueMatches([
+      pool('Pool A', 'a1'), pool('Pool A', 'a2'), pool('Pool B', 'b1'),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Pool A', 'Pool B']);
+    expect(groups[0].matches.map((m) => m.id)).toEqual(['a1', 'a2']);
+    expect(groups[1].matches.map((m) => m.id)).toEqual(['b1']);
+  });
+
+  it('groups playoff matches by round, keyed by round index', () => {
+    const groups = groupQueueMatches([
+      bracket('Semifinals', 0, 's1'), bracket('Semifinals', 0, 's2'), bracket('Final', 1, 'f1'),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Semifinals', 'Final']);
+    expect(groups[0].matches.map((m) => m.id)).toEqual(['s1', 's2']);
+    expect(groups[1].matches.map((m) => m.id)).toEqual(['f1']);
+  });
+
+  it('keeps pools and rounds as separate groups for a mixed comp mid-transition', () => {
+    const groups = groupQueueMatches([
+      pool('Pool A', 'a1'), bracket('Semifinals', 0, 's1'),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Pool A', 'Semifinals']);
   });
 });
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -241,6 +241,32 @@ describe('Viewer Utils', () => {
       expect(compMatches(c)).toEqual([]);
     });
 
+    it('excludes tiebreak/daihyosen bouts from poolCount and poolPosition', () => {
+      // 3-player RR = 3 regular matches; the -TB- and -DH- bouts must NOT count
+      // toward "Match N of M" (they are not part of the round-robin schedule).
+      const c = mkComp({
+        poolMatches: [
+          { id: 'Pool A-0', status: 'completed' },
+          { id: 'Pool A-1', status: 'completed' },
+          { id: 'Pool A-2', status: 'completed' },
+          { id: 'Pool A-TB-0', status: 'scheduled' },
+          { id: 'Pool A-DH-0', status: 'scheduled' },
+        ],
+      });
+      const ms = compMatches(c);
+      const regular = ms.filter(m => /Pool A-\d+$/.test(m.id));
+      const tb = ms.find(m => m.id === 'Pool A-TB-0');
+      const dh = ms.find(m => m.id === 'Pool A-DH-0');
+      // Every regular bout sees a true RR total of 3.
+      expect(regular.map(m => m.poolCount)).toEqual([3, 3, 3]);
+      expect(regular.map(m => m.poolPosition)).toEqual([1, 2, 3]);
+      // TB/DH bouts get no position (undefined → the row hides "Match N of M").
+      expect(tb.poolCount).toBeUndefined();
+      expect(tb.poolPosition).toBeUndefined();
+      expect(dh.poolCount).toBeUndefined();
+      expect(dh.poolPosition).toBeUndefined();
+    });
+
     // mp-116: compKind/teamSize must be threaded onto every match so that
     // MatchDetailCard.isTeam and MatchViewerModal.isTeam evaluate correctly.
     it('threads compKind and teamSize onto pool matches for team comps', () => {

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -439,10 +439,73 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
         </div>
 
         <div className="editor-modal__body">
+          <div className="scoring-board">
+              {/* Score slots + point buttons */}
+              <div className="sb-match">
+                {sides.map((s, idx) => (
+                  <React.Fragment key={s.key}>
+                    <div className={`sb-side sb-side--${s.color}`}>
+                      <div className="sb-name">{s.name}</div>
+                      <div className="sb-slots">
+                        {[0, 1].map((i) => (
+                          <button key={i} className={`sb-slot ${s.pts[i] ? "sb-slot--filled" : ""}`} onClick={() => removePt(s.key, i)} disabled={decidedByHantei} title={decidedByHantei ? (initialDecidedByHantei ? "Locked — hantei already recorded" : "Hantei armed — choose a winner above, or cancel") : "Click to remove"}>
+                            {s.pts[i] || "·"}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="sb-points-grid">
+                        {getIpponButtons(isNaginata).map((cc) => (
+                          <button key={cc} className={`ipt-btn ${cc === "H" ? "ipt-btn--h" : ""}`} onClick={() => addPt(s.key, cc)} disabled={boutDecided || decidedByHantei}>{cc}</button>
+                        ))}
+                      </div>
+                    </div>
+                    {idx === 0 && (
+                      <div className="sb-center">
+                        {!isDrawToggled && (
+                          <div className="sb-vs">
+                            {aTotal === 0 && bTotal === 0 ? "VS" : `${bTotal}–${aTotal}`}
+                          </div>
+                        )}
+                        <button
+                          className={`sb-draw-toggle btn${isDrawToggled ? " sb-draw-toggle--active" : ""}`}
+                          data-testid="scoring-modal-mark-draw"
+                          onClick={() => {
+                            const r = decideDrawToggle({ isDrawToggled, aTotal, bTotal });
+                            if (r.action === "cancel") { setIsDrawToggled(false); markScoringDirty(); } // C1
+                            else if (r.action === "enter") { setIsDrawToggled(true); setAPts([]); setBPts([]); markScoringDirty(); } // C1
+                          }}
+                          disabled={decidedByHantei || (!isDrawToggled && (aTotal > 0 || bTotal > 0)) || (!isDrawToggled && isKnockoutPhase)}
+                          title={decidedByHantei ? (initialDecidedByHantei ? "Locked — hantei already recorded" : "Hantei armed — choose a winner above, or cancel") : (!isDrawToggled && isKnockoutPhase ? "Knockout matches can't draw — decide by hantei after encho" : (!isDrawToggled && (aTotal > 0 || bTotal > 0) ? "Clear scores before marking a draw" : (isDrawToggled ? "Cancel draw" : "Mark as draw (hikiwake)")))}
+                          aria-label={isDrawToggled ? "Cancel draw (hikiwake)" : "Mark as draw (hikiwake)"}
+                        >{isDrawToggled ? "Cancel draw" : "Mark draw"}</button>
+                      </div>
+                    )}
+                  </React.Fragment>
+                ))}
+              </div>
+
+              {/* Independent foul counters */}
+              <div className="sb-fouls">
+                {sides.map((s) => (
+                  <FoulCounter
+                    key={s.key}
+                    label={s.label}
+                    fouls={s.fouls}
+                    setFouls={s.setFouls}
+                    onIncrement={s.onIncrement}
+                    color={s.color}
+                    disabled={boutDecided || decidedByHantei}
+                  />
+                ))}
+              </div>
+          </div>
+
           {/* FR-033 encho toggle: collapses to a small "⏱ Overtime" pill
               when no overtime is active. Click the pill (or set the
               counter through the existing flow) to mount the full
-              counter UI. Saves ~32px of vertical space pre-overtime. */}
+              counter UI. Saves ~32px of vertical space pre-overtime.
+              Sits below the scoring board so the score + foul boxes stay
+              the operator's first focus; overtime/hantei are follow-ups. */}
           <EnchoControl
             enchoPeriodCount={enchoPeriodCount}
             setEnchoPeriodCount={setEnchoPeriodCount}
@@ -454,7 +517,7 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
               The winner is recorded with the hantei flag, distinguishable
               from an ippon-derived win for stats, audit, and Excel. */}
           {aTotal === bTotal && (
-            <div className="hantei-row" data-testid="scoring-modal-hantei-row" style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 8px", marginBottom: 6, background: "var(--card-2, #fafafa)", borderRadius: 6, fontSize: 12 }}>
+            <div className="hantei-row" data-testid="scoring-modal-hantei-row" style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 8px", marginTop: 6, background: "var(--card-2, #fafafa)", borderRadius: 6, fontSize: 12 }}>
               <span style={{ fontWeight: 600, color: "var(--ink-2)" }}>Hantei</span>
               <span style={{ color: "var(--ink-3)" }}>(judges' decision)</span>
               {!decidedByHantei && (
@@ -516,66 +579,6 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
               )}
             </div>
           )}
-          <div className="scoring-board">
-              {/* Score slots + point buttons */}
-              <div className="sb-match">
-                {sides.map((s, idx) => (
-                  <React.Fragment key={s.key}>
-                    <div className={`sb-side sb-side--${s.color}`}>
-                      <div className="sb-name">{s.name}</div>
-                      <div className="sb-slots">
-                        {[0, 1].map((i) => (
-                          <button key={i} className={`sb-slot ${s.pts[i] ? "sb-slot--filled" : ""}`} onClick={() => removePt(s.key, i)} disabled={decidedByHantei} title={decidedByHantei ? (initialDecidedByHantei ? "Locked — hantei already recorded" : "Hantei armed — choose a winner above, or cancel") : "Click to remove"}>
-                            {s.pts[i] || "·"}
-                          </button>
-                        ))}
-                      </div>
-                      <div className="sb-points-grid">
-                        {getIpponButtons(isNaginata).map((cc) => (
-                          <button key={cc} className={`ipt-btn ${cc === "H" ? "ipt-btn--h" : ""}`} onClick={() => addPt(s.key, cc)} disabled={boutDecided || decidedByHantei}>{cc}</button>
-                        ))}
-                      </div>
-                    </div>
-                    {idx === 0 && (
-                      <div className="sb-center">
-                        {!isDrawToggled && (
-                          <div className="sb-vs">
-                            {aTotal === 0 && bTotal === 0 ? "VS" : `${bTotal}–${aTotal}`}
-                          </div>
-                        )}
-                        <button
-                          className={`sb-draw-toggle btn${isDrawToggled ? " sb-draw-toggle--active" : ""}`}
-                          data-testid="scoring-modal-mark-draw"
-                          onClick={() => {
-                            const r = decideDrawToggle({ isDrawToggled, aTotal, bTotal });
-                            if (r.action === "cancel") { setIsDrawToggled(false); markScoringDirty(); } // C1
-                            else if (r.action === "enter") { setIsDrawToggled(true); setAPts([]); setBPts([]); markScoringDirty(); } // C1
-                          }}
-                          disabled={decidedByHantei || (!isDrawToggled && (aTotal > 0 || bTotal > 0)) || (!isDrawToggled && isKnockoutPhase)}
-                          title={decidedByHantei ? (initialDecidedByHantei ? "Locked — hantei already recorded" : "Hantei armed — choose a winner above, or cancel") : (!isDrawToggled && isKnockoutPhase ? "Knockout matches can't draw — decide by hantei after encho" : (!isDrawToggled && (aTotal > 0 || bTotal > 0) ? "Clear scores before marking a draw" : (isDrawToggled ? "Cancel draw" : "Mark as draw (hikiwake)")))}
-                          aria-label={isDrawToggled ? "Cancel draw (hikiwake)" : "Mark as draw (hikiwake)"}
-                        >{isDrawToggled ? "Cancel draw" : "Mark draw"}</button>
-                      </div>
-                    )}
-                  </React.Fragment>
-                ))}
-              </div>
-
-              {/* Independent foul counters */}
-              <div className="sb-fouls">
-                {sides.map((s) => (
-                  <FoulCounter
-                    key={s.key}
-                    label={s.label}
-                    fouls={s.fouls}
-                    setFouls={s.setFouls}
-                    onIncrement={s.onIncrement}
-                    color={s.color}
-                    disabled={boutDecided || decidedByHantei}
-                  />
-                ))}
-              </div>
-          </div>
 
           {/* Ippon-type letter legend — discoverable "?" affordance mapping
               M/K/D/T/H (+S in naginata) to their kendo meaning, so operators

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -421,8 +421,11 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
                 : null}
               {enchoPeriodCount > 0 && <span className="editor-modal__eyebrow-encho">· (E) Overtime ×{enchoPeriodCount}</span>}
             </div>
-            <div className="editor-modal__title">
-              <TermAS name="shiaijo">Shiaijo</TermAS> {m.court} · {m.scheduledAt || "Now"}
+            <div className="editor-modal__title" style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <span><TermAS name="shiaijo">Shiaijo</TermAS> {m.court} · {m.scheduledAt || "Now"}</span>
+              {/* C2: sync status indicator — inline on the title line (no dedicated
+                  row); SyncStatusPill renders nothing unless the match is running. */}
+              <SyncStatusPill isRunning={m.status === "running"} />
             </div>
           </div>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
@@ -431,8 +434,6 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
                 {isComplete ? "CORRECTION" : "PRE-MATCH"}
               </div>
             )}
-            {/* C2: sync status indicator — only visible while the match is running */}
-            <SyncStatusPill isRunning={m.status === "running"} />
             {canClose && <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}
           </div>
         </div>

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -414,6 +414,11 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
           <div style={{ flex: 1 }}>
             <div className="editor-modal__eyebrow">
               {m.compName} · {m.phase === "pool" ? window.poolLabel(m) : m.round}
+              {m.phase === "pool" && m.poolPosition > 0 && m.poolCount > 0
+                ? <span> · Match {m.poolPosition} of {m.poolCount}</span>
+                : m.phase === "bracket" && m.matchNumber > 0
+                ? <span> · Match {m.matchNumber}</span>
+                : null}
               {enchoPeriodCount > 0 && <span className="editor-modal__eyebrow-encho">· (E) Overtime ×{enchoPeriodCount}</span>}
             </div>
             <div className="editor-modal__title">
@@ -421,9 +426,11 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
             </div>
           </div>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
-            <div className={`editor-head-pill ${m.status === "running" ? "sched-row--running" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
-              {isComplete ? "CORRECTION" : m.status === "running" ? "● NOW" : "PRE-MATCH"}
-            </div>
+            {(isComplete || m.status !== "running") && (
+              <div className={`editor-head-pill ${m.status === "running" ? "sched-row--running" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
+                {isComplete ? "CORRECTION" : "PRE-MATCH"}
+              </div>
+            )}
             {/* C2: sync status indicator — only visible while the match is running */}
             <SyncStatusPill isRunning={m.status === "running"} />
             {canClose && <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -504,121 +504,129 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
               when no overtime is active. Click the pill (or set the
               counter through the existing flow) to mount the full
               counter UI. Saves ~32px of vertical space pre-overtime.
-              Sits below the scoring board so the score + foul boxes stay
-              the operator's first focus; overtime/hantei are follow-ups. */}
-          <EnchoControl
-            enchoPeriodCount={enchoPeriodCount}
-            setEnchoPeriodCount={setEnchoPeriodCount}
-            maxEnchoPeriods={maxEnchoPeriods}
-          />
-          {/* A tied match may be decided by referee hantei. Surface the
-              affordance whenever the scoreline is tied — encho is optional,
-              not required (operators may go straight to a judges' decision).
-              The winner is recorded with the hantei flag, distinguishable
-              from an ippon-derived win for stats, audit, and Excel. */}
-          {aTotal === bTotal && (
-            <div className="hantei-row" data-testid="scoring-modal-hantei-row" style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 8px", marginTop: 6, background: "var(--card-2, #fafafa)", borderRadius: 6, fontSize: 12 }}>
-              <span style={{ fontWeight: 600, color: "var(--ink-2)" }}>Hantei</span>
-              <span style={{ color: "var(--ink-3)" }}>(judges' decision)</span>
-              {!decidedByHantei && (
-                <button
-                  type="button"
-                  className="btn btn--sm"
-                  data-testid="scoring-modal-hantei-arm"
-                  onClick={() => setDecidedByHantei(true)}
-                  // Hantei declares a winner from a genuinely tied bout. Disable
-                  // the arm button when totals are unequal (an ippon-derived win
-                  // is already decided), when the bout is already decided by
-                  // ippons (boutDecided), or when a draw is already toggled.
-                  // (0-0 is still a valid tied state. Encho is NOT required.)
-                  disabled={submitting || decisionSubmitting || aTotal !== bTotal || boutDecided || isDrawToggled}
-                  title={
-                    submitting || decisionSubmitting
-                      ? "Saving…"
-                      : isDrawToggled
-                        ? "Cancel the draw toggle before using hantei"
-                        : aTotal !== bTotal || boutDecided
-                          ? "Hantei applies only to a tied scoreline"
-                          : "Record a judges' decision"
-                  }
-                  style={{ marginLeft: "auto" }}
-                >
-                  Decide by hantei…
-                </button>
-              )}
-              {decidedByHantei && (
-                <div style={{ marginLeft: "auto", display: "flex", gap: 6 }}>
-                  <button
-                    type="button"
-                    className="btn btn--sm"
-                    data-testid="scoring-modal-hantei-shiro"
-                    onClick={() => submitHantei("b")}
-                    disabled={submitting || decisionSubmitting}
-                  >
-                    SHIRO wins
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn--sm"
-                    data-testid="scoring-modal-hantei-aka"
-                    onClick={() => submitHantei("a")}
-                    disabled={submitting || decisionSubmitting}
-                  >
-                    AKA wins
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn--ghost btn--sm"
-                    data-testid="scoring-modal-hantei-cancel"
-                    onClick={() => setDecidedByHantei(false)}
-                    disabled={submitting || decisionSubmitting}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
+              Centered below the scoring board so the score + foul boxes
+              stay the operator's first focus; overtime is a follow-up. */}
+          <div className="encho-center">
+            <EnchoControl
+              enchoPeriodCount={enchoPeriodCount}
+              setEnchoPeriodCount={setEnchoPeriodCount}
+              maxEnchoPeriods={maxEnchoPeriods}
+            />
+          </div>
 
           {/* Ippon-type letter legend — discoverable "?" affordance mapping
               M/K/D/T/H (+S in naginata) to their kendo meaning, so operators
               don't depend on the viewer-only glossary. */}
           <IpponLegend isNaginata={isNaginata} />
 
-          {/* T093–T098: decision (kiken/fusenpai) controls + remaining-matches
-              follow-up. Sits between the scoring board and the footer so the
-              flow is: enter score OR record a decision → either way the modal
-              closes (or surfaces the remaining-matches list for kiken). */}
-          {!withdrawnPlayer && !decisionPromptKind && !selfReport && (
-            <div className="decision-controls" style={{ display: "flex", gap: 8, marginTop: 12, fontSize: 12, alignItems: "center" }}>
-              <span style={{ color: "var(--ink-3)", fontWeight: 600 }}>Decision:</span>
-              <div className="decision-btn-group">
-                <button data-testid="scoring-modal-kiken-voluntary-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("kiken-voluntary"); }} disabled={submitting || decisionSubmitting}>
-                  Kiken – Voluntary
-                </button>
-                <GlossaryHintAS name="kiken-voluntary" />
-              </div>
-              <div className="decision-btn-group">
-                <button data-testid="scoring-modal-kiken-injury-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("kiken-injury"); }} disabled={submitting || decisionSubmitting}>
-                  Kiken – Injury
-                </button>
-                <GlossaryHintAS name="kiken-injury" />
-              </div>
-              <div className="decision-btn-group">
-                <button data-testid="scoring-modal-fusenpai-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("fusenpai"); }} disabled={submitting || decisionSubmitting}>
-                  Fusenpai
-                </button>
-                <GlossaryHintAS name="fusenpai" />
-              </div>
-              {/* Per-bout fusensho is a sub-match concept — implemented inside
-                  TeamScoreEditorModal. This placeholder explains the affordance
-                  to operators who open the individual-match editor. */}
-              <div className="decision-btn-group">
-                <button type="button" className="btn btn--sm" disabled title="Fusensho is recorded per-bout inside the team-match editor">
-                  Fusensho (team only)
-                </button>
-                <GlossaryHintAS name="fusensho" />
-              </div>
+          {/* T093–T098: decision place. The judges'-decision (hantei) affordance
+              forms the TOP row whenever the scoreline is tied; the withdrawal/
+              forfeit controls (kiken/fusenpai/fusensho) form the BOTTOM row.
+              Hantei keeps its own tied-scoreline condition so it still surfaces
+              in self-report mode, where the admin-only controls below are hidden.
+              Sits between the scoring board and the footer so the flow is: enter
+              score OR record a decision → either way the modal closes (or
+              surfaces the remaining-matches list for kiken). */}
+          {(aTotal === bTotal || (!withdrawnPlayer && !decisionPromptKind && !selfReport)) && (
+            <div className="decision-controls decision-controls--stacked" style={{ marginTop: 12, fontSize: 12 }}>
+              <span className="decision-controls__label" style={{ color: "var(--ink-3)", fontWeight: 600 }}>Decision:</span>
+              {/* A tied match may be decided by referee hantei. The winner is
+                  recorded with the hantei flag, distinguishable from an
+                  ippon-derived win for stats, audit, and Excel. */}
+              {aTotal === bTotal && (
+                <div className="hantei-row" data-testid="scoring-modal-hantei-row" style={{ display: "flex", gap: 8, alignItems: "center", padding: "6px 8px", background: "var(--card-2, #fafafa)", borderRadius: 6 }}>
+                  <span style={{ fontWeight: 600, color: "var(--ink-2)" }}>Hantei</span>
+                  <span style={{ color: "var(--ink-3)" }}>(judges' decision)</span>
+                  {!decidedByHantei && (
+                    <button
+                      type="button"
+                      className="btn btn--sm"
+                      data-testid="scoring-modal-hantei-arm"
+                      onClick={() => setDecidedByHantei(true)}
+                      // Hantei declares a winner from a genuinely tied bout. Disable
+                      // the arm button when totals are unequal (an ippon-derived win
+                      // is already decided), when the bout is already decided by
+                      // ippons (boutDecided), or when a draw is already toggled.
+                      // (0-0 is still a valid tied state. Encho is NOT required.)
+                      disabled={submitting || decisionSubmitting || aTotal !== bTotal || boutDecided || isDrawToggled}
+                      title={
+                        submitting || decisionSubmitting
+                          ? "Saving…"
+                          : isDrawToggled
+                            ? "Cancel the draw toggle before using hantei"
+                            : aTotal !== bTotal || boutDecided
+                              ? "Hantei applies only to a tied scoreline"
+                              : "Record a judges' decision"
+                      }
+                      style={{ marginLeft: "auto" }}
+                    >
+                      Decide by hantei…
+                    </button>
+                  )}
+                  {decidedByHantei && (
+                    <div style={{ marginLeft: "auto", display: "flex", gap: 6 }}>
+                      <button
+                        type="button"
+                        className="btn btn--sm"
+                        data-testid="scoring-modal-hantei-shiro"
+                        onClick={() => submitHantei("b")}
+                        disabled={submitting || decisionSubmitting}
+                      >
+                        SHIRO wins
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn--sm"
+                        data-testid="scoring-modal-hantei-aka"
+                        onClick={() => submitHantei("a")}
+                        disabled={submitting || decisionSubmitting}
+                      >
+                        AKA wins
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--sm"
+                        data-testid="scoring-modal-hantei-cancel"
+                        onClick={() => setDecidedByHantei(false)}
+                        disabled={submitting || decisionSubmitting}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+              {!withdrawnPlayer && !decisionPromptKind && !selfReport && (
+                <div className="decision-controls__group">
+                  <div className="decision-btn-group">
+                    <button data-testid="scoring-modal-kiken-voluntary-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("kiken-voluntary"); }} disabled={submitting || decisionSubmitting}>
+                      Kiken – Voluntary
+                    </button>
+                    <GlossaryHintAS name="kiken-voluntary" />
+                  </div>
+                  <div className="decision-btn-group">
+                    <button data-testid="scoring-modal-kiken-injury-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("kiken-injury"); }} disabled={submitting || decisionSubmitting}>
+                      Kiken – Injury
+                    </button>
+                    <GlossaryHintAS name="kiken-injury" />
+                  </div>
+                  <div className="decision-btn-group">
+                    <button data-testid="scoring-modal-fusenpai-button" type="button" className="btn btn--sm" onClick={() => { setDecisionErr(""); setDecisionPromptKind("fusenpai"); }} disabled={submitting || decisionSubmitting}>
+                      Fusenpai
+                    </button>
+                    <GlossaryHintAS name="fusenpai" />
+                  </div>
+                  {/* Per-bout fusensho is a sub-match concept — implemented inside
+                      TeamScoreEditorModal. This placeholder explains the affordance
+                      to operators who open the individual-match editor. */}
+                  <div className="decision-btn-group">
+                    <button type="button" className="btn btn--sm" disabled title="Fusensho is recorded per-bout inside the team-match editor">
+                      Fusensho (team only)
+                    </button>
+                    <GlossaryHintAS name="fusensho" />
+                  </div>
+                </div>
+              )}
             </div>
           )}
           {decisionErr && (

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -430,7 +430,7 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
           </div>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
             {(isComplete || m.status !== "running") && (
-              <div className={`editor-head-pill ${m.status === "running" ? "sched-row--running" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
+              <div className="editor-head-pill" style={{ fontSize: 10, fontWeight: 700 }}>
                 {isComplete ? "CORRECTION" : "PRE-MATCH"}
               </div>
             )}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -719,7 +719,7 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
           </div>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
             {(isComplete || m.status !== "running") && (
-              <div className={`editor-head-pill ${m.status === "running" ? "sched-row--running" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
+              <div className="editor-head-pill" style={{ fontSize: 10, fontWeight: 700 }}>
                 {isComplete ? "CORRECTION" : "PRE-MATCH"}
               </div>
             )}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -703,6 +703,11 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
           <div style={{ flex: 1 }}>
             <div className="editor-modal__eyebrow">
               {m.compName} · {m.phase === "pool" ? window.poolLabel(m) : m.round}
+              {m.phase === "pool" && m.poolPosition > 0 && m.poolCount > 0
+                ? <span> · Match {m.poolPosition} of {m.poolCount}</span>
+                : m.phase === "bracket" && m.matchNumber > 0
+                ? <span> · Match {m.matchNumber}</span>
+                : null}
               {enchoPeriodCount > 0 && <span className="editor-modal__eyebrow-encho">· (E) Overtime ×{enchoPeriodCount}</span>}
             </div>
             <div className="editor-modal__title">
@@ -710,9 +715,11 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
             </div>
           </div>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
-            <div className={`editor-head-pill ${m.status === "running" ? "sched-row--running" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
-              {isComplete ? "CORRECTION" : m.status === "running" ? "● NOW" : "PRE-MATCH"}
-            </div>
+            {(isComplete || m.status !== "running") && (
+              <div className={`editor-head-pill ${m.status === "running" ? "sched-row--running" : ""}`} style={{ fontSize: 10, fontWeight: 700 }}>
+                {isComplete ? "CORRECTION" : "PRE-MATCH"}
+              </div>
+            )}
             {/* C2: sync status indicator — only visible while the match is running */}
             <SyncStatusPill isRunning={m.status === "running"} />
             {canClose && <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -710,8 +710,11 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
                 : null}
               {enchoPeriodCount > 0 && <span className="editor-modal__eyebrow-encho">· (E) Overtime ×{enchoPeriodCount}</span>}
             </div>
-            <div className="editor-modal__title">
-              <TermAS name="shiaijo">Shiaijo</TermAS> {m.court} · {m.scheduledAt || "Now"}
+            <div className="editor-modal__title" style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <span><TermAS name="shiaijo">Shiaijo</TermAS> {m.court} · {m.scheduledAt || "Now"}</span>
+              {/* C2: sync status indicator — inline on the title line (no dedicated
+                  row); SyncStatusPill renders nothing unless the match is running. */}
+              <SyncStatusPill isRunning={m.status === "running"} />
             </div>
           </div>
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
@@ -720,8 +723,6 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
                 {isComplete ? "CORRECTION" : "PRE-MATCH"}
               </div>
             )}
-            {/* C2: sync status indicator — only visible while the match is running */}
-            <SyncStatusPill isRunning={m.status === "running"} />
             {canClose && <button className="btn btn--ghost btn--sm" onClick={handleDismiss} disabled={submitting} style={{ padding: "2px 8px" }}>✕ Close</button>}
           </div>
         </div>

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -53,16 +53,6 @@ export function partitionShiaijoMatches(matches) {
 
 const matchKey = (m) => `${m.compId}:${m.id}`;
 
-// Queue-order comparison for two SCHEDULED matches, matching the
-// (scheduledAt, queuePosition) tie-break in sortShiaijoMatches — so the nudge's
-// "another competition has an earlier match" test agrees with the real court
-// queue order, not just the HH:MM string. Returns true when `a` is earlier.
-const scheduledBefore = (a, b) => {
-    const t = (a.scheduledAt || "99:99").localeCompare(b.scheduledAt || "99:99");
-    if (t !== 0) return t < 0;
-    return (Number(a.queuePosition) || 0) < (Number(b.queuePosition) || 0);
-};
-
 // How many of the most-recent completed bouts the Completed section shows
 // before the "Show all N" toggle. Keeps the live queue + standings above the
 // fold on a full-day court without hiding the recent record.
@@ -258,65 +248,37 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         return pool.slice(idx + 1).find((x) => x.status !== "completed") || null;
     };
 
-    // Amber nudge banner logic (AC6): fires when another competition on this
-    // court has matches waiting and the selected comp is done or has an earlier
-    // match. Never red/navy — uses --warn-* tokens only.
+    // Amber nudge banner logic (AC6): fires ONLY when the SELECTED competition
+    // has no more matches to run on this court (it has finished, or hasn't
+    // started yet — no running and no scheduled bouts here) AND another
+    // competition still has scheduled matches on the court. That's the "you're
+    // on the wrong competition, switch" case. It deliberately does NOT fire just
+    // because another competition has an earlier match while this one is still
+    // active — the operator runs their current competition to completion first.
+    // Never red/navy — uses --warn-* tokens only.
     const nudgeBanner = useMemoSh(() => {
         if (!effectiveCompId || !courtKnown) return null;
 
-        // All other comps' scheduled matches on this court
+        // Selected comp still has a running or scheduled match here → no nudge.
+        const selHasActive = running.some(m => m.compId === effectiveCompId) || filteredScheduled.length > 0;
+        if (selHasActive) return null;
+
+        // Other competitions' scheduled matches still on this court.
         const otherScheduled = allMatches.filter(
             m => m.compId !== effectiveCompId && m.status === "scheduled"
         );
-
         if (otherScheduled.length === 0) return null;
 
-        // Condition A: selected comp has no running + no scheduled matches here
-        const selHasActive = running.some(m => m.compId === effectiveCompId) || filteredScheduled.length > 0;
-
-        if (!selHasActive) {
-            // Null-prototype: compId is user-controlled (a comp id of "__proto__"
-            // must not pollute the map or collide with inherited keys).
-            const byComp = Object.create(null);
-            for (const m of otherScheduled) {
-                if (!byComp[m.compId]) byComp[m.compId] = { id: m.compId, name: m.compName, count: 0 };
-                byComp[m.compId].count++;
-            }
-            const entries = Object.values(byComp);
-            entries.sort((a, b) => b.count - a.count);
-            return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "no-matches" };
+        // Null-prototype: compId is user-controlled (a comp id of "__proto__"
+        // must not pollute the map or collide with inherited keys).
+        const byComp = Object.create(null);
+        for (const m of otherScheduled) {
+            if (!byComp[m.compId]) byComp[m.compId] = { id: m.compId, name: m.compName, count: 0 };
+            byComp[m.compId].count++;
         }
-
-        // Condition B: another comp has a match EARLIER than the selected comp's
-        // upNext in the REAL court queue order — (scheduledAt, queuePosition), the
-        // same key sortShiaijoMatches uses — not just the HH:MM string. Comparing
-        // only the time would miss a same-time match that sorts ahead by queue
-        // position.
-        const selUpNext = filteredScheduled[0];
-        if (!selUpNext) return null;
-
-        const earlierOther = otherScheduled.filter(m => scheduledBefore(m, selUpNext));
-
-        if (earlierOther.length > 0) {
-            // Null-prototype: compId is user-controlled (see Condition A above).
-            const byComp = Object.create(null);
-            for (const m of earlierOther) {
-                const e = byComp[m.compId];
-                if (!e) byComp[m.compId] = { id: m.compId, name: m.compName, count: 1, earliestMatch: m };
-                else { e.count++; if (scheduledBefore(m, e.earliestMatch)) e.earliestMatch = m; }
-            }
-            const entries = Object.values(byComp);
-            // Full three-way comparator (return 0 on a tie) so the sort stays
-            // transitive/stable when two comps share an earliest match.
-            entries.sort((a, b) => {
-                if (scheduledBefore(a.earliestMatch, b.earliestMatch)) return -1;
-                if (scheduledBefore(b.earliestMatch, a.earliestMatch)) return 1;
-                return 0;
-            });
-            return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "earlier" };
-        }
-
-        return null;
+        const entries = Object.values(byComp);
+        entries.sort((a, b) => b.count - a.count);
+        return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count };
     }, [allMatches, effectiveCompId, running, filteredScheduled, courtKnown]);
 
     // Delegate to the canonical start-patch factory (admin_schedule.jsx) rather
@@ -715,9 +677,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                 >
                                     <span className="shiaijo-nudge__icon" aria-hidden="true">⚠</span>
                                     <span className="shiaijo-nudge__text">
-                                        {nudgeBanner.reason === "no-matches"
-                                            ? `Switch to ${nudgeBanner.comp} — ${nudgeBanner.count} match${nudgeBanner.count === 1 ? "" : "es"} waiting on this court.`
-                                            : `${nudgeBanner.comp} has ${nudgeBanner.count} earlier match${nudgeBanner.count === 1 ? "" : "es"} on this court.`}
+                                        {`Switch to ${nudgeBanner.comp} — ${nudgeBanner.count} match${nudgeBanner.count === 1 ? "" : "es"} waiting on this court.`}
                                     </span>
                                     <span className="shiaijo-nudge__cta" aria-hidden="true">Switch →</span>
                                 </button>

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -129,6 +129,10 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     // independent of scoring, so the operator can set the lineup and close
     // without starting (or hit Start from inside the modal).
     const [lineupMatch, setLineupMatch] = useStateSh(null);
+    // Selected competition for filtering the queue. Default: running match's comp,
+    // else first comp with scheduled matches here, else any comp with matches here.
+    const [selectedCompId, setSelectedCompId] = useStateSh(null);
+
     // Short-circuit to [] for a blank/unknown court so an accidental landing
     // (e.g. /admin/shiaijo/%20) never sorts/partitions the whole tournament.
     // Same condition as courtKnown below.
@@ -146,6 +150,38 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     const courts = tournament.courts || [];
     const courtKnown = courts.includes(court);
 
+    // All competitions that have at least one match on this court (AC3/AC4).
+    const courtsComps = useMemoSh(() => {
+        const seen = new Set();
+        const out = [];
+        for (const m of allMatches) {
+            if (!seen.has(m.compId)) {
+                seen.add(m.compId);
+                const comp = (tournament.competitions || []).find(c => c.id === m.compId);
+                out.push({ id: m.compId, name: m.compName || (comp && comp.name) || m.compId });
+            }
+        }
+        return out;
+    }, [allMatches, tournament]);
+
+    // Effective selected competition — default logic runs when selectedCompId is
+    // null or no longer present (e.g. a comp was removed). Priority: running
+    // match's comp; else first comp with scheduled matches here; else first comp
+    // with any matches. AC3/AC7.
+    const effectiveCompId = useMemoSh(() => {
+        if (!courtsComps.length) return null;
+        // If explicitly selected and still valid, keep it
+        if (selectedCompId && courtsComps.some(c => c.id === selectedCompId)) return selectedCompId;
+        // Default: running match's comp
+        if (running.length > 0) return running[0].compId;
+        // Else first comp with scheduled matches
+        for (const c of courtsComps) {
+            if (allMatches.some(m => m.compId === c.id && m.status === "scheduled")) return c.id;
+        }
+        // Else any comp
+        return courtsComps[0].id;
+    }, [selectedCompId, courtsComps, running, allMatches]);
+
     // The scoring panel shows the match the operator is officiating. By default
     // that's the running (NOW) bout, but the operator may pick any upcoming
     // match to run out of order via its "Score" button (pickMatch). Picking is
@@ -162,6 +198,18 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     );
     const selectedMatch = useMemoSh(() => pickedMatch || running[0] || null, [pickedMatch, running]);
 
+    // Filtered to the selected competition (AC4).
+    // Running matches are NEVER filtered: the panel must stay on the running
+    // bout even if the operator switches comp (AC7).
+    const filteredScheduled = useMemoSh(
+        () => effectiveCompId ? scheduled.filter(m => m.compId === effectiveCompId) : scheduled,
+        [scheduled, effectiveCompId]
+    );
+    const filteredCompleted = useMemoSh(
+        () => effectiveCompId ? completed.filter(m => m.compId === effectiveCompId) : completed,
+        [completed, effectiveCompId]
+    );
+
     // The standings/context panel follows the court's current focus — not
     // strictly the running match — so it stays visible (and updates) after a
     // bout is finished, instead of collapsing to the empty state. Priority:
@@ -169,30 +217,87 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     // operator sees their result land in the standings; else the next
     // scheduled bout (before the court's first match).
     const contextMatch = useMemoSh(
-        () => selectedMatch || completed[completed.length - 1] || scheduled[0] || null,
-        [selectedMatch, completed, scheduled]
+        () => selectedMatch || filteredCompleted[filteredCompleted.length - 1] || filteredScheduled[0] || null,
+        [selectedMatch, filteredCompleted, filteredScheduled]
     );
 
-    // Up Next = the first non-completed, non-running match (the one to call).
-    const upNext = scheduled[0] || null;
+    // Up Next = the first scheduled match in the selected competition.
+    const upNext = filteredScheduled[0] || null;
 
     // "Which pool is next" for the context panel: the first upcoming pool on
-    // this court whose pool differs from the one currently in focus.
+    // this court (within the selected comp) whose pool differs from the one
+    // currently in focus.
     const nextPoolName = useMemoSh(() => {
         const cur = (contextMatch && contextMatch.phase === "pool") ? (contextMatch.poolName || "") : "";
-        for (const m of scheduled) {
+        for (const m of filteredScheduled) {
             const pn = m.poolName || "";
             if (m.phase === "pool" && pn && pn !== cur) return pn;
         }
         return null;
-    }, [contextMatch, scheduled]);
+    }, [contextMatch, filteredScheduled]);
 
-    // Auto-advance target after a submit: next non-completed match.
+    // Auto-advance target after a submit: next non-completed match in the
+    // selected competition (stays within the same comp, AC4/AC7).
     const nextActiveAfter = (m) => {
-        const idx = sorted.findIndex((x) => matchKey(x) === matchKey(m));
+        // Build a filtered+sorted list: running matches (unfiltered) + selected
+        // comp's scheduled matches, then find the next after the submitted match.
+        const pool = [...running, ...filteredScheduled];
+        const idx = pool.findIndex((x) => matchKey(x) === matchKey(m));
         if (idx < 0) return null;
-        return sorted.slice(idx + 1).find((x) => x.status !== "completed") || null;
+        return pool.slice(idx + 1).find((x) => x.status !== "completed") || null;
     };
+
+    // Amber nudge banner logic (AC6): fires when another competition on this
+    // court has matches waiting and the selected comp is done or has an earlier
+    // match. Never red/navy — uses --warn-* tokens only.
+    const nudgeBanner = useMemoSh(() => {
+        if (!effectiveCompId || !courtKnown) return null;
+
+        // All other comps' scheduled matches on this court
+        const otherScheduled = allMatches.filter(
+            m => m.compId !== effectiveCompId && m.status === "scheduled"
+        );
+
+        if (otherScheduled.length === 0) return null;
+
+        // Condition A: selected comp has no running + no scheduled matches here
+        const selHasActive = running.some(m => m.compId === effectiveCompId) || filteredScheduled.length > 0;
+
+        if (!selHasActive) {
+            const byComp = {};
+            for (const m of otherScheduled) {
+                if (!byComp[m.compId]) byComp[m.compId] = { id: m.compId, name: m.compName, count: 0 };
+                byComp[m.compId].count++;
+            }
+            const entries = Object.values(byComp);
+            entries.sort((a, b) => b.count - a.count);
+            return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "no-matches" };
+        }
+
+        // Condition B: another comp has a match EARLIER than the selected comp's upNext
+        const selUpNext = filteredScheduled[0];
+        if (!selUpNext) return null;
+        const selTime = selUpNext.scheduledAt || "99:99";
+
+        const earlierOther = otherScheduled.filter(m => {
+            const t = m.scheduledAt || "99:99";
+            return t < selTime; // lexicographic HH:MM comparison
+        });
+
+        if (earlierOther.length > 0) {
+            const byComp = {};
+            for (const m of earlierOther) {
+                if (!byComp[m.compId]) byComp[m.compId] = { id: m.compId, name: m.compName, count: 0, earliest: m.scheduledAt || "99:99" };
+                byComp[m.compId].count++;
+                if ((m.scheduledAt || "99:99") < byComp[m.compId].earliest) byComp[m.compId].earliest = m.scheduledAt || "";
+            }
+            const entries = Object.values(byComp);
+            entries.sort((a, b) => a.earliest.localeCompare(b.earliest));
+            return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "earlier" };
+        }
+
+        return null;
+    }, [allMatches, effectiveCompId, running, filteredScheduled, courtKnown]);
 
     // Delegate to the canonical start-patch factory (admin_schedule.jsx) rather
     // than re-declaring its shape — a second copy could silently drift. Both
@@ -366,7 +471,8 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         }
     };
 
-    const allDone = courtKnown && allMatches.length > 0 && running.length === 0 && scheduled.length === 0;
+    // allDone: selected comp has no more matches to run on this court (AC4).
+    const allDone = courtKnown && allMatches.length > 0 && running.length === 0 && filteredScheduled.length === 0;
 
     return (
         <div className="app">
@@ -378,17 +484,36 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                         <h1 className="page-head__title">Shiaijo {court}</h1>
                         <div className="page-head__sub">{`Call, start, and score every match on Shiaijo ${court} from here.`}</div>
                     </div>
-                    {courts.length > 1 && (
+                    {(courtsComps.length > 0 || courts.length > 1) && (
                         <div className="page-head__actions">
-                            <select
-                                className="input" style={{ width: "auto" }}
-                                value={courtKnown ? court : ""}
-                                onChange={(e) => onSwitchCourt(e.target.value)}
-                                aria-label="Switch court"
-                            >
-                                {!courtKnown && <option value="" disabled>Shiaijo {court} (unknown)</option>}
-                                {courts.map((c) => <option key={c} value={c}>Shiaijo {c}</option>)}
-                            </select>
+                            {courtsComps.length > 0 && (
+                                <div className="shiaijo-comp-selector">
+                                    <span className="shiaijo-comp-selector__label">Officiating:</span>
+                                    {courtsComps.length === 1 ? (
+                                        <span className="shiaijo-comp-selector__name">{courtsComps[0].name}</span>
+                                    ) : (
+                                        <select
+                                            className="input shiaijo-comp-select"
+                                            value={effectiveCompId || ""}
+                                            onChange={(e) => setSelectedCompId(e.target.value)}
+                                            aria-label="Select competition to officiate"
+                                        >
+                                            {courtsComps.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                                        </select>
+                                    )}
+                                </div>
+                            )}
+                            {courts.length > 1 && (
+                                <select
+                                    className="input" style={{ width: "auto" }}
+                                    value={courtKnown ? court : ""}
+                                    onChange={(e) => onSwitchCourt(e.target.value)}
+                                    aria-label="Switch court"
+                                >
+                                    {!courtKnown && <option value="" disabled>Shiaijo {court} (unknown)</option>}
+                                    {courts.map((c) => <option key={c} value={c}>Shiaijo {c}</option>)}
+                                </select>
+                            )}
                         </div>
                     )}
                 </div>
@@ -420,7 +545,14 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                 <div className="shiaijo-upnext">
                                     <div className="section-title">Up next</div>
                                     <div className={`shiaijo-upnext__card ${calledKey === matchKey(upNext) ? "is-called" : ""}`}>
-                                        <div className="shiaijo-upnext__time">{upNext.scheduledAt || "—"} · {upNext.compName}</div>
+                                        <div className="shiaijo-upnext__time">
+                                            {upNext.scheduledAt || "—"} · {upNext.compName}
+                                            {upNext.phase === "pool" && upNext.poolPosition > 0 && upNext.poolCount > 0
+                                                ? ` · Match ${upNext.poolPosition} of ${upNext.poolCount}`
+                                                : upNext.phase === "bracket" && upNext.matchNumber > 0
+                                                ? ` · Match ${upNext.matchNumber}`
+                                                : ""}
+                                        </div>
                                         <MatchSides m={upNext} large />
                                         <div className="shiaijo-upnext__actions">
                                             {/* Route through pickMatch (not startMatch) so starting the
@@ -450,7 +582,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                                     {callingKey === matchKey(upNext) ? "Calling…" : (calledKey === matchKey(upNext) ? "Call again" : "Call to court")}
                                                 </button>
                                             )}
-                                            {window.API && typeof window.API.updateMatchTime === "function" && scheduled.length > 1 && (
+                                            {window.API && typeof window.API.updateMatchTime === "function" && filteredScheduled.length > 1 && (
                                                 <button type="button" className="btn btn--sm btn--ghost" aria-label="Move down" onClick={() => moveMatch(upNext, "down")} title="Move this match later in the queue">↓</button>
                                             )}
                                         </div>
@@ -468,18 +600,18 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                 scoring panel on the right, so repeating it in the queue is
                                 redundant. */}
 
-                            {scheduled.length > (upNext ? 1 : 0) && (
+                            {filteredScheduled.length > (upNext ? 1 : 0) && (
                                 <ShiaijoQueueGroup
-                                    label="Upcoming" matches={upNext ? scheduled.slice(1) : scheduled}
+                                    label="Upcoming" matches={upNext ? filteredScheduled.slice(1) : filteredScheduled}
                                     courts={courts} onMoveCourt={requestMoveCourt}
                                     onMove={moveMatch} onEnterLineup={setLineupMatch}
                                     onPick={pickMatch}
                                     onCall={callToCourt} callingKey={callingKey} calledKey={calledKey} startingKey={startingKey}
-                                    scheduled={scheduled}
+                                    scheduled={filteredScheduled}
                                 />
                             )}
 
-                            {completed.length > 0 && (
+                            {filteredCompleted.length > 0 && (
                                 <div className="shiaijo-completed">
                                     {/* Completed matches stay expanded — this is the operator's
                                         running record of what's been played on this court/pool today,
@@ -488,15 +620,15 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                         COMPLETED_PREVIEW show by default; "Show all N" reveals the rest.
                                         completed is sorted ascending, so the most recent are the tail. */}
                                     <div className="section-title">
-                                        Completed <span className="shiaijo-count" aria-label={`${completed.length} matches`}>{completed.length}</span>
+                                        Completed <span className="shiaijo-count" aria-label={`${filteredCompleted.length} matches`}>{filteredCompleted.length}</span>
                                     </div>
                                     <ShiaijoQueueGroup
-                                        matches={(showAllCompleted || completed.length <= COMPLETED_PREVIEW)
-                                            ? completed
-                                            : completed.slice(-COMPLETED_PREVIEW)}
+                                        matches={(showAllCompleted || filteredCompleted.length <= COMPLETED_PREVIEW)
+                                            ? filteredCompleted
+                                            : filteredCompleted.slice(-COMPLETED_PREVIEW)}
                                         courts={courts} onMoveCourt={requestMoveCourt}
                                     />
-                                    {completed.length > COMPLETED_PREVIEW && (
+                                    {filteredCompleted.length > COMPLETED_PREVIEW && (
                                         <button
                                             type="button"
                                             className="linklike shiaijo-completed__more"
@@ -505,7 +637,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                         >
                                             {showAllCompleted
                                                 ? "Show fewer"
-                                                : `Show all ${completed.length}`}
+                                                : `Show all ${filteredCompleted.length}`}
                                         </button>
                                     )}
                                 </div>
@@ -514,6 +646,22 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 
                         {/* ── Scoring / lineup + context (right) ──────── */}
                         <div className="shiaijo__main">
+                            {nudgeBanner && (
+                                <button
+                                    type="button"
+                                    className="alert alert--warn shiaijo-nudge"
+                                    onClick={() => setSelectedCompId(nudgeBanner.compId)}
+                                    aria-label={`Switch to ${nudgeBanner.comp}`}
+                                >
+                                    <span className="shiaijo-nudge__icon" aria-hidden="true">⚠</span>
+                                    <span className="shiaijo-nudge__text">
+                                        {nudgeBanner.reason === "no-matches"
+                                            ? `Switch to ${nudgeBanner.comp} — ${nudgeBanner.count} match${nudgeBanner.count === 1 ? "" : "es"} waiting on this court.`
+                                            : `${nudgeBanner.comp} has ${nudgeBanner.count} earlier match${nudgeBanner.count === 1 ? "" : "es"} on this court.`}
+                                    </span>
+                                    <span className="shiaijo-nudge__cta" aria-hidden="true">Switch →</span>
+                                </button>
+                            )}
                             {allDone && (
                                 <div className="empty">
                                     <h3>All matches complete on Shiaijo {court}</h3>
@@ -687,7 +835,14 @@ function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLin
     return (
         <div className={`shiaijo-qrow ${isComplete ? "shiaijo-qrow--complete" : ""}`}>
             <div className="shiaijo-qrow__top">
-                <span className="shiaijo-qrow__time">{m.scheduledAt || "—"} · {m.compName}</span>
+                <span className="shiaijo-qrow__time">
+                    {m.scheduledAt || "—"} · {m.compName}
+                    {m.phase === "pool" && m.poolPosition > 0 && m.poolCount > 0
+                        ? ` · Match ${m.poolPosition} of ${m.poolCount}`
+                        : m.phase === "bracket" && m.matchNumber > 0
+                        ? ` · Match ${m.matchNumber}`
+                        : ""}
+                </span>
                 <span className="shiaijo-qrow__state">
                     {scoreCell.kind === "team" && <span className="shiaijo-row__teamscore"><abbr className="shiaijo-row__iv" title="Individual Victories">IV</abbr>{scoreCell.iv}</span>}
                     {scoreCell.kind === "ippon" && scoreCell.ippon}

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -623,7 +623,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 
                             {filteredScheduled.length > (upNext ? 1 : 0) && (
                                 <ShiaijoQueueGroup
-                                    label="Upcoming" matches={upNext ? filteredScheduled.slice(1) : filteredScheduled}
+                                    label="Upcoming" subGroup matches={upNext ? filteredScheduled.slice(1) : filteredScheduled}
                                     courts={courts} onMoveCourt={requestMoveCourt}
                                     onMove={moveMatch} onEnterLineup={setLineupMatch}
                                     onPick={pickMatch}
@@ -819,20 +819,61 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 // `scheduled` is the full court scheduled list (used to derive first/last
 // position for disabling the ↑/↓ buttons). `onMove(m, direction)` swaps
 // scheduledAt with the adjacent row via two updateMatchTime calls.
-function ShiaijoQueueGroup({ label, matches, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCall, callingKey, calledKey, startingKey }) {
+// Group an Upcoming slice for display so the operator sees what they'll be
+// scoring: pool matches by pool ("Pool A", "Pool B"), playoff matches by round
+// ("Final", "Round 16"). League is a single round-robin table and needs no
+// grouping → returns null, and the caller renders a flat list. Groups keep
+// first-appearance (i.e. scheduled-time) order; pools are seeded contiguously
+// per court, so each group stays a contiguous time block.
+export function groupQueueMatches(matches) {
+    if (!matches.length || matches.every((m) => m.compFormat === "league")) return null;
+    const order = [];
+    const byKey = new Map();
+    for (const m of matches) {
+        let key, label;
+        if (m.phase === "bracket") {
+            key = "round:" + (m.roundIndex != null ? m.roundIndex : (m.round || ""));
+            label = m.round || "Playoffs";
+        } else if (m.phase === "pool") {
+            key = "pool:" + (m.poolName || "");
+            label = m.poolName || "Pool";
+        } else {
+            key = "other";
+            label = null;
+        }
+        if (!byKey.has(key)) { byKey.set(key, { key, label, matches: [] }); order.push(key); }
+        byKey.get(key).matches.push(m);
+    }
+    return order.map((k) => byKey.get(k));
+}
+
+function ShiaijoQueueGroup({ label, matches, subGroup, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCall, callingKey, calledKey, startingKey }) {
+    const renderRow = (m) => (
+        <ShiaijoQueueRow
+            key={matchKey(m)} m={m}
+            scheduled={scheduled}
+            courts={courts} onMoveCourt={onMoveCourt} onMove={onMove} onEnterLineup={onEnterLineup} onPick={onPick}
+            onCall={onCall} callingKey={callingKey} calledKey={calledKey} startingKey={startingKey}
+        />
+    );
+    const groups = subGroup ? groupQueueMatches(matches) : null;
     return (
         <div className="shiaijo-group">
             {label && <div className="section-title">{label}</div>}
-            <div className="score-editor__list">
-                {matches.map((m) => (
-                    <ShiaijoQueueRow
-                        key={matchKey(m)} m={m}
-                        scheduled={scheduled}
-                        courts={courts} onMoveCourt={onMoveCourt} onMove={onMove} onEnterLineup={onEnterLineup} onPick={onPick}
-                        onCall={onCall} callingKey={callingKey} calledKey={calledKey} startingKey={startingKey}
-                    />
-                ))}
-            </div>
+            {groups
+                ? groups.map((g) => (
+                    <div className="shiaijo-subgroup" key={g.key}>
+                        {g.label && <div className="shiaijo-subgroup__title">{g.label}</div>}
+                        <div className="score-editor__list">
+                            {g.matches.map(renderRow)}
+                        </div>
+                    </div>
+                ))
+                : (
+                    <div className="score-editor__list">
+                        {matches.map(renderRow)}
+                    </div>
+                )}
         </div>
     );
 }

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -237,11 +237,12 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     }, [contextMatch, filteredScheduled]);
 
     // Auto-advance target after a submit: next non-completed match in the
-    // selected competition (stays within the same comp, AC4/AC7).
+    // SUBMITTED match's competition (not the selected one). The scoring panel may
+    // be on a running bout from a different comp than the selector (AC7), so
+    // keying off m.compId keeps Submit+Next within the competition the operator
+    // just scored instead of hopping to the selected comp.
     const nextActiveAfter = (m) => {
-        // Build a filtered+sorted list: running matches (unfiltered) + selected
-        // comp's scheduled matches, then find the next after the submitted match.
-        const pool = [...running, ...filteredScheduled];
+        const pool = [...running, ...scheduled].filter((x) => x.compId === m.compId);
         const idx = pool.findIndex((x) => matchKey(x) === matchKey(m));
         if (idx < 0) return null;
         return pool.slice(idx + 1).find((x) => x.status !== "completed") || null;
@@ -427,9 +428,13 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     const moveMatch = async (m, direction) => {
         if (!window.API || typeof window.API.updateMatchTime !== "function") return;
         if (m.status === "running" || m.status === "completed") return;
-        const idx = scheduled.findIndex((x) => matchKey(x) === matchKey(m));
+        // Reorder WITHIN the filtered (selected-competition) queue — the same list
+        // the rows render and compute first/last against. Swapping against the full
+        // court list would exchange ScheduledAt with a hidden match from another
+        // competition, silently reordering a queue the operator can't even see.
+        const idx = filteredScheduled.findIndex((x) => matchKey(x) === matchKey(m));
         if (idx < 0) return;
-        const neighbour = direction === "up" ? scheduled[idx - 1] : scheduled[idx + 1];
+        const neighbour = direction === "up" ? filteredScheduled[idx - 1] : filteredScheduled[idx + 1];
         if (!neighbour) return; // already first/last
         const label = (m.sideB && m.sideB.name) || (m.sideA && m.sideA.name) || "Match";
         const myTime = m.scheduledAt || "";
@@ -472,7 +477,10 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     };
 
     // allDone: selected comp has no more matches to run on this court (AC4).
+    // Scoped to the SELECTED competition, not the whole court — another comp may
+    // still have matches here (the nudge banner surfaces that).
     const allDone = courtKnown && allMatches.length > 0 && running.length === 0 && filteredScheduled.length === 0;
+    const selectedCompName = (courtsComps.find((c) => c.id === effectiveCompId) || {}).name || "";
 
     return (
         <div className="app">
@@ -546,6 +554,18 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                             This court isn't part of the tournament — it may have been renamed or removed.{" "}
                             <button type="button" onClick={onBack} className="linklike">Back to dashboard</button>.
                         </p>
+                        {/* The title-overlay court switcher is gated on courtKnown, so an
+                            unknown court would otherwise strand the operator. Offer a plain
+                            picker here to jump to a valid court without leaving the page. */}
+                        {courts.length > 0 && (
+                            <label className="empty__action">
+                                Go to a court:{" "}
+                                <select className="input" value="" onChange={(e) => { if (e.target.value) onSwitchCourt(e.target.value); }} aria-label="Switch to a valid court">
+                                    <option value="" disabled>Choose…</option>
+                                    {courts.map((c) => <option key={c} value={c}>Shiaijo {c}</option>)}
+                                </select>
+                            </label>
+                        )}
                     </div>
                 )}
 
@@ -685,9 +705,10 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                             )}
                             {allDone && (
                                 <div className="empty">
-                                    <h3>All matches complete on Shiaijo {court}</h3>
+                                    <h3>{selectedCompName ? `${selectedCompName} is complete on Shiaijo ${court}` : `All matches complete on Shiaijo ${court}`}</h3>
                                     <p style={{ fontSize: 13, color: "var(--ink-3)" }}>
-                                        {completed.length} match{completed.length === 1 ? "" : "es"} scored. Nothing left to run on this court.
+                                        {filteredCompleted.length} match{filteredCompleted.length === 1 ? "" : "es"} scored.{" "}
+                                        {nudgeBanner ? "Another competition still has matches on this court — switch above." : "Nothing left to run on this court."}
                                     </p>
                                 </div>
                             )}
@@ -816,9 +837,10 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 // running match in these groups (the running bout is officiated in the scoring
 // panel on the right), so only scheduled/completed states render here.
 //
-// `scheduled` is the full court scheduled list (used to derive first/last
-// position for disabling the ↑/↓ buttons). `onMove(m, direction)` swaps
-// scheduledAt with the adjacent row via two updateMatchTime calls.
+// `scheduled` is the filtered (selected-competition) scheduled list — the same
+// list `moveMatch` reorders against — used to derive first/last position for
+// disabling the ↑/↓ buttons. `onMove(m, direction)` swaps scheduledAt with the
+// adjacent same-competition row via two updateMatchTime calls.
 // Group an Upcoming slice for display so the operator sees what they'll be
 // scoring: pool matches by pool ("Pool A", "Pool B"), playoff matches by round
 // ("Final", "Round 16"). League is a single round-robin table and needs no

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -504,25 +504,39 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                         )}
                         <div className="page-head__sub">{`Call, start, and score every match on Shiaijo ${court} from here.`}</div>
                     </div>
-                    {courtsComps.length > 0 && (
-                        <div className="page-head__actions">
-                            <div className="shiaijo-comp-selector">
-                                <span className="shiaijo-comp-selector__label">Officiating:</span>
-                                {courtsComps.length === 1 ? (
-                                    <span className="shiaijo-comp-selector__name">{courtsComps[0].name}</span>
-                                ) : (
-                                    <select
-                                        className="input shiaijo-comp-select"
-                                        value={effectiveCompId || ""}
-                                        onChange={(e) => setSelectedCompId(e.target.value)}
-                                        aria-label="Select competition to officiate"
-                                    >
-                                        {courtsComps.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-                                    </select>
-                                )}
+                    {courtsComps.length > 0 && (() => {
+                        // Mirror of the Shiaijo title on the right: the competition being
+                        // officiated gets the same display-title treatment (big name + navy
+                        // chevron chip) so "which court" and "which competition" read as a
+                        // matched pair. Falls back to a plain title when only one comp is
+                        // on this court (no switch affordance needed).
+                        const officiating = courtsComps.find(c => c.id === effectiveCompId) || courtsComps[0];
+                        return (
+                            <div className="page-head__actions">
+                                <div className="shiaijo-officiating">
+                                    {courtsComps.length === 1 ? (
+                                        <h2 className="page-head__title shiaijo-officiating__name">{officiating.name}</h2>
+                                    ) : (
+                                        <div className="shiaijo-title-select shiaijo-title-select--right">
+                                            <h2 className="page-head__title shiaijo-officiating__name">
+                                                {officiating.name}
+                                                <span className="shiaijo-title-select__chevron" aria-hidden="true">▾</span>
+                                            </h2>
+                                            <select
+                                                className="shiaijo-title-select__native"
+                                                value={effectiveCompId || ""}
+                                                onChange={(e) => setSelectedCompId(e.target.value)}
+                                                aria-label="Select competition to officiate"
+                                            >
+                                                {courtsComps.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                                            </select>
+                                        </div>
+                                    )}
+                                    <div className="page-head__sub shiaijo-officiating__sub">Officiating</div>
+                                </div>
                             </div>
-                        </div>
-                    )}
+                        );
+                    })()}
                 </div>
 
                 {!courtKnown && (

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -275,7 +275,9 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         const selHasActive = running.some(m => m.compId === effectiveCompId) || filteredScheduled.length > 0;
 
         if (!selHasActive) {
-            const byComp = {};
+            // Null-prototype: compId is user-controlled (a comp id of "__proto__"
+            // must not pollute the map or collide with inherited keys).
+            const byComp = Object.create(null);
             for (const m of otherScheduled) {
                 if (!byComp[m.compId]) byComp[m.compId] = { id: m.compId, name: m.compName, count: 0 };
                 byComp[m.compId].count++;
@@ -296,14 +298,21 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         const earlierOther = otherScheduled.filter(m => scheduledBefore(m, selUpNext));
 
         if (earlierOther.length > 0) {
-            const byComp = {};
+            // Null-prototype: compId is user-controlled (see Condition A above).
+            const byComp = Object.create(null);
             for (const m of earlierOther) {
                 const e = byComp[m.compId];
                 if (!e) byComp[m.compId] = { id: m.compId, name: m.compName, count: 1, earliestMatch: m };
                 else { e.count++; if (scheduledBefore(m, e.earliestMatch)) e.earliestMatch = m; }
             }
             const entries = Object.values(byComp);
-            entries.sort((a, b) => (scheduledBefore(a.earliestMatch, b.earliestMatch) ? -1 : 1));
+            // Full three-way comparator (return 0 on a tie) so the sort stays
+            // transitive/stable when two comps share an earliest match.
+            entries.sort((a, b) => {
+                if (scheduledBefore(a.earliestMatch, b.earliestMatch)) return -1;
+                if (scheduledBefore(b.earliestMatch, a.earliestMatch)) return 1;
+                return 0;
+            });
             return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "earlier" };
         }
 

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -53,6 +53,16 @@ export function partitionShiaijoMatches(matches) {
 
 const matchKey = (m) => `${m.compId}:${m.id}`;
 
+// Queue-order comparison for two SCHEDULED matches, matching the
+// (scheduledAt, queuePosition) tie-break in sortShiaijoMatches — so the nudge's
+// "another competition has an earlier match" test agrees with the real court
+// queue order, not just the HH:MM string. Returns true when `a` is earlier.
+const scheduledBefore = (a, b) => {
+    const t = (a.scheduledAt || "99:99").localeCompare(b.scheduledAt || "99:99");
+    if (t !== 0) return t < 0;
+    return (Number(a.queuePosition) || 0) < (Number(b.queuePosition) || 0);
+};
+
 // How many of the most-recent completed bouts the Completed section shows
 // before the "Show all N" toggle. Keeps the live queue + standings above the
 // fold on a full-day court without hiding the recent record.
@@ -275,25 +285,25 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
             return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "no-matches" };
         }
 
-        // Condition B: another comp has a match EARLIER than the selected comp's upNext
+        // Condition B: another comp has a match EARLIER than the selected comp's
+        // upNext in the REAL court queue order — (scheduledAt, queuePosition), the
+        // same key sortShiaijoMatches uses — not just the HH:MM string. Comparing
+        // only the time would miss a same-time match that sorts ahead by queue
+        // position.
         const selUpNext = filteredScheduled[0];
         if (!selUpNext) return null;
-        const selTime = selUpNext.scheduledAt || "99:99";
 
-        const earlierOther = otherScheduled.filter(m => {
-            const t = m.scheduledAt || "99:99";
-            return t < selTime; // lexicographic HH:MM comparison
-        });
+        const earlierOther = otherScheduled.filter(m => scheduledBefore(m, selUpNext));
 
         if (earlierOther.length > 0) {
             const byComp = {};
             for (const m of earlierOther) {
-                if (!byComp[m.compId]) byComp[m.compId] = { id: m.compId, name: m.compName, count: 0, earliest: m.scheduledAt || "99:99" };
-                byComp[m.compId].count++;
-                if ((m.scheduledAt || "99:99") < byComp[m.compId].earliest) byComp[m.compId].earliest = m.scheduledAt || "";
+                const e = byComp[m.compId];
+                if (!e) byComp[m.compId] = { id: m.compId, name: m.compName, count: 1, earliestMatch: m };
+                else { e.count++; if (scheduledBefore(m, e.earliestMatch)) e.earliestMatch = m; }
             }
             const entries = Object.values(byComp);
-            entries.sort((a, b) => a.earliest.localeCompare(b.earliest));
+            entries.sort((a, b) => (scheduledBefore(a.earliestMatch, b.earliestMatch) ? -1 : 1));
             return { comp: entries[0].name, compId: entries[0].id, count: entries[0].count, reason: "earlier" };
         }
 

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -481,39 +481,46 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                 <Breadcrumbs items={[{ label: "Dashboard", onClick: onBack }, { label: `Shiaijo ${court}` }]} />
                 <div className="page-head">
                     <div>
-                        <h1 className="page-head__title">Shiaijo {court}</h1>
-                        <div className="page-head__sub">{`Call, start, and score every match on Shiaijo ${court} from here.`}</div>
-                    </div>
-                    {(courtsComps.length > 0 || courts.length > 1) && (
-                        <div className="page-head__actions">
-                            {courtsComps.length > 0 && (
-                                <div className="shiaijo-comp-selector">
-                                    <span className="shiaijo-comp-selector__label">Officiating:</span>
-                                    {courtsComps.length === 1 ? (
-                                        <span className="shiaijo-comp-selector__name">{courtsComps[0].name}</span>
-                                    ) : (
-                                        <select
-                                            className="input shiaijo-comp-select"
-                                            value={effectiveCompId || ""}
-                                            onChange={(e) => setSelectedCompId(e.target.value)}
-                                            aria-label="Select competition to officiate"
-                                        >
-                                            {courtsComps.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
-                                        </select>
-                                    )}
-                                </div>
-                            )}
-                            {courts.length > 1 && (
+                        {courts.length > 1 && courtKnown ? (
+                            // The page title doubles as the court switcher — clicking it
+                            // opens a native court picker (transparent <select> overlay), so
+                            // there's no separate, duplicate "Shiaijo A" control in the actions.
+                            <div className="shiaijo-title-select">
+                                <h1 className="page-head__title">
+                                    Shiaijo {court}
+                                    <span className="shiaijo-title-select__chevron" aria-hidden="true">▾</span>
+                                </h1>
                                 <select
-                                    className="input" style={{ width: "auto" }}
-                                    value={courtKnown ? court : ""}
+                                    className="shiaijo-title-select__native"
+                                    value={court}
                                     onChange={(e) => onSwitchCourt(e.target.value)}
                                     aria-label="Switch court"
                                 >
-                                    {!courtKnown && <option value="" disabled>Shiaijo {court} (unknown)</option>}
                                     {courts.map((c) => <option key={c} value={c}>Shiaijo {c}</option>)}
                                 </select>
-                            )}
+                            </div>
+                        ) : (
+                            <h1 className="page-head__title">Shiaijo {court}</h1>
+                        )}
+                        <div className="page-head__sub">{`Call, start, and score every match on Shiaijo ${court} from here.`}</div>
+                    </div>
+                    {courtsComps.length > 0 && (
+                        <div className="page-head__actions">
+                            <div className="shiaijo-comp-selector">
+                                <span className="shiaijo-comp-selector__label">Officiating:</span>
+                                {courtsComps.length === 1 ? (
+                                    <span className="shiaijo-comp-selector__name">{courtsComps[0].name}</span>
+                                ) : (
+                                    <select
+                                        className="input shiaijo-comp-select"
+                                        value={effectiveCompId || ""}
+                                        onChange={(e) => setSelectedCompId(e.target.value)}
+                                        aria-label="Select competition to officiate"
+                                    >
+                                        {courtsComps.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+                                    </select>
+                                )}
+                            </div>
                         </div>
                     )}
                 </div>

--- a/web-mobile/js/viewer_utils.jsx
+++ b/web-mobile/js/viewer_utils.jsx
@@ -108,7 +108,10 @@ export function compMatches(c) {
   // so they are excluded here — counting them would inflate poolCount and shift
   // "Match N of M" for the regular bouts. Such bouts simply get no position.
   const NON_RR_ID_RE = /-(?:TB|DH)-\d+$/;
-  const poolMatchesByPool = {};
+  // Null-prototype: poolName is user-controlled, so a pool literally named
+  // "__proto__"/"constructor" must not pollute the map or collide with
+  // inherited keys (matches the Object.create(null) pattern used elsewhere).
+  const poolMatchesByPool = Object.create(null);
   for (const m of out) {
     if (m.phase !== "pool") continue;
     if (NON_RR_ID_RE.test(m.id || "")) continue;

--- a/web-mobile/js/viewer_utils.jsx
+++ b/web-mobile/js/viewer_utils.jsx
@@ -98,6 +98,27 @@ export function compMatches(c) {
     compKind: c.kind,
     teamSize: c.teamSize
   })));
+
+  // Add poolPosition (1-based) and poolCount (total RR matches in this pool)
+  // to each pool match so the eyebrow and queue rows can show "Match N of M"
+  // (AC2). Matches are ordered by their natural sort within the pool group;
+  // poolCount is the number of matches with the same poolName, which equals
+  // N*(N-1)/2 for a round-robin pool of N players.
+  const poolMatchesByPool = {};
+  for (const m of out) {
+    if (m.phase !== "pool") continue;
+    const pn = m.poolName || "";
+    if (!poolMatchesByPool[pn]) poolMatchesByPool[pn] = [];
+    poolMatchesByPool[pn].push(m);
+  }
+  for (const pms of Object.values(poolMatchesByPool)) {
+    const count = pms.length;
+    pms.forEach((m, i) => {
+      m.poolPosition = i + 1;
+      m.poolCount = count;
+    });
+  }
+
   return out;
 }
 

--- a/web-mobile/js/viewer_utils.jsx
+++ b/web-mobile/js/viewer_utils.jsx
@@ -102,11 +102,16 @@ export function compMatches(c) {
   // Add poolPosition (1-based) and poolCount (total RR matches in this pool)
   // to each pool match so the eyebrow and queue rows can show "Match N of M"
   // (AC2). Matches are ordered by their natural sort within the pool group;
-  // poolCount is the number of matches with the same poolName, which equals
-  // N*(N-1)/2 for a round-robin pool of N players.
+  // poolCount is the number of REGULAR round-robin matches with the same
+  // poolName, which equals N*(N-1)/2 for a pool of N players. Tiebreak
+  // ("-TB-") and pool-daihyosen ("-DH-") bouts are NOT part of the RR schedule,
+  // so they are excluded here — counting them would inflate poolCount and shift
+  // "Match N of M" for the regular bouts. Such bouts simply get no position.
+  const NON_RR_ID_RE = /-(?:TB|DH)-\d+$/;
   const poolMatchesByPool = {};
   for (const m of out) {
     if (m.phase !== "pool") continue;
+    if (NON_RR_ID_RE.test(m.id || "")) continue;
     const pn = m.poolName || "";
     if (!poolMatchesByPool[pn]) poolMatchesByPool[pn] = [];
     poolMatchesByPool[pn].push(m);


### PR DESCRIPTION
## Summary

Gives the per-court scoring operator (`/admin/shiaijo/:court`) fast answers to "which match am I on, what's next, and am I on the right competition?"

- **Competition selector** in the page-head (`Officiating: <Competition>`); the queue (Up next / Upcoming / Completed) filters to the selected competition.
- **Match number** on the scoring eyebrow and every queue row — pool `Match N of M` (true round-robin count), bracket `Match N` matching the **printed Excel sheet**.
- **Removed the "NOW" pill** — the navy running treatment already signals live state (DESIGN.md §2 Principle 3).
- **Actionable switch nudge** (amber, reuses `.alert--warn`): fires **only** when the selected competition has no more matches on this court (finished, or not yet started) while another competition still has matches waiting. Clicking the banner switches the selector to that competition. Switching never abandons a running match (the scoring panel stays on the running bout).

## Why

Bracket bouts are numbered on the printed sheet, but that number lived **only** in the Excel renderer and never reached the web app — so the operator's screen couldn't show "Match N", and any independent re-derivation risked drifting from the paper sheet. The court console also showed every competition's matches interleaved with no way to focus or to know when another competition needed the court.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_shiaijo.jsx` | Competition selector + queue filter (by `compId`), queue grouping by pool/round, match-number pills, actionable switch nudge (fires when the selected competition has no matches left on the court) |
| `web-mobile/js/admin_scoring_individual.jsx` | Match number in eyebrow; remove NOW pill when running |
| `web-mobile/js/admin_scoring_team.jsx` | Same for the team scorer |
| `web-mobile/js/viewer_utils.jsx` | Compute `poolPosition` / `poolCount` on pool matches |
| `web-mobile/css/styles.css` | `.shiaijo-comp-selector`; `.shiaijo-nudge` composes `.alert--warn`, actionable with hover/focus states |
| `internal/helper/excel_tree.go` | Extract `AssignMatchNumbers` — single Excel numbering walk |
| `internal/helper/excel_tree_test.go` | Unit tests for `AssignMatchNumbers` |
| `internal/helper/tree.go` | `Node.MatchNum()` accessor for the cross-package parity test |
| `internal/engine/bracket.go` | `assignBracketMatchNumbers` — web bracket numbering mirroring Excel (DisplayRound ↓ then ID position) |
| `internal/engine/match_numbering_parity_test.go` | Proves web == Excel numbering position-for-position across bye sizes |
| `internal/state/models.go` | `BracketMatch.MatchNumber` field |
| `DESIGN.md` | Document the two hue-separated pulse meanings (navy = live, amber = expected next action) |

## Screenshots

Operator console (`/admin/shiaijo/:court`), captured live at tablet/desktop width.

**Calm — individual scorer.** The competition being officiated mirrors the Shiaijo title on the right (same display size + navy chevron chip). The Upcoming queue is grouped by pool (`POOL A` / `POOL B`) so the operator sees which pools they'll be scoring. The overtime pill is centered below the foul boxes, and the judges'-decision (Hantei) affordance is the top row of a two-row Decision place. No NOW pill.

![Calm individual scorer](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/314/calm.png)

**Switch nudge (actionable).** The nudge fires **only** when the selected competition has no matches left on this court. Here *Junior Cup* is finished (left column shows only `Completed`), so the amber banner points to the competition that still needs the court — *"Switch to Men's Individual — 27 matches waiting"* — and clicking it switches the selector. It does **not** fire while the selected competition is still active. The scoring panel stays on the running bout (AC7).

![Actionable switch nudge](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/314/nudge.png)

**Team scorer.** `MEN'S TEAM · LEAGUE TABLE · MATCH 1 OF 6` with the sub-bout grid (IV/PW); no NOW pill; queue filtered with team lineup affordances.

![Team scorer](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/314/team.png)

### Upcoming-queue grouping

The Upcoming queue groups by what the operator is about to score, so they can see which pools / rounds are coming. The pool and playoff shots below are the **same competition** — a 16-player mixed "Senior Cup" — captured first in its pools phase, then after every pool match was scored and it advanced to the bracket.

**Pools → grouped by pool.** Senior Cup in its pools phase: `POOL A` / `POOL B` / `POOL C` / `POOL D` headers.

![Pool grouping](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/314/group-pools.png)

**Playoffs → grouped by round.** The *same* Senior Cup after scoring all 24 pool matches: it has advanced to the bracket, the Upcoming queue groups under `QUARTERFINALS` (the four first-round matches), and the 24 pool matches now sit in `Completed`.

![Playoff round grouping](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/314/group-playoffs.png)

**League → no grouping.** A league is a single round-robin table, so the queue is a flat list (`Match N of 28`).

![League — no grouping](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/314/group-league.png)

## Test plan

- [x] `make go/test` passes (lint + gosec + govulncheck + tests; all packages ≥85% coverage)
- [x] New/updated unit tests cover the change — `TestMatchNumberingParity_ExcelVsWeb` (caught & fixed a real numbering drift at 5 and 11 entrants), `TestAssignMatchNumbers`
- [x] Manual browser verification (operator console at tablet/desktop width): individual scorer shows `Match N of M` + no NOW pill; competition dropdown filters the queue; queue groups by pool (Pool A–D) and by round (Quarterfinals) but not for a league; nudge stays silent while the selected competition is active and fires only when it has no matches left on the court ("N matches waiting"); clicking the nudge switches competition and re-filters; scoring panel stays on the running match when switching; team scorer shows match number + no NOW pill
- [x] Screenshots added above (REQUIRED for any UI-affecting change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes mp-ulnb




