### PR TITLE
fix(mp-ydk7): centre bracket parents on feeder anchors (delta 0 on unbalanced brackets)

### DIFF
--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -1695,45 +1695,6 @@ a:hover {
   letter-spacing: 0.04em;
 }
 
-/* G1: phase strip inside a unified pools+knockout competition card */
-.phase-strip {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 8px;
-  flex-wrap: wrap;
-}
-
-.phase-strip__arrow {
-  color: var(--ink-3);
-  font-size: 11px;
-}
-
-.phase-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 9px;
-  border-radius: 99px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.phase-chip--done {
-  background: var(--ok-border);
-  color: var(--ok-strong);
-}
-
-.phase-chip--running {
-  background: #fee2e2;
-  color: #b91c1c;
-}
-
-.phase-chip--pending {
-  background: var(--surface-2);
-  color: var(--ink-3);
-}
-
 /* ---------- Pool match results ---------- */
 .pool-match-row {
   display: flex;

--- a/web-mobile/js/__tests__/bracket_display_model.test.jsx
+++ b/web-mobile/js/__tests__/bracket_display_model.test.jsx
@@ -116,4 +116,41 @@ describe('computeMetaTops', () => {
     // Final is centred between Alice/Bob and Carol's SF.
     expect(centre('m-r3-0')).toBeCloseTo((centre('m-r1-0') + centre('m-r2-1')) / 2, 5);
   });
+
+  // mp-ydk7: connectors anchor at each card's sides-block midline, which sits
+  // BELOW the geometric centre for a match card (the meta-header offset) but AT
+  // the centre for a bye-slot card (no .bc-side). When a parent is fed by one
+  // match card + one bye-slot, centring it on feeder GEOMETRIC CENTRES leaves its
+  // seam ~6px off the feeder-anchor midpoint (the elbow misses the seam). Passing
+  // per-card `offsets` must centre each parent so its OWN anchor equals the mean
+  // of its feeders' anchors → delta 0 for every parent, including the asymmetric
+  // match+bye case. Guards the regression the centre-of-mass layout shipped on
+  // unbalanced (mp-5ng7) brackets.
+  it('zeroes feeder-vs-child delta under asymmetric match/bye anchor offsets', () => {
+    const model = buildDisplayModel(fivePlayerRounds());
+    const MATCH_H = 114, BYE_H = 44;
+    // Match cards: sides-midline 63px from top (12px header + ~half the sides).
+    // Bye-slot cards: centred, so offset = height / 2.
+    const MATCH_OFF = 63, BYE_OFF = BYE_H / 2;
+    const isBye = (id) => id.startsWith('bye-');
+    const heights = {}, offsets = {};
+    for (const col of model.columns) {
+      for (const m of col) {
+        heights[m.id] = isBye(m.id) ? BYE_H : MATCH_H;
+        offsets[m.id] = isBye(m.id) ? BYE_OFF : MATCH_OFF;
+      }
+    }
+    const tops = computeMetaTops(model.columns, model.feedersById, heights, offsets);
+    const anchor = (id) => tops[id] + offsets[id]; // the y the SVG connectors join at
+    // For every parent: its anchor (seam) == mean of its feeders' anchors → delta 0.
+    for (const [childId, feeders] of Object.entries(model.feedersById)) {
+      const fs = feeders.filter(Boolean);
+      if (!fs.length) continue;
+      const mean = fs.reduce((s, fid) => s + anchor(fid), 0) / fs.length;
+      expect(anchor(childId)).toBeCloseTo(mean, 5);
+    }
+    // Sanity: the case under test really is asymmetric — Carol's SF mixes a bye
+    // (centre-anchored) with a match feeder (seam-anchored, larger offset).
+    expect(offsets['bye-m-r2-1-0']).not.toBe(offsets['m-r1-3']);
+  });
 });

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -400,17 +400,27 @@ function buildDisplayModel(rounds) {
 // computeMetaTops lays out an (uneven) effective-round bracket. It walks the
 // feeder graph from the final: matches with no feeders ("seeded" entrants — real
 // players or bye recipients) are stacked top-to-bottom in depth-first encounter
-// order, and every parent is centred on the mean of its feeders. Returns a map
-// of matchId → absolute top (px). heights is matchId → measured card height.
-function computeMetaTops(columns, feedersById, heights) {
+// order, and every parent is centred so its OWN connector anchor sits at the mean
+// of its feeders' anchors. Returns a map of matchId → absolute top (px).
+//
+// `heights` is matchId → measured card height. `offsets` is matchId → anchor
+// distance from the card top (the y the SVG connectors join at: the sides-block
+// midline for match cards, the geometric centre for bye-slot cards). Centring on
+// the mean of feeder ANCHORS rather than geometric centres keeps the elbow on each
+// card's seam even when a tall, header-offset match card feeds a child alongside a
+// shorter bye-slot card — otherwise the asymmetric offset shifts the merge ~6px
+// off the seam (delta != 0). `offsets` defaults to h/2 for any id it omits, so a
+// caller that passes only heights gets the prior geometric-centre-of-mass layout.
+function computeMetaTops(columns, feedersById, heights, offsets = {}) {
   const GAP = 16;
   const DEFAULT_H = 110;
-  const centerOf = {};
+  const offsetOf = (id) => offsets[id] ?? (heights[id] || DEFAULT_H) / 2;
+  const anchorOf = {};
   const inProgress = new Set();
   let cursor = 0;
   const visit = (id) => {
-    if (centerOf[id] != null) return centerOf[id];
-    // Cycle guard (mirrors the DisplayRound!=0 guard in the Go BFS): centerOf is
+    if (anchorOf[id] != null) return anchorOf[id];
+    // Cycle guard (mirrors the DisplayRound!=0 guard in the Go BFS): anchorOf is
     // only set post-order for parents, so a cyclic feeders graph would recurse
     // forever. The engine only emits acyclic trees, but a corrupt/hand-edited
     // bracket.json must not crash the renderer — break the cycle and return 0.
@@ -419,17 +429,18 @@ function computeMetaTops(columns, feedersById, heights) {
     const fs = (feedersById[id] || []).filter(Boolean);
     const h = heights[id] || DEFAULT_H;
     if (fs.length === 0) {
-      const c = cursor + h / 2;
+      // Leaf: stacked in natural flow (top = cursor); its anchor is top + offset.
+      const a = cursor + offsetOf(id);
       cursor += h + GAP;
-      centerOf[id] = c;
+      anchorOf[id] = a;
       inProgress.delete(id);
-      return c;
+      return a;
     }
-    const cs = fs.map(visit);
-    const c = cs.reduce((a, b) => a + b, 0) / cs.length;
-    centerOf[id] = c;
+    const as = fs.map(visit);
+    const a = as.reduce((x, y) => x + y, 0) / as.length;
+    anchorOf[id] = a;
     inProgress.delete(id);
-    return c;
+    return a;
   };
   const rootId = columns[columns.length - 1]?.[0]?.id;
   if (rootId) visit(rootId);
@@ -437,15 +448,15 @@ function computeMetaTops(columns, feedersById, heights) {
   // final, so visit(rootId) already placed every match in `columns`. This loop
   // is a no-op for engine output and only fires on corrupt/hand-written metadata.
   columns.forEach((col) => col.forEach((m) => {
-    if (centerOf[m.id] == null) {
+    if (anchorOf[m.id] == null) {
       const h = heights[m.id] || DEFAULT_H;
-      centerOf[m.id] = cursor + h / 2;
+      anchorOf[m.id] = cursor + offsetOf(m.id);
       cursor += h + GAP;
     }
   }));
   const tops = {};
   columns.forEach((col) => col.forEach((m) => {
-    tops[m.id] = centerOf[m.id] - (heights[m.id] || DEFAULT_H) / 2;
+    tops[m.id] = anchorOf[m.id] - offsetOf(m.id);
   }));
   return tops;
 }
@@ -532,14 +543,29 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
       const tree = treeRef.current;
       if (!tree || !columns || columns.length === 0) return;
       const heights = {};
+      const offsets = {};
       for (const col of columns) {
         for (const m of col) {
           const el = refMap.current[m.id];
           if (!el) return;
-          heights[m.id] = el.getBoundingClientRect().height;
+          const rect = el.getBoundingClientRect();
+          heights[m.id] = rect.height;
+          // Anchor offset from the card top — the y the SVG connectors join at.
+          // Mirrors anchorY(): sides-block midline for match cards, geometric
+          // centre for bye-slot cards (no .bc-side). Passing this to computeMetaTops
+          // centres parents on feeder ANCHORS, not geometric centres, so the elbow
+          // lands on the seam even for a match-card + bye-slot feeder pair.
+          const sides = el.querySelectorAll(".bc-side");
+          if (sides.length >= 2) {
+            const f = sides[0].getBoundingClientRect();
+            const l = sides[sides.length - 1].getBoundingClientRect();
+            offsets[m.id] = (f.top + l.bottom) / 2 - rect.top;
+          } else {
+            offsets[m.id] = rect.height / 2;
+          }
         }
       }
-      const tops = computeMetaTops(columns, feedersById, heights);
+      const tops = computeMetaTops(columns, feedersById, heights, offsets);
       // Every column is absolutely positioned, so the flow height of each
       // round-matches container is 0 and the tree would collapse. Derive the
       // overall content height from the lowest card bottom and pin it on the


### PR DESCRIPTION
## Summary

- Viewer alignment audit (mp-ydk7) after mp-5ng7 (Excel-identical unbalanced bracket) + mp-7f2w (effective-round bye rendering). 4/5 acceptance criteria were already clean; this fixes the one nit and removes dead CSS.
- **Bracket connectors now measure delta 0 on every shape**, including the unbalanced/per-court playoffs bracket. Previously, bye-fed matches (one match feeder + one structural bye-slot) were ~6px off the seam.
- Removes dead `.phase-strip` / `.phase-chip` CSS left behind when the G1 viewer phase strip was deleted in the mp-turx refactor.

## Why

Connectors anchor at each card's sides-block midline. A **match card**'s midline sits +12px below its geometric centre (the meta-header offset); a **bye-slot card** has no `.bc-side`, so its anchor falls back to the geometric centre (+0). `computeMetaTops` centred each parent on the mean of its feeders' **geometric centres** — so the +12 offset cancels for two match feeders (delta 0) but **not** for a match + bye-slot pair, leaving the parent seam ~6px off the feeder-anchor midpoint. That hit every bye-fed match in an unbalanced (mp-5ng7) bracket — e.g. all 8 round-4 matches in a 24-finalist draw. Introduced by mp-7f2w's bye-slot card (pre-mp-7f2w byes were full match cards, so the offset cancelled). The `computeMetaTops` unit test stayed green because it used uniform heights and never modelled the seam-vs-centre offset.

Fix: measure each card's anchor offset in `BracketTreeMeta`'s layout effect (sides-block midline for match cards, geometric centre for bye-slots) and centre each parent so its **own anchor** equals the mean of its feeders' anchors. `offsets` defaults to `h/2`, so callers passing only heights keep the prior centre-of-mass layout.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/bracket.jsx` | `computeMetaTops` centres parents on feeder anchor midpoints (new optional `offsets` arg, defaults to `h/2`); `BracketTreeMeta` measures per-card anchor offset and passes it |
| `web-mobile/css/styles.css` | Remove dead `.phase-strip` / `.phase-chip` / `.phase-strip__arrow` rules (no viewer JSX references them post-mp-turx) |
| `web-mobile/js/__tests__/bracket_display_model.test.jsx` | Regression test: delta 0 under asymmetric match/bye anchor offsets (the centre-of-mass layout fails it) |

## Screenshots

Bye-fed match M9 (Cersei bye + M1 winner → M9). Green dashed = child seam; red dashed = midpoint of the two feeder anchors. When they coincide, delta = 0.

**Before — delta ~6px** (two lines apart):
![before](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/317/before-overlay.png)

**After — delta 0** (lines coincide, connector on the seam):
![after](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/317/after-overlay.png)

**Full unbalanced bracket after the fix (no regression):**
![full](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/317/after-full.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages ≥85% coverage
- [x] New/updated unit tests cover the change — regression test asserts delta 0 under asymmetric match/bye offsets; vitest 1896 pass (84 files)
- [x] Manual browser verification — Playwright DOM geometry across individual / team / mixed-preview / unbalanced playoffs brackets at 1280px and 375px: arm slope 0 everywhere; delta 6px→0 on bye-fed matches; standings (individual W/L/T/PS/PA + team W/L/T/IV/IL/IT/PW/PL) header/data aligned; no page-level overflow (scoped `.bracket-canvas` scroll); cards unclipped
- [x] Screenshots added above (before/after + full bracket)

Closes mp-ydk7
