### PR TITLE
feat(scoring): change default-win decision ippons to ○

### DIFF
--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -349,7 +349,8 @@ func (e *Engine) checkEligibilityExcludingMatch(compID string, playerIDs []strin
 // RecordDecision auto-fills the scoreline from decision/decisionBy/encho
 // and persists the result via RecordMatchResultWithIneligibility. The
 // canonical SideA=Aka / SideB=Shiro mapping (CLAUDE.md) is used to
-// translate decisionBy → which side loses/forfeits the auto-filled ○-0 scoreline.
+// translate decisionBy → which side loses/forfeits: winner gets ○○ (regulation)
+// or ○ (encho), loser gets nothing.
 //
 // When the match already has a kiken/fusenpai decision recorded (the
 // "undo" path, T103/CHK024) the engine enforces the

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -421,7 +421,7 @@ func (e *Engine) RecordDecision(compID, matchID, decision, decisionBy, decisionR
 	}
 	winIppons := make([]string, winningCount)
 	for i := range winIppons {
-		winIppons[i] = "M"
+		winIppons[i] = "○"
 	}
 	result := &state.MatchResult{
 		ID:             matchID,

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -349,7 +349,7 @@ func (e *Engine) checkEligibilityExcludingMatch(compID string, playerIDs []strin
 // RecordDecision auto-fills the scoreline from decision/decisionBy/encho
 // and persists the result via RecordMatchResultWithIneligibility. The
 // canonical SideA=Aka / SideB=Shiro mapping (CLAUDE.md) is used to
-// translate decisionBy → which side loses/forfeits the auto-filled X-0 scoreline.
+// translate decisionBy → which side loses/forfeits the auto-filled ○-0 scoreline.
 //
 // When the match already has a kiken/fusenpai decision recorded (the
 // "undo" path, T103/CHK024) the engine enforces the
@@ -434,7 +434,7 @@ func (e *Engine) RecordDecision(compID, matchID, decision, decisionBy, decisionR
 		Status:         state.MatchStatusCompleted,
 	}
 	// shiro=SideB (White, left), aka=SideA (Red, right). The losing
-	// side ends with 0 ippons; the surviving side gets the X auto-fill
+	// side ends with 0 ippons; the surviving side gets the ○ default-win fill
 	// and becomes Winner.
 	if decisionBy == "shiro" {
 		result.IpponsA = winIppons

--- a/internal/engine/eligibility.go
+++ b/internal/engine/eligibility.go
@@ -421,7 +421,7 @@ func (e *Engine) RecordDecision(compID, matchID, decision, decisionBy, decisionR
 	}
 	winIppons := make([]string, winningCount)
 	for i := range winIppons {
-		winIppons[i] = "○"
+		winIppons[i] = defaultWinIppon
 	}
 	result := &state.MatchResult{
 		ID:             matchID,

--- a/internal/engine/eligibility_test.go
+++ b/internal/engine/eligibility_test.go
@@ -174,6 +174,35 @@ func TestRecordDecision_KikenUndo(t *testing.T) {
 	})
 }
 
+// TestRecordDecision_DefaultWinIpponMarkers pins that a default-win
+// decision auto-fills the winner's ippon slots with the FIK maru "○"
+// marker, not a waza letter: no technique was struck, so "M" (Men)
+// would misrepresent the scoreline (mp-lybf).
+func TestRecordDecision_DefaultWinIpponMarkers(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "default-win-marker"
+	createTestCompetition(t, store, compID, "league", 2)
+
+	aliceID := helper.NewUUID4()
+	bobID := helper.NewUUID4()
+	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+		{ID: aliceID, Name: "Alice", Dojo: "A"},
+		{ID: bobID, Name: "Bob", Dojo: "B"},
+	}))
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "Pool A-0", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusScheduled},
+	}))
+
+	// decisionBy "shiro" → Bob (shiro/SideB) is the no-show, so Alice
+	// (aka/SideA) is the survivor and her IpponsA carries the fill.
+	result, _, err := eng.RecordDecision(compID, "Pool A-0", "fusensho", "shiro", "no-show", nil, false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Alice", result.Winner)
+	assert.Equal(t, []string{"○", "○"}, result.IpponsA)
+	assert.Empty(t, result.IpponsB)
+}
+
 // TestRecordDecision_ConcurrentKiken verifies CHK047/T105: when two
 // operators on different courts simultaneously try to kiken the same
 // player, the second call returns *AlreadyIneligibleError (HTTP 409

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -234,6 +234,14 @@ func backfillMatchIdentity(result, stored *state.MatchResult) {
 	}
 }
 
