### PR TITLE
feat(mp-25bk): Registration desk — cross-competition check-in for operators

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -71,6 +71,11 @@ All tokens are defined in [styles.css#L3-L33](web-mobile/css/styles.css#L3). Ref
 | `--warn-soft` | `#fffbeb` | Warning fill (amber-50) — `.alert--warn`, `.tag-badge--warn`, offline pill background |
 | `--warn-border` | `#fde68a` | Warning hairline border (amber-200) |
 | `--warn-ink` | `#78350f` | Strongest warning text (amber-900, ~8:1 on `--warn-soft`) |
+| `--ok` | `#16a34a` | **Success / present** green — check-in fills, win accents, progress-done. The "this succeeded / is checked-in / advancing / won" signal. Mirrors the `--warn` ramp; **never** for Aka/danger (use `--danger`) or running (use `--accent`). Distinct from the **status-pipeline playoffs** green (`#ecfdf5`/`#065f46`/`#a7f3d0`, badge-only carve-out). |
+| `--ok-strong` | `#15803d` | Stronger success text/border on `--ok-soft` (green-700) |
+| `--ok-soft` | `#f0fdf4` | Success fill — checked-in rows, success alerts, hand-over callout (green-50) |
+| `--ok-border` | `#dcfce7` | Success hairline border (green-100) |
+| `--ok-ink` | `#166534` | Strongest success text, AA on `--ok-soft` (green-800) |
 | `--shiro-edge` | `#2a3346` | Shiro framing on dark surfaces (rare; most Shiro frames use `--accent`) |
 | `--shiro-hatch` | `rgba(42,51,70,0.07)` | 45° diagonal hatch on the Shiro side |
 | `--aka-bright` | `#ff3b3b` | Luminous Aka red for dark TV/overlay surfaces (scoreboard glow) |
@@ -110,15 +115,21 @@ Base: 15px / 1.4. Use the documented sizes below — don't introduce new in-betw
 
 | Size | Use |
 |---|---|
+| 9px | Micro tags/markers (`.pmf__checkin-tag`, scoreboard micro-labels) |
 | 10px | Decision chips, encho marker (`.bc-decision-chip`, `.bc-encho`) |
 | 10.5px | Pill labels, court tags, table column headers |
+| 11px | Dense secondary meta (rail sub-text, row meta, chips) — load-bearing at ~70 uses |
 | 12px | Hints, breadcrumbs, secondary meta |
 | 13–13.5px | Buttons, inputs, badges, bracket sides |
+| 14px | Compact card/list titles, modal body emphasis — ~30 uses |
 | 15px | Body text |
 | 16–18px | Card titles, modal titles |
 | 22px | Large scoreboard numbers (`.sb-name`, `.match-detail-card__ippons-val`, `.stat-box .v`) |
+| 24px | Secondary headings / large modal numerals |
 | 26px | Page-head titles |
 | 28px | Player-viewer hero (`.my-match__name`) — intentionally larger than page-head so the player's name dominates on the viewer screen |
+
+The former in-between strays (11.5 / 12.5 / 9.5 / 14.5 / 17 / 30) were folded into the scale; `9 / 11 / 14 / 24` are promoted as real sizes (they were used consistently, not accidentally). A few `8` and `20` px values remain on specialized scoreboard surfaces — reconcile when next touching those.
 
 Common weights: 500 (default UI), 600 (titles, active state), 700 (badges, scores). 800 appears in localized emphasis (podium step numbers, running strip); 400 in de-emphasis. Prefer the common three unless matching an existing emphasis pattern.
 
@@ -240,6 +251,7 @@ Quick lookup — scan, then `Ctrl+F` the class name to jump to its subsection.
 | Schedule rows | `.sched-row` (admin), `.vsched-item` (viewer) | Schedule list items |
 | Podium | `.podium-step--{1,2,3}` | Final-standings podium |
 | "My Match" hero | `.my-match` | Player-viewer hero card |
+| Registration desk | `.rd-*` | Cross-competition check-in surface (rail + roster + hand-over tag) |
 
 ### Buttons — `.btn`
 
@@ -377,6 +389,19 @@ Three-column layout with `order:` reordering so 1st sits in the middle (visual h
 
 Player-viewer-only. Solid `--accent` background, `--accent-fg` text. The only place white-on-navy body text appears.
 
+### Registration desk — `.rd-*`
+
+Admin-only cross-competition check-in surface ([admin_registration_desk.jsx](web-mobile/js/admin_registration_desk.jsx)). Reuses the `.workspace` shell (rail + main), `.badge`, `.tag-badge`, `.input`, `.select`, `.btn`, `.modal`, and `--focus-ring`. Structure:
+
+- `.rd-rail` / `.rd-rail__item` — competition selector with a per-competition check-in progress meter (`.rd-rail__bar-fill`, navy → `--ok` when complete). Collapses to a horizontal scroller under 860px.
+- `.rd-search` — the surface's visual anchor (16px, autofocused); Enter checks in the top fuzzy hit.
+- `.rd-row` — roster row: `.rd-check` toggle (role=checkbox, `--ok` when checked, `--warn-strong` when partial), identity block, and the **player tag** (`.rd-tag--{number,team,pending}`) — the number/team-name handed to the competitor.
+- `.rd-handoff` — `--ok-soft` callout shown after a check-in, surfacing the tag large enough to read against a placard.
+- `.rd-chip` — a person's other-competition entries; checked chips use the `--ok` family.
+- `.rd-walkup` (inline add, setup-only) and the edit modal reuse the standard field/modal vocabulary.
+
+**Colour:** checked-in = `--ok` family (matches the seeding panel's check-in green); the active rail item and search focus use `--accent`; partial presence uses `--warn-strong`. No red (Aka/danger) appears here.
+
 ## 5. Patterns
 
 ### Page shell
@@ -484,7 +509,7 @@ Before introducing a new component, color, or pattern:
 
 1. **Reuse first.** Check the component list in §4 — there is almost always a match (especially for status badges, cards, table rows).
 2. **Extend, don't fork.** A new button shape is a `.btn--<modifier>`, not a new `.action-button`.
-3. **Token-only colors, with two carve-outs.** If you need a hex literal in a CSS rule, you probably need a new token in `:root` — add it there and reference it. Two existing exceptions: (a) the **status palette** in §3 (badge-only colors that live inside `.badge--*` blocks, never lifted into other components), and (b) the **podium gold/silver/bronze gradients** in `.podium-step--*`. New exceptions need to be argued for, not assumed — and the decision-chip inline styles ([§4 Match cards](#match-cards--bc-match)) are debt, not a precedent.
+3. **Token-only colors, with two carve-outs.** If you need a hex literal in a CSS rule, you probably need a new token in `:root` — add it there and reference it. Two existing exceptions: (a) the **status palette** in §3 (badge-only colors that live inside `.badge--*` blocks, never lifted into other components), and (b) the **podium gold/silver/bronze gradients** in `.podium-step--*`. New exceptions need to be argued for, not assumed — and the decision-chip inline styles ([§4 Match cards](#match-cards--bc-match)) are debt, not a precedent. (The success/present green was exactly this kind of spreading literal — it lived in ~8 component blocks before being promoted to the `--ok*` ramp; if you find another hue repeating across components, tokenize it the same way.)
 4. **Domain-specific is fine.** Match-side colors and podium gradients live inside their component blocks intentionally. Don't generalize them.
 5. **Verify visually.** UI changes are validated in a running browser via `make run-mobile`, not by diff inspection — see [CLAUDE.md](CLAUDE.md) "Common Pitfalls".
 6. **Match the prefix.** Pick the existing prefix that covers your concept (`bc-`, `pool-`, `sched-`, `vsched-`, `tcard-`, `viewer-`, `score-`, `running-`, `my-match-`) before inventing a new one.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -395,7 +395,7 @@ Admin-only cross-competition check-in surface ([admin_registration_desk.jsx](web
 
 - `.rd-rail` / `.rd-rail__item` — competition selector with a per-competition check-in progress meter (`.rd-rail__bar-fill`, navy → `--ok` when complete). Collapses to a horizontal scroller under 860px.
 - `.rd-search` — the surface's visual anchor (16px, autofocused); Enter checks in the top fuzzy hit.
-- `.rd-row` — roster row: `.rd-check` toggle (role=checkbox, `--ok` when checked, `--warn-strong` when partial), identity block, and the **player tag** (`.rd-tag--{number,team,pending}`) — the number/team-name handed to the competitor.
+- `.rd-row` — roster row: `.rd-check` toggle (role=checkbox, `--ok` when checked, `--warn-strong` when partial), identity block, and the **player tag** (`.rd-tag--number` / `.rd-tag--team`) — the number/team-name handed to the competitor (nothing is shown before the draw assigns a number).
 - `.rd-handoff` — `--ok-soft` callout shown after a check-in, surfacing the tag large enough to read against a placard.
 - `.rd-chip` — a person's other-competition entries; checked chips use the `--ok` family.
 - `.rd-walkup` (inline add, setup-only) and the edit modal reuse the standard field/modal vocabulary.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -53,7 +53,7 @@ When extending the design system, **mobile-app is the canonical surface**. The b
 
 ## 3. Design tokens
 
-All tokens are defined in [styles.css#L3-L33](web-mobile/css/styles.css#L3). Reference them via `var(--name)` — never hardcode hex or px scales. The file is ~5,000 lines on purpose; search before adding, but file growth is not a budget.
+All tokens are defined in the `:root` block in [styles.css](web-mobile/css/styles.css). Reference them via `var(--name)` — never hardcode hex or px scales. The file is ~5,000 lines on purpose; search before adding, but file growth is not a budget.
 
 ### Color
 

--- a/internal/mobileapp/middleware.go
+++ b/internal/mobileapp/middleware.go
@@ -228,23 +228,26 @@ func enforceElevated(c *gin.Context, ev ElevatedVerifier) bool {
 func isSelfRunMainGatedConfigRoute(method, fullPath string) bool {
 	switch method + " " + fullPath {
 	case http.MethodGet + " /api/tournament", // Fix 3329406556: password field in full Tournament struct; viewer uses /api/viewer/tournament
-		http.MethodPost + " /api/tournament",                                           // Fix 3329416167: re-bootstrap overwrite when tournament already exists
-		http.MethodPut + " /api/tournament",                                            // tournament name/password/courts/check-in windows
-		http.MethodPost + " /api/competitions",                                         // create a competition (category) — setup
-		http.MethodPut + " /api/competitions/:id",                                      // edit competition config — setup
-		http.MethodPost + " /api/tournament/announce",                                  // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements/:id",                                  // Fix 3329416176: organiser config, not operational play
-		http.MethodDelete + " /api/announcements",                                      // Fix 3329416176: organiser config, not operational play
-		http.MethodPut + " /api/auth/admin-password",                                   // Fix 3330063192: relies on AuthMiddleware main-pw verification; not elevated-gated
-		http.MethodPut + " /api/competitions/:id/schedule",                             // Fix 3330063192: organiser schedule setup, not operational play
-		http.MethodPut + " /api/competitions/:id/matches/:mid/override-winner",         // Fix 3330080949: result correction — organiser, not participant play
-		http.MethodPut + " /api/competitions/:id/pools/:poolId/override-rank",          // Fix 3330080949: standings correction — organiser, not participant play
-		http.MethodPost + " /api/competitions/:id/competitor-status",                   // Fix 3331033814: eligibility mutation — organiser decision, not operational play
-		http.MethodGet + " /api/competitions/:id/export",                               // Fix 3332740291: xlsx export — admin/CPU-heavy, not operational play
-		http.MethodPut + " /api/competitions/:id/matches/:mid/court",                   // court assignment — organiser coordination
-		http.MethodPut + " /api/competitions/:id/matches/:mid/time",                    // match time — organiser coordination
-		http.MethodPut + " /api/competitions/:id/seeds",                                // seeding — organiser pre-draw setup
-		http.MethodPost + " /api/competitions/:id/competitors/:pid/reinstate",          // kiken-injury reinstatement — organiser decision
+		http.MethodPost + " /api/tournament",                                   // Fix 3329416167: re-bootstrap overwrite when tournament already exists
+		http.MethodPut + " /api/tournament",                                    // tournament name/password/courts/check-in windows
+		http.MethodPost + " /api/competitions",                                 // create a competition (category) — setup
+		http.MethodPut + " /api/competitions/:id",                              // edit competition config — setup
+		http.MethodPost + " /api/tournament/announce",                          // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements/:id",                          // Fix 3329416176: organiser config, not operational play
+		http.MethodDelete + " /api/announcements",                              // Fix 3329416176: organiser config, not operational play
+		http.MethodPut + " /api/auth/admin-password",                           // Fix 3330063192: relies on AuthMiddleware main-pw verification; not elevated-gated
+		http.MethodPut + " /api/competitions/:id/schedule",                     // Fix 3330063192: organiser schedule setup, not operational play
+		http.MethodPut + " /api/competitions/:id/matches/:mid/override-winner", // Fix 3330080949: result correction — organiser, not participant play
+		http.MethodPut + " /api/competitions/:id/pools/:poolId/override-rank",  // Fix 3330080949: standings correction — organiser, not participant play
+		http.MethodPost + " /api/competitions/:id/competitor-status",           // Fix 3331033814: eligibility mutation — organiser decision, not operational play
+		http.MethodGet + " /api/competitions/:id/export",                       // Fix 3332740291: xlsx export — admin/CPU-heavy, not operational play
+		http.MethodPut + " /api/competitions/:id/matches/:mid/court",           // court assignment — organiser coordination
+		http.MethodPut + " /api/competitions/:id/matches/:mid/time",            // match time — organiser coordination
+		http.MethodPut + " /api/competitions/:id/seeds",                        // seeding — organiser pre-draw setup
+		http.MethodPost + " /api/competitions/:id/competitors/:pid/reinstate",  // kiken-injury reinstatement — organiser decision
+		// Forward check-in (single PUT + bulk POST /checkin-bulk) is intentionally ungated —
+		// participants and desk staff can check in without the main admin password.
+		// Only reversal (DELETE) requires it.
 		http.MethodDelete + " /api/competitions/:id/participants/:pid/checkin",         // check-in reversal — organiser correction
 		http.MethodPut + " /api/competitions/:id/teams/:tid/lineups/:round",            // team lineup management — organiser
 		http.MethodDelete + " /api/competitions/:id/teams/:tid/lineups/:round",         // team lineup management — organiser

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8172,6 +8172,12 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 .rd-workspace {
   align-items: start;
+  /* Cap the main column so the competitor's name and the number they're handed
+     read as a pair instead of being flung to opposite edges of an ultra-wide
+     row; centre the rail+main block so wide screens stay balanced rather than
+     left-shifted. The <860px media query below resets this to a single column. */
+  grid-template-columns: 240px minmax(0, 720px);
+  justify-content: center;
 }
 
 /* --- Rail: competition selector ----------------------------------------- */

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8147,3 +8147,816 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
     opacity: 1 !important;
   }
 }
+
+/* ===========================================================================
+   Registration desk (mp-25bk) — cross-competition check-in surface.
+   Prefix: rd-. Reuses the .workspace shell, .badge, .tag-badge, .input, .select,
+   .btn, .empty, .spinner vocabulary. "Checked-in = green" matches the existing
+   seeding panel (.seed-row.is-checked-in); navy --accent is reserved for the
+   active rail selection and the search focus, per DESIGN.md Principle 3.
+   Component-local check-in greens mirror the literals already used by
+   .seed-row.is-checked-in (an established carve-out for this exact concept).
+   =========================================================================== */
+
+.rd-workspace {
+  align-items: start;
+}
+
+/* --- Rail: competition selector ----------------------------------------- */
+.rd-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  padding: 8px;
+  position: sticky;
+  top: 70px;
+  max-height: calc(100vh - 90px);
+  overflow-y: auto;
+}
+
+.rd-rail__divider {
+  height: 1px;
+  background: var(--line);
+  margin: 4px 4px;
+}
+
+.rd-rail__item {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 9px 11px;
+  cursor: pointer;
+  transition: background 120ms var(--ease-out), border-color 120ms var(--ease-out);
+}
+
+.rd-rail__item:hover {
+  background: var(--line-2);
+}
+
+.rd-rail__item.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent-soft);
+}
+
+.rd-rail__item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.rd-rail__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.rd-rail__name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ink-1);
+  line-height: 1.25;
+}
+
+.rd-rail__item.is-active .rd-rail__name {
+  color: var(--accent);
+}
+
+.rd-rail__sub {
+  font-size: 11.5px;
+  color: var(--ink-3);
+}
+
+.rd-rail__bar {
+  height: 5px;
+  border-radius: 999px;
+  background: var(--line-2);
+  overflow: hidden;
+}
+
+.rd-rail__bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 300ms var(--ease-out);
+}
+
+.rd-rail__bar-fill.is-done {
+  background: #16a34a;
+}
+
+.rd-rail__count {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.rd-rail__count strong {
+  color: var(--ink-1);
+  font-weight: 700;
+}
+
+/* --- Main column -------------------------------------------------------- */
+.rd-main {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.rd-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+/* Search is the visual anchor — largest control on the surface. */
+.rd-search {
+  position: relative;
+  flex: 1 1 320px;
+  display: flex;
+  align-items: center;
+}
+
+.rd-search__icon {
+  position: absolute;
+  left: 14px;
+  color: var(--ink-3);
+  pointer-events: none;
+}
+
+.rd-search__input {
+  width: 100%;
+  font-size: 16px;
+  font-weight: 500;
+  padding: 13px 40px 13px 42px;
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  background: var(--surface);
+  color: var(--ink-1);
+  transition: border-color 120ms var(--ease-out), box-shadow 120ms var(--ease-out);
+}
+
+.rd-search__input::placeholder {
+  color: var(--ink-4);
+  font-weight: 400;
+}
+
+.rd-search__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.rd-search__clear {
+  position: absolute;
+  right: 10px;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 999px;
+  background: var(--line-2);
+  color: var(--ink-2);
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.rd-search__clear:hover {
+  background: var(--line);
+  color: var(--ink-1);
+}
+
+.rd-headline {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.rd-headline__metric {
+  font-size: 20px;
+  color: var(--ink-2);
+}
+
+.rd-headline__metric strong {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--ink-1);
+}
+
+.rd-headline__noun {
+  font-size: 11.5px;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+.rd-walkup-btn {
+  flex-shrink: 0;
+}
+
+/* --- Toolbar (filters) -------------------------------------------------- */
+.rd-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.rd-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+.rd-filter .select {
+  padding: 6px 26px 6px 9px;
+  font-size: 12.5px;
+  width: auto;
+}
+
+.rd-toggle {
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: background 120ms var(--ease-out), border-color 120ms var(--ease-out), color 120ms var(--ease-out);
+}
+
+.rd-toggle:hover {
+  border-color: var(--ink-4);
+}
+
+.rd-toggle.is-on {
+  background: var(--accent-soft);
+  border-color: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.rd-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.rd-toolbar__busy {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+/* --- Hand-over callout: the moment after a check-in --------------------- */
+.rd-handoff {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: var(--r);
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  animation: rd-handoff-in 200ms var(--ease-out);
+}
+
+@keyframes rd-handoff-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.rd-handoff__close {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  color: #15803d;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 999px;
+}
+
+.rd-handoff__close:hover {
+  background: #dcfce7;
+}
+
+.rd-handoff__lead {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: #166534;
+}
+
+.rd-handoff__lead strong {
+  font-weight: 700;
+}
+
+.rd-handoff__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.rd-handoff__tag {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.rd-handoff__comp {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+/* --- Player tag pill (the thing handed over) ---------------------------- */
+.rd-tag {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.rd-tag__label {
+  font-family: var(--font);
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+}
+
+.rd-tag__value {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.rd-tag--number {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.rd-tag--team {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-family: var(--font);
+}
+
+.rd-tag--team .rd-tag__value {
+  font-family: var(--font);
+}
+
+.rd-tag--pending {
+  /* White (not --line-2) so the muted --ink-4 text clears WCAG AA (4.72:1);
+     the dashed border + italic still read it as an empty/pending slot. */
+  background: var(--surface);
+  color: var(--ink-4);
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 500;
+  font-style: italic;
+  border: 1px dashed var(--ink-4);
+}
+
+.rd-tag--lg {
+  padding: 7px 14px;
+}
+
+.rd-tag--lg .rd-tag__value {
+  font-size: 20px;
+}
+
+/* --- Roster rows -------------------------------------------------------- */
+.rd-roster {
+  display: flex;
+  flex-direction: column;
+}
+
+.rd-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--r);
+  border: 1px solid transparent;
+  border-bottom: 1px solid var(--line-2);
+  transition: background 120ms var(--ease-out);
+}
+
+.rd-row:hover {
+  background: var(--line-2);
+}
+
+.rd-row--last {
+  border-bottom-color: transparent;
+}
+
+.rd-row.is-checked {
+  background: #f0fdf4;
+  border-color: #dcfce7;
+}
+
+.rd-row.is-checked:hover {
+  background: #e7fbec;
+}
+
+.rd-row.is-partial {
+  background: var(--warn-soft);
+  border-color: var(--warn-border);
+}
+
+/* The check toggle — the primary action. Generous hit area (≥44px coarse). */
+.rd-check {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
+.rd-check__box {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  border: 2px solid var(--ink-4);
+  background: var(--surface);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  transition: background 120ms var(--ease-out), border-color 120ms var(--ease-out);
+}
+
+.rd-check:hover .rd-check__box {
+  border-color: #16a34a;
+}
+
+.rd-row.is-checked .rd-check__box {
+  background: #16a34a;
+  border-color: #16a34a;
+}
+
+.rd-row.is-partial .rd-check__box {
+  background: var(--warn-strong);
+  border-color: var(--warn-strong);
+}
+
+.rd-check:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.rd-check:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.rd-row__id {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.rd-row__name-line {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.rd-row__name {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--ink-1);
+}
+
+.rd-row__zekken {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--ink-3);
+  background: var(--line-2);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.rd-row__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--ink-3);
+  flex-wrap: wrap;
+}
+
+.rd-row__dojo {
+  color: var(--ink-2);
+  font-weight: 500;
+}
+
+.rd-row__seed {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.rd-row__right {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rd-row__handover {
+  flex-shrink: 0;
+}
+
+/* Inline edit (pencil): quiet until the row is hovered/focused, so it never
+   competes with the check toggle or player tag. */
+.rd-row__edit {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: none;
+  color: var(--ink-4);
+  border-radius: 8px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms var(--ease-out), background 120ms var(--ease-out), color 120ms var(--ease-out);
+}
+
+.rd-row:hover .rd-row__edit,
+.rd-row__edit:focus-visible {
+  opacity: 1;
+}
+
+.rd-row__edit:hover {
+  background: var(--line-2);
+  color: var(--ink-1);
+}
+
+.rd-row__edit:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.rd-row__edit:disabled {
+  cursor: default;
+  opacity: 0;
+}
+
+/* Touch devices have no hover — keep the pencil visible so it's reachable. */
+@media (pointer: coarse) {
+  .rd-row__edit {
+    opacity: 1;
+  }
+}
+
+.rd-edit__note {
+  margin: 12px 0 0;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+/* Other-competition chips */
+.rd-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+.rd-chips__label {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ink-4);
+}
+
+.rd-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink-2);
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 120ms var(--ease-out), background 120ms var(--ease-out);
+}
+
+.rd-chip:hover:not(:disabled) {
+  border-color: #16a34a;
+}
+
+.rd-chip__mark {
+  width: 14px;
+  height: 14px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  color: #16a34a;
+}
+
+.rd-chip.is-checked {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+  color: #166534;
+  cursor: default;
+}
+
+.rd-chip.is-withdrawn {
+  opacity: 0.5;
+  text-decoration: line-through;
+  cursor: not-allowed;
+}
+
+.rd-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* --- Group-by-dojo ------------------------------------------------------ */
+.rd-group {
+  margin-bottom: 10px;
+}
+
+.rd-group__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px 6px;
+  position: sticky;
+  top: 60px;
+  background: var(--bg);
+  z-index: 1;
+}
+
+.rd-group__name {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ink-2);
+}
+
+.rd-group__count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink-4);
+  background: var(--line-2);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.rd-group__bulk {
+  margin-left: auto;
+}
+
+/* --- Walk-up inline form ------------------------------------------------ */
+.rd-walkup {
+  border: 1px solid var(--accent-soft);
+  background: var(--accent-soft);
+  border-radius: var(--r);
+  padding: 14px 16px;
+}
+
+.rd-walkup__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.rd-walkup__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.rd-walkup__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.rd-walkup .field__opt {
+  font-weight: 400;
+  color: var(--ink-3);
+}
+
+.rd-walkup__actions {
+  margin-top: 12px;
+}
+
+/* --- Empty / no-match states ------------------------------------------- */
+.rd-empty {
+  margin-top: 8px;
+}
+
+.rd-empty__sub {
+  font-size: 13px;
+  color: var(--ink-2);
+  max-width: 420px;
+  margin: 4px auto 14px;
+  line-height: 1.5;
+}
+
+.rd-empty--done .icon {
+  color: #16a34a;
+  opacity: 1;
+}
+
+/* --- Responsive --------------------------------------------------------- */
+@media (max-width: 860px) {
+  .rd-workspace {
+    grid-template-columns: 1fr;
+  }
+  .rd-rail {
+    position: static;
+    max-height: none;
+    flex-direction: row;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scroll-snap-type: x proximity;
+  }
+  .rd-rail__item {
+    width: 210px;
+    min-width: 210px;
+    max-width: 210px;
+    flex: 0 0 210px;
+    scroll-snap-align: start;
+  }
+  .rd-rail__divider {
+    width: 1px;
+    height: auto;
+    margin: 4px 2px;
+    flex: 0 0 1px;
+  }
+}
+
+@media (max-width: 560px) {
+  .rd-row {
+    flex-wrap: wrap;
+  }
+  .rd-row__handover {
+    width: 100%;
+    padding-left: 48px;
+  }
+  .rd-headline {
+    order: 3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rd-handoff {
+    animation: none;
+  }
+  .rd-rail__bar-fill,
+  .rd-row,
+  .rd-check__box,
+  .rd-toggle,
+  .rd-chip,
+  .rd-search__input {
+    transition: none;
+  }
+}

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8261,9 +8261,11 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 .rd-rail__bar-fill {
   height: 100%;
+  width: 100%;
   border-radius: 999px;
   background: var(--accent);
-  transition: width 300ms var(--ease-out);
+  transform-origin: left;
+  transition: transform 300ms var(--ease-out);
 }
 
 .rd-rail__bar-fill.is-done {
@@ -8737,10 +8739,15 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   opacity: 0;
 }
 
-/* Touch devices have no hover — keep the pencil visible so it's reachable. */
+/* Touch devices have no hover — keep the pencil visible so it's reachable.
+   Also bump the check toggle to the DESIGN.md ≥44px coarse-pointer minimum. */
 @media (pointer: coarse) {
   .rd-row__edit {
     opacity: 1;
+  }
+  .rd-check {
+    width: 44px;
+    height: 44px;
   }
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8517,15 +8517,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   white-space: nowrap;
 }
 
-.rd-tag__label {
-  font-family: var(--font);
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  opacity: 0.7;
-}
-
 .rd-tag__value {
   font-size: 15px;
   font-weight: 700;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8804,12 +8804,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   cursor: default;
 }
 
-.rd-chip.is-withdrawn {
-  opacity: 0.5;
-  text-decoration: line-through;
-  cursor: not-allowed;
-}
-
 .rd-chip:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8546,17 +8546,6 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   font-family: var(--font);
 }
 
-.rd-tag--pending {
-  /* White (not --line-2) so the muted --ink-4 text clears WCAG AA (4.72:1);
-     the dashed border + italic still read it as an empty/pending slot. */
-  background: var(--surface);
-  color: var(--ink-4);
-  font-family: var(--font);
-  font-size: 12px;
-  font-weight: 500;
-  font-style: italic;
-  border: 1px dashed var(--ink-4);
-}
 
 .rd-tag--lg {
   padding: 7px 14px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -43,6 +43,18 @@
   --warn-soft: #fffbeb;   /* amber-50: warning fill */
   --warn-border: #fde68a; /* amber-200: warning hairline border */
   --warn-ink: #78350f;    /* amber-900: strongest warning text, ~8:1 on --warn-soft */
+
+  /* Success / present — green. The "this is checked-in / advancing / a winner /
+     succeeded" signal, distinct from the status-pipeline playoffs green
+     (#ecfdf5/#065f46/#a7f3d0, badge-only carve-out) and never used for
+     Aka/danger or running. Promoted from per-component literals that had spread
+     across check-in rows, the seeding panel, league matrix, alerts and the
+     registration desk. Mirrors the --warn ramp. */
+  --ok: #16a34a;          /* green-600: check fills, win accents, progress-done */
+  --ok-strong: #15803d;   /* green-700: stronger text/border on soft */
+  --ok-soft: #f0fdf4;     /* green-50: success fill */
+  --ok-border: #dcfce7;   /* green-100: success hairline border */
+  --ok-ink: #166534;      /* green-800: strongest success text, AA on --ok-soft */
   --white-side: #f6f7fb;
 
   --ink: #1a1d24;
@@ -585,7 +597,7 @@ a:hover {
 
 .btn--sm {
   padding: 5px 10px;
-  font-size: 12.5px;
+  font-size: 12px;
   border-radius: 6px;
 }
 
@@ -722,7 +734,7 @@ a:hover {
 }
 
 .field__label {
-  font-size: 12.5px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--ink-2);
   letter-spacing: 0.01em;
@@ -926,7 +938,7 @@ a:hover {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.02em;
   padding: 2px 8px;
@@ -1039,7 +1051,7 @@ a:hover {
 }
 
 .tcard__meta {
-  font-size: 12.5px;
+  font-size: 12px;
   color: var(--ink-3);
   display: flex;
   flex-wrap: wrap;
@@ -1312,7 +1324,7 @@ a:hover {
 /* Explicit winner marker — weight/colour alone are weak signals (a11y +
    colour-blind). A green check makes the advancing side unambiguous. */
 .bc-winner-tick {
-  color: #16a34a;
+  color: var(--ok);
   font-weight: 800;
   margin-right: 4px;
 }
@@ -1508,7 +1520,7 @@ a:hover {
 }
 
 .pool__meta {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
 }
 
@@ -1538,7 +1550,7 @@ a:hover {
   text-align: center;
   font-variant-numeric: tabular-nums;
   font-family: var(--font-mono);
-  font-size: 12.5px;
+  font-size: 12px;
 }
 
 .pool__table th:last-child,
@@ -1708,8 +1720,8 @@ a:hover {
 }
 
 .phase-chip--done {
-  background: #dcfce7;
-  color: #15803d;
+  background: var(--ok-border);
+  color: var(--ok-strong);
 }
 
 .phase-chip--running {
@@ -1829,7 +1841,7 @@ a:hover {
 }
 
 .sched-row__side .dojo {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
   white-space: nowrap;
   overflow: hidden;
@@ -1881,7 +1893,7 @@ a:hover {
 }
 .shiaijo-move-confirm__title {
   margin: 0 0 8px;
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 700;
   color: var(--ink-1);
 }
@@ -1988,12 +2000,12 @@ a:hover {
 
 .auth__error {
   color: var(--red);
-  font-size: 12.5px;
+  font-size: 12px;
   margin-top: 6px;
 }
 
 .auth__hint {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
   text-align: center;
   margin-top: 14px;
@@ -2148,7 +2160,7 @@ a:hover {
 }
 
 .viewer__sub {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
 }
 
@@ -2375,7 +2387,7 @@ a:hover {
   background: rgba(255, 255, 255, 0.16);
   border-radius: 8px;
   padding: 8px 10px;
-  font-size: 11.5px;
+  font-size: 11px;
   flex: 1;
 }
 
@@ -3198,7 +3210,7 @@ button.pool-match-row {
 }
 
 .awards-hero__crown {
-  font-size: 30px;
+  font-size: 28px;
   line-height: 1;
 }
 
@@ -3418,7 +3430,7 @@ button.pool-match-row {
 
 .comp-step__cta {
   margin-top: 8px;
-  font-size: 12.5px;
+  font-size: 12px;
 }
 
 .comp-steps__hint {
@@ -3546,8 +3558,8 @@ button.pool-match-row {
 }
 
 .seed-row.is-checked-in {
-  background: #f0fdf4; /* Very light green */
-  border-color: #dcfce7;
+  background: var(--ok-soft); /* Very light green */
+  border-color: var(--ok-border);
 }
 
 .seed-row.is-checked-in .seed-row__name {
@@ -3569,7 +3581,7 @@ button.pool-match-row {
 }
 
 .seed-row.has-seed.is-checked-in {
-  background: linear-gradient(90deg, #fffbeb 0%, #f0fdf4 100%);
+  background: linear-gradient(90deg, #fffbeb 0%, var(--ok-soft) 100%);
 }
 
 .seed-row__handle {
@@ -3804,7 +3816,7 @@ button.pool-match-row {
 
 .pmf__placeholder {
   color: var(--ink-3);
-  font-size: 12.5px;
+  font-size: 12px;
   padding: 2px 4px;
 }
 
@@ -3821,8 +3833,8 @@ button.pool-match-row {
 }
 
 .pmf__chip.is-checked-in {
-  background: #f0fdf4;
-  color: #166534;
+  background: var(--ok-soft);
+  color: var(--ok-ink);
 }
 
 .pmf__chip button {
@@ -3970,7 +3982,7 @@ button.pool-match-row {
 }
 
 .dropzone__sub {
-  font-size: 12.5px;
+  font-size: 12px;
   color: var(--ink-3);
   margin-top: 2px;
 }
@@ -3993,7 +4005,7 @@ button.pool-match-row {
 }
 
 .tw-sched__filter-label {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
   font-weight: 600;
   text-transform: uppercase;
@@ -5394,7 +5406,7 @@ button.pool-match-row {
 .pool-match-row__badge {
   display: inline-flex;
   align-items: center;
-  font-size: 7px;
+  font-size: 8px;
   font-weight: 800;
   letter-spacing: 0.06em;
   padding: 1px 3px;
@@ -5425,7 +5437,7 @@ button.pool-match-row {
 .se-color-badge {
   display: inline-flex;
   align-items: center;
-  font-size: 7px;
+  font-size: 8px;
   font-weight: 800;
   letter-spacing: 0.06em;
   padding: 1px 4px;
@@ -5502,7 +5514,7 @@ button.pool-match-row {
   padding: 6px 14px;
   border: 1px solid var(--line);
   border-radius: 999px;
-  font-size: 12.5px;
+  font-size: 12px;
   font-weight: 500;
   background: var(--surface);
   color: var(--ink-2);
@@ -5603,7 +5615,7 @@ button.pool-match-row {
 
 .parse-preview .cell--missing {
   color: var(--red, #c00);
-  background: #fff0f0;
+  background: var(--danger-soft);
 }
 
 .alert {
@@ -5614,7 +5626,7 @@ button.pool-match-row {
 }
 
 .alert--error {
-  background: #fff0f0;
+  background: var(--danger-soft);
   border-color: #f5c2c2;
   color: #9b1c1c;
 }
@@ -5626,9 +5638,9 @@ button.pool-match-row {
 }
 
 .alert--success {
-  background: #f0fdf4;
-  border-color: #86efac;
-  color: #15803d;
+  background: var(--ok-soft);
+  border-color: var(--ok-border);
+  color: var(--ok-strong);
 }
 
 /* ---------- League tie-breaker banner (.league-tiebreak) ----------
@@ -5977,7 +5989,7 @@ button.pool-match-row {
 .msb-slot--aka { color: var(--red, #b91c1c); }
 .msb-vs { min-width: 16px; text-align: center; color: #9ca3af; font-size: 11px; font-weight: 700; }
 .msb-hansoku { color: var(--red, #dc2626); font-weight: 700; }
-.msb-ht { font-size: 10px; color: #6b7280; font-weight: 600; }
+.msb-ht { font-size: 10px; color: var(--ink-3); font-weight: 600; }
 /* Win indicator for an ippon-less decision (hantei "Ht" / fusensho·kiken "○"):
    the mark sits in the winning side's slot. No special colour — the slot keeps
    its side colour (Shiro dark, Aka red); only the weight is bumped so the mark
@@ -5987,7 +5999,7 @@ button.pool-match-row {
 .msb-row--summary { border-top: 2px solid #111; }
 .msb-row--summary .msb-slot { border: none; flex-direction: column; min-width: 26px;
   font-size: 16px; font-weight: 800; height: auto; }
-.msb-lab { display: block; font-size: 10px; font-weight: 600; color: #6b7280; letter-spacing: .04em; }
+.msb-lab { display: block; font-size: 10px; font-weight: 600; color: var(--ink-3); letter-spacing: .04em; }
 abbr.msb-lab { text-decoration: none; cursor: help; }
 /* running-match highlight: navy running-signal language (DESIGN.md Principle 3).
    --accent-soft fill (same token used by bc-match--running / sched-row--running)
@@ -6004,7 +6016,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .msb-row--dh-banner { justify-content: center; border-top: 2px solid #111; padding: 6px 0 2px; }
 .msb-dh-tag { display: inline-block; background: #111; color: #fff; font-size: 10px;
   font-weight: 700; letter-spacing: .1em; padding: 2px 8px; border-radius: 3px; }
-.msb-dh-pending { text-align: center; padding: 8px 0; font-size: 12px; color: #6b7280; }
+.msb-dh-pending { text-align: center; padding: 8px 0; font-size: 12px; color: var(--ink-3); }
 /* TV variant — scale up for the fullscreen board */
 .msb--tv .msb-row { font-size: 3vh; padding: 1.2vh 1vw; border-top: 1px solid #e5e7eb; }
 .msb--tv .msb-name { font-size: 3vh; }
@@ -6092,8 +6104,8 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .league-matrix__cell[role="button"]:hover { filter: brightness(0.92); }
 .league-matrix__cell[role="button"]:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 
-.league-matrix__win { color: #16a34a; }
-.league-matrix__loss { color: #dc2626; }
+.league-matrix__win { color: var(--ok); }
+.league-matrix__loss { color: var(--danger); }
 /* Draw = neutral ippon letters (no win/loss hue). Plain text — never underlined:
    an underline reads as a hyperlink on static data. The draw is already the
    visual odd-one-out (uncoloured letters on the neutral cell), and the Matches
@@ -6117,7 +6129,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   border-radius: 3px;
   font-weight: 700;
 }
-.league-matrix__legend-item--win { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
+.league-matrix__legend-item--win { color: var(--ok); background: rgba(22, 163, 74, 0.1); }
 .league-matrix__legend-item--loss { color: #dc2626; background: rgba(220, 38, 38, 0.08); }
 .league-matrix__legend-item--draw { color: var(--ink-2); background: var(--bg-2); }
 
@@ -6617,7 +6629,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 .editor-modal--compact .sb-name {
   font-family: var(--font-display);
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 800;
   letter-spacing: -0.01em;
   margin-bottom: 2px;
@@ -8230,7 +8242,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-rail__sub {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
 }
 
@@ -8249,7 +8261,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-rail__bar-fill.is-done {
-  background: #16a34a;
+  background: var(--ok);
 }
 
 .rd-rail__count {
@@ -8324,7 +8336,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   border-radius: 999px;
   background: var(--line-2);
   color: var(--ink-2);
-  font-size: 17px;
+  font-size: 16px;
   line-height: 1;
   cursor: pointer;
   display: grid;
@@ -8355,7 +8367,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-headline__noun {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--ink-3);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -8386,12 +8398,12 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 .rd-filter .select {
   padding: 6px 26px 6px 9px;
-  font-size: 12.5px;
+  font-size: 12px;
   width: auto;
 }
 
 .rd-toggle {
-  font-size: 12.5px;
+  font-size: 12px;
   font-weight: 500;
   padding: 6px 11px;
   border-radius: 999px;
@@ -8435,8 +8447,8 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   gap: 10px;
   padding: 14px 16px;
   border-radius: var(--r);
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
+  background: var(--ok-soft);
+  border: 1px solid var(--ok-border);
   animation: rd-handoff-in 200ms var(--ease-out);
 }
 
@@ -8453,7 +8465,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   height: 24px;
   border: none;
   background: none;
-  color: #15803d;
+  color: var(--ok-strong);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
@@ -8461,7 +8473,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-handoff__close:hover {
-  background: #dcfce7;
+  background: var(--ok-border);
 }
 
 .rd-handoff__lead {
@@ -8470,7 +8482,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   gap: 7px;
   font-size: 13.5px;
   font-weight: 600;
-  color: #166534;
+  color: var(--ok-ink);
 }
 
 .rd-handoff__lead strong {
@@ -8507,7 +8519,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 
 .rd-tag__label {
   font-family: var(--font);
-  font-size: 9.5px;
+  font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -8580,12 +8592,12 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-row.is-checked {
-  background: #f0fdf4;
-  border-color: #dcfce7;
+  background: var(--ok-soft);
+  border-color: var(--ok-border);
 }
 
 .rd-row.is-checked:hover {
-  background: #e7fbec;
+  background: var(--ok-border);
 }
 
 .rd-row.is-partial {
@@ -8619,12 +8631,12 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-check:hover .rd-check__box {
-  border-color: #16a34a;
+  border-color: var(--ok);
 }
 
 .rd-row.is-checked .rd-check__box {
-  background: #16a34a;
-  border-color: #16a34a;
+  background: var(--ok);
+  border-color: var(--ok);
 }
 
 .rd-row.is-partial .rd-check__box {
@@ -8658,7 +8670,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-row__name {
-  font-size: 14.5px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--ink-1);
 }
@@ -8778,14 +8790,14 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   border: 1px solid var(--line);
   background: var(--surface);
   color: var(--ink-2);
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 500;
   cursor: pointer;
   transition: border-color 120ms var(--ease-out), background 120ms var(--ease-out);
 }
 
 .rd-chip:hover:not(:disabled) {
-  border-color: #16a34a;
+  border-color: var(--ok);
 }
 
 .rd-chip__mark {
@@ -8794,13 +8806,13 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   display: grid;
   place-items: center;
   border-radius: 999px;
-  color: #16a34a;
+  color: var(--ok);
 }
 
 .rd-chip.is-checked {
-  background: #f0fdf4;
-  border-color: #bbf7d0;
-  color: #166534;
+  background: var(--ok-soft);
+  border-color: var(--ok-border);
+  color: var(--ok-ink);
   cursor: default;
 }
 
@@ -8896,7 +8908,7 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 }
 
 .rd-empty--done .icon {
-  color: #16a34a;
+  color: var(--ok);
   opacity: 1;
 }
 

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -8816,6 +8816,24 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
   cursor: default;
 }
 
+/* Player number (the tag to hand over) for this competition, shown on the chip
+   so it's visible in "all competitions" mode where there's no single tag. */
+.rd-chip__num {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 4px;
+  padding: 0 5px;
+  margin-left: 1px;
+}
+
+.rd-chip.is-checked .rd-chip__num {
+  color: var(--ok-ink);
+  background: var(--surface);
+}
+
 .rd-chip:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -5639,7 +5639,7 @@ button.pool-match-row {
 
 .alert--success {
   background: var(--ok-soft);
-  border-color: var(--ok-border);
+  border-color: #86efac; /* green-300: alert border is stronger than the hairline ok-border token */
   color: var(--ok-strong);
 }
 

--- a/web-mobile/index.html
+++ b/web-mobile/index.html
@@ -143,6 +143,10 @@
     <!-- admin_shiaijo.js exports AdminShiaijoPage to window. Must load before
          admin.js which reads window.AdminShiaijoPage (mp-c2yr). -->
     <script type="module" src="/dist/admin_shiaijo.js?v=5"></script>
+    <!-- admin_registration_desk.js exports AdminRegistrationDeskPage to window.
+         Must load before admin.js which reads window.AdminRegistrationDeskPage
+         in its "registrationDesk" view branch (mp-25bk). -->
+    <script type="module" src="/dist/admin_registration_desk.js?v=5"></script>
     <script type="module" src="/dist/admin.js?v=5"></script>
     <script type="module" src="/dist/app.js?v=5"></script>
 </body>

--- a/web-mobile/js/__tests__/admin_registration_desk.test.jsx
+++ b/web-mobile/js/__tests__/admin_registration_desk.test.jsx
@@ -58,6 +58,12 @@ describe('rdTokenScore (fuzzy)', () => {
     // real hit — the gap cap rejects it.
     expect(rdTokenScore('yama', 'ryo nakamura wakaba transfer')).toBeNull();
   });
+  it('rejects at the gap-cap boundary (gaps == needle length)', () => {
+    // "yama" over "ryonakama": y@1,a@5,m@8,a@9 → gaps 3+2+0 = ... the boundary
+    // case where total gaps equal the needle length must be rejected (>=), not
+    // accepted. A spread this wide is never a real desk hit.
+    expect(rdTokenScore('yama', 'ryonakama')).toBeNull();
+  });
   it('returns null when a character is missing entirely', () => {
     expect(rdTokenScore('zzz', 'tanaka')).toBeNull();
   });

--- a/web-mobile/js/__tests__/admin_registration_desk.test.jsx
+++ b/web-mobile/js/__tests__/admin_registration_desk.test.jsx
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rdNorm, rdPersonKey, rdPid, rdTokenScore, rdQueryScore, rdPlayerTag,
+  rdBuildPeopleIndex, rdHaystack, rdPresence, rdZekken,
+} from '../admin_registration_desk.jsx';
+
+// Pure helpers behind the Registration desk (mp-25bk). These carry the
+// cross-competition identity, fuzzy search, player-tag resolution, and
+// presence logic — pinning them behaviorally so a refactor can't silently
+// regress the desk's arrival loop.
+
+describe('rdNorm', () => {
+  it('lowercases, trims, and collapses whitespace', () => {
+    expect(rdNorm('  Akira   Tanaka ')).toBe('akira tanaka');
+  });
+  it('strips combining diacritics (fallback path)', () => {
+    // window.normalizeParticipantName is absent under vitest, so rdNorm uses
+    // its NFD-strip fallback. "Aïko" → "aiko".
+    expect(rdNorm('Aïko')).toBe('aiko');
+  });
+  it('is null/undefined safe', () => {
+    expect(rdNorm(undefined)).toBe('');
+    expect(rdNorm(null)).toBe('');
+  });
+});
+
+describe('rdPersonKey', () => {
+  it('keys a person by normalized name + dojo (cross-competition identity)', () => {
+    expect(rdPersonKey({ name: 'Akira Tanaka', dojo: 'Gyokusen' }))
+      .toBe(rdPersonKey({ name: 'akira  tanaka', dojo: ' GYOKUSEN ' }));
+  });
+  it('distinguishes same name at different dojos', () => {
+    expect(rdPersonKey({ name: 'John Smith', dojo: 'Wakaba' }))
+      .not.toBe(rdPersonKey({ name: 'John Smith', dojo: 'Tora' }));
+  });
+});
+
+describe('rdPid', () => {
+  it('prefers the UUID, falls back to the name', () => {
+    expect(rdPid({ id: 'uuid-1', name: 'A' })).toBe('uuid-1');
+    expect(rdPid({ name: 'A' })).toBe('A');
+  });
+});
+
+describe('rdTokenScore (fuzzy)', () => {
+  it('scores a contiguous substring by position (prefix best)', () => {
+    expect(rdTokenScore('tan', 'akira tanaka gyokusen')).toBeGreaterThanOrEqual(0);
+    expect(rdTokenScore('aki', 'akira tanaka')).toBe(0); // prefix
+    expect(rdTokenScore('aki', 'x akira')).toBeGreaterThan(0); // later position
+  });
+  it('accepts a tight subsequence (typo tolerance) but ranks it below substrings', () => {
+    const sub = rdTokenScore('tnk', 'tanaka');
+    expect(sub).not.toBeNull();
+    expect(sub).toBeGreaterThan(rdTokenScore('tan', 'tanaka'));
+  });
+  it('rejects a scattered subsequence with gaps larger than the needle', () => {
+    // "yama" coincidentally subsequences "ryo nakamura wakaba" but is not a
+    // real hit — the gap cap rejects it.
+    expect(rdTokenScore('yama', 'ryo nakamura wakaba transfer')).toBeNull();
+  });
+  it('returns null when a character is missing entirely', () => {
+    expect(rdTokenScore('zzz', 'tanaka')).toBeNull();
+  });
+});
+
+describe('rdQueryScore', () => {
+  it('returns 0 for an empty query (everything matches)', () => {
+    expect(rdQueryScore('', 'anything')).toBe(0);
+  });
+  it('requires every token to match (AND), order-independent', () => {
+    const hay = 'akira tanaka gyokusen';
+    expect(rdQueryScore('tanaka akira', hay)).not.toBeNull();
+    expect(rdQueryScore('tanaka kobayashi', hay)).toBeNull();
+  });
+});
+
+describe('rdPlayerTag', () => {
+  it('uses the team name for team competitions', () => {
+    expect(rdPlayerTag({ kind: 'team' }, { name: 'Tora A', number: 'T1' }))
+      .toEqual({ kind: 'team', value: 'Tora A' });
+  });
+  it('uses the assigned number for individuals', () => {
+    expect(rdPlayerTag({ kind: 'individual' }, { name: 'Akira', number: 'M1' }))
+      .toEqual({ kind: 'number', value: 'M1' });
+  });
+  it('reports pending when an individual has no number yet (pre-draw)', () => {
+    expect(rdPlayerTag({ kind: 'individual' }, { name: 'Akira', number: '' }))
+      .toEqual({ kind: 'pending', value: null });
+  });
+});
+
+describe('rdBuildPeopleIndex', () => {
+  const comps = [
+    { id: 'm', kind: 'individual', players: [{ name: 'Akira Tanaka', dojo: 'Gyokusen', checkedIn: true }, { name: 'Kenji Sato', dojo: 'Mumeishi' }] },
+    { id: 'v', kind: 'individual', players: [{ name: 'Akira Tanaka', dojo: 'Gyokusen', checkedIn: false }] },
+  ];
+  it('dedups a person across competitions and collects their entries', () => {
+    const idx = rdBuildPeopleIndex(comps);
+    expect(idx.size).toBe(2); // Akira (×2 comps) + Kenji
+    const akira = idx.get(rdPersonKey({ name: 'Akira Tanaka', dojo: 'Gyokusen' }));
+    expect(akira.entries.map((e) => e.comp.id)).toEqual(['m', 'v']);
+  });
+  it('is empty-safe', () => {
+    expect(rdBuildPeopleIndex(undefined).size).toBe(0);
+  });
+});
+
+describe('rdHaystack', () => {
+  it('includes name, dojo, zekken, number, and team name', () => {
+    const hay = rdHaystack('Akira Tanaka', 'Gyokusen', [
+      { comp: { kind: 'individual', withZekkenName: true }, player: { displayName: 'TANAKA', number: 'M1' } },
+    ]);
+    expect(hay).toContain('akira tanaka');
+    expect(hay).toContain('gyokusen');
+    expect(hay).toContain('tanaka');
+    expect(hay).toContain('m1');
+  });
+  it('includes the team name for team entries', () => {
+    const hay = rdHaystack('Tora A', 'Tora Dojo', [
+      { comp: { kind: 'team' }, player: { name: 'Tora A' } },
+    ]);
+    expect(hay).toContain('tora a');
+  });
+});
+
+describe('rdPresence', () => {
+  const e = (checkedIn) => ({ player: { checkedIn } });
+  it('reports none / partial / all', () => {
+    expect(rdPresence([e(false), e(false)])).toBe('none');
+    expect(rdPresence([e(true), e(false)])).toBe('partial');
+    expect(rdPresence([e(true), e(true)])).toBe('all');
+  });
+});
+
+describe('rdZekken', () => {
+  it('returns the display name only from a zekken competition', () => {
+    expect(rdZekken([{ comp: { withZekkenName: true }, player: { name: 'Akira Tanaka', displayName: 'TANAKA' } }]))
+      .toBe('TANAKA');
+  });
+  it('ignores derived display names from non-zekken competitions', () => {
+    // Women's etc. carry a server-derived DisplayName ("A. SATO") that is not a
+    // real zekken — it must not surface.
+    expect(rdZekken([{ comp: { withZekkenName: false }, player: { name: 'Aiko Sato', displayName: 'A. SATO' } }]))
+      .toBe('');
+  });
+  it('ignores a display name that merely echoes the name', () => {
+    expect(rdZekken([{ comp: { withZekkenName: true }, player: { name: 'Akira', displayName: 'Akira' } }]))
+      .toBe('');
+  });
+  it('picks the zekken entry when a person spans zekken and non-zekken competitions', () => {
+    expect(rdZekken([
+      { comp: { withZekkenName: false }, player: { name: 'Akira Tanaka', displayName: 'A. TANAKA' } },
+      { comp: { withZekkenName: true }, player: { name: 'Akira Tanaka', displayName: 'TANAKA' } },
+    ])).toBe('TANAKA');
+  });
+});

--- a/web-mobile/js/__tests__/render/admin_registration_desk.render.test.jsx
+++ b/web-mobile/js/__tests__/render/admin_registration_desk.render.test.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+// RENDER-SMOKE for the Registration desk (mp-25bk). The unit suite calls the
+// pure helpers directly but never MOUNTS the page, so a window.* dep that's
+// captured at module-eval (the `const X = window.X` block) or read at render
+// time would slip through. This harness mounts with REAL React 18 + jsdom and
+// FAILS on any console.warn/error, so a missing global throws here — the
+// load-order class of breakage the default stub can't catch.
+//
+// All window.* deps captured at admin_registration_desk.jsx module load
+// (AdminTopbar / Breadcrumbs / StatusBadge / pluralize) MUST be set before the
+// dynamic import, or the captured const is undefined and the page throws.
+
+const noop = () => {};
+const Stub = (name) => {
+  const C = () => <div data-stub={name} />;
+  C.displayName = `Stub(${name})`;
+  return C;
+};
+
+const STUBBED_GLOBALS = {
+  AdminTopbar: Stub('AdminTopbar'),
+  Breadcrumbs: Stub('Breadcrumbs'),
+  StatusBadge: Stub('StatusBadge'),
+  pluralize: (n, s, p) => `${n} ${n === 1 ? s : (p || s + 's')}`,
+  // The page opens its own SSE subscription on mount; return a no-op unsub.
+  API: {
+    subscribeToEvents: vi.fn(() => () => {}),
+    fetchCompetitions: vi.fn().mockResolvedValue([]),
+  },
+};
+
+const originals = {};
+let AdminRegistrationDeskPage;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  await import('../../admin_registration_desk.jsx');
+  AdminRegistrationDeskPage = window.AdminRegistrationDeskPage;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+function makeTournament(overrides = {}) {
+  return {
+    name: 'Spring Taikai',
+    competitions: [
+      {
+        id: 'men', name: "Men's Individual", kind: 'individual', status: 'draw-ready',
+        withZekkenName: true, checkInEnabled: true,
+        players: [
+          { id: 'p1', name: 'Akira Tanaka', displayName: 'TANAKA', dojo: 'Gyokusen', number: 'M1', checkedIn: true },
+          { id: 'p2', name: 'Kenji Sato', dojo: 'Mumeishi', number: 'M2', checkedIn: false },
+        ],
+      },
+      {
+        id: 'team', name: 'Team Championship', kind: 'team', status: 'setup',
+        checkInEnabled: true,
+        players: [{ id: 't1', name: 'Tora A', dojo: 'Tora Dojo', checkedIn: false }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function mount(tournament) {
+  let result;
+  await act(async () => {
+    result = render(
+      <AdminRegistrationDeskPage
+        tournament={tournament}
+        onBack={noop}
+        password="pw"
+        showToast={noop}
+        onUpdate={noop}
+        onLogout={noop}
+        onViewerMode={noop}
+      />
+    );
+  });
+  return result;
+}
+
+describe('AdminRegistrationDeskPage render-smoke', () => {
+  it('mounts the populated desk without console errors', async () => {
+    const { container, getByText, unmount } = await mount(makeTournament());
+    expect(getByText('Registration desk')).toBeTruthy();
+    // Rail renders the pinned "All competitions" entry + one item per competition.
+    expect(container.querySelector('.rd-rail')).toBeTruthy();
+    expect(getByText('All competitions')).toBeTruthy();
+    // The roster mounts with rows in the default "all" view.
+    expect(container.querySelector('.rd-row')).toBeTruthy();
+    unmount();
+  });
+
+  it('mounts the empty (no competitions) state', async () => {
+    const { getByText, unmount } = await mount(makeTournament({ competitions: [] }));
+    expect(getByText('No competitions yet')).toBeTruthy();
+    unmount();
+  });
+});

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -536,6 +536,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
         onAnnounce={() => setAnnounceOpen(true)}
         onOpenSchedule={() => setView({ kind: "schedule" })}
         onOpenScoreEditor={() => setView({ kind: "scoreEditor" })}
+        onOpenRegistration={() => setView({ kind: "registrationDesk" })}
         onOpenImport={() => setView({ kind: "import" })}
         onOpenShiaijo={(court) => setView({ kind: "shiaijo", court })}
         onStartAll={startAllCompetitions}
@@ -627,6 +628,18 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       showToast={showToast}
       tweaks={tweaks}
       onSwitchCourt={(court) => setView({ kind: "shiaijo", court })}
+    />;
+  }
+
+  if (view.kind === "registrationDesk") {
+    return <window.AdminRegistrationDeskPage
+      tournament={t}
+      onBack={() => setView({ kind: "dashboard" })}
+      onLogout={onLogout}
+      onViewerMode={onViewerMode}
+      onUpdate={onUpdate}
+      password={password}
+      showToast={showToast}
     />;
   }
 

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -32,8 +32,6 @@ const BreadcrumbsRD = window.Breadcrumbs;
 const StatusBadgeRD = window.StatusBadge;
 const pluralizeRD = window.pluralize;
 
-const PARTICIPANT_TAGS_RD = ["manual", "registered", "transfer"];
-
 // ---------------------------------------------------------------------------
 // Pure helpers (no React) — kept module-scoped so they're unit-testable.
 // ---------------------------------------------------------------------------
@@ -263,6 +261,11 @@ function RdOtherChips({ entries, onToggle, busy, label }) {
       <span className="rd-chips__label">{label || "Also in"}</span>
       {entries.map(({ comp, player }) => {
         const checked = player.checkedIn;
+        // The player tag (number) to hand over for THIS competition. Individuals
+        // get a per-competition number ("M1"); teams' tag is the team name,
+        // which is already the row's name, so we don't repeat it on the chip.
+        const tag = rdPlayerTag(comp, player);
+        const num = tag.kind === "number" ? tag.value : null;
         return (
           <button
             type="button"
@@ -274,6 +277,7 @@ function RdOtherChips({ entries, onToggle, busy, label }) {
           >
             <span className="rd-chip__mark" aria-hidden="true">{checked ? <RdCheckIcon /> : null}</span>
             <span className="rd-chip__name">{comp.name}</span>
+            {num && <span className="rd-chip__num">{num}</span>}
           </button>
         );
       })}
@@ -288,8 +292,6 @@ function RdOtherChips({ entries, onToggle, busy, label }) {
 // ---------------------------------------------------------------------------
 function RdRow({ mode, comp, player, zekken, entries, others, checked, presence, busy, onPrimary, onToggle, onEdit, isLast }) {
   const danGrade = player.danGrade || (player.metadata && player.metadata[0]) || "";
-  const tag = (player.tag || "").toLowerCase();
-  const showTag = PARTICIPANT_TAGS_RD.includes(tag);
 
   const stateClass = mode === "all"
     ? (presence === "all" ? "is-checked" : presence === "partial" ? "is-partial" : "")
@@ -329,7 +331,6 @@ function RdRow({ mode, comp, player, zekken, entries, others, checked, presence,
           {zekken && (
             <span className="rd-row__zekken" title="Zekken / display name">{zekken}</span>
           )}
-          {showTag && <span className={`tag-badge${tag === "manual" ? " tag-badge--warn" : ""}`}>{tag}</span>}
         </div>
         <div className="rd-row__meta">
           {player.dojo && <span className="rd-row__dojo">{player.dojo}</span>}
@@ -533,7 +534,6 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
 
   const [selected, setSelected] = useStateRD("all");
   const [query, setQuery] = useStateRD("");
-  const [tagFilter, setTagFilter] = useStateRD("all");
   const [dojoFilter, setDojoFilter] = useStateRD("all");
   const [uncheckedOnly, setUncheckedOnly] = useStateRD(false);
   const [groupByDojo, setGroupByDojo] = useStateRD(false);
@@ -706,7 +706,6 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
   const rows = useMemoRD(() => {
     const matchesFilters = (player) => {
       if (uncheckedOnly && player.checkedIn) return false;
-      if (tagFilter !== "all" && (player.tag || "").toLowerCase() !== tagFilter) return false;
       if (dojoFilter !== "all" && player.dojo !== dojoFilter) return false;
       return true;
     };
@@ -752,7 +751,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
       return a.player.name.localeCompare(b.player.name);
     });
     return out;
-  }, [selected, comps, peopleIndex, queryNorm, uncheckedOnly, tagFilter, dojoFilter]);
+  }, [selected, comps, peopleIndex, queryNorm, uncheckedOnly, dojoFilter]);
 
   // Dojo list for the filter (scoped to the selected competition / all).
   const dojoOptions = useMemoRD(() => {
@@ -863,13 +862,6 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
               </div>
 
               <div className="rd-toolbar">
-                <label className="rd-filter">
-                  <span>Tag</span>
-                  <select className="select" value={tagFilter} onChange={(e) => setTagFilter(e.target.value)}>
-                    <option value="all">All</option>
-                    {PARTICIPANT_TAGS_RD.map((t) => <option key={t} value={t}>{t}</option>)}
-                  </select>
-                </label>
                 {dojoOptions.length > 0 && (
                   <label className="rd-filter">
                     <span>Dojo</span>

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -416,22 +416,22 @@ function RdWalkUp({ comp, seedName, password, showToast, onAdded, onCancel }) {
       <div className="rd-walkup__grid">
         <label className="field">
           <span className="field__label">{isTeam ? "Team name" : "Name"}</span>
-          <input ref={nameRef} className="input" value={name} onChange={(e) => setName(e.target.value)} placeholder={isTeam ? "Tora A" : "Akira Tanaka"} />
+          <input ref={nameRef} className="input" maxLength={100} value={name} onChange={(e) => setName(e.target.value)} placeholder={isTeam ? "Tora A" : "Akira Tanaka"} />
         </label>
         <label className="field">
           <span className="field__label">Dojo</span>
-          <input className="input" value={dojo} onChange={(e) => setDojo(e.target.value)} placeholder={isTeam ? "Tora Dojo London" : "Gyokusen"} />
+          <input className="input" maxLength={100} value={dojo} onChange={(e) => setDojo(e.target.value)} placeholder={isTeam ? "Tora Dojo London" : "Gyokusen"} />
         </label>
         {!isTeam && comp.withZekkenName && (
           <label className="field">
             <span className="field__label">Zekken</span>
-            <input className="input" value={zekken} onChange={(e) => setZekken(e.target.value)} placeholder="TANAKA" />
+            <input className="input" maxLength={40} value={zekken} onChange={(e) => setZekken(e.target.value)} placeholder="TANAKA" />
           </label>
         )}
         {!isTeam && (
           <label className="field">
             <span className="field__label">Dan grade <span className="field__opt">(optional)</span></span>
-            <input className="input" value={dan} onChange={(e) => setDan(e.target.value)} placeholder="3 dan" />
+            <input className="input" maxLength={20} value={dan} onChange={(e) => setDan(e.target.value)} placeholder="3 dan" />
           </label>
         )}
       </div>
@@ -489,22 +489,22 @@ function RdEditModal({ comp, player, password, showToast, onSaved, onClose }) {
       <div className="rd-walkup__grid">
         <label className="field">
           <span className="field__label">{isTeam ? "Team name" : "Name"}</span>
-          <input className="input" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
+          <input className="input" maxLength={100} value={name} onChange={(e) => setName(e.target.value)} autoFocus />
         </label>
         <label className="field">
           <span className="field__label">Dojo</span>
-          <input className="input" value={dojo} onChange={(e) => setDojo(e.target.value)} />
+          <input className="input" maxLength={100} value={dojo} onChange={(e) => setDojo(e.target.value)} />
         </label>
         {!isTeam && comp.withZekkenName && (
           <label className="field">
             <span className="field__label">Zekken</span>
-            <input className="input" value={zekken} onChange={(e) => setZekken(e.target.value)} placeholder="TANAKA" />
+            <input className="input" maxLength={40} value={zekken} onChange={(e) => setZekken(e.target.value)} placeholder="TANAKA" />
           </label>
         )}
         {!isTeam && (
           <label className="field">
             <span className="field__label">Dan grade <span className="field__opt">(optional)</span></span>
-            <input className="input" value={dan} onChange={(e) => setDan(e.target.value)} placeholder="3 dan" />
+            <input className="input" maxLength={20} value={dan} onChange={(e) => setDan(e.target.value)} placeholder="3 dan" />
           </label>
         )}
       </div>

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -195,10 +195,8 @@ function RdPlayerTag({ comp, player, size }) {
   // a "not assigned yet" placeholder.
   if (tag.kind === "pending") return null;
   const cls = `rd-tag rd-tag--${tag.kind}${size === "lg" ? " rd-tag--lg" : ""}`;
-  const label = tag.kind === "team" ? "Team" : "Tag";
   return (
     <span className={cls}>
-      <span className="rd-tag__label">{label}</span>
       <span className="rd-tag__value">{tag.value}</span>
     </span>
   );
@@ -806,7 +804,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
         <div className="page-head">
           <div>
             <h1 className="page-head__title">Registration desk</h1>
-            <div className="page-head__sub">Check competitors in across every competition and hand them their player tag.</div>
+            <div className="page-head__sub">Check competitors in across every competition and hand them their number.</div>
           </div>
         </div>
 
@@ -889,7 +887,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
                       {handoff.tags.filter((t) => t.kind !== "pending").map((t, i) => (
                         <div key={i} className="rd-handoff__tag">
                           {handoff.tags.length > 1 && <span className="rd-handoff__comp">{t.compName}</span>}
-                          <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__label">{t.kind === "team" ? "Team" : "Tag"}</span><span className="rd-tag__value">{t.value}</span></span>
+                          <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__value">{t.value}</span></span>
                         </div>
                       ))}
                     </div>

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -227,7 +227,7 @@ function RdRail({ comps, allStats, selected, onSelect }) {
         </div>
         <div className="rd-rail__sub">{sub}</div>
         <div className="rd-rail__bar" role="presentation">
-          <div className={`rd-rail__bar-fill${done ? " is-done" : ""}`} style={{ width: `${pct}%` }} />
+          <div className={`rd-rail__bar-fill${done ? " is-done" : ""}`} style={{ transform: `scaleX(${pct / 100})` }} />
         </div>
         <div className="rd-rail__count">
           <strong>{present}</strong> / {total} checked in

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -393,13 +393,15 @@ function RdWalkUp({ comp, seedName, password, showToast, onAdded, onCancel }) {
       if (!isTeam && comp.withZekkenName && zekken.trim()) payload.displayName = zekken.trim();
       const added = await window.API.addParticipant(comp.id, payload, password, admin);
       // Check them in straight away — they're standing at the desk.
+      let checkInOk = false;
       try {
         await window.API.toggleCheckIn(comp.id, rdPid(added), true, password);
         added.checkedIn = true;
+        checkInOk = true;
       } catch (err) {
         showToast(`${n} added but check-in failed: ${err.message}`, "error");
       }
-      onAdded(comp, added);
+      onAdded(comp, added, checkInOk);
     } catch (err) {
       showToast(err.message, "error");
     } finally {
@@ -668,12 +670,14 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
     const pending = recs.filter((rec) => rdPresence(rec.entries) !== "all");
     if (!pending.length) return;
     setBusy(true);
+    inFlightRef.current += 1;
     try {
       const results = await Promise.allSettled(pending.map((rec) => checkPersonEntries(rec, true)));
       const failed = results.reduce((n, r) => n + (r.status === "fulfilled" ? r.value.failed : 1), 0);
       if (failed) showToast(`${failed} check-in(s) failed — reloading`, "error");
       await refresh();
     } finally {
+      inFlightRef.current -= 1;
       if (mountedRef.current) setBusy(false);
     }
   };
@@ -718,7 +722,6 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
         const anyEntry = rec.entries.some(({ player }) => matchesFilters(player));
         if (!anyEntry) return;
         const presence = rdPresence(rec.entries);
-        if (uncheckedOnly && presence === "all") return;
         const hay = rdHaystack(rec.name, rec.dojo, rec.entries);
         const score = rdQueryScore(queryNorm, hay);
         if (score == null) return;
@@ -789,9 +792,9 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
     searchRef.current && searchRef.current.focus();
   };
 
-  const onAdded = async (comp, added) => {
+  const onAdded = async (comp, added, checkInOk) => {
     setWalkUpOpen(false);
-    announceHandoff(added.name, [{ compName: comp.name, ...rdPlayerTag(comp, added) }]);
+    if (checkInOk) announceHandoff(added.name, [{ compName: comp.name, ...rdPlayerTag(comp, added) }]);
     await refresh();
   };
 
@@ -881,22 +884,25 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
                 {busy && <span className="rd-toolbar__busy"><span className="spinner" aria-hidden="true" /> Saving…</span>}
               </div>
 
-              {handoff && (
-                <div className="rd-handoff" role="status" aria-live="polite">
-                  <button type="button" className="rd-handoff__close" aria-label="Dismiss" onClick={() => setHandoff(null)}>×</button>
-                  <div className="rd-handoff__lead"><RdCheckIcon /> Checked in — <strong>{handoff.name}</strong></div>
-                  {handoff.tags.some((t) => t.kind !== "pending") && (
-                    <div className="rd-handoff__tags">
-                      {handoff.tags.filter((t) => t.kind !== "pending").map((t, i) => (
-                        <div key={i} className="rd-handoff__tag">
-                          {handoff.tags.length > 1 && <span className="rd-handoff__comp">{t.compName}</span>}
-                          <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__value">{t.value}</span></span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
+              {handoff && (() => {
+                const visibleTags = handoff.tags.filter((t) => t.kind !== "pending");
+                return (
+                  <div className="rd-handoff" role="status" aria-live="polite">
+                    <button type="button" className="rd-handoff__close" aria-label="Dismiss" onClick={() => setHandoff(null)}>×</button>
+                    <div className="rd-handoff__lead"><RdCheckIcon /> Checked in — <strong>{handoff.name}</strong></div>
+                    {visibleTags.length > 0 && (
+                      <div className="rd-handoff__tags">
+                        {visibleTags.map((t, i) => (
+                          <div key={i} className="rd-handoff__tag">
+                            {handoff.tags.length > 1 && <span className="rd-handoff__comp">{t.compName}</span>}
+                            <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__value">{t.value}</span></span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })()}
 
               {walkUpOpen && selectedComp && (
                 <RdWalkUp
@@ -928,7 +934,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
                     } : {});
                   }
                 }}
-                onToggleChip={(compId, pid, val) => toggleOne(compId, pid, val)}
+                onToggleChip={toggleOne}
                 onEdit={(row) => setEditTarget({ comp: row.comp, player: row.player })}
                 onBulkDojo={(dojo, theseRows) => {
                   if (selected === "all") {

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -299,13 +299,21 @@ function RdRow({ mode, comp, player, zekken, entries, others, checked, presence,
     ? (presence === "all" ? `Undo check-in for ${player.name}` : `Check in ${player.name} for all their competitions`)
     : (checked ? `Undo check-in for ${player.name}` : `Check in ${player.name}`);
 
+  // In "all" mode a person checked into SOME-but-not-all of their competitions
+  // is a partial/indeterminate checkbox: it shows a checkmark visually, so it
+  // must report aria-checked="mixed" (not "false") or a screen reader would
+  // announce it as unchecked. comp mode is a plain boolean.
+  const ariaChecked = mode === "all"
+    ? (presence === "all" ? "true" : presence === "partial" ? "mixed" : "false")
+    : checked;
+
   return (
     <div className={`rd-row ${stateClass}${isLast ? " rd-row--last" : ""}`}>
       <button
         type="button"
         className="rd-check"
         role="checkbox"
-        aria-checked={mode === "all" ? presence === "all" : checked}
+        aria-checked={ariaChecked}
         aria-label={checkLabel}
         disabled={busy}
         onClick={onPrimary}

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -883,7 +883,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
               {handoff && (
                 <div className="rd-handoff" role="status" aria-live="polite">
                   <button type="button" className="rd-handoff__close" aria-label="Dismiss" onClick={() => setHandoff(null)}>×</button>
-                  <div className="rd-handoff__lead"><RdCheckIcon /> Checked in — hand over to <strong>{handoff.name}</strong></div>
+                  <div className="rd-handoff__lead"><RdCheckIcon /> Checked in — <strong>{handoff.name}</strong></div>
                   {handoff.tags.some((t) => t.kind !== "pending") && (
                     <div className="rd-handoff__tags">
                       {handoff.tags.filter((t) => t.kind !== "pending").map((t, i) => (

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -806,7 +806,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
         <div className="page-head">
           <div>
             <h1 className="page-head__title">Registration desk</h1>
-            <div className="page-head__sub">Check competitors in across every competition and hand them their number.</div>
+            <div className="page-head__sub">Check competitors in as they arrive, across every competition.</div>
           </div>
         </div>
 

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -7,8 +7,8 @@
 //     fuzzy-find  →  check in  →  hand over the player tag
 //
 // "Player tag" is the thing physically handed to the competitor: the assigned
-// competitor number for individuals (e.g. "K1"; "Not assigned yet" before the
-// draw), or the team name for team competitions. It is NOT the zekken (the
+// competitor number for individuals (e.g. "K1"; nothing is shown before the
+// draw assigns it), or the team name for team competitions. It is NOT the zekken (the
 // back name-tag, used only for identity/search) nor the provenance tag pill
 // (manual/registered/transfer).
 //
@@ -187,14 +187,14 @@ function RdPencilIcon() {
 
 // ---------------------------------------------------------------------------
 // Player-tag pill — the hand-over element. Loud for individuals' numbers and
-// team names; muted "Not assigned yet" before the draw.
+// team names; nothing before the draw assigns a number (no placeholder noise).
 // ---------------------------------------------------------------------------
 function RdPlayerTag({ comp, player, size }) {
   const tag = rdPlayerTag(comp, player);
+  // Before the draw there's no number to hand over — render nothing rather than
+  // a "not assigned yet" placeholder.
+  if (tag.kind === "pending") return null;
   const cls = `rd-tag rd-tag--${tag.kind}${size === "lg" ? " rd-tag--lg" : ""}`;
-  if (tag.kind === "pending") {
-    return <span className={cls} title="The competitor number is assigned when the draw runs">Not assigned yet</span>;
-  }
   const label = tag.kind === "team" ? "Team" : "Tag";
   return (
     <span className={cls}>
@@ -884,16 +884,16 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
                 <div className="rd-handoff" role="status" aria-live="polite">
                   <button type="button" className="rd-handoff__close" aria-label="Dismiss" onClick={() => setHandoff(null)}>×</button>
                   <div className="rd-handoff__lead"><RdCheckIcon /> Checked in — hand over to <strong>{handoff.name}</strong></div>
-                  <div className="rd-handoff__tags">
-                    {handoff.tags.map((t, i) => (
-                      <div key={i} className="rd-handoff__tag">
-                        {handoff.tags.length > 1 && <span className="rd-handoff__comp">{t.compName}</span>}
-                        {t.kind === "pending"
-                          ? <span className="rd-tag rd-tag--pending rd-tag--lg">Not assigned yet</span>
-                          : <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__label">{t.kind === "team" ? "Team" : "Tag"}</span><span className="rd-tag__value">{t.value}</span></span>}
-                      </div>
-                    ))}
-                  </div>
+                  {handoff.tags.some((t) => t.kind !== "pending") && (
+                    <div className="rd-handoff__tags">
+                      {handoff.tags.filter((t) => t.kind !== "pending").map((t, i) => (
+                        <div key={i} className="rd-handoff__tag">
+                          {handoff.tags.length > 1 && <span className="rd-handoff__comp">{t.compName}</span>}
+                          <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__label">{t.kind === "team" ? "Team" : "Tag"}</span><span className="rd-tag__value">{t.value}</span></span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -50,8 +50,9 @@ function rdPersonKey(p) {
   return `${rdNorm(p.name)}|${rdNorm(p.dojo)}`;
 }
 
-// Stable per-competition participant id used by the check-in endpoints, mirroring
-// the rest of the admin code: prefer the UUID, fall back to the name.
+// Client-side key for check-in calls. Prefers the UUID; falls back to the name
+// only for legacy non-UUID rows where the persisted id column IS the name.
+// The server always matches by the id column — it never resolves by name.
 function rdPid(p) {
   return p.id ?? p.name;
 }

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -77,8 +77,9 @@ function rdTokenScore(needle, hay) {
   }
   // Reject scattered "matches": if the characters are spread far apart (e.g.
   // "yama" landing on r-y-o n-a-k-a-m-…-a) it isn't a real hit. A tight typo
-  // ("tnk" → tanaka) keeps small gaps; a coincidental spread doesn't.
-  if (gaps > needle.length) return null;
+  // ("tnk" → tanaka, gaps 2 < len 3) keeps small gaps; a coincidental spread
+  // (gaps ≥ needle length, e.g. "yama"→"ryonakama" with gaps 4 == len 4) doesn't.
+  if (gaps >= needle.length) return null;
   return 200 + start + gaps; // any subsequence ranks below any contiguous hit
 }
 
@@ -209,11 +210,7 @@ function RdPlayerTag({ comp, player, size }) {
 // Rail — competition selector. Pinned "All competitions" entry on top, then one
 // row per competition with a check-in progress meter.
 // ---------------------------------------------------------------------------
-function RdRail({ comps, peopleIndex, selected, onSelect }) {
-  const allTotal = peopleIndex.size;
-  let allPresent = 0;
-  peopleIndex.forEach((rec) => { if (rdPresence(rec.entries) === "all") allPresent += 1; });
-
+function RdRail({ comps, allStats, selected, onSelect }) {
   const item = (key, label, sub, present, total, status) => {
     const pct = total > 0 ? Math.round((present / total) * 100) : 0;
     const done = total > 0 && present === total;
@@ -242,7 +239,7 @@ function RdRail({ comps, peopleIndex, selected, onSelect }) {
 
   return (
     <nav className="rd-rail" aria-label="Competitions">
-      {item("all", "All competitions", `${pluralizeRD(comps.length, "competition")} · everyone`, allPresent, allTotal, null)}
+      {item("all", "All competitions", `${pluralizeRD(comps.length, "competition")} · everyone`, allStats.present, allStats.total, null)}
       <div className="rd-rail__divider" role="presentation" />
       {comps.map((c) => {
         const players = c.players || [];
@@ -266,14 +263,13 @@ function RdOtherChips({ entries, onToggle, busy, label }) {
       <span className="rd-chips__label">{label || "Also in"}</span>
       {entries.map(({ comp, player }) => {
         const checked = player.checkedIn;
-        const withdrawn = player.__ineligible; // reserved guard (see desk notes)
         return (
           <button
             type="button"
             key={comp.id}
-            className={`rd-chip${checked ? " is-checked" : ""}${withdrawn ? " is-withdrawn" : ""}`}
-            disabled={busy || withdrawn}
-            title={withdrawn ? "Withdrawn from this competition" : checked ? `Checked in — ${comp.name}` : `Check in for ${comp.name}`}
+            className={`rd-chip${checked ? " is-checked" : ""}`}
+            disabled={busy}
+            title={checked ? `Checked in — ${comp.name}` : `Check in for ${comp.name}`}
             onClick={() => !checked && onToggle(comp.id, rdPid(player), true)}
           >
             <span className="rd-chip__mark" aria-hidden="true">{checked ? <RdCheckIcon /> : null}</span>
@@ -511,13 +507,21 @@ function RdEditModal({ comp, player, password, showToast, onSaved, onClose }) {
 // Page.
 // ---------------------------------------------------------------------------
 function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, onUpdate, onLogout, onViewerMode }) {
-  // Local authoritative copy of competitions, seeded from the parent. While
-  // this view is mounted the parent tournament only changes when WE call
-  // onUpdate, so re-seeding on prop change can't clobber an optimistic write.
+  // `comps` is the desk's own authoritative copy, seeded once from the parent
+  // and thereafter mutated only via setLocal (optimistic) and refresh() (server
+  // truth). We deliberately do NOT re-seed from the tournament prop: app.jsx
+  // runs its own SSE-driven setTournament independently of this desk, so a
+  // prop-sync effect would clobber an in-flight optimistic check-in with
+  // possibly-stale parent data. The desk's own SSE subscription (below) keeps
+  // it fresh; tRef tracks the latest tournament only so refresh()'s onUpdate
+  // merge starts from the newest snapshot.
   const [comps, setComps] = useStateRD(() => tournament.competitions || []);
   const tRef = useRefRD(tournament);
   useEffectRD(() => { tRef.current = tournament; }, [tournament]);
-  useEffectRD(() => { setComps(tournament.competitions || []); }, [tournament.competitions]);
+  // Number of check-in writes in flight. While > 0 the SSE-driven refresh
+  // defers, so a concurrent reload (this desk's echo or another desk's event)
+  // can't momentarily revert an optimistic check-in mid-write.
+  const inFlightRef = useRefRD(0);
 
   const [selected, setSelected] = useStateRD("all");
   const [query, setQuery] = useStateRD("");
@@ -556,16 +560,31 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
   useEffectRD(() => {
     if (!window.API || typeof window.API.subscribeToEvents !== "function") return;
     let timer = null;
+    const fire = () => {
+      // Don't reconcile while our own writes are mid-flight — wait for them to
+      // settle so the refetch can't transiently revert an optimistic check-in.
+      if (inFlightRef.current > 0) { timer = setTimeout(fire, 300); return; }
+      timer = null;
+      refresh();
+    };
     const unsub = window.API.subscribeToEvents((event) => {
       if (event && (event.type === "participants_updated" || event.type === "competition_started" || event.type === "competition_completed" || event.type === "competition_deleted")) {
         if (timer) return;
-        timer = setTimeout(() => { timer = null; refresh(); }, 600);
+        timer = setTimeout(fire, 600);
       }
     });
     return () => { if (timer) clearTimeout(timer); unsub(); };
   }, [refresh]);
 
   const peopleIndex = useMemoRD(() => rdBuildPeopleIndex(comps), [comps]);
+  // Tournament-wide presence, computed once and shared by the rail's "All
+  // competitions" item and the "all" headline (previously each re-walked the
+  // index independently).
+  const allStats = useMemoRD(() => {
+    let present = 0;
+    peopleIndex.forEach((rec) => { if (rdPresence(rec.entries) === "all") present += 1; });
+    return { present, total: peopleIndex.size };
+  }, [peopleIndex]);
   const selectedComp = selected === "all" ? null : comps.find((c) => c.id === selected);
 
   // Optimistic local mutation of one check-in flag.
@@ -583,6 +602,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
   // Toggle one (competition, participant). Optimistic; SSE refresh reconciles.
   const toggleOne = async (compId, pid, val, opts = {}) => {
     setLocal(compId, pid, val);
+    inFlightRef.current += 1;
     try {
       await window.API.toggleCheckIn(compId, pid, val, password);
       if (val && opts.handoff) announceHandoff(opts.handoff.name, opts.handoff.tags);
@@ -590,26 +610,59 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
       if (!mountedRef.current) return;
       showToast(e.message, "error");
       setLocal(compId, pid, !val); // revert
+    } finally {
+      inFlightRef.current -= 1;
+    }
+  };
+
+  // Core "set this person's check-in across every competition they entered" —
+  // optimistic local writes + parallel API calls, returning the failure count.
+  // No busy/refresh side effects so callers can coordinate one bulk operation
+  // around many people without each clearing the shared busy flag early.
+  const checkPersonEntries = async (rec, makeChecked) => {
+    const targets = rec.entries.filter(({ player }) => player.checkedIn !== makeChecked);
+    if (!targets.length) return { failed: 0, total: 0 };
+    targets.forEach(({ comp, player }) => setLocal(comp.id, rdPid(player), makeChecked));
+    inFlightRef.current += 1;
+    try {
+      const results = await Promise.allSettled(
+        targets.map(({ comp, player }) => window.API.toggleCheckIn(comp.id, rdPid(player), makeChecked, password))
+      );
+      return { failed: results.filter((r) => r.status === "rejected").length, total: targets.length };
+    } finally {
+      inFlightRef.current -= 1;
     }
   };
 
   // Person-level toggle in "all" mode: check into every competition (or undo all).
   const togglePerson = async (rec) => {
-    const presence = rdPresence(rec.entries);
-    const makeChecked = presence !== "all"; // none/partial → check all; all → undo all
-    const targets = rec.entries.filter(({ player }) => player.checkedIn !== makeChecked);
-    if (!targets.length) return;
+    const makeChecked = rdPresence(rec.entries) !== "all"; // none/partial → check all; all → undo all
     setBusy(true);
-    targets.forEach(({ comp, player }) => setLocal(comp.id, rdPid(player), makeChecked));
     try {
-      const results = await Promise.allSettled(
-        targets.map(({ comp, player }) => window.API.toggleCheckIn(comp.id, rdPid(player), makeChecked, password))
-      );
-      const failed = results.filter((r) => r.status === "rejected");
-      if (failed.length) showToast(`${failed.length} of ${targets.length} check-ins failed — reloading`, "error");
-      if (makeChecked && !failed.length) {
+      const { failed, total } = await checkPersonEntries(rec, makeChecked);
+      if (total === 0) return;
+      if (failed) showToast(`${failed} of ${total} check-ins failed — reloading`, "error");
+      else if (makeChecked) {
         announceHandoff(rec.name, rec.entries.map(({ comp, player }) => ({ compName: comp.name, ...rdPlayerTag(comp, player) })));
       }
+      await refresh();
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  };
+
+  // Bulk-check a whole dojo of people into all their competitions ("all" mode).
+  // One coordinated operation: busy is set once, every person's writes run
+  // concurrently, and a single refresh reconciles — instead of N independent
+  // togglePerson calls each racing the shared busy flag.
+  const bulkCheckPeople = async (recs) => {
+    const pending = recs.filter((rec) => rdPresence(rec.entries) !== "all");
+    if (!pending.length) return;
+    setBusy(true);
+    try {
+      const results = await Promise.allSettled(pending.map((rec) => checkPersonEntries(rec, true)));
+      const failed = results.reduce((n, r) => n + (r.status === "fulfilled" ? r.value.failed : 1), 0);
+      if (failed) showToast(`${failed} check-in(s) failed — reloading`, "error");
       await refresh();
     } finally {
       if (mountedRef.current) setBusy(false);
@@ -621,13 +674,20 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
     if (!pids.length) return;
     setBusy(true);
     pids.forEach((pid) => setLocal(compId, pid, true));
+    inFlightRef.current += 1;
     try {
-      await window.API.bulkCheckIn(compId, pids, password);
+      const res = await window.API.bulkCheckIn(compId, pids, password);
+      // A 200 can still report unmatched ids (e.g. legacy name-keyed pids the
+      // server couldn't resolve) — surface that rather than silently dropping it.
+      if (res && res.notFound && res.notFound.length) {
+        showToast(`${res.notFound.length} not matched — reloading`, "error");
+      }
       await refresh();
     } catch (e) {
       showToast(e.message, "error");
       await refresh();
     } finally {
+      inFlightRef.current -= 1;
       if (mountedRef.current) setBusy(false);
     }
   };
@@ -697,14 +757,12 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
   // Headline metric for the current view.
   const headline = useMemoRD(() => {
     if (selected === "all") {
-      let present = 0;
-      peopleIndex.forEach((rec) => { if (rdPresence(rec.entries) === "all") present += 1; });
-      return { present, total: peopleIndex.size, noun: "people" };
+      return { present: allStats.present, total: allStats.total, noun: "people" };
     }
     const comp = comps.find((c) => c.id === selected);
     const players = comp ? comp.players || [] : [];
     return { present: players.filter((p) => p.checkedIn).length, total: players.length, noun: comp && comp.kind === "team" ? "teams" : "competitors" };
-  }, [selected, comps, peopleIndex]);
+  }, [selected, comps, allStats]);
 
   // Enter on the search box checks in the single top hit — the arrival loop.
   const onSearchKeyDown = (e) => {
@@ -755,7 +813,7 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
           </div>
         ) : (
           <div className="workspace rd-workspace">
-            <RdRail comps={comps} peopleIndex={peopleIndex} selected={selected} onSelect={setSelected} />
+            <RdRail comps={comps} allStats={allStats} selected={selected} onSelect={setSelected} />
 
             <div className="rd-main">
               <div className="rd-header">
@@ -873,8 +931,9 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
                 onEdit={(row) => setEditTarget({ comp: row.comp, player: row.player })}
                 onBulkDojo={(dojo, theseRows) => {
                   if (selected === "all") {
-                    // check every listed person from this dojo into all their comps
-                    theseRows.forEach((r) => r.presence !== "all" && togglePerson(r.rec));
+                    // One coordinated op: check every listed person from this dojo
+                    // into all their competitions (single busy + single refresh).
+                    bulkCheckPeople(theseRows.map((r) => r.rec));
                   } else {
                     const pids = theseRows.filter((r) => !r.player.checkedIn).map((r) => rdPid(r.player));
                     bulkDojoComp(selected, pids);

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -1,0 +1,1016 @@
+// Registration Desk — cross-competition check-in surface for operators (mp-25bk).
+//
+// Reached from the Admin dashboard "Registration desk" card. Gathers every
+// competition's roster into one place so the desk never has to hop between
+// per-competition Participants tabs. The arrival loop is the whole design:
+//
+//     fuzzy-find  →  check in  →  hand over the player tag
+//
+// "Player tag" is the thing physically handed to the competitor: the assigned
+// competitor number for individuals (e.g. "K1"; "Not assigned yet" before the
+// draw), or the team name for team competitions. It is NOT the zekken (the
+// back name-tag, used only for identity/search) nor the provenance tag pill
+// (manual/registered/transfer).
+//
+// Backend facts this relies on (see internal/mobileapp/handlers_participants.go):
+//   - check-in (PUT/DELETE/bulk) is NOT status-gated and NOT gated on
+//     checkInEnabled — anyone can be checked in for any competition at any time
+//     (latecomers included).
+//   - walk-up add (POST single) needs the elevated password and only works
+//     while a competition is in "setup" status.
+//
+// SSE: when this view is mounted, AdminApp renders ONLY this page — neither the
+// dashboard's nor the competition-view's SSE subscription is active. So this
+// page owns its own freshness: optimistic local writes for snappy feedback, a
+// participants_updated subscription that reconciles other desks' changes, and
+// onUpdate() pushes back to the parent so navigating "Back" shows fresh data.
+
+const { useState: useStateRD, useEffect: useEffectRD, useRef: useRefRD, useMemo: useMemoRD, useCallback: useCallbackRD } = React;
+
+const AdminTopbarRD = window.AdminTopbar;
+const BreadcrumbsRD = window.Breadcrumbs;
+const StatusBadgeRD = window.StatusBadge;
+const pluralizeRD = window.pluralize;
+
+const PARTICIPANT_TAGS_RD = ["manual", "registered", "transfer"];
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no React) — kept module-scoped so they're unit-testable.
+// ---------------------------------------------------------------------------
+
+// Shared normalization for fuzzy matching and person identity. Falls back to a
+// minimal lowercase/trim if the shared helper isn't loaded yet.
+function rdNorm(s) {
+  if (window.normalizeParticipantName) return window.normalizeParticipantName(s || "");
+  return (s || "").toString().normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+// A competitor's cross-competition identity: same name + same dojo is the same
+// person, regardless of which competitions they entered. Matches the backend's
+// check-in-preservation key (normalizedName + normalizedDojo).
+function rdPersonKey(p) {
+  return `${rdNorm(p.name)}|${rdNorm(p.dojo)}`;
+}
+
+// Stable per-competition participant id used by the check-in endpoints, mirroring
+// the rest of the admin code: prefer the UUID, fall back to the name.
+function rdPid(p) {
+  return p.id ?? p.name;
+}
+
+// Subsequence score for one token against a normalized haystack. Returns null
+// when the token isn't even a subsequence; otherwise a score where lower is a
+// better match (contiguous substrings beat scattered subsequences, and earlier
+// positions beat later ones). This is what makes the search genuinely fuzzy —
+// "tnk" finds "Tanaka", "sato a" finds "Aiko Sato".
+function rdTokenScore(needle, hay) {
+  if (!needle) return 0;
+  const at = hay.indexOf(needle);
+  if (at >= 0) return at; // contiguous: rank by position, prefix is best
+  let h = 0, start = -1, gaps = 0;
+  for (let i = 0; i < needle.length; i++) {
+    const found = hay.indexOf(needle[i], h);
+    if (found < 0) return null;
+    if (start < 0) start = found;
+    if (i > 0 && found > h) gaps += found - h;
+    h = found + 1;
+  }
+  // Reject scattered "matches": if the characters are spread far apart (e.g.
+  // "yama" landing on r-y-o n-a-k-a-m-…-a) it isn't a real hit. A tight typo
+  // ("tnk" → tanaka) keeps small gaps; a coincidental spread doesn't.
+  if (gaps > needle.length) return null;
+  return 200 + start + gaps; // any subsequence ranks below any contiguous hit
+}
+
+// Whole-query score: every whitespace-separated token must match (AND), so
+// multi-word queries work in any order. Returns null on no-match, else a score.
+function rdQueryScore(queryNorm, hay) {
+  if (!queryNorm) return 0;
+  let total = 0;
+  for (const tok of queryNorm.split(" ")) {
+    if (!tok) continue;
+    const s = rdTokenScore(tok, hay);
+    if (s == null) return null;
+    total += s;
+  }
+  return total;
+}
+
+// The player tag to hand over for a given (competition, participant).
+//   team  → the team name (always present)
+//   indiv → the assigned competitor number, or null before the draw runs
+function rdPlayerTag(comp, p) {
+  if (comp && comp.kind === "team") return { kind: "team", value: p.name };
+  if (p.number) return { kind: "number", value: p.number };
+  return { kind: "pending", value: null };
+}
+
+// Build the cross-competition people index from the competitions array.
+// Map<personKey, { key, name, dojo, displayName, entries: [{comp, player}] }>
+// entries preserve competition order.
+function rdBuildPeopleIndex(comps) {
+  const index = new Map();
+  (comps || []).forEach((comp) => {
+    (comp.players || []).forEach((player) => {
+      const key = rdPersonKey(player);
+      let rec = index.get(key);
+      if (!rec) {
+        rec = { key, name: player.name, dojo: player.dojo, displayName: player.displayName || "", entries: [] };
+        index.set(key, rec);
+      }
+      rec.entries.push({ comp, player });
+    });
+  });
+  return index;
+}
+
+// Normalized search haystack for a person across one or more entries.
+function rdHaystack(name, dojo, entries) {
+  const parts = [name, dojo];
+  entries.forEach(({ comp, player }) => {
+    if (player.displayName) parts.push(player.displayName);
+    if (player.number) parts.push(player.number);
+    if (comp && comp.kind === "team") parts.push(player.name);
+  });
+  return rdNorm(parts.join(" "));
+}
+
+// The genuine zekken to show for identity: the display name from a competition
+// that actually uses zekken (withZekkenName). Non-zekken competitions still
+// carry a server-derived DisplayName (e.g. "A. SATO" from "Aiko Sato"), which
+// is NOT a real zekken and must not be surfaced as one. Returns "" when there
+// is no real zekken or it just echoes the name.
+function rdZekken(entries) {
+  for (const { comp, player } of entries) {
+    if (comp && comp.withZekkenName && player.displayName && player.displayName !== player.name) {
+      return player.displayName;
+    }
+  }
+  return "";
+}
+
+// A person is "present" (checked in) when every competition they entered has
+// recorded their check-in. Partial = some-but-not-all.
+function rdPresence(entries) {
+  const total = entries.length;
+  const checked = entries.filter((e) => e.player.checkedIn).length;
+  if (checked === 0) return "none";
+  if (checked === total) return "all";
+  return "partial";
+}
+
+// ---------------------------------------------------------------------------
+// Small inline icons (the project's Icon set doesn't ship search/check glyphs).
+// ---------------------------------------------------------------------------
+function RdSearchIcon() {
+  return (
+    <svg className="rd-search__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+      <line x1="16.5" y1="16.5" x2="21" y2="21" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+function RdCheckIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M5 12.5l4.5 4.5L19 7" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+function RdPencilIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 20h9" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Player-tag pill — the hand-over element. Loud for individuals' numbers and
+// team names; muted "Not assigned yet" before the draw.
+// ---------------------------------------------------------------------------
+function RdPlayerTag({ comp, player, size }) {
+  const tag = rdPlayerTag(comp, player);
+  const cls = `rd-tag rd-tag--${tag.kind}${size === "lg" ? " rd-tag--lg" : ""}`;
+  if (tag.kind === "pending") {
+    return <span className={cls} title="The competitor number is assigned when the draw runs">Not assigned yet</span>;
+  }
+  const label = tag.kind === "team" ? "Team" : "Tag";
+  return (
+    <span className={cls}>
+      <span className="rd-tag__label">{label}</span>
+      <span className="rd-tag__value">{tag.value}</span>
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rail — competition selector. Pinned "All competitions" entry on top, then one
+// row per competition with a check-in progress meter.
+// ---------------------------------------------------------------------------
+function RdRail({ comps, peopleIndex, selected, onSelect }) {
+  const allTotal = peopleIndex.size;
+  let allPresent = 0;
+  peopleIndex.forEach((rec) => { if (rdPresence(rec.entries) === "all") allPresent += 1; });
+
+  const item = (key, label, sub, present, total, status) => {
+    const pct = total > 0 ? Math.round((present / total) * 100) : 0;
+    const done = total > 0 && present === total;
+    return (
+      <button
+        type="button"
+        key={key}
+        className={`rd-rail__item${selected === key ? " is-active" : ""}`}
+        aria-current={selected === key ? "true" : undefined}
+        onClick={() => onSelect(key)}
+      >
+        <div className="rd-rail__top">
+          <span className="rd-rail__name">{label}</span>
+          {status && <StatusBadgeRD status={status} />}
+        </div>
+        <div className="rd-rail__sub">{sub}</div>
+        <div className="rd-rail__bar" role="presentation">
+          <div className={`rd-rail__bar-fill${done ? " is-done" : ""}`} style={{ width: `${pct}%` }} />
+        </div>
+        <div className="rd-rail__count">
+          <strong>{present}</strong> / {total} checked in
+        </div>
+      </button>
+    );
+  };
+
+  return (
+    <nav className="rd-rail" aria-label="Competitions">
+      {item("all", "All competitions", `${pluralizeRD(comps.length, "competition")} · everyone`, allPresent, allTotal, null)}
+      <div className="rd-rail__divider" role="presentation" />
+      {comps.map((c) => {
+        const players = c.players || [];
+        const checked = players.filter((p) => p.checkedIn).length;
+        const kindLabel = c.kind === "team" ? "teams" : "competitors";
+        return item(c.id, c.name, `${players.length} ${kindLabel}`, checked, players.length, c.status);
+      })}
+    </nav>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Other-competition chips — shown on a row to reveal the person's footprint.
+// Each chip carries its own check status; clicking checks them into that
+// competition too (the cross-competition convenience).
+// ---------------------------------------------------------------------------
+function RdOtherChips({ entries, onToggle, busy, label }) {
+  if (!entries.length) return null;
+  return (
+    <div className="rd-chips">
+      <span className="rd-chips__label">{label || "Also in"}</span>
+      {entries.map(({ comp, player }) => {
+        const checked = player.checkedIn;
+        const withdrawn = player.__ineligible; // reserved guard (see desk notes)
+        return (
+          <button
+            type="button"
+            key={comp.id}
+            className={`rd-chip${checked ? " is-checked" : ""}${withdrawn ? " is-withdrawn" : ""}`}
+            disabled={busy || withdrawn}
+            title={withdrawn ? "Withdrawn from this competition" : checked ? `Checked in — ${comp.name}` : `Check in for ${comp.name}`}
+            onClick={() => !checked && onToggle(comp.id, rdPid(player), true)}
+          >
+            <span className="rd-chip__mark" aria-hidden="true">{checked ? <RdCheckIcon /> : null}</span>
+            <span className="rd-chip__name">{comp.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Roster row. In competition mode the primary toggle is THIS competition's
+// check-in and the player tag is shown prominently. In "all" mode the toggle is
+// person-level presence (checks into every competition at once).
+// ---------------------------------------------------------------------------
+function RdRow({ mode, comp, player, zekken, entries, others, checked, presence, busy, onPrimary, onToggle, onEdit, isLast }) {
+  const danGrade = player.danGrade || (player.metadata && player.metadata[0]) || "";
+  const tag = (player.tag || "").toLowerCase();
+  const showTag = PARTICIPANT_TAGS_RD.includes(tag);
+
+  const stateClass = mode === "all"
+    ? (presence === "all" ? "is-checked" : presence === "partial" ? "is-partial" : "")
+    : (checked ? "is-checked" : "");
+
+  const checkLabel = mode === "all"
+    ? (presence === "all" ? `Undo check-in for ${player.name}` : `Check in ${player.name} for all their competitions`)
+    : (checked ? `Undo check-in for ${player.name}` : `Check in ${player.name}`);
+
+  return (
+    <div className={`rd-row ${stateClass}${isLast ? " rd-row--last" : ""}`}>
+      <button
+        type="button"
+        className="rd-check"
+        role="checkbox"
+        aria-checked={mode === "all" ? presence === "all" : checked}
+        aria-label={checkLabel}
+        disabled={busy}
+        onClick={onPrimary}
+      >
+        <span className="rd-check__box" aria-hidden="true">
+          {(mode === "all" ? presence !== "none" : checked) && <RdCheckIcon />}
+        </span>
+      </button>
+
+      <div className="rd-row__id">
+        <div className="rd-row__name-line">
+          <span className="rd-row__name">{player.name}</span>
+          {zekken && (
+            <span className="rd-row__zekken" title="Zekken / display name">{zekken}</span>
+          )}
+          {showTag && <span className={`tag-badge${tag === "manual" ? " tag-badge--warn" : ""}`}>{tag}</span>}
+        </div>
+        <div className="rd-row__meta">
+          {player.dojo && <span className="rd-row__dojo">{player.dojo}</span>}
+          {danGrade && <span className="rd-row__dan">{danGrade}</span>}
+          {player.seed ? <span className="rd-row__seed">Seed {player.seed}</span> : null}
+        </div>
+        {mode === "all" && <RdOtherChips entries={entries} onToggle={onToggle} busy={busy} label="In" />}
+        {mode === "comp" && others.length > 0 && <RdOtherChips entries={others} onToggle={onToggle} busy={busy} label="Also in" />}
+      </div>
+
+      {mode === "comp" && (
+        <div className="rd-row__right">
+          <div className="rd-row__handover">
+            <RdPlayerTag comp={comp} player={player} />
+          </div>
+          {onEdit && (
+            <button
+              type="button"
+              className="rd-row__edit"
+              aria-label={`Edit ${player.name}`}
+              title="Fix name, dojo or zekken"
+              disabled={busy}
+              onClick={onEdit}
+            >
+              <RdPencilIcon />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Walk-up add — inline panel. Setup-only (the add endpoint rejects started
+// competitions). For team competitions the "name" is the team name.
+// ---------------------------------------------------------------------------
+function RdWalkUp({ comp, seedName, password, showToast, onAdded, onCancel }) {
+  const isTeam = comp.kind === "team";
+  const [name, setName] = useStateRD(seedName || "");
+  const [dojo, setDojo] = useStateRD("");
+  const [zekken, setZekken] = useStateRD("");
+  const [dan, setDan] = useStateRD("");
+  const [busy, setBusy] = useStateRD(false);
+  const nameRef = useRefRD(null);
+
+  useEffectRD(() => { nameRef.current && nameRef.current.focus(); }, []);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    const n = name.trim(), d = dojo.trim();
+    if (!n || !d) { showToast(isTeam ? "Team name and dojo are required" : "Name and dojo are required", "error"); return; }
+    const admin = await window.promptAdminPassword();
+    if (admin === null) return;
+    setBusy(true);
+    try {
+      const payload = { name: n, dojo: d };
+      if (!isTeam && dan.trim()) payload.danGrade = dan.trim();
+      if (!isTeam && comp.withZekkenName && zekken.trim()) payload.displayName = zekken.trim();
+      const added = await window.API.addParticipant(comp.id, payload, password, admin);
+      // Check them in straight away — they're standing at the desk.
+      try {
+        await window.API.toggleCheckIn(comp.id, rdPid(added), true, password);
+        added.checkedIn = true;
+      } catch (err) {
+        showToast(`${n} added but check-in failed: ${err.message}`, "error");
+      }
+      onAdded(comp, added);
+    } catch (err) {
+      showToast(err.message, "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form className="rd-walkup" onSubmit={submit}>
+      <div className="rd-walkup__head">
+        <span className="rd-walkup__title">Add walk-up to {comp.name}</span>
+        <button type="button" className="btn btn--ghost btn--sm" onClick={onCancel}>Cancel</button>
+      </div>
+      <div className="rd-walkup__grid">
+        <label className="field">
+          <span className="field__label">{isTeam ? "Team name" : "Name"}</span>
+          <input ref={nameRef} className="input" value={name} onChange={(e) => setName(e.target.value)} placeholder={isTeam ? "Tora A" : "Akira Tanaka"} />
+        </label>
+        <label className="field">
+          <span className="field__label">Dojo</span>
+          <input className="input" value={dojo} onChange={(e) => setDojo(e.target.value)} placeholder={isTeam ? "Tora Dojo London" : "Gyokusen"} />
+        </label>
+        {!isTeam && comp.withZekkenName && (
+          <label className="field">
+            <span className="field__label">Zekken</span>
+            <input className="input" value={zekken} onChange={(e) => setZekken(e.target.value)} placeholder="TANAKA" />
+          </label>
+        )}
+        {!isTeam && (
+          <label className="field">
+            <span className="field__label">Dan grade <span className="field__opt">(optional)</span></span>
+            <input className="input" value={dan} onChange={(e) => setDan(e.target.value)} placeholder="3 dan" />
+          </label>
+        )}
+      </div>
+      <div className="rd-walkup__actions">
+        <button type="submit" className="btn btn--primary" disabled={busy}>{busy ? "Adding…" : "Add & check in"}</button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline edit — fix a wrong name / dojo / zekken on an existing entry without
+// leaving the desk. Operates on one (competition, participant); editing here
+// changes only that competition's record (the per-competition data model). Uses
+// the same elevated-password gate and replace endpoint as the Participants tab.
+// ---------------------------------------------------------------------------
+function RdEditModal({ comp, player, password, showToast, onSaved, onClose }) {
+  const isTeam = comp.kind === "team";
+  const Modal = window.Modal;
+  const [name, setName] = useStateRD(player.name || "");
+  const [dojo, setDojo] = useStateRD(player.dojo || "");
+  const [zekken, setZekken] = useStateRD(player.displayName && player.displayName !== player.name ? player.displayName : "");
+  const [dan, setDan] = useStateRD(player.danGrade || (player.metadata && player.metadata[0]) || "");
+  const [busy, setBusy] = useStateRD(false);
+
+  const save = async () => {
+    const n = name.trim(), d = dojo.trim();
+    if (!n || !d) { showToast(isTeam ? "Team name and dojo are required" : "Name and dojo are required", "error"); return; }
+    const admin = await window.promptAdminPassword();
+    if (admin === null) return;
+    setBusy(true);
+    try {
+      const metadata = window.buildPlayerMetadata(isTeam ? "" : dan.trim(), player.metadata);
+      const payload = { name: n, dojo: d, displayName: !isTeam && comp.withZekkenName ? zekken.trim() : "", tag: player.tag || "" };
+      if (metadata !== undefined) payload.metadata = metadata;
+      const updated = await window.API.replaceParticipant(comp.id, rdPid(player), payload, password, admin);
+      onSaved(comp, updated);
+    } catch (err) {
+      showToast(err.message, "error");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={`Edit ${isTeam ? "team" : "competitor"}`}
+      onClose={onClose}
+      dismissable={!busy}
+      footer={<>
+        <button type="button" className="btn btn--ghost" onClick={onClose} disabled={busy}>Cancel</button>
+        <button type="button" className="btn btn--primary" onClick={save} disabled={busy}>{busy ? "Saving…" : "Save changes"}</button>
+      </>}
+    >
+      <div className="rd-walkup__grid">
+        <label className="field">
+          <span className="field__label">{isTeam ? "Team name" : "Name"}</span>
+          <input className="input" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
+        </label>
+        <label className="field">
+          <span className="field__label">Dojo</span>
+          <input className="input" value={dojo} onChange={(e) => setDojo(e.target.value)} />
+        </label>
+        {!isTeam && comp.withZekkenName && (
+          <label className="field">
+            <span className="field__label">Zekken</span>
+            <input className="input" value={zekken} onChange={(e) => setZekken(e.target.value)} placeholder="TANAKA" />
+          </label>
+        )}
+        {!isTeam && (
+          <label className="field">
+            <span className="field__label">Dan grade <span className="field__opt">(optional)</span></span>
+            <input className="input" value={dan} onChange={(e) => setDan(e.target.value)} placeholder="3 dan" />
+          </label>
+        )}
+      </div>
+      <p className="rd-edit__note">Edits apply to this competition's record only.</p>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page.
+// ---------------------------------------------------------------------------
+function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, onUpdate, onLogout, onViewerMode }) {
+  // Local authoritative copy of competitions, seeded from the parent. While
+  // this view is mounted the parent tournament only changes when WE call
+  // onUpdate, so re-seeding on prop change can't clobber an optimistic write.
+  const [comps, setComps] = useStateRD(() => tournament.competitions || []);
+  const tRef = useRefRD(tournament);
+  useEffectRD(() => { tRef.current = tournament; }, [tournament]);
+  useEffectRD(() => { setComps(tournament.competitions || []); }, [tournament.competitions]);
+
+  const [selected, setSelected] = useStateRD("all");
+  const [query, setQuery] = useStateRD("");
+  const [tagFilter, setTagFilter] = useStateRD("all");
+  const [dojoFilter, setDojoFilter] = useStateRD("all");
+  const [uncheckedOnly, setUncheckedOnly] = useStateRD(false);
+  const [groupByDojo, setGroupByDojo] = useStateRD(false);
+  const [busy, setBusy] = useStateRD(false);
+  const [walkUpOpen, setWalkUpOpen] = useStateRD(false);
+  const [editTarget, setEditTarget] = useStateRD(null); // { comp, player }
+  const [handoff, setHandoff] = useStateRD(null); // { name, tags: [{compName, kind, value}] }
+  const searchRef = useRefRD(null);
+  const mountedRef = useRefRD(true);
+  useEffectRD(() => () => { mountedRef.current = false; }, []);
+
+  // Autofocus search on mount and whenever the selected competition changes —
+  // the desk's first move is always to type a name.
+  useEffectRD(() => { searchRef.current && searchRef.current.focus(); }, [selected]);
+
+  // Reset competition-scoped UI when switching rail entries.
+  useEffectRD(() => { setWalkUpOpen(false); setDojoFilter("all"); setHandoff(null); setEditTarget(null); }, [selected]);
+
+  // Refresh from the server and reconcile both local + parent state.
+  const refresh = useCallbackRD(async () => {
+    try {
+      const fresh = await window.API.fetchCompetitions();
+      if (!mountedRef.current) return;
+      setComps(fresh);
+      onUpdate({ ...tRef.current, competitions: fresh });
+    } catch (e) {
+      console.warn("Registration desk refresh failed", e);
+    }
+  }, [onUpdate]);
+
+  // SSE: reconcile other desks' check-ins. Debounced so a burst is one refetch.
+  useEffectRD(() => {
+    if (!window.API || typeof window.API.subscribeToEvents !== "function") return;
+    let timer = null;
+    const unsub = window.API.subscribeToEvents((event) => {
+      if (event && (event.type === "participants_updated" || event.type === "competition_started" || event.type === "competition_completed" || event.type === "competition_deleted")) {
+        if (timer) return;
+        timer = setTimeout(() => { timer = null; refresh(); }, 600);
+      }
+    });
+    return () => { if (timer) clearTimeout(timer); unsub(); };
+  }, [refresh]);
+
+  const peopleIndex = useMemoRD(() => rdBuildPeopleIndex(comps), [comps]);
+  const selectedComp = selected === "all" ? null : comps.find((c) => c.id === selected);
+
+  // Optimistic local mutation of one check-in flag.
+  const setLocal = (compId, pid, val) => {
+    setComps((cs) => cs.map((c) => c.id !== compId ? c : {
+      ...c,
+      players: (c.players || []).map((p) => rdPid(p) === pid ? { ...p, checkedIn: val } : p),
+    }));
+  };
+
+  const announceHandoff = (name, pairs) => {
+    setHandoff({ name, tags: pairs });
+  };
+
+  // Toggle one (competition, participant). Optimistic; SSE refresh reconciles.
+  const toggleOne = async (compId, pid, val, opts = {}) => {
+    setLocal(compId, pid, val);
+    try {
+      await window.API.toggleCheckIn(compId, pid, val, password);
+      if (val && opts.handoff) announceHandoff(opts.handoff.name, opts.handoff.tags);
+    } catch (e) {
+      if (!mountedRef.current) return;
+      showToast(e.message, "error");
+      setLocal(compId, pid, !val); // revert
+    }
+  };
+
+  // Person-level toggle in "all" mode: check into every competition (or undo all).
+  const togglePerson = async (rec) => {
+    const presence = rdPresence(rec.entries);
+    const makeChecked = presence !== "all"; // none/partial → check all; all → undo all
+    const targets = rec.entries.filter(({ player }) => player.checkedIn !== makeChecked);
+    if (!targets.length) return;
+    setBusy(true);
+    targets.forEach(({ comp, player }) => setLocal(comp.id, rdPid(player), makeChecked));
+    try {
+      const results = await Promise.allSettled(
+        targets.map(({ comp, player }) => window.API.toggleCheckIn(comp.id, rdPid(player), makeChecked, password))
+      );
+      const failed = results.filter((r) => r.status === "rejected");
+      if (failed.length) showToast(`${failed.length} of ${targets.length} check-ins failed — reloading`, "error");
+      if (makeChecked && !failed.length) {
+        announceHandoff(rec.name, rec.entries.map(({ comp, player }) => ({ compName: comp.name, ...rdPlayerTag(comp, player) })));
+      }
+      await refresh();
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  };
+
+  // Bulk check-in a dojo within the selected competition (uses the bulk endpoint).
+  const bulkDojoComp = async (compId, pids) => {
+    if (!pids.length) return;
+    setBusy(true);
+    pids.forEach((pid) => setLocal(compId, pid, true));
+    try {
+      await window.API.bulkCheckIn(compId, pids, password);
+      await refresh();
+    } catch (e) {
+      showToast(e.message, "error");
+      await refresh();
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  };
+
+  // ---- Build the filtered, sorted rows for the current view ----------------
+  const queryNorm = rdNorm(query);
+
+  const rows = useMemoRD(() => {
+    const matchesFilters = (player) => {
+      if (uncheckedOnly && player.checkedIn) return false;
+      if (tagFilter !== "all" && (player.tag || "").toLowerCase() !== tagFilter) return false;
+      if (dojoFilter !== "all" && player.dojo !== dojoFilter) return false;
+      return true;
+    };
+
+    if (selected === "all") {
+      const out = [];
+      peopleIndex.forEach((rec) => {
+        // person-level filters: match if ANY entry passes tag/dojo filters
+        const anyEntry = rec.entries.some(({ player }) => matchesFilters(player));
+        if (!anyEntry) return;
+        const presence = rdPresence(rec.entries);
+        if (uncheckedOnly && presence === "all") return;
+        const hay = rdHaystack(rec.name, rec.dojo, rec.entries);
+        const score = rdQueryScore(queryNorm, hay);
+        if (score == null) return;
+        out.push({ rec, presence, score });
+      });
+      out.sort((a, b) => {
+        if (queryNorm) return a.score - b.score;
+        const ap = a.presence === "all" ? 1 : 0, bp = b.presence === "all" ? 1 : 0;
+        if (ap !== bp) return ap - bp; // unchecked first
+        return a.rec.name.localeCompare(b.rec.name);
+      });
+      return out;
+    }
+
+    const comp = comps.find((c) => c.id === selected);
+    if (!comp) return [];
+    const out = [];
+    (comp.players || []).forEach((player) => {
+      if (!matchesFilters(player)) return;
+      const hay = rdHaystack(player.name, player.dojo, [{ comp, player }]);
+      const score = rdQueryScore(queryNorm, hay);
+      if (score == null) return;
+      const rec = peopleIndex.get(rdPersonKey(player));
+      const others = rec ? rec.entries.filter((e) => e.comp.id !== comp.id) : [];
+      out.push({ comp, player, others, score });
+    });
+    out.sort((a, b) => {
+      if (queryNorm) return a.score - b.score;
+      const ac = a.player.checkedIn ? 1 : 0, bc = b.player.checkedIn ? 1 : 0;
+      if (ac !== bc) return ac - bc;
+      return a.player.name.localeCompare(b.player.name);
+    });
+    return out;
+  }, [selected, comps, peopleIndex, queryNorm, uncheckedOnly, tagFilter, dojoFilter]);
+
+  // Dojo list for the filter (scoped to the selected competition / all).
+  const dojoOptions = useMemoRD(() => {
+    const set = new Set();
+    const scope = selected === "all" ? comps : comps.filter((c) => c.id === selected);
+    scope.forEach((c) => (c.players || []).forEach((p) => p.dojo && set.add(p.dojo)));
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [comps, selected]);
+
+  // Headline metric for the current view.
+  const headline = useMemoRD(() => {
+    if (selected === "all") {
+      let present = 0;
+      peopleIndex.forEach((rec) => { if (rdPresence(rec.entries) === "all") present += 1; });
+      return { present, total: peopleIndex.size, noun: "people" };
+    }
+    const comp = comps.find((c) => c.id === selected);
+    const players = comp ? comp.players || [] : [];
+    return { present: players.filter((p) => p.checkedIn).length, total: players.length, noun: comp && comp.kind === "team" ? "teams" : "competitors" };
+  }, [selected, comps, peopleIndex]);
+
+  // Enter on the search box checks in the single top hit — the arrival loop.
+  const onSearchKeyDown = (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    if (!rows.length) return;
+    const top = rows[0];
+    if (selected === "all") {
+      if (top.presence !== "all") togglePerson(top.rec);
+    } else if (!top.player.checkedIn) {
+      toggleOne(top.comp.id, rdPid(top.player), true, {
+        handoff: { name: top.player.name, tags: [{ compName: top.comp.name, ...rdPlayerTag(top.comp, top.player) }] },
+      });
+    }
+    setQuery("");
+    searchRef.current && searchRef.current.focus();
+  };
+
+  const onAdded = async (comp, added) => {
+    setWalkUpOpen(false);
+    announceHandoff(added.name, [{ compName: comp.name, ...rdPlayerTag(comp, added) }]);
+    await refresh();
+  };
+
+  const canWalkUp = selectedComp && (selectedComp.status === "setup" || !selectedComp.status);
+  const allChecked = headline.total > 0 && headline.present === headline.total;
+  const noComps = comps.length === 0;
+
+  return (
+    <div className="app">
+      <AdminTopbarRD onLogout={onLogout} onViewerMode={onViewerMode} tournament={tournament} />
+      <div className="page page--wide" style={{ maxWidth: 1280 }}>
+        <BreadcrumbsRD items={[{ label: "Dashboard", onClick: onBack }, { label: "Registration desk" }]} />
+        <div className="page-head">
+          <div>
+            <h1 className="page-head__title">Registration desk</h1>
+            <div className="page-head__sub">Check competitors in across every competition and hand them their player tag.</div>
+          </div>
+        </div>
+
+        {noComps ? (
+          <div className="empty" style={{ padding: "48px 24px" }}>
+            <div className="icon" aria-hidden="true">🥋</div>
+            <h3>No competitions yet</h3>
+            <div style={{ fontSize: 13, color: "var(--ink-2)", maxWidth: 440, margin: "0 auto", lineHeight: 1.5 }}>
+              Add a competition and its participants first, then the registration desk will gather every roster here for check-in.
+            </div>
+          </div>
+        ) : (
+          <div className="workspace rd-workspace">
+            <RdRail comps={comps} peopleIndex={peopleIndex} selected={selected} onSelect={setSelected} />
+
+            <div className="rd-main">
+              <div className="rd-header">
+                <div className="rd-search">
+                  <RdSearchIcon />
+                  <input
+                    ref={searchRef}
+                    className="rd-search__input"
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={onSearchKeyDown}
+                    placeholder={selectedComp && selectedComp.kind === "team"
+                      ? "Search team name or dojo… (Enter checks in the top match)"
+                      : "Search name, dojo or zekken… (Enter checks in the top match)"}
+                    aria-label="Search competitors"
+                    autoComplete="off"
+                    spellCheck="false"
+                  />
+                  {query && (
+                    <button type="button" className="rd-search__clear" onClick={() => { setQuery(""); searchRef.current && searchRef.current.focus(); }} aria-label="Clear search">×</button>
+                  )}
+                </div>
+                <div className="rd-headline">
+                  <span className="rd-headline__metric"><strong>{headline.present}</strong> of {headline.total}</span>
+                  <span className="rd-headline__noun">{headline.noun} checked in</span>
+                </div>
+                {selectedComp && (
+                  <button
+                    type="button"
+                    className="btn btn--primary rd-walkup-btn"
+                    disabled={!canWalkUp}
+                    title={canWalkUp ? undefined : "Walk-ups can only be added before the draw is generated"}
+                    onClick={() => setWalkUpOpen((v) => !v)}
+                  >
+                    + Add walk-up
+                  </button>
+                )}
+              </div>
+
+              <div className="rd-toolbar">
+                <label className="rd-filter">
+                  <span>Tag</span>
+                  <select className="select" value={tagFilter} onChange={(e) => setTagFilter(e.target.value)}>
+                    <option value="all">All</option>
+                    {PARTICIPANT_TAGS_RD.map((t) => <option key={t} value={t}>{t}</option>)}
+                  </select>
+                </label>
+                {dojoOptions.length > 0 && (
+                  <label className="rd-filter">
+                    <span>Dojo</span>
+                    <select className="select" value={dojoFilter} onChange={(e) => setDojoFilter(e.target.value)}>
+                      <option value="all">All dojos</option>
+                      {dojoOptions.map((d) => <option key={d} value={d}>{d}</option>)}
+                    </select>
+                  </label>
+                )}
+                <button type="button" className={`rd-toggle${uncheckedOnly ? " is-on" : ""}`} aria-pressed={uncheckedOnly} onClick={() => setUncheckedOnly((v) => !v)}>
+                  Unchecked only
+                </button>
+                <button type="button" className={`rd-toggle${groupByDojo ? " is-on" : ""}`} aria-pressed={groupByDojo} onClick={() => setGroupByDojo((v) => !v)}>
+                  Group by dojo
+                </button>
+                {busy && <span className="rd-toolbar__busy"><span className="spinner" aria-hidden="true" /> Saving…</span>}
+              </div>
+
+              {handoff && (
+                <div className="rd-handoff" role="status" aria-live="polite">
+                  <button type="button" className="rd-handoff__close" aria-label="Dismiss" onClick={() => setHandoff(null)}>×</button>
+                  <div className="rd-handoff__lead"><RdCheckIcon /> Checked in — hand over to <strong>{handoff.name}</strong></div>
+                  <div className="rd-handoff__tags">
+                    {handoff.tags.map((t, i) => (
+                      <div key={i} className="rd-handoff__tag">
+                        {handoff.tags.length > 1 && <span className="rd-handoff__comp">{t.compName}</span>}
+                        {t.kind === "pending"
+                          ? <span className="rd-tag rd-tag--pending rd-tag--lg">Not assigned yet</span>
+                          : <span className={`rd-tag rd-tag--${t.kind} rd-tag--lg`}><span className="rd-tag__label">{t.kind === "team" ? "Team" : "Tag"}</span><span className="rd-tag__value">{t.value}</span></span>}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {walkUpOpen && selectedComp && (
+                <RdWalkUp
+                  comp={selectedComp}
+                  seedName={query.trim()}
+                  password={password}
+                  showToast={showToast}
+                  onAdded={onAdded}
+                  onCancel={() => setWalkUpOpen(false)}
+                />
+              )}
+
+              <RdRoster
+                mode={selected === "all" ? "all" : "comp"}
+                rows={rows}
+                groupByDojo={groupByDojo}
+                query={query}
+                busy={busy}
+                allChecked={allChecked}
+                canWalkUp={canWalkUp}
+                onOpenWalkUp={() => setWalkUpOpen(true)}
+                onPrimary={(row) => {
+                  if (selected === "all") {
+                    togglePerson(row.rec);
+                  } else {
+                    const willCheck = !row.player.checkedIn;
+                    toggleOne(row.comp.id, rdPid(row.player), willCheck, willCheck ? {
+                      handoff: { name: row.player.name, tags: [{ compName: row.comp.name, ...rdPlayerTag(row.comp, row.player) }] },
+                    } : {});
+                  }
+                }}
+                onToggleChip={(compId, pid, val) => toggleOne(compId, pid, val)}
+                onEdit={(row) => setEditTarget({ comp: row.comp, player: row.player })}
+                onBulkDojo={(dojo, theseRows) => {
+                  if (selected === "all") {
+                    // check every listed person from this dojo into all their comps
+                    theseRows.forEach((r) => r.presence !== "all" && togglePerson(r.rec));
+                  } else {
+                    const pids = theseRows.filter((r) => !r.player.checkedIn).map((r) => rdPid(r.player));
+                    bulkDojoComp(selected, pids);
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
+        {window.VersionFooter && <window.VersionFooter />}
+      </div>
+      {editTarget && (
+        <RdEditModal
+          comp={editTarget.comp}
+          player={editTarget.player}
+          password={password}
+          showToast={showToast}
+          onSaved={async (comp, updated) => {
+            setEditTarget(null);
+            showToast(`${updated && updated.name ? updated.name : "Competitor"} updated`);
+            await refresh();
+          }}
+          onClose={() => setEditTarget(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Roster list — flat or grouped-by-dojo, with empty / no-match / all-done states.
+// ---------------------------------------------------------------------------
+function RdRoster({ mode, rows, groupByDojo, query, busy, allChecked, canWalkUp, onOpenWalkUp, onPrimary, onToggleChip, onEdit, onBulkDojo }) {
+  const rowOf = (row, isLast) => {
+    if (mode === "all") {
+      const rep = row.rec.entries[0].player;
+      return (
+        <RdRow
+          key={row.rec.key}
+          mode="all"
+          comp={row.rec.entries[0].comp}
+          player={{ ...rep, name: row.rec.name, dojo: row.rec.dojo }}
+          zekken={rdZekken(row.rec.entries)}
+          entries={row.rec.entries}
+          others={[]}
+          presence={row.presence}
+          busy={busy}
+          isLast={isLast}
+          onPrimary={() => onPrimary(row)}
+          onToggle={onToggleChip}
+        />
+      );
+    }
+    return (
+      <RdRow
+        key={`${row.comp.id}:${rdPid(row.player)}`}
+        mode="comp"
+        comp={row.comp}
+        player={row.player}
+        zekken={rdZekken([{ comp: row.comp, player: row.player }])}
+        entries={[]}
+        others={row.others}
+        checked={row.player.checkedIn}
+        busy={busy}
+        isLast={isLast}
+        onPrimary={() => onPrimary(row)}
+        onToggle={onToggleChip}
+        onEdit={onEdit ? () => onEdit(row) : undefined}
+      />
+    );
+  };
+
+  if (!rows.length) {
+    if (query.trim()) {
+      return (
+        <div className="empty rd-empty">
+          <h3>No one matches “{query.trim()}”</h3>
+          <div className="rd-empty__sub">Check the spelling, or clear filters. If they're not registered yet:</div>
+          {canWalkUp && <button type="button" className="btn btn--primary" onClick={onOpenWalkUp}>+ Add “{query.trim()}” as walk-up</button>}
+        </div>
+      );
+    }
+    if (allChecked) {
+      return (
+        <div className="empty rd-empty rd-empty--done">
+          <div className="icon" aria-hidden="true">✓</div>
+          <h3>Everyone's here</h3>
+          <div className="rd-empty__sub">All checked in. Search above to undo or re-check anyone.</div>
+        </div>
+      );
+    }
+    return (
+      <div className="empty rd-empty">
+        <h3>No one to show</h3>
+        <div className="rd-empty__sub">{canWalkUp ? "Add a walk-up, or adjust the filters above." : "Adjust the filters above."}</div>
+      </div>
+    );
+  }
+
+  if (groupByDojo) {
+    const groups = new Map();
+    rows.forEach((row) => {
+      const dojo = (mode === "all" ? row.rec.dojo : row.player.dojo) || "—";
+      if (!groups.has(dojo)) groups.set(dojo, []);
+      groups.get(dojo).push(row);
+    });
+    const ordered = Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    return (
+      <div className="rd-roster">
+        {ordered.map(([dojo, theseRows]) => {
+          const pending = theseRows.filter((r) => mode === "all" ? r.presence !== "all" : !r.player.checkedIn).length;
+          return (
+            <div key={dojo} className="rd-group">
+              <div className="rd-group__head">
+                <span className="rd-group__name">{dojo}</span>
+                <span className="rd-group__count">{theseRows.length}</span>
+                {pending > 0 && (
+                  <button type="button" className="btn btn--sm rd-group__bulk" disabled={busy} onClick={() => onBulkDojo(dojo, theseRows)}>
+                    Check in all {pending}
+                  </button>
+                )}
+              </div>
+              {theseRows.map((row, i) => rowOf(row, i === theseRows.length - 1))}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return <div className="rd-roster">{rows.map((row, i) => rowOf(row, i === rows.length - 1))}</div>;
+}
+
+window.AdminRegistrationDeskPage = AdminRegistrationDeskPage;
+
+export {
+  rdNorm, rdPersonKey, rdPid, rdTokenScore, rdQueryScore, rdPlayerTag,
+  rdBuildPeopleIndex, rdHaystack, rdPresence, rdZekken,
+};

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -559,9 +559,9 @@ function AdminRegistrationDeskPage({ tournament, onBack, password, showToast, on
   const refresh = useCallbackRD(async () => {
     try {
       const fresh = await window.API.fetchCompetitions();
+      onUpdate({ ...tRef.current, competitions: fresh });
       if (!mountedRef.current) return;
       setComps(fresh);
-      onUpdate({ ...tRef.current, competitions: fresh });
     } catch (e) {
       console.warn("Registration desk refresh failed", e);
     }

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -78,7 +78,9 @@ function rdTokenScore(needle, hay) {
   // ("tnk" → tanaka, gaps 2 < len 3) keeps small gaps; a coincidental spread
   // (gaps ≥ needle length, e.g. "yama"→"ryonakama" with gaps 4 == len 4) doesn't.
   if (gaps >= needle.length) return null;
-  return 200 + start + gaps; // any subsequence ranks below any contiguous hit
+  // Base offset large enough that a subsequence can never outrank a contiguous
+  // hit, even for a long haystack where a contiguous match's `at` index is big.
+  return 1e6 + start + gaps;
 }
 
 // Whole-query score: every whitespace-separated token must match (AND), so

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -327,7 +327,7 @@ function AllWinnersModal({ comps, onClose }) {
   );
 }
 
-function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompetition, onEditTournament, onAnnounce, onOpenSchedule, onOpenScoreEditor, onOpenImport, onOpenShiaijo, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate, showToast, authConfig }) {
+function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompetition, onEditTournament, onAnnounce, onOpenSchedule, onOpenScoreEditor, onOpenImport, onOpenShiaijo, onOpenRegistration, onStartAll, onStartCompetition, onLogout, onViewerMode, onUpdate, showToast, authConfig }) {
   const t = tournament;
   const comps = t.competitions || [];
   const [exportPdfOpen, setExportPdfOpen] = useStateA(false);
@@ -467,6 +467,12 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
         </div>
 
         <div className="row" style={{ marginBottom: 24 }}>
+          {onOpenRegistration && (
+            <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenRegistration}>
+              <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="clipboard-check" size={18} />Registration desk →</div>
+              <div className="card__sub">Check competitors in across every competition and hand them their player tag.</div>
+            </button>
+          )}
           {scheduleEnabled && (
             <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenSchedule}>
               <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="calendar" size={18} />Tournament schedule →</div>

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -470,7 +470,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
           {onOpenRegistration && (
             <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenRegistration}>
               <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="clipboard-check" size={18} />Registration desk →</div>
-              <div className="card__sub">Check competitors in across every competition and hand them their player tag.</div>
+              <div className="card__sub">Check competitors in across every competition and hand them their number.</div>
             </button>
           )}
           {scheduleEnabled && (

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -470,7 +470,7 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
           {onOpenRegistration && (
             <button type="button" className="card" style={{ textAlign: "left", cursor: "pointer", border: "1px solid var(--line)" }} onClick={onOpenRegistration}>
               <div className="card__title" style={{ marginBottom: 6, display: "inline-flex", alignItems: "center", gap: 8 }}><Icon name="clipboard-check" size={18} />Registration desk →</div>
-              <div className="card__sub">Check competitors in across every competition and hand them their number.</div>
+              <div className="card__sub">Check competitors in as they arrive, across every competition.</div>
             </button>
           )}
           {scheduleEnabled && (

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1149,7 +1149,7 @@ const API = {
         return res.json();
     },
     async addParticipant(compID, payload, password, adminPassword) {
-        const res = await fetch(`/api/competitions/${compID}/participants`, {
+        const res = await fetch(`/api/competitions/${encodeURIComponent(compID)}/participants`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password, ...adminHdr(adminPassword) },
             body: JSON.stringify(payload)

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1134,7 +1134,7 @@ const API = {
         return res.json();
     },
     // Bulk check-in for one competition. participantIds is an array of stable
-    // participant ids (UUID or name). Returns { checkedIn, alreadyCheckedIn,
+    // participant ids that must match the persisted id column exactly. Returns { checkedIn, alreadyCheckedIn,
     // notFound }. Used by the Registration desk's "check in a whole dojo" action.
     async bulkCheckIn(compID, participantIds, password) {
         const res = await fetch(`/api/competitions/${compID}/participants/checkin-bulk`, {

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1133,6 +1133,21 @@ const API = {
         }
         return res.json();
     },
+    // Bulk check-in for one competition. participantIds is an array of stable
+    // participant ids (UUID or name). Returns { checkedIn, alreadyCheckedIn,
+    // notFound }. Used by the Registration desk's "check in a whole dojo" action.
+    async bulkCheckIn(compID, participantIds, password) {
+        const res = await fetch(`/api/competitions/${compID}/participants/checkin-bulk`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password },
+            body: JSON.stringify({ participantIds })
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || 'Failed to check in participants');
+        }
+        return res.json();
+    },
     async addParticipant(compID, payload, password, adminPassword) {
         const res = await fetch(`/api/competitions/${compID}/participants`, {
             method: 'POST',

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1137,7 +1137,7 @@ const API = {
     // participant ids that must match the persisted id column exactly. Returns { checkedIn, alreadyCheckedIn,
     // notFound }. Used by the Registration desk's "check in a whole dojo" action.
     async bulkCheckIn(compID, participantIds, password) {
-        const res = await fetch(`/api/competitions/${compID}/participants/checkin-bulk`, {
+        const res = await fetch(`/api/competitions/${encodeURIComponent(compID)}/participants/checkin-bulk`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password },
             body: JSON.stringify({ participantIds })

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1123,7 +1123,7 @@ const API = {
     },
     async toggleCheckIn(compID, pid, checkedIn, password) {
         const method = checkedIn ? 'PUT' : 'DELETE';
-        const res = await fetch(`/api/competitions/${compID}/participants/${pid}/checkin`, {
+        const res = await fetch(`/api/competitions/${encodeURIComponent(compID)}/participants/${encodeURIComponent(pid)}/checkin`, {
             method,
             headers: { 'X-Tournament-Password': password }
         });
@@ -1161,7 +1161,7 @@ const API = {
         return res.json();
     },
     async replaceParticipant(compID, pid, payload, password, adminPassword) {
-        const res = await fetch(`/api/competitions/${compID}/participants/${pid}`, {
+        const res = await fetch(`/api/competitions/${encodeURIComponent(compID)}/participants/${encodeURIComponent(pid)}`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json', 'X-Tournament-Password': password, ...adminHdr(adminPassword) },
             body: JSON.stringify(payload)

--- a/web-mobile/js/ui.jsx
+++ b/web-mobile/js/ui.jsx
@@ -432,6 +432,7 @@ function Icon({ name, size = 16, className }) {
     calendar: <><rect width="18" height="18" x="3" y="4" rx="2" /><path d="M3 10h18" /><path d="M8 2v4" /><path d="M16 2v4" /></>,
     pencil: <><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.4 2.6a2 2 0 0 1 2.8 2.8L11 15.6 7 17l1.4-4z" /></>,
     folder: <><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" /></>,
+    "clipboard-check": <><rect width="8" height="4" x="8" y="2" rx="1" ry="1" /><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" /><path d="m9 14 2 2 4-4" /></>,
   }[name];
   if (!inner) return null;
   return (


### PR DESCRIPTION
## Summary

- Adds a **Registration desk** — a single operator surface, reached from the Admin dashboard, that runs venue check-in across **every** competition. Previously an operator had to open each competition's Participants tab one at a time.
- The arrival loop: **fuzzy-find a competitor → check them in → hand over their player tag.** The hand-over callout shows the tag big enough to read against a placard.
- **Player tag** = assigned competitor number for individuals (`M1`), team name for teams (nothing is shown before the draw assigns a number) — distinct from the zekken. Registration provenance (`manual`/`registered`/`transfer`) is intentionally NOT shown here; it stays in the Participants tab.
- **Competition-first rail** with a pinned "All competitions" entry; per-competition and tournament-wide check-in progress meters.
- **All-competitions mode** dedups a person across competitions and shows green/amber **present / partial** state, with per-competition chips that one-tap check them into their other competitions.
- **Fuzzy search** over name / zekken / dojo (team name for teams) with a gap cap so scattered matches are rejected; **Enter checks in the top hit**.
- **Walk-up add** (setup-only, elevated password) and **inline edit** of an existing entry's name/dojo/zekken; **group-by-dojo** with bulk check-in.

**Also bundled (from a `/design-system audit`):** promoted the success/present green that had spread across ~8 component families into a documented `--ok*` token ramp (value-preserving), tokenized the exact `--ink-3` duplicate and the error-semantic reds, folded the in-between font-size strays into the scale, and documented the `--ok` ramp + the `rd-` component in `DESIGN.md`. No visual change intended; verified the registration desk + seeding panel render the green identically.

## Why

The day-of check-in mechanism (`CheckedIn` flag + `/checkin` endpoints) already existed per competition (bracket-creator-9oj), but an operator running a registration desk had to hop between every competition's Participants tab. This gathers all rosters into one purpose-built surface optimized for the arrival trickle.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_registration_desk.jsx` | New surface: rail, fuzzy roster, hand-over callout, walk-up add, inline edit, group-by-dojo + pure helpers |
| `web-mobile/js/__tests__/admin_registration_desk.test.jsx` | 25 unit tests for the pure helpers (identity, fuzzy + gap cap, player tag, presence, zekken authenticity) |
| `web-mobile/js/__tests__/render/admin_registration_desk.render.test.jsx` | Render-smoke: mounts the page with stubbed window globals (populated + empty states) |
| `web-mobile/js/admin.jsx` | `registrationDesk` route + `onOpenRegistration` wiring |
| `web-mobile/js/admin_shell.jsx` | Dashboard "Registration desk" entry card |
| `web-mobile/js/api_client.jsx` | `API.bulkCheckIn` client method (existing `/checkin-bulk` endpoint) |
| `web-mobile/js/ui.jsx` | `clipboard-check` Icon glyph |
| `web-mobile/css/styles.css` | `rd-` styles (rail, search, roster, tags, chips, callout, walk-up, responsive) |
| `web-mobile/index.html` | Script tag for the new module |
| `DESIGN.md` | Document the `--ok*` success token ramp, typography promotions, and the `rd-` component |

## Screenshots

**Dashboard entry point** — the new "Registration desk" card.
![Dashboard with Registration desk card](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/315/01-dashboard-card.png)

**All competitions** — one person deduped across competitions; green = fully present, amber = partial (checked into some but not all). Per-competition chips check them into the rest with one tap.
![All-competitions mode with cross-competition presence](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/315/02-all-competitions.png)

**Competition mode** — the competitor number to hand over (`M1`…`M8`) on the right, zekken inline for identity, "Also in" chips for cross-entries. In all-competitions mode the number rides on each competition chip (`Men's Individual  M2`).
![Competition mode with player numbers](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/315/03-competition-tags.png)

**Hand-over moment** — after a check-in the number is shown large enough to read against the placard.
![Hand-over callout showing the number M5](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/315/04-handover.png)

**Walk-up add (teams)** — setup-only inline walk-up; for team competitions the handed-over value is the team name.
![Walk-up form on a team competition](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/315/05-walkup-team.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests; coverage ≥85% all packages)
- [x] New/updated unit tests cover the change (25 unit + 2 render-smoke; full JS suite 1830 pass; ESLint clean)
- [x] Manual browser verification — exercised in Chrome via Playwright + Claude Preview: dashboard entry card; all-competitions dedup + partial state; competition mode player tags + zekken + cross-comp chips; check-in → hand-over callout; walk-up add end-to-end; inline edit end-to-end (persisted to disk); fuzzy search (gap cap); group-by-dojo; tablet responsive (rail → horizontal scroller)
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] No new console errors or warnings

Closes mp-25bk
