### PR TITLE
fix(check-in): resolve legacy UUID-less participants by name|dojo

### DIFF
--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -368,11 +368,12 @@ func pidPairKey(pid string) string {
 // resolveParticipantIndex finds the index of the participant addressed by pid.
 // It matches a stable UUID first; failing that — legacy participants.csv files
 // loaded without a UUID column have empty IDs (loadParticipantsNoLock mints
-// none, and saveParticipantsNoLock never backfills) — it falls back to matching
-// the composite "name|dojo" key the client sends for ID-less rows. The fallback
-// is restricted to ID-less rows (UUID rows are only addressable by their id) and
-// the (name, dojo) pair is unique per roster, so resolution is unambiguous.
-// Returns -1 when no participant matches.
+// none; the first write via saveParticipantsNoLock migrates those rows to UUIDs
+// because marshalParticipantsCSV backfills empty IDs) — it falls back to
+// matching the composite "name|dojo" key the client sends for ID-less rows. The
+// fallback is restricted to ID-less rows (UUID rows are only addressable by
+// their id) and the (name, dojo) pair is unique per roster, so resolution is
+// unambiguous. Returns -1 when no participant matches.
 func resolveParticipantIndex(players []domain.Player, pid string) int {
 	if pid == "" {
 		return -1

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -433,25 +433,32 @@ func (s *Store) BulkCheckIn(compID string, pids []string) (BulkCheckInResult, er
 		}
 	}
 
-	seen := make(map[string]struct{}, len(pids))
+	// Deduplicate by resolved participant index so that semantically equivalent
+	// pids (same normalized name|dojo with different whitespace/case) don't count
+	// the same participant twice. NotFound pids are deduped by raw string because
+	// there is no index to compare against.
+	seenIdx := make(map[int]struct{}, len(pids))
+	seenNotFound := make(map[string]struct{})
 	result := BulkCheckInResult{NotFound: []string{}}
 	for _, pid := range pids {
 		if pid == "" {
 			continue
 		}
-		if _, dup := seen[pid]; dup {
-			continue
-		}
-		seen[pid] = struct{}{}
-
 		idx, ok := byID[pid]
 		if !ok {
 			idx, ok = byKey[pidPairKey(pid)]
 		}
 		if !ok {
-			result.NotFound = append(result.NotFound, pid)
+			if _, dup := seenNotFound[pid]; !dup {
+				result.NotFound = append(result.NotFound, pid)
+				seenNotFound[pid] = struct{}{}
+			}
 			continue
 		}
+		if _, dup := seenIdx[idx]; dup {
+			continue
+		}
+		seenIdx[idx] = struct{}{}
 		if players[idx].CheckedIn {
 			result.AlreadyCheckedIn++
 		} else {

--- a/internal/state/participants.go
+++ b/internal/state/participants.go
@@ -345,6 +345,55 @@ func (s *Store) withZekkenNameLocked(compID string) (bool, error) {
 	return comp.WithZekkenName, nil
 }
 
+// participantPairKey is the (normalizedName, normalizedDojo) identity key used
+// to resolve a participant when no stable UUID is available. It mirrors the
+// Tier-1 dedup key (NormalizeParticipantName on both halves joined by "|"), so
+// the pair is unique across a roster by construction — name alone is NOT unique
+// (same name at a different dojo is allowed). Keep in sync with checkInKey in
+// handlers_participants.go and checkinPid in web-mobile/js/data.jsx.
+func participantPairKey(name, dojo string) string {
+	return helper.NormalizeParticipantName(name) + "|" + helper.NormalizeParticipantName(dojo)
+}
+
+// pidPairKey derives the (normalizedName, normalizedDojo) key from a composite
+// "name|dojo" pid sent by the client for legacy UUID-less rows. The raw pid is
+// split on the FIRST "|" and each half normalized separately — splitting before
+// normalizing trims whitespace around the delimiter, which normalizing the whole
+// string would not. A pid with no "|" resolves as a name with an empty dojo.
+func pidPairKey(pid string) string {
+	name, dojo, _ := strings.Cut(pid, "|")
+	return participantPairKey(name, dojo)
+}
+
+// resolveParticipantIndex finds the index of the participant addressed by pid.
+// It matches a stable UUID first; failing that — legacy participants.csv files
+// loaded without a UUID column have empty IDs (loadParticipantsNoLock mints
+// none, and saveParticipantsNoLock never backfills) — it falls back to matching
+// the composite "name|dojo" key the client sends for ID-less rows. The fallback
+// is restricted to ID-less rows (UUID rows are only addressable by their id) and
+// the (name, dojo) pair is unique per roster, so resolution is unambiguous.
+// Returns -1 when no participant matches.
+func resolveParticipantIndex(players []domain.Player, pid string) int {
+	if pid == "" {
+		return -1
+	}
+	for i := range players {
+		if players[i].ID != "" && players[i].ID == pid {
+			return i
+		}
+	}
+	want := pidPairKey(pid)
+	for i := range players {
+		if players[i].ID != "" {
+			continue
+		}
+		if participantPairKey(players[i].Name, players[i].Dojo) == want {
+			return i
+		}
+	}
+	return -1
+}
+
 // BulkCheckInResult carries the outcome of a BulkCheckIn call.
 type BulkCheckInResult struct {
 	CheckedIn        int      `json:"checkedIn"`
@@ -371,10 +420,15 @@ func (s *Store) BulkCheckIn(compID string, pids []string) (BulkCheckInResult, er
 		return BulkCheckInResult{}, err
 	}
 
-	byPID := make(map[string]int, len(players))
+	// Two lookup maps so resolution matches resolveParticipantIndex: UUID rows
+	// by their stable id, legacy UUID-less rows by their (name, dojo) pair key.
+	byID := make(map[string]int, len(players))
+	byKey := make(map[string]int, len(players))
 	for i := range players {
 		if players[i].ID != "" {
-			byPID[players[i].ID] = i
+			byID[players[i].ID] = i
+		} else {
+			byKey[participantPairKey(players[i].Name, players[i].Dojo)] = i
 		}
 	}
 
@@ -389,7 +443,10 @@ func (s *Store) BulkCheckIn(compID string, pids []string) (BulkCheckInResult, er
 		}
 		seen[pid] = struct{}{}
 
-		idx, ok := byPID[pid]
+		idx, ok := byID[pid]
+		if !ok {
+			idx, ok = byKey[pidPairKey(pid)]
+		}
 		if !ok {
 			result.NotFound = append(result.NotFound, pid)
 			continue
@@ -433,14 +490,9 @@ func (s *Store) updateParticipantNoLock(compID string, pid string, withZekkenNam
 		return nil, err
 	}
 
-	foundIdx := -1
-	for i := range players {
-		if players[i].ID == pid {
-			foundIdx = i
-			break
-		}
-	}
-
+	// Resolve by stable UUID, falling back to the composite "name|dojo" key for
+	// legacy UUID-less rosters (see resolveParticipantIndex).
+	foundIdx := resolveParticipantIndex(players, pid)
 	if foundIdx == -1 {
 		return nil, ErrParticipantNotFound
 	}

--- a/internal/state/participants_legacy_checkin_test.go
+++ b/internal/state/participants_legacy_checkin_test.go
@@ -1,0 +1,157 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLegacyRoster writes a genuine legacy (UUID-less) participants.csv to a
+// fresh competition directory. SaveParticipants can't be used here because
+// marshalParticipantsCSV mints a UUID for every empty ID — which is exactly the
+// migration that masks the bug. Writing the file directly reproduces a roster
+// that was never re-saved through the app, so loadParticipantsNoLock returns
+// players with empty IDs (the pre-condition for the check-in resolution bug).
+func writeLegacyRoster(t *testing.T, store *Store, compID, csv string) {
+	t.Helper()
+	require.NoError(t, store.SaveCompetition(&Competition{ID: compID, Name: compID, Kind: "individual"}))
+	dir := filepath.Join(store.folder, "competitions", compID)
+	require.NoError(t, os.MkdirAll(dir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "participants.csv"), []byte(csv), 0600))
+}
+
+// TestCheckIn_LegacyUUIDlessRoster pins mp-8bjq: check-in must resolve
+// participants on a legacy roster whose participants.csv has no UUID column, by
+// falling back to the composite "name|dojo" pid the client sends for ID-less
+// rows. Without the fallback both the single and bulk paths 404 / NotFound.
+func TestCheckIn_LegacyUUIDlessRoster(t *testing.T) {
+	t.Run("single check-in resolves by name|dojo and persists", func(t *testing.T) {
+		store, err := NewStore(t.TempDir())
+		require.NoError(t, err)
+		compID := "legacy-single"
+		writeLegacyRoster(t, store, compID, "Alice,DojoA\nBob,DojoB\n")
+
+		updated, err := store.UpdateParticipant(compID, "Alice|DojoA", false, func(p *domain.Player) error {
+			p.CheckedIn = true
+			return nil
+		})
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+		assert.Equal(t, "Alice", updated.Name)
+		assert.True(t, updated.CheckedIn)
+
+		// Persisted: reload and confirm Alice is checked in, Bob is not.
+		loaded, err := store.LoadParticipants(compID, false)
+		require.NoError(t, err)
+		byName := map[string]bool{}
+		for _, p := range loaded {
+			byName[p.Name] = p.CheckedIn
+		}
+		assert.True(t, byName["Alice"], "Alice must be checked in")
+		assert.False(t, byName["Bob"], "Bob must remain unchecked")
+	})
+
+	t.Run("single check-in is whitespace-tolerant around the delimiter", func(t *testing.T) {
+		store, err := NewStore(t.TempDir())
+		require.NoError(t, err)
+		compID := "legacy-ws"
+		writeLegacyRoster(t, store, compID, "Alice,DojoA\n")
+
+		// Client could send raw fields with surrounding spaces; the server
+		// splits before normalizing, so " Alice | DojoA " still resolves.
+		updated, err := store.UpdateParticipant(compID, " Alice | DojoA ", false, func(p *domain.Player) error {
+			p.CheckedIn = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Alice", updated.Name)
+	})
+
+	t.Run("bulk check-in resolves by name|dojo", func(t *testing.T) {
+		store, err := NewStore(t.TempDir())
+		require.NoError(t, err)
+		compID := "legacy-bulk"
+		writeLegacyRoster(t, store, compID, "Alice,DojoA\nBob,DojoB\nCarol,DojoC\n")
+
+		result, err := store.BulkCheckIn(compID, []string{"Alice|DojoA", "Bob|DojoB"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.CheckedIn)
+		assert.Empty(t, result.NotFound)
+	})
+
+	t.Run("same name at different dojos resolves to the correct row", func(t *testing.T) {
+		store, err := NewStore(t.TempDir())
+		require.NoError(t, err)
+		compID := "legacy-collision"
+		writeLegacyRoster(t, store, compID, "John Smith,Wakaba\nJohn Smith,Tora\n")
+
+		updated, err := store.UpdateParticipant(compID, "John Smith|Tora", false, func(p *domain.Player) error {
+			p.CheckedIn = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Tora", updated.Dojo, "must check in the Tora John Smith, not Wakaba")
+
+		loaded, err := store.LoadParticipants(compID, false)
+		require.NoError(t, err)
+		for _, p := range loaded {
+			if p.Dojo == "Wakaba" {
+				assert.False(t, p.CheckedIn, "the Wakaba John Smith must remain unchecked")
+			}
+		}
+	})
+
+	t.Run("unknown name|dojo reports NotFound, not an error", func(t *testing.T) {
+		store, err := NewStore(t.TempDir())
+		require.NoError(t, err)
+		compID := "legacy-unknown"
+		writeLegacyRoster(t, store, compID, "Alice,DojoA\n")
+
+		_, err = store.UpdateParticipant(compID, "Ghost|Nowhere", false, func(p *domain.Player) error {
+			p.CheckedIn = true
+			return nil
+		})
+		assert.ErrorIs(t, err, ErrParticipantNotFound)
+
+		result, berr := store.BulkCheckIn(compID, []string{"Ghost|Nowhere"})
+		require.NoError(t, berr)
+		assert.Equal(t, 0, result.CheckedIn)
+		assert.Equal(t, []string{"Ghost|Nowhere"}, result.NotFound)
+	})
+}
+
+// TestResolveParticipantIndex unit-tests the resolver directly across the UUID
+// and legacy fallback branches, including the rule that UUID rows are only
+// addressable by their id (never by a name|dojo composite).
+func TestResolveParticipantIndex(t *testing.T) {
+	const uuid = "a1b2c3d4-0000-4000-8000-000000000001"
+	players := []domain.Player{
+		{ID: uuid, Name: "Uuidy", Dojo: "DojoU"},
+		{Name: "Alice", Dojo: "DojoA"},
+		{Name: "John Smith", Dojo: "Wakaba"},
+		{Name: "John Smith", Dojo: "Tora"},
+	}
+
+	tests := []struct {
+		name string
+		pid  string
+		want int
+	}{
+		{"empty pid", "", -1},
+		{"uuid match", uuid, 0},
+		{"legacy name|dojo", "Alice|DojoA", 1},
+		{"legacy normalizes case + diacritics", "alice|dojoa", 1},
+		{"collision picks correct dojo", "John Smith|Tora", 3},
+		{"uuid row not addressable by name", "Uuidy|DojoU", -1},
+		{"unknown", "Nobody|Nowhere", -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveParticipantIndex(players, tc.pid))
+		})
+	}
+}

--- a/web-mobile/js/__tests__/admin_registration_desk.test.jsx
+++ b/web-mobile/js/__tests__/admin_registration_desk.test.jsx
@@ -36,9 +36,14 @@ describe('rdPersonKey', () => {
 });
 
 describe('rdPid', () => {
-  it('prefers the UUID, falls back to the name', () => {
-    expect(rdPid({ id: 'uuid-1', name: 'A' })).toBe('uuid-1');
-    expect(rdPid({ name: 'A' })).toBe('A');
+  it('prefers the UUID', () => {
+    expect(rdPid({ id: 'uuid-1', name: 'A', dojo: 'D' })).toBe('uuid-1');
+  });
+  it('falls back to the composite name|dojo key for legacy UUID-less rows', () => {
+    expect(rdPid({ name: 'A', dojo: 'D' })).toBe('A|D');
+  });
+  it('emits an empty dojo segment when dojo is missing', () => {
+    expect(rdPid({ name: 'A' })).toBe('A|');
   });
 });
 

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -354,15 +354,15 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   // doesn't jump when the list is searched/sorted. Rendered as provisional
   // (muted, dotted) since the final numbers may differ after the draw.
   const provisionalNumberById = useMemoA(() => {
-    // Null-prototype object: keys are user-controlled (p.id ?? p.name), so a
-    // participant named "__proto__" or "constructor" against a plain `{}` map
+    // Null-prototype object: keys are user-controlled (window.checkinPid(p)), so
+    // a participant named "__proto__" or "constructor" against a plain `{}` map
     // could pollute the prototype chain or return inherited values on lookup.
     // `Object.create(null)` removes both risks and keeps the `map[key]` /
     // `map[key] = …` ergonomics. (Copilot mp-1tk follow-up.)
     const map = Object.create(null);
     if (c.numberPrefix) {
       (c.players || []).forEach((p, i) => {
-        map[p.id ?? p.name] = `${c.numberPrefix}${i + 1}`;
+        map[window.checkinPid(p)] = `${c.numberPrefix}${i + 1}`;
       });
     }
     return map;
@@ -370,7 +370,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   const allSources = useMemoA(() => [...new Set(players.map(p => p.source).filter(Boolean))], [players]);
   const playerSearchTargets = useMemoA(() => {
     const map = new Map();
-    players.forEach(p => { map.set(p.id ?? p.name, participantSearchTarget(p)); });
+    players.forEach(p => { map.set(window.checkinPid(p), participantSearchTarget(p)); });
     return map;
   }, [players]);
   const visiblePlayers = useMemoA(() => {
@@ -378,14 +378,14 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     let out = players;
     if (sourceFilter) out = out.filter(p => p.source === sourceFilter);
     if (showOnlyUnchecked) out = out.filter(p => !p.checkedIn);
-    if (q) out = out.filter(p => playerSearchTargets.get(p.id ?? p.name)?.includes(q));
+    if (q) out = out.filter(p => playerSearchTargets.get(window.checkinPid(p))?.includes(q));
     return out;
   }, [players, sourceFilter, showOnlyUnchecked, trimmedSearch, playerSearchTargets]);
   const dojoFirstRowSet = useMemoA(() => {
     const seen = new Set();
     const first = new Set();
     visiblePlayers.forEach((p) => {
-      if (!seen.has(p.dojo)) { seen.add(p.dojo); first.add(p.id ?? p.name); }
+      if (!seen.has(p.dojo)) { seen.add(p.dojo); first.add(window.checkinPid(p)); }
     });
     return first;
   }, [visiblePlayers]);
@@ -564,7 +564,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
     // Capture the old name before the await so the success toast is accurate
     // even if replaceTarget has changed by the time the response arrives.
     const oldName = replaceTarget.name;
-    const targetId = replaceTarget.id;
+    const targetPid = window.checkinPid(replaceTarget);
     const targetSource = replaceTarget.source || "";
     const admin = await window.promptAdminPassword();
     if (admin === null) return;
@@ -583,7 +583,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
       const metadata = window.buildPlayerMetadata(danGrade, replaceTarget.metadata);
       const payload = { name, dojo, displayName: c.withZekkenName ? zekken : "", source: targetSource };
       if (metadata !== undefined) payload.metadata = metadata;
-      const updated = await window.API.replaceParticipant(c.id, targetId, payload, password, admin);
+      const updated = await window.API.replaceParticipant(c.id, targetPid, payload, password, admin);
       if (!mountedRef.current) return;
       setReplaceTarget(null);
       showToast(oldName === updated.name ? `Saved changes for ${updated.name}` : `Renamed ${oldName} → ${updated.name}`);
@@ -951,7 +951,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                 const reorderDisabled = !!sourceFilter || showOnlyUnchecked || !!trimmedSearch || isDrawReady;
                 return (
                   <div
-                    key={p.id ?? p.name}
+                    key={window.checkinPid(p)}
                     className={`seed-row ${p.seed ? "has-seed" : ""} ${p.checkedIn ? "is-checked-in" : ""} ${dragOverIdx === i ? "seed-row--drop-target" : ""}`}
                     draggable={!reorderDisabled}
                     onDragStart={() => { if (reorderDisabled) return; dragIdxRef.current = i; }}
@@ -989,8 +989,8 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                         <div className="seed-row__name" title={p.name} style={{ minWidth: 0 }}>
                           {p.number ? (
                             <span className="num-prefix">{p.number}</span>
-                          ) : provisionalNumberById[p.id ?? p.name] ? (
-                            <span className="num-prefix num-prefix--provisional" title="Provisional number — the final competitor number is assigned when the draw runs">{provisionalNumberById[p.id ?? p.name]}</span>
+                          ) : provisionalNumberById[window.checkinPid(p)] ? (
+                            <span className="num-prefix num-prefix--provisional" title="Provisional number — the final competitor number is assigned when the draw runs">{provisionalNumberById[window.checkinPid(p)]}</span>
                           ) : null}
                           {p.name}
                         </div>
@@ -998,7 +998,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                       </div>
                       <div className="seed-row__dojo">
                         {p.dojo}
-                        {c.checkInEnabled && dojoFirstRowSet.has(p.id ?? p.name) && (dojoUncheckedCount.get(p.dojo) || 0) > 0 && (
+                        {c.checkInEnabled && dojoFirstRowSet.has(window.checkinPid(p)) && (dojoUncheckedCount.get(p.dojo) || 0) > 0 && (
                           <button type="button"
                             className="btn--link"
                             style={{ marginLeft: 8, fontSize: 10, padding: 0 }}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -506,7 +506,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
 
     if (!(await window.confirmDialog({ message: `Mark all ${targets.length} participants from ${dojo} as checked-in?`, confirmLabel: "Check in all" }))) return;
 
-    const results = await Promise.allSettled(targets.map(p => window.API.toggleCheckIn(c.id, p.id ?? p.name, true, password)));
+    const results = await Promise.allSettled(targets.map(p => window.API.toggleCheckIn(c.id, window.checkinPid(p), true, password)));
     const failed = results.filter(r => r.status === "rejected").length;
     const succeeded = results.length - failed;
     if (failed > 0) {
@@ -520,7 +520,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   const bulkCheckInAll = async () => {
     const targets = (c.players || []).filter(p => !p.checkedIn);
     if (targets.length === 0) { showToast("All participants already checked in"); return; }
-    const results = await Promise.allSettled(targets.map(p => window.API.toggleCheckIn(c.id, p.id ?? p.name, true, password)));
+    const results = await Promise.allSettled(targets.map(p => window.API.toggleCheckIn(c.id, window.checkinPid(p), true, password)));
     const failed = results.filter(r => r.status === "rejected").length;
     const succeeded = results.length - failed;
     if (failed > 0) {
@@ -976,7 +976,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
                         <input
                           type="checkbox"
                           checked={p.checkedIn}
-                          onChange={(e) => toggleCheckIn(p.id ?? p.name, e.target.checked)}
+                          onChange={(e) => toggleCheckIn(window.checkinPid(p), e.target.checked)}
                           style={{ width: 18, height: 18, cursor: "pointer" }}
                           aria-label={p.checkedIn ? `Undo check-in for ${p.name}` : `Mark ${p.name} as checked-in`}
                         />

--- a/web-mobile/js/admin_registration_desk.jsx
+++ b/web-mobile/js/admin_registration_desk.jsx
@@ -50,11 +50,16 @@ function rdPersonKey(p) {
   return `${rdNorm(p.name)}|${rdNorm(p.dojo)}`;
 }
 
-// Client-side key for check-in calls. Prefers the UUID; falls back to the name
-// only for legacy non-UUID rows where the persisted id column IS the name.
-// The server always matches by the id column — it never resolves by name.
+// Client-side identifier for check-in / edit calls (and for local row keys and
+// optimistic-update matching, which must use the same value symmetrically).
+// Prefers the stable UUID; for legacy UUID-less rows it falls back to the
+// composite "name|dojo" key the server resolves on (resolveParticipantIndex in
+// internal/state/participants.go) — the (name, dojo) pair, not name alone, is
+// the uniqueness invariant. Kept inline (not via window.checkinPid) so the
+// standalone unit tests work under vitest, where window helpers are absent;
+// keep it identical to checkinPid in data.jsx.
 function rdPid(p) {
-  return p.id ?? p.name;
+  return p.id ?? `${p.name}|${p.dojo ?? ""}`;
 }
 
 // Subsequence score for one token against a normalized haystack. Returns null

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1133,9 +1133,11 @@ const API = {
         }
         return res.json();
     },
-    // Bulk check-in for one competition. participantIds is an array of stable
-    // participant ids that must match the persisted id column exactly. Returns { checkedIn, alreadyCheckedIn,
-    // notFound }. Used by the Registration desk's "check in a whole dojo" action.
+    // Bulk check-in for one competition. participantIds is an array of pids as
+    // built by checkinPid: a stable UUID, or the composite "name|dojo" key for
+    // legacy UUID-less rows (the server resolves either). Returns { checkedIn,
+    // alreadyCheckedIn, notFound }. Used by the Registration desk's "check in a
+    // whole dojo" action.
     async bulkCheckIn(compID, participantIds, password) {
         const res = await fetch(`/api/competitions/${encodeURIComponent(compID)}/participants/checkin-bulk`, {
             method: 'POST',

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -389,13 +389,25 @@ function arraysEqual(a, b) {
   return a.length === b.length && a.every((v, i) => v === b[i]);
 }
 
+// checkinPid builds the server-bound participant identifier for the check-in,
+// uncheck, bulk check-in, and edit endpoints. Modern rows carry a stable UUID;
+// legacy UUID-less rosters (a participants.csv never re-saved through the app)
+// have no id, so we fall back to the composite "name|dojo" key the server
+// resolves on (pidPairKey / resolveParticipantIndex in
+// internal/state/participants.go). The dojo is included because (name, dojo) —
+// not name alone — is the uniqueness invariant: the same name at a different
+// dojo is two distinct people. Keep in sync with the Go resolver.
+function checkinPid(p) {
+  return p.id ?? `${p.name}|${p.dojo ?? ""}`;
+}
+
 export {
   makePlayer, makeTeam, makeCompetitors, standardSeedOrder, nextPow2, newMatchId,
   buildBracket, advanceByes, pickIppons, simulateRounds, scheduleRound, addMinutes, diffMinutes,
   buildPools, simulatePools, computeStandings, poolWinners,
   buildEmptyCompetition, applyFormat, buildCompetition,
   buildTournament, competitionStatus, SAMPLE_TOURNAMENTS, parseParticipantLines,
-  assignCourt, arraysEqual, mergeMatchPatch, normalizeParticipantName
+  assignCourt, arraysEqual, mergeMatchPatch, normalizeParticipantName, checkinPid
 };
 
 if (typeof window !== 'undefined') {
@@ -415,4 +427,5 @@ if (typeof window !== 'undefined') {
   window.addMinutes = addMinutes;
   window.diffMinutes = diffMinutes;
   window.arraysEqual = arraysEqual;
+  window.checkinPid = checkinPid;
 }


### PR DESCRIPTION
## Summary

- Check-in (single, uncheck, edit) and bulk check-in could not resolve participants on a **legacy `participants.csv` that has no UUID column**. Such rows load with empty `Player.ID`, the client sends `pid = p.id ?? p.name`, and both server paths matched on `Player.ID` only — so every legacy row 404'd / landed in `NotFound`, leaving those rosters impossible to check in.
- Resolve on the **(normalizedName, normalizedDojo)** pair — the system's uniqueness invariant (the same name at a different dojo is two distinct people), so the fallback is collision-free. The client now sends a composite `"name|dojo"` pid for UUID-less rows; the server splits before normalizing and restricts the fallback to ID-less rows (UUID rows stay addressable only by their id).
- The first successful check-in re-saves the roster and **migrates every row to a UUID** (`marshalParticipantsCSV` backfills empty IDs), so the SSE-refreshed UI then sends UUIDs — i.e. the fix is self-healing after the first action.

## Why

Root cause: `loadParticipantsNoLock` mints no UUID for a UUID-less CSV (the documented legacy schema), and `updateParticipantNoLock` / `BulkCheckIn` looked participants up by `Player.ID` exclusively. mp-25bk made `BulkCheckIn`'s `notFound` count visible; this PR fixes the underlying resolution so legacy rosters can actually be checked in. Name alone is **not** a valid key (the dedup guard allows the same name at different dojos), which is why resolution is on the `(name, dojo)` pair.

## Files changed

| File | What |
|---|---|
| `internal/state/participants.go` | Add `resolveParticipantIndex` (+ `participantPairKey` / `pidPairKey`); wire into `updateParticipantNoLock` and `BulkCheckIn` (UUID first, then `name|dojo` among ID-less rows) |
| `internal/state/participants_legacy_checkin_test.go` | New: legacy-roster single + bulk check-in, whitespace tolerance, same-name/different-dojo collision, UUID-still-resolves, unknown→NotFound, and a direct `resolveParticipantIndex` table test |
| `web-mobile/js/data.jsx` | New shared `checkinPid(p)` = `p.id ?? \`${p.name}|${p.dojo ?? ""}\`` (+ window export) |
| `web-mobile/js/admin_participants.jsx` | Use `window.checkinPid(p)` at the three server-bound check-in sites |
| `web-mobile/js/admin_registration_desk.jsx` | `rdPid` returns the composite inline (also fixes legacy `replaceParticipant`, which shares the resolver); kept self-contained for vitest |
| `web-mobile/js/api_client.jsx` | Correct the stale "must match the persisted id column exactly" `bulkCheckIn` doc comment |
| `web-mobile/js/__tests__/admin_registration_desk.test.jsx` | Update `rdPid` expectations for the composite key |

## Screenshots

Legacy UUID-less roster checked in via the admin Participants surface — **2/5 checked in**, Alice Tanaka/Gyokusen ✓ and John Smith/**Tora** ✓, while the second John Smith (**Hokuto**) correctly stays unchecked (the same-name/different-dojo collision resolves to the right row). The right-hand roster textarea shows the legacy CSV (no UUID column).

![legacy check-in](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/318/checkin-legacy.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — `internal/state` coverage 88.0%
- [x] New/updated unit tests cover the change — Go legacy-roster + resolver tests; `web-mobile` vitest 1897 passed
- [x] Manual browser verification — drove the admin Participants page against a hand-planted UUID-less `participants.csv`: 1st check-in sent `PUT .../Alice Tanaka|Gyokusen/checkin` → **200** (was 404); roster migrated to UUIDs; 2nd check-in (collision) sent the UUID and flipped only John Smith/Tora
- [x] Screenshots added above
- [x] No new console errors or warnings — console error log was empty during the flow

Closes mp-8bjq