+// defaultWinIppon is the FIK maru "○" (U+25CB) written into a winner's
+// ippon slots for a default win (fusensho/fusenpai/kiken/daihyosen): no
+// technique was struck, so a waza letter (M/K/D/T/H) would misrepresent the
+// scoreline. Centralised so the two RecordDecision twins (eligibility.go,
+// scoring_tx.go) can't drift onto a Unicode lookalike. countScoringIppons
+// still counts it — it is non-empty and not the "•" placeholder.
+const defaultWinIppon = "○"
+
 // countScoringIppons counts real ippon marks, ignoring empty entries and the
 // "•" placeholder the UI uses for an unfilled slot.
 func countScoringIppons(ippons []string) int {

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -970,7 +970,7 @@ func (e *Engine) RecordDecisionTx(tx state.StoreTx, compID, matchID, decision, d
 	}
 	winIppons := make([]string, winningCount)
 	for i := range winIppons {
-		winIppons[i] = "M"
+		winIppons[i] = "○"
 	}
 	result := &state.MatchResult{
 		ID:             matchID,

--- a/internal/engine/scoring_tx.go
+++ b/internal/engine/scoring_tx.go
@@ -970,7 +970,7 @@ func (e *Engine) RecordDecisionTx(tx state.StoreTx, compID, matchID, decision, d
 	}
 	winIppons := make([]string, winningCount)
 	for i := range winIppons {
-		winIppons[i] = "○"
+		winIppons[i] = defaultWinIppon
 	}
 	result := &state.MatchResult{
 		ID:             matchID,

--- a/internal/engine/scoring_tx_test.go
+++ b/internal/engine/scoring_tx_test.go
@@ -57,6 +57,11 @@ func TestRecordDecisionTx_BasicEquivalence(t *testing.T) {
 	assert.Equal(t, "Bob", matches[0].Winner)
 	assert.Equal(t, "kiken", matches[0].Decision)
 	assert.Equal(t, state.MatchStatusCompleted, matches[0].Status)
+	// The default-win ippon slots carry the FIK maru "○" marker, not a
+	// waza letter — no technique was struck (mp-lybf). Bob (shiro/SideB)
+	// is the survivor, so the fill lands on IpponsB.
+	assert.Equal(t, []string{"○", "○"}, matches[0].IpponsB)
+	assert.Empty(t, matches[0].IpponsA)
 
 	// Verify ineligibility landed on disk.
 	statuses, err := store.LoadCompetitorStatus(compID)

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -571,7 +571,7 @@ type MatchResult struct {
 	// share a name. Never persisted (json/CSV omit) — it only carries the
 	// side decision from the handler to the id-resolution step.
 	WinnerSide     string           `json:"-" yaml:"-"`
-	IpponsA        []string         `json:"ipponsA"` // waza letters M/K/D/T/H, or ○ (FIK default-win marker)
+	IpponsA        []string         `json:"ipponsA"` // waza letters M/K/D/T/H/S (naginata), or ○ (FIK default-win marker)
 	IpponsB        []string         `json:"ipponsB"`
 	HansokuA       int              `json:"hansokuA"`
 	HansokuB       int              `json:"hansokuB"`

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -571,7 +571,7 @@ type MatchResult struct {
 	// share a name. Never persisted (json/CSV omit) — it only carries the
 	// side decision from the handler to the id-resolution step.
 	WinnerSide     string           `json:"-" yaml:"-"`
-	IpponsA        []string         `json:"ipponsA"` // M, K, D, T, H
+	IpponsA        []string         `json:"ipponsA"` // waza letters M/K/D/T/H, or ○ (FIK default-win marker)
 	IpponsB        []string         `json:"ipponsB"`
 	HansokuA       int              `json:"hansokuA"`
 	HansokuB       int              `json:"hansokuB"`

--- a/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
+++ b/web-mobile/js/__tests__/admin_scoring_modal.test.jsx
@@ -849,7 +849,7 @@ describe('applyFusenshoToggle', () => {
     const prev = { aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "" };
     const next = applyFusenshoToggle(prev, "a");
     expect(next).toEqual({
-      aPts: ['M', 'M'],
+      aPts: ['○', '○'],
       bPts: [],
       aFouls: 0,
       bFouls: 0,
@@ -863,7 +863,7 @@ describe('applyFusenshoToggle', () => {
     const next = applyFusenshoToggle(prev, "b");
     expect(next).toEqual({
       aPts: [],
-      bPts: ['M', 'M'],
+      bPts: ['○', '○'],
       aFouls: 0,
       bFouls: 0,
       fusensho: "b",
@@ -899,7 +899,7 @@ describe('applyFusenshoToggle', () => {
     const afterSwitch = applyFusenshoToggle(afterA, "b");
     expect(afterSwitch.fusensho).toBe("b");
     expect(afterSwitch.aPts).toEqual([]);
-    expect(afterSwitch.bPts).toEqual(['M', 'M']);
+    expect(afterSwitch.bPts).toEqual(['○', '○']);
     // Snapshot stays anchored to the genuine pre-fusensho state.
     expect(afterSwitch._preFusensho).toEqual({ aPts: ['M'], bPts: [], aFouls: 0, bFouls: 0 });
 
@@ -916,7 +916,7 @@ describe('applyFusenshoToggle', () => {
 
   it('fresh-match round-trip: zeros → toggle → untoggle returns to zeros', () => {
     const afterOn = applyFusenshoToggle(clean(), "a");
-    expect(afterOn.aPts).toEqual(['M', 'M']);
+    expect(afterOn.aPts).toEqual(['○', '○']);
     expect(afterOn._preFusensho).toEqual({ aPts: [], bPts: [], aFouls: 0, bFouls: 0 });
     const afterOff = applyFusenshoToggle(afterOn, "a");
     expect(afterOff).toEqual({
@@ -934,10 +934,10 @@ describe('applyFusenshoToggle', () => {
     // from the backend payload and lights up the button, but does NOT
     // round-trip the snapshot. Untoggling in that state must not crash;
     // it falls through to clearing the flag and leaving the score alone.
-    const prev = { aPts: ['M', 'M'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a" };
+    const prev = { aPts: ['○', '○'], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a" };
     const next = applyFusenshoToggle(prev, "a");
     expect(next).toEqual({
-      aPts: ['M', 'M'],
+      aPts: ['○', '○'],
       bPts: [],
       aFouls: 0,
       bFouls: 0,

--- a/web-mobile/js/admin_scoring_shared.jsx
+++ b/web-mobile/js/admin_scoring_shared.jsx
@@ -130,8 +130,8 @@ function applyFusenshoToggle(prev, side) {
     return { ...prev, fusensho: "", _preFusensho: undefined };
   }
   const snap = prev._preFusensho || { aPts: prev.aPts, bPts: prev.bPts, aFouls: prev.aFouls, bFouls: prev.bFouls };
-  if (side === "a") return { aPts: ["M", "M"], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a", _preFusensho: snap };
-  return { aPts: [], bPts: ["M", "M"], aFouls: 0, bFouls: 0, fusensho: "b", _preFusensho: snap };
+  if (side === "a") return { aPts: ["○", "○"], bPts: [], aFouls: 0, bFouls: 0, fusensho: "a", _preFusensho: snap };
+  return { aPts: [], bPts: ["○", "○"], aFouls: 0, bFouls: 0, fusensho: "b", _preFusensho: snap };
 }
 
 // applyFoulIncrement — pure helper modelling a single `+` press on a

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -133,7 +133,7 @@ function ipponLetters(arr) {
 // outer edge is the left), aka fills right→left (its outer edge is the right),
 // so for aka we reverse the visual cell order. The testid stays on the logical
 // outer cell (letters[0]) regardless of which side renders it.
-const WAZA_NAMES = { M: "Men (head)", K: "Kote (wrist)", D: "Do (body)", T: "Tsuki (throat)", H: "Hansoku (penalty)", S: "Sune (shin)" };
+const WAZA_NAMES = { M: "Men (head)", K: "Kote (wrist)", D: "Do (body)", T: "Tsuki (throat)", H: "Hansoku (penalty)", S: "Sune (shin)", "○": "Default win" };
 
 function slotCells(letters, side, testid) {
   const cells = [0, 1].map(i => {

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -150,8 +150,10 @@ function slotCells(letters, side, testid) {
 // centreMarks — the §263 inner cells: [shiro slot][shiro slot] | vs/X | [aka slot][aka slot].
 // Hansoku ▲ shows on the offending side, on the OUTER edge of the slots (away
 // from centre); X marks a hikiwake; "Ht" flags hantei. For an ippon-less
-// decision (hantei, fusensho, kiken) the winning side is otherwise invisible,
-// so we mark it with ○ (FIK hantei-win symbol) in the winner's first slot.
+// decision (hantei, or legacy records predating the ○ default-win change)
+// the winning side is otherwise invisible, so we mark it with ○ (FIK
+// hantei-win symbol) in the winner's first slot. Modern fusensho/kiken
+// carry ["○","○"] ippons and render through the normal slot path.
 // A plain helper (not a component) so it renders inline into the parent's tree.
 function centreMarks(sub, matchSideA, matchSideB) {
   const lettersB = ipponLetters(sub.ipponsB); // shiro / left

--- a/web-mobile/js/match_scoreboard.jsx
+++ b/web-mobile/js/match_scoreboard.jsx
@@ -149,11 +149,11 @@ function slotCells(letters, side, testid) {
 
 // centreMarks — the §263 inner cells: [shiro slot][shiro slot] | vs/X | [aka slot][aka slot].
 // Hansoku ▲ shows on the offending side, on the OUTER edge of the slots (away
-// from centre); X marks a hikiwake; "Ht" flags hantei. For an ippon-less
-// decision (hantei, or legacy records predating the ○ default-win change)
-// the winning side is otherwise invisible, so we mark it with ○ (FIK
-// hantei-win symbol) in the winner's first slot. Modern fusensho/kiken
-// carry ["○","○"] ippons and render through the normal slot path.
+// from centre); X marks a hikiwake; "Ht" flags hantei. For an ippon-less win
+// the winning side is otherwise invisible, so we mark the winner's first slot:
+// "Ht" when decided by hantei, else ○ for a non-hantei ippon-less win (see
+// the winMark line below). Modern fusensho/kiken carry ["○","○"] ippons
+// and render through the normal slot path, so they never reach this fallback.
 // A plain helper (not a component) so it renders inline into the parent's tree.
 function centreMarks(sub, matchSideA, matchSideB) {
   const lettersB = ipponLetters(sub.ipponsB); // shiro / left

--- a/web-mobile/js/viewer_standings.jsx
+++ b/web-mobile/js/viewer_standings.jsx
@@ -356,7 +356,7 @@ export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPla
         <span className="league-matrix__legend-item league-matrix__legend-item--win">win</span>
         <span className="league-matrix__legend-item league-matrix__legend-item--loss">loss</span>
         <span className="league-matrix__legend-item league-matrix__legend-item--draw">draw</span>
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H, ○ = default win) · X = scoreless draw</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H/S, ○ = default win) · X = scoreless draw</span>
         <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row player's result vs column player"}</span>
       </div>
     </div>

--- a/web-mobile/js/viewer_standings.jsx
+++ b/web-mobile/js/viewer_standings.jsx
@@ -356,7 +356,7 @@ export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPla
         <span className="league-matrix__legend-item league-matrix__legend-item--win">win</span>
         <span className="league-matrix__legend-item league-matrix__legend-item--loss">loss</span>
         <span className="league-matrix__legend-item league-matrix__legend-item--draw">draw</span>
-        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H) · X = scoreless draw</span>
+        <span style={{ color: "var(--ink-3)", fontSize: 11 }}>letters = ippons (M/K/D/T/H, ○ = default win) · X = scoreless draw</span>
         <span style={{ color: "var(--ink-3)", fontSize: 11 }}>{onMatchClick ? "Tap a cell to view match details" : "Row player's result vs column player"}</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Changes the default-win decision scoring ippon markers in Kendo team tournaments from \`"M"\` (Men technique) to \`"○"\` (circle/maru) for fusensho, fusenpai, kiken, and other non-fought decisions. 

- Modifies \`RecordDecision\` and \`RecordDecisionTx\` to populate two \`"○"\` markers for the winner.
- Modifies \`applyFusenshoToggle\` in \`web-mobile\` admin scoring screen to write \`["○", "○"]\` instead of \`["M", "M"]\`.
- Adds \`"○"\` to the frontend tooltip \`WAZA_NAMES\` dictionary, translating to \`"Default win"\`.
- Centralises the marker as \`defaultWinIppon\` constant in \`scoring.go\` to prevent Unicode drift.

## Files changed

| File | What |
|---|---|
| \`internal/engine/scoring.go\` | New \`defaultWinIppon = "○"\` constant; shared by both RecordDecision twins |
| \`internal/engine/eligibility.go\` | \`RecordDecision\` ippon auto-fill now uses \`defaultWinIppon\`; stale X/X-0 comments corrected |
| \`internal/engine/scoring_tx.go\` | \`RecordDecisionTx\` ippon auto-fill now uses \`defaultWinIppon\` |
| \`internal/state/models.go\` | \`IpponsA\` doc comment updated: waza letters M/K/D/T/H/S (naginata), or ○ |
| \`web-mobile/js/admin_scoring_shared.jsx\` | \`applyFusenshoToggle\` writes \`["○", "○"]\` instead of \`["M", "M"]\` |
| \`web-mobile/js/match_scoreboard.jsx\` | Adds \`"○": "Default win"\` in \`WAZA_NAMES\`; corrects centreMarks comment |
| \`web-mobile/js/viewer_standings.jsx\` | League-matrix legend now documents \`○\` marker and adds \`/S\` (naginata) to waza list |
| \`web-mobile/js/__tests__/admin_scoring_modal.test.jsx\` | Vitest expectations updated to verify the \`"○"\` marker |
| \`internal/engine/eligibility_test.go\` | New \`TestRecordDecision_DefaultWinIpponMarkers\` asserts auto-fill is \`["○", "○"]\` |
| \`internal/engine/scoring_tx_test.go\` | Asserts the tx twin writes \`["○", "○"]\` on a default win |

## Screenshots

Live captures from the running mobile app (\`make run-mobile\`) after recording a **fusensho** default win (Suzuki Jiro def. Yamada Taro). The winner's ippon slots now render the FIK maru \`○\` instead of \`M\`.

**TV display scoreboard** — winner shows \`○ ○\`, loser empty:

![TV display showing the default-win scoreboard with two circle markers](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/316/display_default_win.png)

**Public viewer (Recent Results)** — same result in context, \`○○–·\`:

![Public viewer competition page showing the default-win result with circle markers](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/316/viewer_default_win.png)


## Test plan

- [x] \`make go/test\` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change
- [x] Manual browser verification (for \`web-mobile/\` or \`web/\` changes) — ran the mobile app, recorded a fusensho default win, and confirmed \`○○\` renders on the TV display and public viewer (screenshots above).
- [x] Screenshots added above (real browser captures of the TV display and public viewer)
- [x] No new console errors or warnings

Closes mp-lybf