### PR TITLE
feat(mp-9h1f): right-size operator console data; rename court endpoint to /current

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ The mobile app exposes several court-scoped URLs for running a multi-court event
 | `/display?court=A` | Spectator screen / TV | Single-court display: current match, upcoming queue, recent results. |
 | `/display?court=all` | Lobby / overview | 4-card grid showing all courts at once. |
 | `/display?court=A&overlay=true` | OBS / streaming | Transparent variant suitable for chroma-keying into a broadcast overlay. |
-| `/api/viewer/court/:court/live` | Public JSON | Read-only snapshot of one court's current state. No auth. |
+| `/api/viewer/court/:court/current` | Public JSON | Read-only snapshot of one court's current state. No auth. |
 
 ### Data format
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ The mobile app exposes several court-scoped URLs for running a multi-court event
 | `/display?court=all` | Lobby / overview | 4-card grid showing all courts at once. |
 | `/display?court=A&overlay=true` | OBS / streaming | Transparent variant suitable for chroma-keying into a broadcast overlay. |
 | `/api/viewer/court/:court/current` | Public JSON | Read-only snapshot of one court's current state. No auth. |
+| `/api/viewer/court/:court/matches` | Public JSON | Court-scoped match feed (per-comp config + matches) for comps with a match on this court, by actual placement. No auth. |
 
 ### Data format
 

--- a/internal/mobileapp/coverage_gap_test.go
+++ b/internal/mobileapp/coverage_gap_test.go
@@ -696,9 +696,9 @@ func TestNewRouterWithHub_NilVerifier(t *testing.T) {
 // Display handler — match on different court and non-running match
 // ---------------------------------------------------------------------------
 
-// TestCourtLive_MatchOnDifferentCourt covers the !strings.EqualFold(m.Court, court)
+// TestCourtCurrent_MatchOnDifferentCourt covers the !strings.EqualFold(m.Court, court)
 // continue branch (line 69-70 in handlers_display.go).
-func TestCourtLive_MatchOnDifferentCourt(t *testing.T) {
+func TestCourtCurrent_MatchOnDifferentCourt(t *testing.T) {
 	r, store, _, _, _ := setupTestRouter(t)
 	require.NoError(t, store.SaveTournament(&state.Tournament{
 		Name: "T", Password: "", Courts: []string{"A", "B"},
@@ -710,14 +710,14 @@ func TestCourtLive_MatchOnDifferentCourt(t *testing.T) {
 	}))
 	// Request court B — match is on court A, so the court-mismatch continue fires.
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/B/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/B/current", nil)
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// TestCourtLive_MatchNotRunning covers the m.Status != MatchStatusRunning
+// TestCourtCurrent_MatchNotRunning covers the m.Status != MatchStatusRunning
 // continue branch (line 72-73 in handlers_display.go).
-func TestCourtLive_MatchNotRunning(t *testing.T) {
+func TestCourtCurrent_MatchNotRunning(t *testing.T) {
 	r, store, _, _, _ := setupTestRouter(t)
 	require.NoError(t, store.SaveTournament(&state.Tournament{
 		Name: "T", Password: "", Courts: []string{"A"},
@@ -729,14 +729,14 @@ func TestCourtLive_MatchNotRunning(t *testing.T) {
 	}))
 	// Match exists on court A but is completed, not running.
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// TestCourtLive_HasParticipantIDs covers the comp.HasParticipantIDs hasIDsHint
+// TestCourtCurrent_HasParticipantIDs covers the comp.HasParticipantIDs hasIDsHint
 // branch (lines 80-83 in handlers_display.go) when finding a running match.
-func TestCourtLive_HasParticipantIDs(t *testing.T) {
+func TestCourtCurrent_HasParticipantIDs(t *testing.T) {
 	r, store, _, _, _ := setupTestRouter(t)
 	require.NoError(t, store.SaveTournament(&state.Tournament{
 		Name: "T", Password: "", Courts: []string{"A"},
@@ -752,7 +752,7 @@ func TestCourtLive_HasParticipantIDs(t *testing.T) {
 		{ID: "m1", SideA: "Alice", SideB: "Bob", Status: state.MatchStatusRunning, Court: "A"},
 	}))
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -11,7 +11,7 @@ import (
 
 // RegisterDisplayHandlers wires the public, no-auth display surfaces used by
 // non-browser streaming integrations (vMix, OBS plugins, scoreboards). The
-// only route today is GET /api/viewer/court/:court/live — a one-shot polled
+// only route today is GET /api/viewer/court/:court/current — a one-shot polled
 // view of the currently-running match on a court. Browser clients should
 // continue to use SSE (/api/events); the polled surface exists for clients
 // that cannot subscribe.
@@ -22,7 +22,7 @@ import (
 // for a single consumer would be premature. If a second polled surface
 // lands later we can hoist a DisplayStore interface then.
 func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
-	r.GET("/court/:court/live", func(c *gin.Context) {
+	r.GET("/court/:court/current", func(c *gin.Context) {
 		// Streaming clients poll this on a 1-2s cadence; never let an
 		// upstream cache them. The router-level CORS already exposes
 		// Access-Control-Allow-Origin, but the contract pins it here too
@@ -72,7 +72,7 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 				if m.Status != state.MatchStatusRunning {
 					continue
 				}
-				// Found the live match — build the live payload.
+				// Found the current match — build the current payload.
 				// LoadParticipantsOpt is the canonical read so we
 				// pick up DisplayName/Dojo even on legacy competitions
 				// that predate the HasParticipantIDs flag.
@@ -97,7 +97,7 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 
 				c.JSON(http.StatusOK, gin.H{
 					"court":  court,
-					"status": "live",
+					"status": "current",
 					"competition": gin.H{
 						"id":   comp.ID,
 						"name": comp.Name,
@@ -126,7 +126,7 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 
 // buildSide turns a participant name (which is what MatchResult.SideA/SideB
 // carries — see state/models.go) into the per-side payload defined by the
-// court-live contract. When the participants list cannot resolve the name
+// court-current contract. When the participants list cannot resolve the name
 // we fall back to a name-only side so the overlay can still render
 // "Player vs Player" rather than blanking out.
 func buildSide(name string, players []domain.Player, withZekkenName bool) gin.H {
@@ -158,8 +158,8 @@ func buildSide(name string, players []domain.Player, withZekkenName bool) gin.H 
 // Pool match IDs are formatted "PoolName-Idx" by engine/pools.go; we strip
 // the suffix and return the pool name verbatim. Bracket matches will land
 // in a later slice — for now we return the raw ID as a fallback so the
-// field is never empty for a live match (the contract documents the field
-// is always present on live payloads).
+// field is never empty for a current match (the contract documents the field
+// is always present on current payloads).
 func phaseFromMatchID(id string) string {
 	if i := strings.LastIndex(id, "-"); i > 0 {
 		return id[:i]

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -3,6 +3,7 @@ package mobileapp
 import (
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -39,7 +40,11 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 		// Scan competitions in listing order; the first running match on
 		// this court wins. Two running matches on the same court would
 		// already be a tournament-data error (one court runs one match
-		// at a time per R8) and we surface whichever appears first.
+		// at a time per R8) and we surface whichever appears first. Within a
+		// competition we check pool matches then the bracket — the same order
+		// state.RunningMatchOnCourt uses — so a running KNOCKOUT bout is just
+		// as "current" as a pool bout (mp-9h1f follow-up: the prior code
+		// scanned only poolMatches, so a running elimination match read as idle).
 		ids, _ := store.ListCompetitions()
 		for _, compID := range ids {
 			comp, _ := store.LoadCompetition(compID)
@@ -49,56 +54,41 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 
 			poolMatches, _ := store.LoadPoolMatches(compID)
 			for _, m := range poolMatches {
-				if !strings.EqualFold(m.Court, court) {
+				if !strings.EqualFold(m.Court, court) || m.Status != state.MatchStatusRunning {
 					continue
 				}
-				if m.Status != state.MatchStatusRunning {
-					continue
-				}
-				// Found the current match — build the current payload.
-				// LoadParticipantsOpt is the canonical read so we
-				// pick up DisplayName/Dojo even on legacy competitions
-				// that predate the HasParticipantIDs flag.
-				var hasIDsHint *bool
-				if comp.HasParticipantIDs {
-					t := true
-					hasIDsHint = &t
-				}
-				players, _ := store.LoadParticipantsOpt(compID, comp.WithZekkenName, state.LoadParticipantsOpts{WithSeeds: false, HasIDs: hasIDsHint})
-				// mp-13y: merge numberPrefix-derived numbers from pools.csv
-				// directly onto the slice so buildSide can include "number"
-				// in the polled OBS/vMix overlay payload. Skip the pools.csv
-				// read entirely when no prefix is configured (the common
-				// case).
-				if comp.NumberPrefix != "" {
-					pools, _ := store.LoadPools(compID)
-					mergePoolNumbersIntoPlayersSlice(comp.NumberPrefix, players, pools, comp.Format)
-				}
-
-				sideA := buildSide(m.SideA, players, comp.WithZekkenName)
-				sideB := buildSide(m.SideB, players, comp.WithZekkenName)
-
-				c.JSON(http.StatusOK, gin.H{
-					"court":  court,
-					"status": "current",
-					"competition": gin.H{
-						"id":   comp.ID,
-						"name": comp.Name,
-					},
-					"phase":    phaseFromMatchID(m.ID),
-					"sideA":    sideA,
-					"sideB":    sideB,
-					"ipponsA":  m.IpponsA,
-					"ipponsB":  m.IpponsB,
-					"hansokuA": m.HansokuA,
-					"hansokuB": m.HansokuB,
-					// Pool daihyosen/tiebreaker rep bouts carry team names in
-					// sideA/sideB; the representative fighter for each side lives
-					// here. Empty for every regular match (mp-62vr).
-					"repPlayerA": m.RepPlayerA,
-					"repPlayerB": m.RepPlayerB,
-				})
+				players := currentMatchPlayers(store, comp)
+				// Pool daihyosen/tiebreaker rep bouts carry team names in
+				// sideA/sideB; the representative fighter for each side lives in
+				// RepPlayerA/B. Empty for every regular match (mp-62vr).
+				c.JSON(http.StatusOK, currentMatchPayload(court, comp, players,
+					m.SideA, m.SideB, m.IpponsA, m.IpponsB, m.HansokuA, m.HansokuB,
+					phaseFromMatchID(m.ID), m.RepPlayerA, m.RepPlayerB))
 				return
+			}
+
+			// Bracket/knockout: a running elimination bout persists its running
+			// score as the formatted ScoreA/ScoreB string (engine.formatScore),
+			// not the ippon arrays a pool MatchResult carries — parseScore turns
+			// it back into the {ippons, hansoku} shape the contract returns.
+			// Elimination matches have no representative-bout fighters.
+			bracket, _ := store.LoadBracket(compID)
+			if bracket == nil {
+				continue
+			}
+			for _, round := range bracket.Rounds {
+				for _, bm := range round {
+					if !strings.EqualFold(bm.Court, court) || bm.Status != state.MatchStatusRunning {
+						continue
+					}
+					players := currentMatchPlayers(store, comp)
+					ipponsA, hansokuA := parseScore(bm.ScoreA)
+					ipponsB, hansokuB := parseScore(bm.ScoreB)
+					c.JSON(http.StatusOK, currentMatchPayload(court, comp, players,
+						bm.SideA, bm.SideB, ipponsA, ipponsB, hansokuA, hansokuB,
+						phaseFromMatchID(bm.ID), "", ""))
+					return
+				}
 			}
 		}
 
@@ -223,6 +213,80 @@ func matchesPresentOnCourt(poolMatches []state.MatchResult, bracket *state.Brack
 		}
 	}
 	return false
+}
+
+// currentMatchPlayers loads the participant slice used to enrich a court's
+// current-match payload (DisplayName/Dojo/number). LoadParticipantsOpt is the
+// canonical read so we pick up DisplayName/Dojo even on legacy competitions
+// that predate the HasParticipantIDs flag. mp-13y: when a numberPrefix is
+// configured, merge the pools.csv-derived numbers onto the slice so buildSide
+// can include "number" in the polled OBS/vMix overlay payload; the pools.csv
+// read is skipped entirely otherwise (the common case).
+func currentMatchPlayers(store *state.Store, comp *state.Competition) []domain.Player {
+	var hasIDsHint *bool
+	if comp.HasParticipantIDs {
+		t := true
+		hasIDsHint = &t
+	}
+	players, _ := store.LoadParticipantsOpt(comp.ID, comp.WithZekkenName, state.LoadParticipantsOpts{WithSeeds: false, HasIDs: hasIDsHint})
+	if comp.NumberPrefix != "" {
+		pools, _ := store.LoadPools(comp.ID)
+		mergePoolNumbersIntoPlayersSlice(comp.NumberPrefix, players, pools, comp.Format)
+	}
+	return players
+}
+
+// currentMatchPayload builds the GET /court/:court/current "current" body shared
+// by the pool and bracket branches. repA/repB are the representative-bout
+// fighters for a pool daihyosen (empty for regular and bracket matches).
+func currentMatchPayload(court string, comp *state.Competition, players []domain.Player,
+	sideAName, sideBName string, ipponsA, ipponsB []string, hansokuA, hansokuB int,
+	phase, repA, repB string) gin.H {
+	return gin.H{
+		"court":  court,
+		"status": "current",
+		"competition": gin.H{
+			"id":   comp.ID,
+			"name": comp.Name,
+		},
+		"phase":      phase,
+		"sideA":      buildSide(sideAName, players, comp.WithZekkenName),
+		"sideB":      buildSide(sideBName, players, comp.WithZekkenName),
+		"ipponsA":    ipponsA,
+		"ipponsB":    ipponsB,
+		"hansokuA":   hansokuA,
+		"hansokuB":   hansokuB,
+		"repPlayerA": repA,
+		"repPlayerB": repB,
+	}
+}
+
+// parseScore is the inverse of engine.formatScore (internal/engine/scoring.go):
+// "MK (H1)" → (["M","K"], 1), "MK" → (["M","K"], 0), "(H1)" → (nil, 1). Ippon
+// letters are single runes (M/K/D/T/H/S or the ○ default-win marker), so
+// splitting the non-hansoku remainder on runes recovers the slice. Used to fill
+// the ippon/hansoku fields for a RUNNING bracket match, which persists its
+// running score as the formatted ScoreA/ScoreB string rather than the ippon
+// arrays a pool MatchResult carries.
+func parseScore(s string) ([]string, int) {
+	s = strings.TrimSpace(s)
+	hansoku := 0
+	if i := strings.LastIndex(s, "(H"); i >= 0 {
+		if j := strings.Index(s[i:], ")"); j >= 0 {
+			if n, err := strconv.Atoi(s[i+2 : i+j]); err == nil {
+				hansoku = n
+			}
+			s = strings.TrimSpace(s[:i])
+		}
+	}
+	var ippons []string
+	for _, r := range s {
+		if r == ' ' {
+			continue
+		}
+		ippons = append(ippons, string(r))
+	}
+	return ippons, hansoku
 }
 
 // buildSide turns a participant name (which is what MatchResult.SideA/SideB

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -24,33 +24,11 @@ import (
 // lands later we can hoist a DisplayStore interface then.
 func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 	r.GET("/court/:court/current", func(c *gin.Context) {
-		// Streaming clients poll this on a 1-2s cadence; never let an
-		// upstream cache them. The router-level CORS already exposes
-		// Access-Control-Allow-Origin, but the contract pins it here too
-		// so the polled-surface guarantee survives router refactors.
-		c.Header("Cache-Control", "no-store")
-		c.Header("Access-Control-Allow-Origin", "*")
-
-		court := strings.ToUpper(strings.TrimSpace(c.Param("court")))
-
-		tour, err := store.LoadTournament()
-		if err != nil || tour == nil {
-			// 503 distinguishes "tournament not loaded yet" from a
-			// genuine 4xx — clients can retry without reporting it as
-			// an error to the operator.
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "no_active_tournament"})
-			return
-		}
-
-		validCourt := false
-		for _, ct := range tour.Courts {
-			if strings.EqualFold(ct, court) {
-				validCourt = true
-				break
-			}
-		}
-		if !validCourt {
-			c.JSON(http.StatusNotFound, gin.H{"error": "court_not_found", "court": court})
+		// Streaming clients poll this on a 1-2s cadence; resolveCourt pins the
+		// no-store + CORS headers so the polled-surface guarantee survives
+		// router refactors, normalises the :court param, and writes the 503/404.
+		court, ok := resolveCourt(c, store)
+		if !ok {
 			return
 		}
 
@@ -141,46 +119,18 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 	// "Match N of M" pool counts stay correct; the right-sizing is by
 	// competition COUNT (only comps on this court, not the whole tournament).
 	r.GET("/court/:court/matches", func(c *gin.Context) {
-		c.Header("Cache-Control", "no-store")
-		c.Header("Access-Control-Allow-Origin", "*")
-
-		court := strings.ToUpper(strings.TrimSpace(c.Param("court")))
-
-		tour, err := store.LoadTournament()
-		if err != nil || tour == nil {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "no_active_tournament"})
-			return
-		}
-
-		validCourt := false
-		for _, ct := range tour.Courts {
-			if strings.EqualFold(ct, court) {
-				validCourt = true
-				break
-			}
-		}
-		if !validCourt {
-			c.JSON(http.StatusNotFound, gin.H{"error": "court_not_found", "court": court})
+		court, ok := resolveCourt(c, store)
+		if !ok {
 			return
 		}
 
 		ids, _ := store.ListCompetitions()
 		comps := make([]gin.H, 0, len(ids))
 		for _, compID := range ids {
-			comp, _ := store.LoadCompetition(compID)
-			if comp == nil {
-				continue
-			}
-			// A setup competition exposes no public matches (parity with
-			// compMatches in viewer_utils.jsx, which returns [] for setup),
-			// so it never appears on the court feed.
-			if comp.Status == state.CompStatusSetup {
-				continue
-			}
-			if !competitionHasMatchOnCourt(store, compID, court) {
-				continue
-			}
-			if payload := buildViewerCompetitionPayload(store, compID); payload != nil {
+			// The court filter does the setup-skip and "real match on this
+			// court" gating inside the single per-comp load (no separate
+			// presence pre-check that would re-read poolMatches/bracket).
+			if payload := buildViewerCompetitionPayload(store, compID, court); payload != nil {
 				comps = append(comps, payload)
 			}
 		}
@@ -217,20 +167,48 @@ func courtMatchSidesReal(a, b string) bool {
 	return true
 }
 
-// competitionHasMatchOnCourt reports whether the competition has at least one
-// real match (pool or non-preview bracket) physically placed on the given
-// court. A preview bracket (mixed-comp placeholder structure) is skipped — it
-// is read-only and never played, mirroring the aggregate viewer's preview
-// strip in handlers_viewer.go.
-func competitionHasMatchOnCourt(store *state.Store, compID, court string) bool {
-	poolMatches, _ := store.LoadPoolMatches(compID)
+// resolveCourt is the shared preamble for the court-scoped display surfaces. It
+// pins the no-store + CORS headers (streaming clients poll on a 1-2s cadence and
+// must never be cached), normalises the :court param, validates it against the
+// active tournament, and writes the error response on failure. Returns
+// (court, true) on success; (\"\", false) after writing a 503 (no tournament) or
+// 404 (unknown court), in which case the handler must return immediately.
+func resolveCourt(c *gin.Context, store *state.Store) (string, bool) {
+	c.Header("Cache-Control", "no-store")
+	c.Header("Access-Control-Allow-Origin", "*")
+
+	court := strings.ToUpper(strings.TrimSpace(c.Param("court")))
+
+	tour, err := store.LoadTournament()
+	if err != nil || tour == nil {
+		// 503 distinguishes "tournament not loaded yet" from a genuine 4xx —
+		// clients can retry without reporting it as an error to the operator.
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "no_active_tournament"})
+		return "", false
+	}
+
+	for _, ct := range tour.Courts {
+		if strings.EqualFold(ct, court) {
+			return court, true
+		}
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "court_not_found", "court": court})
+	return "", false
+}
+
+// matchesPresentOnCourt reports whether the given (already-loaded) pool matches
+// or non-preview bracket contain at least one real match (both sides resolved,
+// see courtMatchSidesReal) physically placed on the court. A preview bracket
+// (mixed-comp placeholder structure) is skipped — it is read-only and never
+// played, mirroring the aggregate viewer's preview strip. Pure (no store reads)
+// so buildViewerCompetitionPayload can gate the court feed off the same
+// poolMatches/bracket it already loaded, without a second read.
+func matchesPresentOnCourt(poolMatches []state.MatchResult, bracket *state.Bracket, court string) bool {
 	for _, m := range poolMatches {
 		if strings.EqualFold(m.Court, court) && courtMatchSidesReal(m.SideA, m.SideB) {
 			return true
 		}
 	}
-
-	bracket, _ := store.LoadBracket(compID)
 	if bracket != nil && !bracket.Preview {
 		for _, round := range bracket.Rounds {
 			for _, bm := range round {

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -249,16 +249,31 @@ func currentMatchPayload(court string, comp *state.Competition, players []domain
 			"id":   comp.ID,
 			"name": comp.Name,
 		},
-		"phase":      phase,
-		"sideA":      buildSide(sideAName, players, comp.WithZekkenName),
-		"sideB":      buildSide(sideBName, players, comp.WithZekkenName),
-		"ipponsA":    ipponsA,
-		"ipponsB":    ipponsB,
+		"phase": phase,
+		"sideA": buildSide(sideAName, players, comp.WithZekkenName),
+		"sideB": buildSide(sideBName, players, comp.WithZekkenName),
+		// Normalize nil → [] so the JSON encodes empty arrays, not null: the
+		// contract models ipponsA/ipponsB as arrays and overlay clients assume
+		// []. A nil slice reaches here from an unscored pool match or a bracket
+		// score with no ippons ("(H2)" or "" via parseScore, which stays
+		// nil-returning so its unit tests hold).
+		"ipponsA":    emptyIfNil(ipponsA),
+		"ipponsB":    emptyIfNil(ipponsB),
 		"hansokuA":   hansokuA,
 		"hansokuB":   hansokuB,
 		"repPlayerA": repA,
 		"repPlayerB": repB,
 	}
+}
+
+// emptyIfNil returns a non-nil slice so JSON encodes [] rather than null.
+// Applied at the response boundary (currentMatchPayload) so parseScore can keep
+// returning nil (its unit tests pin that) while the wire stays array-typed.
+func emptyIfNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 // parseScore is the inverse of engine.formatScore (internal/engine/scoring.go):

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -2,6 +2,7 @@ package mobileapp
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -122,6 +123,124 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 		// No running match on this court.
 		c.JSON(http.StatusOK, gin.H{"court": court, "status": "idle"})
 	})
+
+	// GET /api/viewer/court/:court/matches — the court-scoped match feed for
+	// the operator console. Returns {court, competitions:[…]} where each entry
+	// is the SAME public per-competition payload the aggregate GET /competitions
+	// returns ({config, poolMatches, bracket}), but ONLY for competitions that
+	// have at least one real (both-sides-resolved) match — pool or non-preview
+	// bracket — physically placed on this court right now.
+	//
+	// The operator console is court-first AND cross-competition by design: the
+	// running bout stays put across comps (AC7), the switch nudge watches other
+	// comps on the court (AC6), and Submit+Next advances within the submitted
+	// comp — all need every competition on the court, not just the selected one.
+	// Keying on actual match placement (not comp.courts config) keeps the page
+	// correct after an operator MOVES a match to another shiaijo. The per-comp
+	// match data is full (not court-filtered) so client-side derivations like
+	// "Match N of M" pool counts stay correct; the right-sizing is by
+	// competition COUNT (only comps on this court, not the whole tournament).
+	r.GET("/court/:court/matches", func(c *gin.Context) {
+		c.Header("Cache-Control", "no-store")
+		c.Header("Access-Control-Allow-Origin", "*")
+
+		court := strings.ToUpper(strings.TrimSpace(c.Param("court")))
+
+		tour, err := store.LoadTournament()
+		if err != nil || tour == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "no_active_tournament"})
+			return
+		}
+
+		validCourt := false
+		for _, ct := range tour.Courts {
+			if strings.EqualFold(ct, court) {
+				validCourt = true
+				break
+			}
+		}
+		if !validCourt {
+			c.JSON(http.StatusNotFound, gin.H{"error": "court_not_found", "court": court})
+			return
+		}
+
+		ids, _ := store.ListCompetitions()
+		comps := make([]gin.H, 0, len(ids))
+		for _, compID := range ids {
+			comp, _ := store.LoadCompetition(compID)
+			if comp == nil {
+				continue
+			}
+			// A setup competition exposes no public matches (parity with
+			// compMatches in viewer_utils.jsx, which returns [] for setup),
+			// so it never appears on the court feed.
+			if comp.Status == state.CompStatusSetup {
+				continue
+			}
+			if !competitionHasMatchOnCourt(store, compID, court) {
+				continue
+			}
+			if payload := buildViewerCompetitionPayload(store, compID); payload != nil {
+				comps = append(comps, payload)
+			}
+		}
+
+		c.JSON(http.StatusOK, gin.H{"court": court, "competitions": comps})
+	})
+}
+
+// bracketPlaceholderRE / poolOriginPlaceholderRE mirror the same-named regexes
+// in web-mobile/js/admin_helpers.jsx. A side matching either is an unresolved
+// placeholder ("Winner of r2-m1", "Pool A-1st"), not a real fighter.
+var (
+	bracketPlaceholderRE    = regexp.MustCompile(`^Winner of r\d+-m\d+$`)
+	poolOriginPlaceholderRE = regexp.MustCompile(`^Pool .+-\d+(st|nd|rd|th)$`)
+)
+
+// courtMatchSidesReal mirrors hasBothSides (web-mobile/js/admin_helpers.jsx):
+// a match counts only when both sides are present AND neither is a bracket
+// "Winner of…" or pool-origin "Pool A-1st" placeholder. Keeping this in lockstep
+// with the JS predicate ensures the court→competitions index lists exactly the
+// competitions the operator selector derives from the aggregate today.
+func courtMatchSidesReal(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if bracketPlaceholderRE.MatchString(a) || bracketPlaceholderRE.MatchString(b) {
+		return false
+	}
+	if poolOriginPlaceholderRE.MatchString(a) || poolOriginPlaceholderRE.MatchString(b) {
+		return false
+	}
+	return true
+}
+
+// competitionHasMatchOnCourt reports whether the competition has at least one
+// real match (pool or non-preview bracket) physically placed on the given
+// court. A preview bracket (mixed-comp placeholder structure) is skipped — it
+// is read-only and never played, mirroring the aggregate viewer's preview
+// strip in handlers_viewer.go.
+func competitionHasMatchOnCourt(store *state.Store, compID, court string) bool {
+	poolMatches, _ := store.LoadPoolMatches(compID)
+	for _, m := range poolMatches {
+		if strings.EqualFold(m.Court, court) && courtMatchSidesReal(m.SideA, m.SideB) {
+			return true
+		}
+	}
+
+	bracket, _ := store.LoadBracket(compID)
+	if bracket != nil && !bracket.Preview {
+		for _, round := range bracket.Rounds {
+			for _, bm := range round {
+				if strings.EqualFold(bm.Court, court) && courtMatchSidesReal(bm.SideA, bm.SideB) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // buildSide turns a participant name (which is what MatchResult.SideA/SideB

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -10,12 +10,16 @@ import (
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
-// RegisterDisplayHandlers wires the public, no-auth display surfaces used by
-// non-browser streaming integrations (vMix, OBS plugins, scoreboards). The
-// only route today is GET /api/viewer/court/:court/current — a one-shot polled
-// view of the currently-running match on a court. Browser clients should
-// continue to use SSE (/api/events); the polled surface exists for clients
-// that cannot subscribe.
+// RegisterDisplayHandlers wires the public, no-auth court-scoped surfaces:
+//   - GET /api/viewer/court/:court/current — a one-shot polled view of the
+//     currently-running match on a court, for non-browser streaming
+//     integrations (vMix, OBS plugins, scoreboards).
+//   - GET /api/viewer/court/:court/matches — the operator console's court feed:
+//     every competition with a real match physically placed on the court, each
+//     with its full {config, poolMatches, bracket} payload.
+//
+// Browser clients otherwise use SSE (/api/events); these polled surfaces exist
+// for clients that cannot subscribe (and to right-size the operator console).
 //
 // Per NFR-002 the handler depends on the *state.Store concrete type (the
 // same boundary handlers_viewer.go uses); there is no snug-fit interface
@@ -171,7 +175,7 @@ func courtMatchSidesReal(a, b string) bool {
 // pins the no-store + CORS headers (streaming clients poll on a 1-2s cadence and
 // must never be cached), normalises the :court param, validates it against the
 // active tournament, and writes the error response on failure. Returns
-// (court, true) on success; (\"\", false) after writing a 503 (no tournament) or
+// (court, true) on success; ("", false) after writing a 503 (no tournament) or
 // 404 (unknown court), in which case the handler must return immediately.
 func resolveCourt(c *gin.Context, store *state.Store) (string, bool) {
 	c.Header("Cache-Control", "no-store")

--- a/internal/mobileapp/handlers_display.go
+++ b/internal/mobileapp/handlers_display.go
@@ -133,9 +133,11 @@ func RegisterDisplayHandlers(r *gin.RouterGroup, store *state.Store) {
 	})
 }
 
-// bracketPlaceholderRE / poolOriginPlaceholderRE mirror the same-named regexes
-// in web-mobile/js/admin_helpers.jsx. A side matching either is an unresolved
-// placeholder ("Winner of r2-m1", "Pool A-1st"), not a real fighter.
+// bracketPlaceholderRE / poolOriginPlaceholderRE use the same patterns as the
+// BRACKET_PLACEHOLDER_RE / POOL_ORIGIN_PLACEHOLDER_RE constants in
+// web-mobile/js/admin_helpers.jsx (the Go and JS identifiers differ in casing).
+// A side matching either is an unresolved placeholder ("Winner of r2-m1",
+// "Pool A-1st"), not a real fighter.
 var (
 	bracketPlaceholderRE    = regexp.MustCompile(`^Winner of r\d+-m\d+$`)
 	poolOriginPlaceholderRE = regexp.MustCompile(`^Pool .+-\d+(st|nd|rd|th)$`)
@@ -143,9 +145,14 @@ var (
 
 // courtMatchSidesReal mirrors hasBothSides (web-mobile/js/admin_helpers.jsx):
 // a match counts only when both sides are present AND neither is a bracket
-// "Winner of…" or pool-origin "Pool A-1st" placeholder. Keeping this in lockstep
-// with the JS predicate ensures the court→competitions index lists exactly the
-// competitions the operator selector derives from the aggregate today.
+// "Winner of…" or pool-origin "Pool A-1st" placeholder, so the
+// court→competitions index lists exactly the competitions the operator selector
+// derives from the aggregate today. One intentional difference from the JS
+// helper: this Go side additionally TrimSpace-normalizes each name before the
+// empty/placeholder checks. That only widens the empty-side guard (a
+// whitespace-only side reads as absent) and never changes which real names
+// pass, so the two predicates agree on every real match — they are not
+// byte-for-byte identical implementations.
 func courtMatchSidesReal(a, b string) bool {
 	a = strings.TrimSpace(a)
 	b = strings.TrimSpace(b)

--- a/internal/mobileapp/handlers_display_test.go
+++ b/internal/mobileapp/handlers_display_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// courtLiveSide mirrors the per-side payload defined in
-// contracts/api-viewer-court-live.md. Kept local to the test file
+// courtCurrentSide mirrors the per-side payload defined in
+// contracts/api-viewer-court-current.md. Kept local to the test file
 // because the production response type does not exist yet — the Red
 // state for T052/T053/T055 is that the route is not registered, so
 // the JSON body assertions on this struct will fail because Gin's
 // default no-route returns plain text.
-type courtLiveSide struct {
+type courtCurrentSide struct {
 	PlayerID    string `json:"playerId"`
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`
@@ -27,34 +27,34 @@ type courtLiveSide struct {
 	Number      string `json:"number"`
 }
 
-// courtLiveResponse mirrors the full live/idle response shape from the
+// courtCurrentResponse mirrors the full current/idle response shape from the
 // contract. Fields that don't appear on the idle branch are zero-valued
 // after json.Unmarshal — the assertions read only what each test cares
 // about.
-type courtLiveResponse struct {
+type courtCurrentResponse struct {
 	Court       string `json:"court"`
 	Status      string `json:"status"`
 	Competition *struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"competition,omitempty"`
-	Phase      string         `json:"phase,omitempty"`
-	SideA      *courtLiveSide `json:"sideA,omitempty"`
-	SideB      *courtLiveSide `json:"sideB,omitempty"`
-	IpponsA    []string       `json:"ipponsA,omitempty"`
-	IpponsB    []string       `json:"ipponsB,omitempty"`
-	HansokuA   int            `json:"hansokuA,omitempty"`
-	HansokuB   int            `json:"hansokuB,omitempty"`
-	RepPlayerA string         `json:"repPlayerA,omitempty"`
-	RepPlayerB string         `json:"repPlayerB,omitempty"`
-	Error      string         `json:"error,omitempty"`
+	Phase      string            `json:"phase,omitempty"`
+	SideA      *courtCurrentSide `json:"sideA,omitempty"`
+	SideB      *courtCurrentSide `json:"sideB,omitempty"`
+	IpponsA    []string          `json:"ipponsA,omitempty"`
+	IpponsB    []string          `json:"ipponsB,omitempty"`
+	HansokuA   int               `json:"hansokuA,omitempty"`
+	HansokuB   int               `json:"hansokuB,omitempty"`
+	RepPlayerA string            `json:"repPlayerA,omitempty"`
+	RepPlayerB string            `json:"repPlayerB,omitempty"`
+	Error      string            `json:"error,omitempty"`
 }
 
-// TestCourtLiveReturnsLivePayload — T052
+// TestCourtCurrentReturnsCurrentPayload — T052
 // Setup a tournament with Court A, save a competition, place a match in
-// "running" status on Court A, then GET /api/viewer/court/A/live and
-// assert the contract payload (200 + status=="live" + sides + counts).
-func TestCourtLiveReturnsLivePayload(t *testing.T) {
+// "running" status on Court A, then GET /api/viewer/court/A/current and
+// assert the contract payload (200 + status=="current" + sides + counts).
+func TestCourtCurrentReturnsCurrentPayload(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -90,30 +90,30 @@ func TestCourtLiveReturnsLivePayload(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code,
-		"expected 200 for live match on Court A; got %d body=%q", w.Code, w.Body.String())
+		"expected 200 for current match on Court A; got %d body=%q", w.Code, w.Body.String())
 
-	var resp courtLiveResponse
+	var resp courtCurrentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
 		"response body must be valid JSON: %q", w.Body.String())
-	assert.Equal(t, "live", resp.Status, "status field must be 'live' when a match is running")
+	assert.Equal(t, "current", resp.Status, "status field must be 'current' when a match is running")
 	assert.Equal(t, "A", resp.Court, "court must be normalized to uppercase 'A'")
-	require.NotNil(t, resp.Competition, "competition object must be present on live payload")
+	require.NotNil(t, resp.Competition, "competition object must be present on current payload")
 	assert.Equal(t, "kyu-individual", resp.Competition.ID)
 	assert.NotEmpty(t, resp.Phase, "phase field must be populated (pool name or round label)")
-	require.NotNil(t, resp.SideA, "sideA must be present on live payload")
-	require.NotNil(t, resp.SideB, "sideB must be present on live payload")
+	require.NotNil(t, resp.SideA, "sideA must be present on current payload")
+	require.NotNil(t, resp.SideB, "sideB must be present on current payload")
 	assert.Equal(t, "Takeshi Yamada", resp.SideA.Name)
 	assert.Equal(t, "Ichiro Tanaka", resp.SideB.Name)
 }
 
-// TestCourtLiveSurfacesRepPlayersForDaihyosen — mp-62vr.
+// TestCourtCurrentSurfacesRepPlayersForDaihyosen — mp-62vr.
 // A pool daihyosen bout carries TEAM names in sideA/sideB; the representative
 // fighter for each side lives in repPlayerA/repPlayerB. The polled OBS/vMix
 // endpoint must forward those names or the overlay can't show who is fighting.
-func TestCourtLiveSurfacesRepPlayersForDaihyosen(t *testing.T) {
+func TestCourtCurrentSurfacesRepPlayersForDaihyosen(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -144,25 +144,25 @@ func TestCourtLiveSurfacesRepPlayersForDaihyosen(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code,
-		"expected 200 for live DH match; got %d body=%q", w.Code, w.Body.String())
+		"expected 200 for current DH match; got %d body=%q", w.Code, w.Body.String())
 
-	var resp courtLiveResponse
+	var resp courtCurrentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
 		"response body must be valid JSON: %q", w.Body.String())
-	assert.Equal(t, "live", resp.Status)
+	assert.Equal(t, "current", resp.Status)
 	assert.Equal(t, "Takeshi Yamada", resp.RepPlayerA,
 		"rep-player A must be forwarded for a pool daihyosen bout")
 	assert.Equal(t, "Ichiro Tanaka", resp.RepPlayerB,
 		"rep-player B must be forwarded for a pool daihyosen bout")
 }
 
-// TestCourtLiveReturnsIdleWhenNoLive — T053
+// TestCourtCurrentReturnsIdleWhenNoCurrent — T053
 // Tournament with Court A but no running match — assert
 // 200 + {court:"A", status:"idle"}.
-func TestCourtLiveReturnsIdleWhenNoLive(t *testing.T) {
+func TestCourtCurrentReturnsIdleWhenNoCurrent(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -173,25 +173,25 @@ func TestCourtLiveReturnsIdleWhenNoLive(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code,
 		"expected 200 for idle court A; got %d body=%q", w.Code, w.Body.String())
 
-	var resp courtLiveResponse
+	var resp courtCurrentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
 		"response body must be valid JSON: %q", w.Body.String())
 	assert.Equal(t, "A", resp.Court)
-	assert.Equal(t, "idle", resp.Status, "status must be 'idle' when no live match")
+	assert.Equal(t, "idle", resp.Status, "status must be 'idle' when no current match")
 	assert.Nil(t, resp.Competition, "idle payload must not include competition object")
 	assert.Nil(t, resp.SideA, "idle payload must not include sideA")
 	assert.Nil(t, resp.SideB, "idle payload must not include sideB")
 }
 
-// TestCourtLiveReturns404ForUnknownCourt — T054
+// TestCourtCurrentReturns404ForUnknownCourt — T054
 // Tournament has Courts A,B; GET court Z — assert 404 +
 // error=="court_not_found", court=="Z".
-func TestCourtLiveReturns404ForUnknownCourt(t *testing.T) {
+func TestCourtCurrentReturns404ForUnknownCourt(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -202,12 +202,12 @@ func TestCourtLiveReturns404ForUnknownCourt(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/Z/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/Z/current", nil)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusNotFound, w.Code,
 		"expected 404 for unknown court Z; got %d body=%q", w.Code, w.Body.String())
 
-	var resp courtLiveResponse
+	var resp courtCurrentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
 		"response body must be valid JSON: %q", w.Body.String())
 	assert.Equal(t, "court_not_found", resp.Error,
@@ -216,10 +216,10 @@ func TestCourtLiveReturns404ForUnknownCourt(t *testing.T) {
 		"court field must echo the requested (normalized uppercase) court label")
 }
 
-// TestCourtLiveRespectsZekkenName — T055
+// TestCourtCurrentRespectsZekkenName — T055
 // Competition has withZekkenName=true; GET — assert sideA.displayName
 // equals the zekken (different from name).
-func TestCourtLiveRespectsZekkenName(t *testing.T) {
+func TestCourtCurrentRespectsZekkenName(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -252,16 +252,16 @@ func TestCourtLiveRespectsZekkenName(t *testing.T) {
 	}))
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code,
-		"expected 200 for live match; got %d body=%q", w.Code, w.Body.String())
+		"expected 200 for current match; got %d body=%q", w.Code, w.Body.String())
 
-	var resp courtLiveResponse
+	var resp courtCurrentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
 		"response body must be valid JSON: %q", w.Body.String())
-	require.NotNil(t, resp.SideA, "sideA must be present on live payload")
-	require.NotNil(t, resp.SideB, "sideB must be present on live payload")
+	require.NotNil(t, resp.SideA, "sideA must be present on current payload")
+	require.NotNil(t, resp.SideB, "sideB must be present on current payload")
 	assert.Equal(t, "Takeshi Yamada", resp.SideA.Name)
 	assert.Equal(t, "Yamada", resp.SideA.DisplayName,
 		"displayName must equal the zekken when withZekkenName=true")
@@ -271,9 +271,9 @@ func TestCourtLiveRespectsZekkenName(t *testing.T) {
 		"sideB.displayName must equal the zekken when withZekkenName=true")
 }
 
-// TestCourtLiveReturns503WhenNoTournament — T055a
+// TestCourtCurrentReturns503WhenNoTournament — T055a
 // No tournament loaded; GET — assert 503 + error=="no_active_tournament".
-func TestCourtLiveReturns503WhenNoTournament(t *testing.T) {
+func TestCourtCurrentReturns503WhenNoTournament(t *testing.T) {
 	r, _, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
@@ -281,12 +281,12 @@ func TestCourtLiveReturns503WhenNoTournament(t *testing.T) {
 	// with an empty Store. The contract requires 503 in this case.
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/viewer/court/A/live", nil)
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusServiceUnavailable, w.Code,
 		"expected 503 when no tournament loaded; got %d body=%q", w.Code, w.Body.String())
 
-	var resp courtLiveResponse
+	var resp courtCurrentResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
 		"response body must be valid JSON: %q", w.Body.String())
 	assert.Equal(t, "no_active_tournament", resp.Error,

--- a/internal/mobileapp/handlers_display_test.go
+++ b/internal/mobileapp/handlers_display_test.go
@@ -162,6 +162,43 @@ func TestCourtCurrentReturnsRunningBracketMatch(t *testing.T) {
 	assert.Equal(t, 0, resp.HansokuB)
 }
 
+// TestCourtCurrentEmptyIpponsAreArraysNotNull — Copilot review. An unscored
+// match (here a bracket bout with only a hansoku and no ippons) must encode
+// ipponsA/ipponsB as [] on the wire, not null — the contract models them as
+// arrays and overlay clients assume []. Asserted on the raw body because the
+// test struct's omitempty can't distinguish [] from null.
+func TestCourtCurrentEmptyIpponsAreArraysNotNull(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "secret", Courts: []string{"A"},
+	}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "ko", Name: "Knockout", Status: state.CompStatusPlayoffs, Courts: []string{"A"},
+	}))
+	require.NoError(t, store.SaveBracket("ko", &state.Bracket{
+		Rounds: [][]state.BracketMatch{{
+			{
+				ID: "m-r1-0", SideA: "Aoi", SideB: "Ken",
+				Status: state.MatchStatusRunning, Court: "A",
+				ScoreA: "(H2)", // hansoku only — no ippons → parseScore returns nil
+				ScoreB: "",     // nothing scored yet → nil
+			},
+		}},
+	}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, `"ipponsA":[]`, "nil ippons must encode as [] not null: %q", body)
+	assert.Contains(t, body, `"ipponsB":[]`, "nil ippons must encode as [] not null: %q", body)
+	assert.NotContains(t, body, `"ipponsA":null`)
+	assert.NotContains(t, body, `"ipponsB":null`)
+}
+
 // TestParseScore covers the inverse of engine.formatScore used by the bracket
 // branch of the current-match handler.
 func TestParseScore(t *testing.T) {

--- a/internal/mobileapp/handlers_display_test.go
+++ b/internal/mobileapp/handlers_display_test.go
@@ -306,3 +306,217 @@ func TestPhaseFromMatchID_WithDash(t *testing.T) {
 	assert.Equal(t, "Pool A", phaseFromMatchID("Pool A-0"))
 	assert.Equal(t, "R1", phaseFromMatchID("R1-2"))
 }
+
+// --- Court → matches feed (operator-console data source) ---
+
+// courtMatchesResponse mirrors GET /api/viewer/court/:court/matches. Each entry
+// is the same {config, poolMatches, bracket} per-competition payload the
+// aggregate GET /competitions returns, scoped to comps with a match on the court.
+type courtMatchesResponse struct {
+	Court        string `json:"court"`
+	Competitions []struct {
+		Config struct {
+			ID     string `json:"id"`
+			Name   string `json:"name"`
+			Status string `json:"status"`
+		} `json:"config"`
+		PoolMatches []struct {
+			ID    string `json:"id"`
+			Court string `json:"court"`
+			SideA string `json:"sideA"`
+			SideB string `json:"sideB"`
+		} `json:"poolMatches"`
+		Bracket *struct {
+			Rounds [][]struct {
+				Court string `json:"court"`
+			} `json:"rounds"`
+			Preview bool `json:"preview"`
+		} `json:"bracket"`
+	} `json:"competitions"`
+	Error string `json:"error,omitempty"`
+}
+
+func getCourtMatches(t *testing.T, r http.Handler, court string) (*httptest.ResponseRecorder, courtMatchesResponse) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/viewer/court/"+court+"/matches", nil)
+	r.ServeHTTP(w, req)
+	var resp courtMatchesResponse
+	if w.Body.Len() > 0 {
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp),
+			"response body must be valid JSON: %q", w.Body.String())
+	}
+	return w, resp
+}
+
+func compIDs(resp courtMatchesResponse) []string {
+	out := make([]string, 0, len(resp.Competitions))
+	for _, c := range resp.Competitions {
+		out = append(out, c.Config.ID)
+	}
+	return out
+}
+
+// TestCourtMatches_ListsCompsWithRealMatchOnCourt — a comp with a real pool
+// match on the court appears (with its full per-comp payload); a comp whose
+// match is on another court does not.
+func TestCourtMatches_ListsCompsWithRealMatchOnCourt(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "", Courts: []string{"A", "B"},
+	}))
+
+	onA := state.Competition{ID: "on-a", Name: "Comp On A", Status: state.CompStatusPools, Courts: []string{"A"}}
+	require.NoError(t, store.SaveCompetition(&onA))
+	require.NoError(t, store.SavePoolMatches("on-a", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "P1", SideB: "P2", Status: state.MatchStatusScheduled, Court: "A"},
+	}))
+
+	onB := state.Competition{ID: "on-b", Name: "Comp On B", Status: state.CompStatusPools, Courts: []string{"B"}}
+	require.NoError(t, store.SaveCompetition(&onB))
+	require.NoError(t, store.SavePoolMatches("on-b", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "P3", SideB: "P4", Status: state.MatchStatusScheduled, Court: "B"},
+	}))
+
+	w, resp := getCourtMatches(t, r, "A")
+	require.Equal(t, http.StatusOK, w.Code, "body=%q", w.Body.String())
+	require.Equal(t, []string{"on-a"}, compIDs(resp), "only the comp with a match on A should appear")
+	assert.Equal(t, "Comp On A", resp.Competitions[0].Config.Name)
+	assert.Equal(t, "pools", resp.Competitions[0].Config.Status)
+	require.Len(t, resp.Competitions[0].PoolMatches, 1, "the comp's match data must be included for the queue")
+	assert.Equal(t, "A", resp.Competitions[0].PoolMatches[0].Court)
+}
+
+// TestCourtMatches_ReturnsFullCompMatchDataNotCourtFiltered — the comp's payload
+// includes ALL its matches (both courts), not just the requested court, so
+// client-side derivations like pool "Match N of M" counts stay correct.
+func TestCourtMatches_ReturnsFullCompMatchDataNotCourtFiltered(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "", Courts: []string{"A", "B"},
+	}))
+
+	comp := state.Competition{ID: "spread", Name: "Spread", Status: state.CompStatusPools, Courts: []string{"A", "B"}}
+	require.NoError(t, store.SaveCompetition(&comp))
+	require.NoError(t, store.SavePoolMatches("spread", []state.MatchResult{
+		{ID: "PoolA-0", SideA: "P1", SideB: "P2", Status: state.MatchStatusScheduled, Court: "A"},
+		{ID: "PoolA-1", SideA: "P1", SideB: "P3", Status: state.MatchStatusScheduled, Court: "B"},
+	}))
+
+	_, resp := getCourtMatches(t, r, "A")
+	require.Equal(t, []string{"spread"}, compIDs(resp))
+	require.Len(t, resp.Competitions[0].PoolMatches, 2,
+		"full comp match data (both courts) must be returned so pool counts stay correct")
+}
+
+// TestCourtMatches_FollowsMovedMatchNotConfig — the load-bearing case: a comp
+// configured for court A whose match was MOVED to court B appears under B
+// (actual placement), not A (config).
+func TestCourtMatches_FollowsMovedMatchNotConfig(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "", Courts: []string{"A", "B"},
+	}))
+
+	comp := state.Competition{ID: "moved", Name: "Moved Comp", Status: state.CompStatusPools, Courts: []string{"A"}}
+	require.NoError(t, store.SaveCompetition(&comp))
+	require.NoError(t, store.SavePoolMatches("moved", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "P1", SideB: "P2", Status: state.MatchStatusScheduled, Court: "B"},
+	}))
+
+	_, onA := getCourtMatches(t, r, "A")
+	assert.Empty(t, onA.Competitions, "config-court A must NOT list the comp once its match moved to B")
+
+	_, onB := getCourtMatches(t, r, "B")
+	assert.Equal(t, []string{"moved"}, compIDs(onB), "actual-court B must list the comp whose match was moved there")
+}
+
+// TestCourtMatches_IncludesBracketMatch — a comp whose only match on the court
+// is a (non-preview) bracket match appears, with its bracket payload.
+func TestCourtMatches_IncludesBracketMatch(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "", Courts: []string{"A"},
+	}))
+	comp := state.Competition{ID: "ko", Name: "Knockout", Status: state.CompStatusPlayoffs, Courts: []string{"A"}}
+	require.NoError(t, store.SaveCompetition(&comp))
+	require.NoError(t, store.SaveBracket("ko", &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{{ID: "r0-m0", SideA: "P1", SideB: "P2", Status: state.MatchStatusScheduled, Court: "A"}},
+		},
+	}))
+
+	w, resp := getCourtMatches(t, r, "A")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"ko"}, compIDs(resp))
+	require.NotNil(t, resp.Competitions[0].Bracket, "bracket payload must be present")
+	require.Len(t, resp.Competitions[0].Bracket.Rounds, 1)
+}
+
+// TestCourtMatches_ExcludesPlaceholderOnlyAndPreviewAndSetup — comps whose only
+// court match is an unresolved placeholder, a preview bracket, or that are still
+// in setup, do NOT appear.
+func TestCourtMatches_ExcludesPlaceholderOnlyAndPreviewAndSetup(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "", Courts: []string{"A"},
+	}))
+
+	ph := state.Competition{ID: "ph", Name: "Placeholder", Status: state.CompStatusPlayoffs, Courts: []string{"A"}}
+	require.NoError(t, store.SaveCompetition(&ph))
+	require.NoError(t, store.SaveBracket("ph", &state.Bracket{
+		Rounds: [][]state.BracketMatch{
+			{{ID: "r0-m0", SideA: "Winner of r1-m0", SideB: "Pool A-1st", Status: state.MatchStatusScheduled, Court: "A"}},
+		},
+	}))
+
+	pv := state.Competition{ID: "pv", Name: "Preview", Status: state.CompStatusPools, Courts: []string{"A"}}
+	require.NoError(t, store.SaveCompetition(&pv))
+	require.NoError(t, store.SaveBracket("pv", &state.Bracket{
+		Preview: true,
+		Rounds: [][]state.BracketMatch{
+			{{ID: "r0-m0", SideA: "P1", SideB: "P2", Status: state.MatchStatusScheduled, Court: "A"}},
+		},
+	}))
+
+	su := state.Competition{ID: "su", Name: "Setup", Status: state.CompStatusSetup, Courts: []string{"A"}}
+	require.NoError(t, store.SaveCompetition(&su))
+	require.NoError(t, store.SavePoolMatches("su", []state.MatchResult{
+		{ID: "PoolA-1", SideA: "P1", SideB: "P2", Status: state.MatchStatusScheduled, Court: "A"},
+	}))
+
+	w, resp := getCourtMatches(t, r, "A")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, resp.Competitions,
+		"placeholder-only, preview-bracket, and setup comps must all be excluded; got %v", compIDs(resp))
+}
+
+// TestCourtMatches_UnknownCourtAndNoTournament — 404 for an unknown court, 503
+// when no tournament is loaded (same contract as /court/:court/current).
+func TestCourtMatches_UnknownCourtAndNoTournament(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	w503, resp503 := getCourtMatches(t, r, "A")
+	require.Equal(t, http.StatusServiceUnavailable, w503.Code)
+	assert.Equal(t, "no_active_tournament", resp503.Error)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "T", Password: "", Courts: []string{"A", "B"},
+	}))
+
+	w404, resp404 := getCourtMatches(t, r, "Z")
+	require.Equal(t, http.StatusNotFound, w404.Code)
+	assert.Equal(t, "court_not_found", resp404.Error)
+	assert.Equal(t, "Z", resp404.Court)
+}

--- a/internal/mobileapp/handlers_display_test.go
+++ b/internal/mobileapp/handlers_display_test.go
@@ -13,12 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// courtCurrentSide mirrors the per-side payload defined in
-// contracts/api-viewer-court-current.md. Kept local to the test file
-// because the production response type does not exist yet — the Red
-// state for T052/T053/T055 is that the route is not registered, so
-// the JSON body assertions on this struct will fail because Gin's
-// default no-route returns plain text.
+// courtCurrentSide mirrors the per-side payload the
+// GET /api/viewer/court/:court/current handler builds via buildSide (see
+// handlers_display.go; documented in specs/openapi.yaml). Kept local to the
+// test file because the handler assembles the JSON inline — there is no
+// exported production response type to assert against.
 type courtCurrentSide struct {
 	PlayerID    string `json:"playerId"`
 	Name        string `json:"name"`

--- a/internal/mobileapp/handlers_display_test.go
+++ b/internal/mobileapp/handlers_display_test.go
@@ -108,6 +108,84 @@ func TestCourtCurrentReturnsCurrentPayload(t *testing.T) {
 	assert.Equal(t, "Ichiro Tanaka", resp.SideB.Name)
 }
 
+// TestCourtCurrentReturnsRunningBracketMatch — mp-9h1f follow-up. A running
+// KNOCKOUT (bracket) bout must surface as the court's current match; the prior
+// handler scanned only poolMatches, so an elimination bout read as idle. The
+// bracket persists its running score as the formatted ScoreA/ScoreB string, so
+// the handler parses it back into ippon/hansoku via parseScore.
+func TestCourtCurrentReturnsRunningBracketMatch(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "Test Tournament", Password: "secret", Courts: []string{"A"},
+	}))
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "ko", Name: "Knockout", Status: state.CompStatusPlayoffs, Courts: []string{"A"},
+	}))
+	require.NoError(t, store.SaveParticipants("ko", []domain.Player{
+		{Name: "Aoi Mori", DisplayName: "Aoi Mori", Dojo: "North"},
+		{Name: "Ken Sato", DisplayName: "Ken Sato", Dojo: "South"},
+	}))
+	require.NoError(t, store.SaveBracket("ko", &state.Bracket{
+		Rounds: [][]state.BracketMatch{{
+			{
+				ID:     "m-r1-0",
+				SideA:  "Aoi Mori",
+				SideB:  "Ken Sato",
+				Status: state.MatchStatusRunning,
+				Court:  "A",
+				ScoreA: "MK (H1)", // two ippons + one hansoku
+				ScoreB: "D",       // one ippon
+			},
+		}},
+	}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/viewer/court/A/current", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%q", w.Body.String())
+
+	var resp courtCurrentResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "body=%q", w.Body.String())
+	assert.Equal(t, "current", resp.Status, "running bracket match must be 'current', not idle")
+	require.NotNil(t, resp.Competition)
+	assert.Equal(t, "ko", resp.Competition.ID)
+	require.NotNil(t, resp.SideA)
+	require.NotNil(t, resp.SideB)
+	assert.Equal(t, "Aoi Mori", resp.SideA.Name)
+	assert.Equal(t, "Ken Sato", resp.SideB.Name)
+	// ScoreA/ScoreB parsed back to ippon arrays + hansoku counts.
+	assert.Equal(t, []string{"M", "K"}, resp.IpponsA)
+	assert.Equal(t, 1, resp.HansokuA)
+	assert.Equal(t, []string{"D"}, resp.IpponsB)
+	assert.Equal(t, 0, resp.HansokuB)
+}
+
+// TestParseScore covers the inverse of engine.formatScore used by the bracket
+// branch of the current-match handler.
+func TestParseScore(t *testing.T) {
+	tests := []struct {
+		in      string
+		ippons  []string
+		hansoku int
+	}{
+		{"", nil, 0},
+		{"MK", []string{"M", "K"}, 0},
+		{"MK (H1)", []string{"M", "K"}, 1},
+		{"(H2)", nil, 2},
+		{"D (H1)", []string{"D"}, 1},
+		{"  M K  ", []string{"M", "K"}, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			ippons, hansoku := parseScore(tc.in)
+			assert.Equal(t, tc.ippons, ippons)
+			assert.Equal(t, tc.hansoku, hansoku)
+		})
+	}
+}
+
 // TestCourtCurrentSurfacesRepPlayersForDaihyosen — mp-62vr.
 // A pool daihyosen bout carries TEAM names in sideA/sideB; the representative
 // fighter for each side lives in repPlayerA/repPlayerB. The polled OBS/vMix

--- a/internal/mobileapp/handlers_viewer.go
+++ b/internal/mobileapp/handlers_viewer.go
@@ -92,6 +92,62 @@ var viewerLoadCompetition = func(store *state.Store, compID string) (*state.Comp
 	return store.LoadCompetition(compID)
 }
 
+// buildViewerCompetitionPayload assembles the public per-competition viewer
+// payload ({config, poolMatches, bracket}) shared by the aggregate
+// GET /competitions and the court-scoped GET /court/:court/matches. It applies
+// the identical participant/number merge, preview-bracket strip, queue-position
+// annotation, and audit-field redaction so every PUBLIC surface sees the same
+// non-sensitive data. Returns nil when the competition cannot be loaded.
+func buildViewerCompetitionPayload(store *state.Store, compID string) gin.H {
+	comp, _ := viewerLoadCompetition(store, compID)
+	if comp == nil {
+		return nil
+	}
+	// Only pass HasIDs=true hint; false means unset so auto-detect runs for
+	// competitions created before the flag existed AND for the narrow window
+	// where a deferred HasParticipantIDs flip fails after SaveParticipants
+	// succeeded (file has UUIDs but flag is still false on disk).
+	var hasIDsHint *bool
+	if comp.HasParticipantIDs {
+		t := true
+		hasIDsHint = &t
+	}
+	players, _ := store.LoadParticipantsOpt(compID, comp.WithZekkenName, state.LoadParticipantsOpts{WithSeeds: false, HasIDs: hasIDsHint})
+	comp.Players = players
+
+	// Global views like Scoring/Schedule need matches and brackets.
+	poolMatches, _ := store.LoadPoolMatches(compID)
+	bracket, _ := store.LoadBracket(compID)
+	// mp-13y: merge numberPrefix-derived numbers from pools.csv. Skip the
+	// pools.csv read entirely when no prefix is configured (the common case).
+	if comp.NumberPrefix != "" {
+		pools, _ := store.LoadPools(compID)
+		mergePoolNumbersIntoPlayers(comp, pools)
+	}
+
+	// mp-9dz: a preview bracket carries pool-origin placeholders ("Pool A-1st")
+	// with assigned times. It MUST NOT leak into the public match-list payloads
+	// (Find-My-Matches / Watchlist / global schedule / TV / operator console),
+	// which treat every bracket match as a real, scheduled bout.
+	if bracket != nil && bracket.Preview {
+		bracket = nil
+	}
+
+	// FR-025, T036: derive per-court queue position at serve time.
+	annotateQueuePositions(poolMatches)
+	annotateBracketQueuePositions(bracket)
+
+	// Redact operator-only audit fields before this PUBLIC payload.
+	stripMatchesAudit(poolMatches)
+	stripBracketAudit(bracket)
+
+	return gin.H{
+		"config":      comp,
+		"poolMatches": poolMatches,
+		"bracket":     bracket,
+	}
+}
+
 func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.Engine) {
 	// P2 (mp-9afd): singleflight group for the two expensive viewer read
 	// endpoints. Created once per router setup and shared by all requests
@@ -138,65 +194,13 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 			for i, id := range ids {
 				idx, compID := i, id
 				safeGo(&wg, &panicRef, func() {
-					comp, _ := viewerLoadCompetition(store, compID)
-					if comp == nil {
-						return
-					}
-					// Only pass HasIDs=true hint; false means unset so auto-detect
-					// runs for competitions created before the flag existed AND
-					// for the narrow window where a deferred HasParticipantIDs
-					// flip fails after SaveParticipants succeeded (file has UUIDs
-					// but flag is still false on disk). Pre-fix this site passed
-					// `&hasIDs` (non-nil false) which bypassed auto-detect and
-					// misparsed UUID-prefix rows as plain Name fields. Mirrors
-					// the detail-view pattern at line ~101 and the engine load
-					// pattern in StartCompetition.
-					var hasIDsHint *bool
-					if comp.HasParticipantIDs {
-						t := true
-						hasIDsHint = &t
-					}
-					players, _ := store.LoadParticipantsOpt(compID, comp.WithZekkenName, state.LoadParticipantsOpts{WithSeeds: false, HasIDs: hasIDsHint})
-					comp.Players = players
-
-					// Global views like Scoring/Schedule need matches and brackets
-					poolMatches, _ := store.LoadPoolMatches(compID)
-					bracket, _ := store.LoadBracket(compID)
-					// mp-13y: merge numberPrefix-derived numbers from pools.csv.
-					// Skip the pools.csv read entirely when no prefix is
-					// configured — the common case, and the list endpoint
-					// otherwise loads pools for every competition on every hit.
-					if comp.NumberPrefix != "" {
-						pools, _ := store.LoadPools(compID)
-						mergePoolNumbersIntoPlayers(comp, pools)
-					}
-
-					// mp-9dz: a preview bracket on a mixed source carries pool-
-					// origin placeholders ("Pool A-1st") with scheduled times
-					// assigned by assignBracketMatchSlots. It MUST NOT leak into
-					// the aggregate viewer payload that feeds Find-My-Matches /
-					// Watchlist / global schedule / TV displays — those treat
-					// every bracket match as a real, scheduled bout. Strip it
-					// here so only the per-competition detail endpoint (which
-					// powers the Bracket — preview tab) sees it.
-					if bracket != nil && bracket.Preview {
-						bracket = nil
-					}
-
-					// FR-025, T036: derive per-court queue position at serve time
-					// so viewers see "Next up: 3" without persisting a value that
-					// would go stale the moment any match transitions.
-					annotateQueuePositions(poolMatches)
-					annotateBracketQueuePositions(bracket)
-
-					// Redact operator-only audit fields before this PUBLIC payload.
-					stripMatchesAudit(poolMatches)
-					stripBracketAudit(bracket)
-
-					results[idx] = gin.H{
-						"config":      comp,
-						"poolMatches": poolMatches,
-						"bracket":     bracket,
+					// Shared per-comp builder (also used by the court-scoped
+					// /court/:court/matches feed). A nil payload (comp failed to
+					// load) leaves results[idx] as a nil `any` so the collect
+					// loop below skips it — assigning a nil gin.H directly would
+					// box into a non-nil interface and slip past that filter.
+					if payload := buildViewerCompetitionPayload(store, compID); payload != nil {
+						results[idx] = payload
 					}
 				})
 			}

--- a/internal/mobileapp/handlers_viewer.go
+++ b/internal/mobileapp/handlers_viewer.go
@@ -98,11 +98,35 @@ var viewerLoadCompetition = func(store *state.Store, compID string) (*state.Comp
 // the identical participant/number merge, preview-bracket strip, queue-position
 // annotation, and audit-field redaction so every PUBLIC surface sees the same
 // non-sensitive data. Returns nil when the competition cannot be loaded.
-func buildViewerCompetitionPayload(store *state.Store, compID string) gin.H {
+//
+// courtFilter scopes the result for the court feed: when non-empty, the comp is
+// included ONLY if it is not in setup AND has at least one real match physically
+// on that court (matchesPresentOnCourt). The gate runs off the same
+// poolMatches/bracket this function already loads — no second read. The
+// aggregate passes "" (no filter).
+func buildViewerCompetitionPayload(store *state.Store, compID, courtFilter string) gin.H {
 	comp, _ := viewerLoadCompetition(store, compID)
 	if comp == nil {
 		return nil
 	}
+	// A setup competition exposes no public matches (parity with compMatches in
+	// viewer_utils.jsx, which returns [] for setup), so it never appears on the
+	// court feed. The aggregate (courtFilter == "") still includes it.
+	if courtFilter != "" && comp.Status == state.CompStatusSetup {
+		return nil
+	}
+
+	// Global views like Scoring/Schedule need matches and brackets.
+	poolMatches, _ := store.LoadPoolMatches(compID)
+	bracket, _ := store.LoadBracket(compID)
+
+	// Court feed: drop comps with no real match on the requested court. Checked
+	// on the RAW bracket (before the preview strip below) so a preview bracket
+	// never qualifies a comp for a court.
+	if courtFilter != "" && !matchesPresentOnCourt(poolMatches, bracket, courtFilter) {
+		return nil
+	}
+
 	// Only pass HasIDs=true hint; false means unset so auto-detect runs for
 	// competitions created before the flag existed AND for the narrow window
 	// where a deferred HasParticipantIDs flip fails after SaveParticipants
@@ -114,10 +138,6 @@ func buildViewerCompetitionPayload(store *state.Store, compID string) gin.H {
 	}
 	players, _ := store.LoadParticipantsOpt(compID, comp.WithZekkenName, state.LoadParticipantsOpts{WithSeeds: false, HasIDs: hasIDsHint})
 	comp.Players = players
-
-	// Global views like Scoring/Schedule need matches and brackets.
-	poolMatches, _ := store.LoadPoolMatches(compID)
-	bracket, _ := store.LoadBracket(compID)
 	// mp-13y: merge numberPrefix-derived numbers from pools.csv. Skip the
 	// pools.csv read entirely when no prefix is configured (the common case).
 	if comp.NumberPrefix != "" {
@@ -199,7 +219,7 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 					// load) leaves results[idx] as a nil `any` so the collect
 					// loop below skips it — assigning a nil gin.H directly would
 					// box into a non-nil interface and slip past that filter.
-					if payload := buildViewerCompetitionPayload(store, compID); payload != nil {
+					if payload := buildViewerCompetitionPayload(store, compID, ""); payload != nil {
 						results[idx] = payload
 					}
 				})

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2275,8 +2275,12 @@ paths:
   /api/viewer/court/{court}/current:
     get:
       tags: [viewer]
-      summary: Get current and upcoming matches for a court
-      description: Court display feed. Returns the in-progress match and a queue of upcoming matches for the given court.
+      summary: Get the current running match on a court
+      description: >
+        One-shot polled view for non-browser streaming integrations (vMix, OBS,
+        scoreboards). Returns the single currently-running match on the court in
+        an overlay-friendly shape, or status "idle" when nothing is running.
+        Public, no auth; sent with Cache-Control no-store.
       parameters:
         - in: path
           name: court
@@ -2286,23 +2290,49 @@ paths:
           description: Court label (e.g. "A").
       responses:
         '200':
-          description: Court state.
+          description: >
+            The running match (status "current") or status "idle". The match
+            fields are present only on the "current" branch.
           content:
             application/json:
               schema:
                 type: object
-                required: [court, current, upcoming]
+                required: [court, status]
                 properties:
                   court:
                     type: string
-                  current:
-                    nullable: true
-                    allOf:
-                      - $ref: '#/components/schemas/MatchResult'
-                  upcoming:
+                  status:
+                    type: string
+                    enum: [current, idle]
+                  competition:
+                    type: object
+                    properties:
+                      id: { type: string }
+                      name: { type: string }
+                  phase:
+                    type: string
+                    description: Pool name or round label derived from the match ID.
+                  sideA:
+                    $ref: '#/components/schemas/CourtMatchSide'
+                  sideB:
+                    $ref: '#/components/schemas/CourtMatchSide'
+                  ipponsA:
                     type: array
-                    items:
-                      $ref: '#/components/schemas/MatchResult'
+                    items: { type: string }
+                  ipponsB:
+                    type: array
+                    items: { type: string }
+                  hansokuA: { type: integer }
+                  hansokuB: { type: integer }
+                  repPlayerA:
+                    type: string
+                    description: Representative fighter for a pool daihyosen bout (team names in sideA/sideB); empty otherwise.
+                  repPlayerB:
+                    type: string
+        '404':
+          description: Unknown court.
+        '503':
+          description: No active tournament loaded.
 
   /api/viewer/court/{court}/matches:
     get:
@@ -3120,6 +3150,26 @@ components:
             can restore hantei state and bout-level detail on re-open.
           items:
             $ref: '#/components/schemas/SubMatchResult'
+
+    CourtMatchSide:
+      type: object
+      description: >
+        Per-side overlay payload for GET /api/viewer/court/{court}/current,
+        assembled by buildSide. `name` is the canonical participant/team name;
+        `displayName` is the zekken when withZekkenName is set, else equals name.
+      properties:
+        playerId:
+          type: string
+          description: Participant UUID, or empty when the name could not be resolved.
+        name:
+          type: string
+        displayName:
+          type: string
+        dojo:
+          type: string
+        number:
+          type: string
+          description: numberPrefix-derived competitor number (e.g. "A1"), when configured.
 
     Bracket:
       type: object

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2304,6 +2304,58 @@ paths:
                     items:
                       $ref: '#/components/schemas/MatchResult'
 
+  /api/viewer/court/{court}/matches:
+    get:
+      tags: [viewer]
+      summary: Court-scoped match feed for the operator console
+      description: >
+        Returns the same per-competition payload as GET /api/viewer/competitions
+        (config + poolMatches + bracket), but ONLY for competitions that have at
+        least one real (both-sides-resolved) match — pool or non-preview bracket
+        — physically placed on the given court right now. Keyed on actual match
+        placement (not competition court config) so the feed stays correct after
+        an operator moves a match to another shiaijo. Per-competition match data
+        is full (not court-filtered) so client-side derivations like pool
+        "Match N of M" counts stay correct; the right-sizing is by competition
+        count (only comps on this court). Public, no auth.
+      parameters:
+        - in: path
+          name: court
+          required: true
+          schema:
+            type: string
+          description: Court label (e.g. "A").
+      responses:
+        '200':
+          description: Competitions with a match on the court, full match data each.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [court, competitions]
+                properties:
+                  court:
+                    type: string
+                  competitions:
+                    type: array
+                    items:
+                      type: object
+                      required: [config, poolMatches, bracket]
+                      properties:
+                        config:
+                          $ref: '#/components/schemas/Competition'
+                        poolMatches:
+                          type: array
+                          items:
+                            $ref: '#/components/schemas/MatchResult'
+                        bracket:
+                          nullable: true
+                          $ref: '#/components/schemas/Bracket'
+        '404':
+          description: Unknown court.
+        '503':
+          description: No active tournament loaded.
+
 components:
 
   securitySchemes:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2379,8 +2379,9 @@ paths:
                           items:
                             $ref: '#/components/schemas/MatchResult'
                         bracket:
-                          nullable: true
-                          $ref: '#/components/schemas/Bracket'
+                          anyOf:
+                            - $ref: '#/components/schemas/Bracket'
+                            - type: "null"
         '404':
           description: Unknown court.
         '503':
@@ -3330,9 +3331,10 @@ components:
             type: string
           description: Map of position label to player ID.
         lockedAt:
-          type: string
+          type:
+            - string
+            - "null"
           format: date-time
-          nullable: true
 
     ScheduleEstimate:
       type: object

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2272,7 +2272,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/ScheduleEntry'
 
-  /api/viewer/court/{court}/live:
+  /api/viewer/court/{court}/current:
     get:
       tags: [viewer]
       summary: Get current and upcoming matches for a court

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4986,12 +4986,12 @@ button.pool-match-row {
 
 /* Typeable lineup picker/writer — reuses the .pmf chrome (viewer WatchPicker)
    but sized for the narrow bout row; the dropdown floats above sibling rows. */
-.team-bouts-scroll .lineup-name {
+.lineup-name {
   min-width: 0;
   flex: 1 1 auto;
   margin-bottom: 0;
 }
-.team-bouts-scroll .lineup-name__bar {
+.lineup-name__bar {
   min-height: 36px;
   padding: 4px 6px;
   flex-wrap: nowrap;
@@ -5000,14 +5000,14 @@ button.pool-match-row {
    two sides are already Aka (red) / Shiro per the colour system, so a red
    outline here reads as "both sides are Aka". Use the amber --warn family
    (DESIGN.md Principle 3: amber = attention, never error/running, never red). */
-.team-bouts-scroll .lineup-name--empty .pmf__bar {
+.lineup-name--empty .pmf__bar {
   border-color: var(--warn-border);
 }
-.team-bouts-scroll .lineup-name--empty .pmf__input::placeholder {
+.lineup-name--empty .pmf__input::placeholder {
   color: var(--warn);
   opacity: 0.85;
 }
-.team-bouts-scroll .lineup-name__clear {
+.lineup-name__clear {
   border: none;
   background: transparent;
   cursor: pointer;
@@ -5016,19 +5016,19 @@ button.pool-match-row {
   color: var(--ink-3);
   padding: 0 2px;
 }
-.team-bouts-scroll .lineup-name__clear:hover {
+.lineup-name__clear:hover {
   color: var(--ink-1);
 }
-.team-bouts-scroll .lineup-name__dropdown {
+.lineup-name__dropdown {
   z-index: 60;
   min-width: 200px;
   max-height: 240px;
   overflow-y: auto;
 }
-.team-bouts-scroll .pmf__option--active {
+.pmf__option--active {
   background: var(--surface-2);
 }
-.team-bouts-scroll .lineup-name__add .pmf__opt-name {
+.lineup-name__add .pmf__opt-name {
   color: var(--accent);
   font-weight: 600;
 }

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7882,6 +7882,16 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .shiaijo-qrow__side--aka { flex-direction: row-reverse; text-align: right; }
 .shiaijo-qrow__name { font-weight: 600; font-size: 14px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .shiaijo-qrow__vs { font-size: 11px; color: var(--ink-3); }
+/* Completed result, centred on its own line below the names (the names keep the
+   full-width matchup line so they never crowd in the narrow queue column). */
+.shiaijo-qrow__result {
+  text-align: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--ink);
+  margin-top: 2px;
+}
 
 /* Team encounter score in the queue row: always carries an IV label so a
    bare figure is never shown out of context (a team number could read as

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -4996,12 +4996,16 @@ button.pool-match-row {
   padding: 4px 6px;
   flex-wrap: nowrap;
 }
+/* An unfilled lineup slot is a "fill this" caution, not an error — and the
+   two sides are already Aka (red) / Shiro per the colour system, so a red
+   outline here reads as "both sides are Aka". Use the amber --warn family
+   (DESIGN.md Principle 3: amber = attention, never error/running, never red). */
 .team-bouts-scroll .lineup-name--empty .pmf__bar {
-  border-color: color-mix(in srgb, var(--danger) 50%, transparent);
+  border-color: var(--warn-border);
 }
 .team-bouts-scroll .lineup-name--empty .pmf__input::placeholder {
-  color: var(--danger);
-  opacity: 0.75;
+  color: var(--warn);
+  opacity: 0.85;
 }
 .team-bouts-scroll .lineup-name__clear {
   border: none;

--- a/web-mobile/js/__tests__/admin_lineup.test.jsx
+++ b/web-mobile/js/__tests__/admin_lineup.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { canRevise, rosterFor, teamIdOf, positionsForSize } from '../admin_lineup.jsx';
+import { canRevise, rosterFor, mergeRosterWithAssigned, teamIdOf, positionsForSize } from '../admin_lineup.jsx';
 
 // admin_lineup.jsx ships three module-private helpers that gate the
 // "Revise lineup" flow and normalize the team-shape variants that the
@@ -188,6 +188,70 @@ describe('rosterFor', () => {
   it('returns [] when metadata is not an array (defensive)', () => {
     expect(rosterFor({ metadata: 'not an array' })).toEqual([]);
     expect(rosterFor({ Metadata: { 0: 'wrong shape' } })).toEqual([]);
+  });
+});
+
+describe('mergeRosterWithAssigned', () => {
+  // An operator entering a substitute via the picker's "+ Add …" row stores a
+  // free name that is NOT in team.metadata. Without folding the lineup's
+  // already-assigned names back into the roster, that substitute vanishes from
+  // the autocomplete for the team's other positions.
+
+  it('returns the base roster unchanged when no lineup is given', () => {
+    const base = ['Tanaka', 'Sato'];
+    expect(mergeRosterWithAssigned(base, null)).toEqual(['Tanaka', 'Sato']);
+    expect(mergeRosterWithAssigned(base, undefined)).toEqual(['Tanaka', 'Sato']);
+    expect(mergeRosterWithAssigned(base, {})).toEqual(['Tanaka', 'Sato']);
+  });
+
+  it('appends an added substitute not present in the base roster', () => {
+    const base = ['Tanaka', 'Sato'];
+    const lineup = { positions: { senpo: 'Tanaka', jiho: 'Newcomer' } };
+    expect(mergeRosterWithAssigned(base, lineup)).toEqual(['Tanaka', 'Sato', 'Newcomer']);
+  });
+
+  it('keeps base names first, then extras in first-seen order', () => {
+    const base = ['Tanaka', 'Sato'];
+    const lineup = { positions: { senpo: 'Zeta', taisho: 'Alpha' } };
+    expect(mergeRosterWithAssigned(base, lineup)).toEqual(['Tanaka', 'Sato', 'Zeta', 'Alpha']);
+  });
+
+  it('de-duplicates case-insensitively against base and other extras', () => {
+    const base = ['Tanaka', 'Sato'];
+    const lineup = { positions: { p1: 'tanaka', p2: 'Newcomer', p3: 'NEWCOMER' } };
+    // "tanaka" collides with base "Tanaka"; second "NEWCOMER" collides with the
+    // first "Newcomer" — both dropped.
+    expect(mergeRosterWithAssigned(base, lineup)).toEqual(['Tanaka', 'Sato', 'Newcomer']);
+  });
+
+  it('ignores blank / whitespace-only assignments', () => {
+    const base = ['Tanaka'];
+    const lineup = { positions: { p1: '', p2: '   ', p3: 'Sub' } };
+    expect(mergeRosterWithAssigned(base, lineup)).toEqual(['Tanaka', 'Sub']);
+  });
+
+  it('trims surrounding whitespace on added names', () => {
+    const base = [];
+    const lineup = { positions: { p1: '  Padded  ' } };
+    expect(mergeRosterWithAssigned(base, lineup)).toEqual(['Padded']);
+  });
+
+  it('tolerates a non-array base roster', () => {
+    const lineup = { positions: { p1: 'Solo' } };
+    expect(mergeRosterWithAssigned(null, lineup)).toEqual(['Solo']);
+    expect(mergeRosterWithAssigned(undefined, lineup)).toEqual(['Solo']);
+  });
+
+  it('does not mutate the base roster array', () => {
+    const base = ['Tanaka'];
+    mergeRosterWithAssigned(base, { positions: { p1: 'Sub' } });
+    expect(base).toEqual(['Tanaka']);
+  });
+
+  it('returns the same base array reference when there are no extras (no needless copy)', () => {
+    const base = ['Tanaka', 'Sato'];
+    const lineup = { positions: { senpo: 'Tanaka', jiho: 'Sato' } };
+    expect(mergeRosterWithAssigned(base, lineup)).toBe(base);
   });
 });
 

--- a/web-mobile/js/__tests__/admin_lineup_form.test.jsx
+++ b/web-mobile/js/__tests__/admin_lineup_form.test.jsx
@@ -127,4 +127,39 @@ describe('AdminLineup form (competition-admin Lineups)', () => {
     // Save is enabled here too.
     expect(saveButton(tree).props.disabled).toBeFalsy();
   });
+
+  it('sanitizes the datalist id when teamId falls back to a name with spaces/punctuation', async () => {
+    // No id on the team → teamIdOf falls back to the (messy) name.
+    const tree = await mountFor({ name: 'Team Bravo! (A)' });
+    const inputs = positionInputs(tree);
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const inp of inputs) {
+      // A valid HTML id: no whitespace or punctuation that would break list binding.
+      expect(inp.props.list).toMatch(/^[A-Za-z0-9_-]+$/);
+    }
+  });
+
+  it('trims leading/trailing whitespace before saving (Save without blur)', async () => {
+    let tree = await mountFor({ id: 'uuid-x', name: 'Grouped' });
+    const inp = positionInputs(tree).find(n => n.props['data-testid'] === 'lineup-position-1');
+    inp.props.onChange({ target: { value: '  Padded Name  ' } });
+    tree = runtime.currentTree();
+    saveButton(tree).props.onClick();
+    await Promise.resolve();
+    expect(global.window.API.putTeamLineup).toHaveBeenCalled();
+    // putTeamLineup(compId, teamId, round, positionsOut, password)
+    const positionsOut = global.window.API.putTeamLineup.mock.calls.at(-1)[3];
+    expect(positionsOut['1']).toBe('Padded Name');
+  });
+
+  it('drops a whitespace-only position instead of persisting blanks', async () => {
+    let tree = await mountFor({ id: 'uuid-x', name: 'Grouped' });
+    const inp = positionInputs(tree).find(n => n.props['data-testid'] === 'lineup-position-1');
+    inp.props.onChange({ target: { value: '   ' } });
+    tree = runtime.currentTree();
+    saveButton(tree).props.onClick();
+    await Promise.resolve();
+    const positionsOut = global.window.API.putTeamLineup.mock.calls.at(-1)[3];
+    expect(positionsOut['1']).toBeUndefined();
+  });
 });

--- a/web-mobile/js/__tests__/admin_lineup_form.test.jsx
+++ b/web-mobile/js/__tests__/admin_lineup_form.test.jsx
@@ -3,9 +3,14 @@
 // Regression guard: a team with NO member metadata used to render a fixed
 // <select> limited to roster members, with the Save button disabled when the
 // roster was empty — so for teams formed by grouping individuals (no metadata)
-// the operator could not enter ANY lineup. The form now uses a free-text
-// combobox (<input list> + <datalist>) so any name can be typed, and Save is
+// the operator could not enter ANY lineup. The form now uses LineupNameInput
+// (a typeable autocomplete combobox) so any name can be typed, and Save is
 // no longer gated on the roster being non-empty.
+//
+// Because the test runtime (makeReactive) does NOT recurse into child
+// component bodies, LineupNameInput appears in the tree as a component
+// node with type === LineupNameInput function. Assertions check props on
+// those nodes rather than the inner <input>/<datalist> DOM elements.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { makeReactive } from './helpers/reactive_react.js';
@@ -33,6 +38,15 @@ function findHosts(tree, typeName) {
   return out;
 }
 
+// Find component nodes (where type is a function) by function name.
+function findComponents(tree, name) {
+  const out = [];
+  walk(tree, n => {
+    if (n && typeof n.type === 'function' && n.type.name === name) out.push(n);
+  });
+  return out;
+}
+
 function collectText(node) {
   if (node == null) return '';
   if (typeof node === 'string' || typeof node === 'number') return String(node);
@@ -42,9 +56,6 @@ function collectText(node) {
   return '';
 }
 
-const positionInputs = (tree) =>
-  findHosts(tree, 'input').filter(n => String(n.props?.['data-testid'] || '').startsWith('lineup-position-'));
-
 const saveButton = (tree) =>
   findHosts(tree, 'button').find(b => /Save lineup/.test(collectText(b)));
 
@@ -53,17 +64,56 @@ describe('AdminLineup form (competition-admin Lineups)', () => {
   let AdminLineup;
   let origAPI;
   let origCompMatches;
+  let origAdminLineupHelpers;
 
   const COMP = { id: 'comp-1', name: 'Team Event', kind: 'team', teamSize: 3 };
 
   beforeEach(async () => {
     origAPI = global.window.API;
     origCompMatches = global.window.compMatches;
+    origAdminLineupHelpers = global.window.AdminLineupHelpers;
     global.window.compMatches = () => [];
     global.window.API = {
       fetchTeamLineup: vi.fn().mockResolvedValue(null), // 404 → fresh form
       putTeamLineup: vi.fn().mockResolvedValue({ lockedAt: null }),
     };
+    // mergeRosterWithAssigned must be available for the suggestions computation
+    // in AdminLineup (it reads window.AdminLineupHelpers only in admin_schedule_lineup;
+    // admin_lineup.jsx calls mergeRosterWithAssigned directly from its own scope).
+    // But window.AdminLineupHelpers is used by admin_schedule_lineup — set it up
+    // here in case the module re-exports trigger it.
+    global.window.AdminLineupHelpers = {
+      positionsForSize: (n) => Array.from({ length: n }, (_, i) => ({
+        key: String(i + 1), label: String(i + 1),
+      })),
+      rosterFor: (team) => {
+        if (!team) return [];
+        if (Array.isArray(team.metadata) && team.metadata.length > 0) return team.metadata;
+        if (Array.isArray(team.Metadata) && team.Metadata.length > 0) return team.Metadata;
+        return [];
+      },
+      mergeRosterWithAssigned: (base, lineup) => {
+        const arr = Array.isArray(base) ? base : [];
+        const positions = lineup && lineup.positions ? lineup.positions : null;
+        if (!positions) return arr;
+        const seen = new Set(arr.map(n => String(n).trim().toLowerCase()));
+        const extras = [];
+        for (const raw of Object.values(positions)) {
+          const name = String(raw == null ? '' : raw).trim();
+          if (!name) continue;
+          const key = name.toLowerCase();
+          if (seen.has(key)) continue;
+          seen.add(key);
+          extras.push(name);
+        }
+        return extras.length ? [...arr, ...extras] : arr;
+      },
+      teamIdOf: (team) => team?.id || team?.ID || team?.name || team?.Name || '',
+      canRevise: () => false,
+    };
+    // useClickOutside is needed by LineupNameInput (called via window.useClickOutside).
+    // ui.jsx is loaded by vitest.setup.js, which sets window.useClickOutside.
+    // Nothing extra needed here.
 
     runtime = makeReactive();
     global.React = runtime.React;
@@ -76,6 +126,7 @@ describe('AdminLineup form (competition-admin Lineups)', () => {
     global.React = realReact;
     global.window.API = origAPI;
     global.window.compMatches = origCompMatches;
+    global.window.AdminLineupHelpers = origAdminLineupHelpers;
     vi.resetModules();
   });
 
@@ -89,17 +140,14 @@ describe('AdminLineup form (competition-admin Lineups)', () => {
     return runtime.currentTree();
   }
 
-  it('renders free-text comboboxes (not fixed selects) for a team WITHOUT metadata', async () => {
+  it('renders pickers for a team WITHOUT metadata', async () => {
     const tree = await mountFor({ id: 'uuid-grouped', name: 'Grouped Team' });
 
-    // One input per position (teamSize 3), each a text combobox bound to a datalist.
-    const inputs = positionInputs(tree);
-    expect(inputs.length).toBe(3);
-    for (const inp of inputs) {
-      expect(inp.props.type).toBe('text');
-      expect(inp.props.list).toBeTruthy();
-    }
-    // No <select> position controls remain.
+    // LineupNameInput component nodes — one per position (teamSize 3).
+    const pickers = findComponents(tree, 'LineupNameInput');
+    expect(pickers.length).toBe(3);
+
+    // No host <select> with a data-testid starting "lineup-position-".
     const selects = findHosts(tree, 'select').filter(
       s => String(s.props?.['data-testid'] || '').startsWith('lineup-position-'));
     expect(selects.length).toBe(0);
@@ -114,50 +162,44 @@ describe('AdminLineup form (competition-admin Lineups)', () => {
     expect(collectText(tree)).toContain('type each competitor');
   });
 
-  it('offers the registered roster as datalist suggestions when metadata exists', async () => {
+  it('offers the registered roster as suggestions when metadata exists', async () => {
     const tree = await mountFor({
       id: 'uuid-meta', name: 'Tora', metadata: ['Tanaka', 'Sato', 'Yamada'],
     });
-    const optionValues = findHosts(tree, 'datalist')
-      .flatMap(dl => findHosts(dl, 'option'))
-      .map(o => o.props?.value);
-    expect(optionValues).toContain('Tanaka');
-    expect(optionValues).toContain('Sato');
-    expect(optionValues).toContain('Yamada');
+    // Each LineupNameInput receives the roster as a prop.
+    const pickers = findComponents(tree, 'LineupNameInput');
+    expect(pickers.length).toBeGreaterThan(0);
+    const roster = pickers[0].props.roster;
+    expect(roster).toContain('Tanaka');
+    expect(roster).toContain('Sato');
+    expect(roster).toContain('Yamada');
     // Save is enabled here too.
     expect(saveButton(tree).props.disabled).toBeFalsy();
   });
 
-  it('sanitizes the datalist id when teamId falls back to a name with spaces/punctuation', async () => {
-    // No id on the team → teamIdOf falls back to the (messy) name.
-    const tree = await mountFor({ name: 'Team Bravo! (A)' });
-    const inputs = positionInputs(tree);
-    expect(inputs.length).toBeGreaterThan(0);
-    for (const inp of inputs) {
-      // A valid HTML id: no whitespace or punctuation that would break list binding.
-      expect(inp.props.list).toMatch(/^[A-Za-z0-9_-]+$/);
-    }
-  });
-
-  it('trims leading/trailing whitespace before saving (Save without blur)', async () => {
-    let tree = await mountFor({ id: 'uuid-x', name: 'Grouped' });
-    const inp = positionInputs(tree).find(n => n.props['data-testid'] === 'lineup-position-1');
-    inp.props.onChange({ target: { value: '  Padded Name  ' } });
-    tree = runtime.currentTree();
-    saveButton(tree).props.onClick();
+  it('trims leading/trailing whitespace before saving (onSelect + Save)', async () => {
+    const tree = await mountFor({ id: 'uuid-x', name: 'Grouped' });
+    // Drive the first LineupNameInput's onSelect with a padded name.
+    const pickers = findComponents(tree, 'LineupNameInput');
+    expect(pickers.length).toBeGreaterThan(0);
+    pickers[0].props.onSelect('  Padded  ');
+    const tree2 = runtime.currentTree();
+    saveButton(tree2).props.onClick();
     await Promise.resolve();
     expect(global.window.API.putTeamLineup).toHaveBeenCalled();
     // putTeamLineup(compId, teamId, round, positionsOut, password)
     const positionsOut = global.window.API.putTeamLineup.mock.calls.at(-1)[3];
-    expect(positionsOut['1']).toBe('Padded Name');
+    expect(positionsOut['1']).toBe('Padded');
   });
 
   it('drops a whitespace-only position instead of persisting blanks', async () => {
-    let tree = await mountFor({ id: 'uuid-x', name: 'Grouped' });
-    const inp = positionInputs(tree).find(n => n.props['data-testid'] === 'lineup-position-1');
-    inp.props.onChange({ target: { value: '   ' } });
-    tree = runtime.currentTree();
-    saveButton(tree).props.onClick();
+    const tree = await mountFor({ id: 'uuid-x', name: 'Grouped' });
+    const pickers = findComponents(tree, 'LineupNameInput');
+    expect(pickers.length).toBeGreaterThan(0);
+    // onSelect with whitespace-only string — save() trims to "" and drops it.
+    pickers[0].props.onSelect('   ');
+    const tree2 = runtime.currentTree();
+    saveButton(tree2).props.onClick();
     await Promise.resolve();
     const positionsOut = global.window.API.putTeamLineup.mock.calls.at(-1)[3];
     expect(positionsOut['1']).toBeUndefined();

--- a/web-mobile/js/__tests__/admin_lineup_form.test.jsx
+++ b/web-mobile/js/__tests__/admin_lineup_form.test.jsx
@@ -1,0 +1,130 @@
+// AdminLineup (competition-admin → Lineups) form behaviour.
+//
+// Regression guard: a team with NO member metadata used to render a fixed
+// <select> limited to roster members, with the Save button disabled when the
+// roster was empty — so for teams formed by grouping individuals (no metadata)
+// the operator could not enter ANY lineup. The form now uses a free-text
+// combobox (<input list> + <datalist>) so any name can be typed, and Save is
+// no longer gated on the roster being non-empty.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+
+const realReact = global.React;
+
+function childrenOf(node) {
+  const c = node.children;
+  if (c !== undefined && c !== null && !(Array.isArray(c) && c.length === 0)) return c;
+  return node.props?.children;
+}
+
+// Recurse through both element nodes AND nested arrays (e.g. positions.map()).
+function walk(node, visit) {
+  if (node == null || node === false || node === true) return;
+  if (Array.isArray(node)) { for (const n of node) walk(n, visit); return; }
+  if (typeof node !== 'object') return;
+  visit(node);
+  walk(childrenOf(node), visit);
+}
+
+function findHosts(tree, typeName) {
+  const out = [];
+  walk(tree, n => { if (n && n.type === typeName) out.push(n); });
+  return out;
+}
+
+function collectText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children) return collectText(node.children);
+  if (node.props?.children) return collectText(node.props.children);
+  return '';
+}
+
+const positionInputs = (tree) =>
+  findHosts(tree, 'input').filter(n => String(n.props?.['data-testid'] || '').startsWith('lineup-position-'));
+
+const saveButton = (tree) =>
+  findHosts(tree, 'button').find(b => /Save lineup/.test(collectText(b)));
+
+describe('AdminLineup form (competition-admin Lineups)', () => {
+  let runtime;
+  let AdminLineup;
+  let origAPI;
+  let origCompMatches;
+
+  const COMP = { id: 'comp-1', name: 'Team Event', kind: 'team', teamSize: 3 };
+
+  beforeEach(async () => {
+    origAPI = global.window.API;
+    origCompMatches = global.window.compMatches;
+    global.window.compMatches = () => [];
+    global.window.API = {
+      fetchTeamLineup: vi.fn().mockResolvedValue(null), // 404 → fresh form
+      putTeamLineup: vi.fn().mockResolvedValue({ lockedAt: null }),
+    };
+
+    runtime = makeReactive();
+    global.React = runtime.React;
+    vi.resetModules();
+    ({ AdminLineup } = await import('../admin_lineup.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    global.window.API = origAPI;
+    global.window.compMatches = origCompMatches;
+    vi.resetModules();
+  });
+
+  async function mountFor(team) {
+    runtime.mount(AdminLineup, {
+      comp: COMP, team, round: 0, password: 'pw', showToast: vi.fn(), onClose: vi.fn(),
+    });
+    // Let the mount effect's fetchTeamLineup promise resolve and flip loading.
+    await Promise.resolve();
+    await Promise.resolve();
+    return runtime.currentTree();
+  }
+
+  it('renders free-text comboboxes (not fixed selects) for a team WITHOUT metadata', async () => {
+    const tree = await mountFor({ id: 'uuid-grouped', name: 'Grouped Team' });
+
+    // One input per position (teamSize 3), each a text combobox bound to a datalist.
+    const inputs = positionInputs(tree);
+    expect(inputs.length).toBe(3);
+    for (const inp of inputs) {
+      expect(inp.props.type).toBe('text');
+      expect(inp.props.list).toBeTruthy();
+    }
+    // No <select> position controls remain.
+    const selects = findHosts(tree, 'select').filter(
+      s => String(s.props?.['data-testid'] || '').startsWith('lineup-position-'));
+    expect(selects.length).toBe(0);
+  });
+
+  it('does NOT disable Save when the team has no roster', async () => {
+    const tree = await mountFor({ id: 'uuid-grouped', name: 'Grouped Team' });
+    const btn = saveButton(tree);
+    expect(btn).toBeTruthy();
+    expect(btn.props.disabled).toBeFalsy();
+    // And the hint invites typing names directly.
+    expect(collectText(tree)).toContain('type each competitor');
+  });
+
+  it('offers the registered roster as datalist suggestions when metadata exists', async () => {
+    const tree = await mountFor({
+      id: 'uuid-meta', name: 'Tora', metadata: ['Tanaka', 'Sato', 'Yamada'],
+    });
+    const optionValues = findHosts(tree, 'datalist')
+      .flatMap(dl => findHosts(dl, 'option'))
+      .map(o => o.props?.value);
+    expect(optionValues).toContain('Tanaka');
+    expect(optionValues).toContain('Sato');
+    expect(optionValues).toContain('Yamada');
+    // Save is enabled here too.
+    expect(saveButton(tree).props.disabled).toBeFalsy();
+  });
+});

--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
 import { parsePath, pathFromState } from '../app.jsx';
 import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, isTeamMatch, groupQueueMatches } from '../admin_shiaijo.jsx';
 
@@ -35,6 +36,79 @@ describe('shiaijoScoreCell — team numbers are never context-free', () => {
   it('shows "vs" for a scheduled match regardless of team size', () => {
     expect(shiaijoScoreCell({ status: 'scheduled', teamSize: 5 })).toEqual({ kind: 'vs' });
     expect(shiaijoScoreCell({ status: 'scheduled', teamSize: 0 })).toEqual({ kind: 'vs' });
+  });
+});
+
+// The completed result is rendered on its own centred line BELOW the names
+// (.shiaijo-qrow__result), NOT in the top-right state slot — so the (often long)
+// names keep the full-width matchup line. The state slot carries only "Final".
+describe('ShiaijoQueueRow — completed result placement', () => {
+  const realReact = global.React;
+  let runtime, ShiaijoQueueRow, orig = {};
+
+  function walk(node, visit) {
+    if (node == null || node === false || node === true) return;
+    if (Array.isArray(node)) { for (const n of node) walk(n, visit); return; }
+    if (typeof node !== 'object') return;
+    visit(node);
+    const kids = (node.children !== undefined && node.children !== null && !(Array.isArray(node.children) && !node.children.length))
+      ? node.children : node.props?.children;
+    walk(kids, visit);
+  }
+  const byClass = (tree, cls) => {
+    const out = [];
+    walk(tree, n => { if (n && typeof n.props?.className === 'string' && n.props.className.split(/\s+/).includes(cls)) out.push(n); });
+    return out;
+  };
+  const text = (node) => {
+    if (node == null) return '';
+    if (typeof node === 'string' || typeof node === 'number') return String(node);
+    if (Array.isArray(node)) return node.map(text).join('');
+    if (node.children) return text(node.children);
+    if (node.props?.children) return text(node.props.children);
+    return '';
+  };
+
+  beforeEach(async () => {
+    orig.fmt = window.formatIpponsScore; orig.ip = window.ipponsFromScore; orig.iv = window.teamIVScore;
+    window.formatIpponsScore = () => '·—MK';
+    window.ipponsFromScore = () => [];
+    window.teamIVScore = () => null;
+    runtime = makeReactive();
+    global.React = runtime.React;
+    ({ ShiaijoQueueRow } = await import('../admin_shiaijo.jsx'));
+  });
+  afterEach(() => {
+    runtime.unmount(); global.React = realReact;
+    window.formatIpponsScore = orig.fmt; window.ipponsFromScore = orig.ip; window.teamIVScore = orig.iv;
+  });
+
+  it('puts the score in a centred result line below the names, not the corner', () => {
+    runtime.mount(ShiaijoQueueRow, {
+      m: { id: 'm1', compId: 'c1', status: 'completed', teamSize: 0,
+           sideA: { name: 'Mens Player 01' }, sideB: { name: 'Mens Player 03' } },
+      scheduled: [], courts: ['A'],
+    });
+    const tree = runtime.currentTree();
+    const result = byClass(tree, 'shiaijo-qrow__result');
+    expect(result.length).toBe(1);
+    expect(text(result[0])).toContain('·—MK');
+    // The top-right state slot shows only "Final" — the score is NOT there.
+    const state = byClass(tree, 'shiaijo-qrow__state');
+    expect(state.length).toBe(1);
+    expect(text(state[0])).toContain('Final');
+    expect(text(state[0])).not.toContain('MK');
+  });
+
+  it('shows no result line for a scheduled match (centre stays vs)', () => {
+    runtime.mount(ShiaijoQueueRow, {
+      m: { id: 'm2', compId: 'c1', status: 'scheduled', teamSize: 0,
+           sideA: { name: 'A' }, sideB: { name: 'B' } },
+      scheduled: [], courts: ['A'],
+    });
+    const tree = runtime.currentTree();
+    expect(byClass(tree, 'shiaijo-qrow__result').length).toBe(0);
+    expect(byClass(tree, 'shiaijo-qrow__vs').length).toBe(1);
   });
 });
 

--- a/web-mobile/js/__tests__/match_lineup_side_editor_trim.test.jsx
+++ b/web-mobile/js/__tests__/match_lineup_side_editor_trim.test.jsx
@@ -1,0 +1,123 @@
+// MatchLineupSideEditor (per-match lineup, used by MatchLineupPanel / shiaijo
+// "Enter lineup") must not persist leading/trailing or whitespace-only names
+// now that positions are free-text (LineupNameInput). Copilot review on PR #319:
+// the picker's onSelect stored the raw value into `values`, so save() could PUT
+// untrimmed names. We trim at the selection boundary AND in save() (matching
+// AdminLineup); this test pins the saved positions are trimmed.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+
+const realReact = global.React;
+
+function childrenOf(node) {
+  const c = node.children;
+  if (c !== undefined && c !== null && !(Array.isArray(c) && c.length === 0)) return c;
+  return node.props?.children;
+}
+function walk(node, visit) {
+  if (node == null || node === false || node === true) return;
+  if (Array.isArray(node)) { for (const n of node) walk(n, visit); return; }
+  if (typeof node !== 'object') return;
+  visit(node);
+  walk(childrenOf(node), visit);
+}
+function findHosts(tree, typeName) {
+  const out = [];
+  walk(tree, n => { if (n && n.type === typeName) out.push(n); });
+  return out;
+}
+function findComponents(tree, name) {
+  const out = [];
+  walk(tree, n => { if (n && typeof n.type === 'function' && n.type.name === name) out.push(n); });
+  return out;
+}
+function collectText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join('');
+  if (node.children) return collectText(node.children);
+  if (node.props?.children) return collectText(node.props.children);
+  return '';
+}
+const saveButton = (tree) =>
+  findHosts(tree, 'button').find(b => /Save lineup/.test(collectText(b)));
+
+describe('MatchLineupSideEditor trims names before saving', () => {
+  let runtime, MatchLineupSideEditor;
+  let origAPI, origHelpers, origResolveRound, origCompMatches;
+
+  const COMP = { id: 'comp-1', name: 'Team Event', kind: 'team', teamSize: 3 };
+  const TEAM = { id: 'uuid-grouped', name: 'Grouped Team' }; // no metadata
+  const MATCH = { id: 'match-1', compId: 'comp-1', sideA: { id: 'uuid-grouped', name: 'Grouped Team' }, sideB: { id: 'other', name: 'Other' }, status: 'scheduled' };
+
+  beforeEach(async () => {
+    origAPI = global.window.API;
+    origHelpers = global.window.AdminLineupHelpers;
+    origResolveRound = global.window.resolveRoundIndex;
+    origCompMatches = global.window.compMatches;
+
+    global.window.resolveRoundIndex = () => 0;
+    global.window.compMatches = () => [];
+    global.window.AdminLineupHelpers = {
+      positionsForSize: (n) => Array.from({ length: n }, (_, i) => ({ key: String(i + 1), label: String(i + 1) })),
+      rosterFor: () => [],
+      mergeRosterWithAssigned: (base) => (Array.isArray(base) ? base : []),
+      teamIdOf: (t) => t?.id || t?.name || '',
+    };
+    global.window.API = {
+      fetchMatchLineup: vi.fn().mockResolvedValue(null),
+      fetchTeamLineup: vi.fn().mockResolvedValue(null),
+      putMatchLineup: vi.fn().mockResolvedValue({ positions: {}, lockedAt: null }),
+    };
+
+    runtime = makeReactive();
+    global.React = runtime.React;
+    vi.resetModules();
+    ({ MatchLineupSideEditor } = await import('../admin_schedule_lineup.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    global.window.API = origAPI;
+    global.window.AdminLineupHelpers = origHelpers;
+    global.window.resolveRoundIndex = origResolveRound;
+    global.window.compMatches = origCompMatches;
+    vi.resetModules();
+  });
+
+  async function mount() {
+    runtime.mount(MatchLineupSideEditor, {
+      comp: COMP, team: TEAM, match: MATCH, allMatches: [MATCH], password: 'pw', showToast: vi.fn(),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    return runtime.currentTree();
+  }
+
+  it('trims leading/trailing whitespace from a selected name before PUT', async () => {
+    let tree = await mount();
+    const pickers = findComponents(tree, 'LineupNameInput');
+    expect(pickers.length).toBe(3);
+    pickers[0].props.onSelect('  Padded Name  ');
+    tree = runtime.currentTree();
+    saveButton(tree).props.onClick();
+    await Promise.resolve();
+    expect(global.window.API.putMatchLineup).toHaveBeenCalled();
+    // putMatchLineup(compId, teamId, matchId, positionsOut, ...)
+    const positionsOut = global.window.API.putMatchLineup.mock.calls.at(-1)[3];
+    expect(positionsOut['1']).toBe('Padded Name');
+  });
+
+  it('drops a whitespace-only name rather than persisting blanks', async () => {
+    let tree = await mount();
+    const pickers = findComponents(tree, 'LineupNameInput');
+    pickers[0].props.onSelect('   ');
+    tree = runtime.currentTree();
+    saveButton(tree).props.onClick();
+    await Promise.resolve();
+    const positionsOut = global.window.API.putMatchLineup.mock.calls.at(-1)[3];
+    expect(positionsOut['1']).toBeUndefined();
+  });
+});

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -164,6 +164,10 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
 
   const isLocked = !!lockedAt && !revising;
 
+  // Autocomplete suggestions: the registered roster (if any) plus names already
+  // typed into this lineup, so a name entered once is reusable across positions.
+  const suggestions = mergeRosterWithAssigned(roster, { positions: values });
+
   const save = async () => {
     setError("");
     setSaving(true);
@@ -232,31 +236,43 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
 
       <div className="card" style={{ padding: 16 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-          {positions.map(p => (
-            <label key={p.key} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-              <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink-2)" }}>
-                {p.termId
-                  ? <TermAL name={p.termId}>{p.label}</TermAL>
-                  : p.label}
-              </span>
-              <select
-                data-testid={`lineup-position-${p.key}`}
-                className="input"
-                value={values[p.key] || ""}
-                disabled={isLocked || saving}
-                onChange={(e) => setValues(v => ({ ...v, [p.key]: e.target.value }))}
-                style={{ padding: "6px 8px", fontSize: 14 }}
-              >
-                <option value="">— Select —</option>
-                {roster.map(member => (
-                  <option key={member} value={member}>{member}</option>
-                ))}
-              </select>
-            </label>
-          ))}
+          {positions.map(p => {
+            const listId = `lineup-roster-${teamId}-${p.key}`;
+            return (
+              <label key={p.key} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink-2)" }}>
+                  {p.termId
+                    ? <TermAL name={p.termId}>{p.label}</TermAL>
+                    : p.label}
+                </span>
+                {/* A combobox, not a fixed <select>: many teams carry no member
+                    metadata (the common case when a team is formed by grouping
+                    individual participants), so the operator MUST be able to
+                    type any name. The datalist supplies autocomplete from the
+                    roster plus names already entered in this lineup when
+                    metadata is present, without restricting what can be saved. */}
+                <input
+                  data-testid={`lineup-position-${p.key}`}
+                  className="input"
+                  type="text"
+                  list={listId}
+                  placeholder="Type or pick a name…"
+                  value={values[p.key] || ""}
+                  disabled={isLocked || saving}
+                  onChange={(e) => setValues(v => ({ ...v, [p.key]: e.target.value }))}
+                  style={{ padding: "6px 8px", fontSize: 14 }}
+                />
+                <datalist id={listId}>
+                  {suggestions.map(member => (
+                    <option key={member} value={member} />
+                  ))}
+                </datalist>
+              </label>
+            );
+          })}
           {roster.length === 0 && (
             <div style={{ fontSize: 12, color: "var(--ink-3)", fontStyle: "italic" }}>
-              No roster found on this team. Add member names as metadata in the participant CSV.
+              This team has no registered members — type each competitor's name directly.
             </div>
           )}
         </div>
@@ -277,7 +293,7 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
             <button type="button"
               className="btn btn--primary"
               onClick={save}
-              disabled={saving || roster.length === 0}
+              disabled={saving}
             >
               {saving ? "Saving…" : "Save lineup"}
             </button>

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -63,6 +63,31 @@ function rosterFor(team) {
   return [];
 }
 
+// mergeRosterWithAssigned unions a team's base roster (its registered members,
+// from team.metadata via rosterFor) with any names already assigned in the
+// team's lineup. An operator who enters a substitute via the picker's "+ Add …"
+// row stores a free name that is NOT in team.metadata; without this union that
+// name would never reappear in the autocomplete for the team's OTHER positions.
+// Base (registered) names come first in their original order; extra assigned
+// names follow in first-seen order. De-duplication is case-insensitive; blank /
+// whitespace assignments are ignored. The base array is never mutated.
+function mergeRosterWithAssigned(baseRoster, lineup) {
+  const base = Array.isArray(baseRoster) ? baseRoster : [];
+  const positions = lineup && lineup.positions ? lineup.positions : null;
+  if (!positions) return base;
+  const seen = new Set(base.map(n => String(n).trim().toLowerCase()));
+  const extras = [];
+  for (const raw of Object.values(positions)) {
+    const name = String(raw == null ? "" : raw).trim();
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    extras.push(name);
+  }
+  return extras.length ? [...base, ...extras] : base;
+}
+
 // Resolve the team's stable ID. Backend uses player.id (UUID assigned
 // at first persist); pre-persist teams may not have one yet — fall back
 // to name as a best-effort key.
@@ -340,7 +365,7 @@ if (typeof window !== "undefined") {
   // via window.AdminLineupHelpers without creating a cross-module import
   // dependency (both files are type="module" but share the window object
   // at runtime in the browser and in the esbuild bundle).
-  window.AdminLineupHelpers = { positionsForSize, rosterFor, teamIdOf, canRevise };
+  window.AdminLineupHelpers = { positionsForSize, rosterFor, mergeRosterWithAssigned, teamIdOf, canRevise };
 }
 
-export { AdminLineup, AdminTeamLineupsList, positionsForSize, rosterFor, teamIdOf, canRevise };
+export { AdminLineup, AdminTeamLineupsList, positionsForSize, rosterFor, mergeRosterWithAssigned, teamIdOf, canRevise };

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -177,7 +177,10 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
       // empty values as "missing", which is what we want.
       const positionsOut = {};
       Object.entries(values).forEach(([k, v]) => {
-        if (v) positionsOut[k] = v;
+        // Trim here too (not just onBlur) so a Save triggered without a blur —
+        // e.g. Enter — never persists leading/trailing or whitespace-only names.
+        const trimmed = (v || "").trim();
+        if (trimmed) positionsOut[k] = trimmed;
       });
       const updated = await window.API.putTeamLineup(compId, teamId, round, positionsOut, password);
       setLockedAt(updated.lockedAt || null);
@@ -237,7 +240,11 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
       <div className="card" style={{ padding: 16 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           {positions.map(p => {
-            const listId = `lineup-roster-${teamId}-${p.key}`;
+            // teamId can fall back to the team NAME (spaces/punctuation), which
+            // is not a valid HTML id and would break the input↔datalist binding
+            // in some browsers — sanitize to [A-Za-z0-9_-]. Only one AdminLineup
+            // (one team) renders at a time, so p.key keeps ids unique per form.
+            const listId = `lineup-roster-${teamId}-${p.key}`.replace(/[^a-zA-Z0-9_-]/g, "-");
             return (
               <label key={p.key} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
                 <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink-2)" }}>
@@ -260,6 +267,10 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
                   value={values[p.key] || ""}
                   disabled={isLocked || saving}
                   onChange={(e) => setValues(v => ({ ...v, [p.key]: e.target.value }))}
+                  onBlur={(e) => {
+                    const trimmed = e.target.value.trim();
+                    if (trimmed !== e.target.value) setValues(v => ({ ...v, [p.key]: trimmed }));
+                  }}
                   style={{ padding: "6px 8px", fontSize: 14 }}
                 />
                 <datalist id={listId}>

--- a/web-mobile/js/admin_lineup.jsx
+++ b/web-mobile/js/admin_lineup.jsx
@@ -21,6 +21,8 @@
 // name, its Metadata is the list of member names per the CSV parser at
 // internal/helper/tournament.go).
 
+import { LineupNameInput } from './admin_scoring_shared.jsx';
+
 const { useState: useStateA, useEffect: useEffectA, useMemo: useMemoA } = React;
 
 // Term — kendo-glossary tooltip wrapper. Lazy lookup so the script
@@ -239,48 +241,22 @@ function AdminLineup({ comp, team, round, password, showToast, onClose }) {
 
       <div className="card" style={{ padding: 16 }}>
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-          {positions.map(p => {
-            // teamId can fall back to the team NAME (spaces/punctuation), which
-            // is not a valid HTML id and would break the input↔datalist binding
-            // in some browsers — sanitize to [A-Za-z0-9_-]. Only one AdminLineup
-            // (one team) renders at a time, so p.key keeps ids unique per form.
-            const listId = `lineup-roster-${teamId}-${p.key}`.replace(/[^a-zA-Z0-9_-]/g, "-");
-            return (
-              <label key={p.key} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink-2)" }}>
-                  {p.termId
-                    ? <TermAL name={p.termId}>{p.label}</TermAL>
-                    : p.label}
-                </span>
-                {/* A combobox, not a fixed <select>: many teams carry no member
-                    metadata (the common case when a team is formed by grouping
-                    individual participants), so the operator MUST be able to
-                    type any name. The datalist supplies autocomplete from the
-                    roster plus names already entered in this lineup when
-                    metadata is present, without restricting what can be saved. */}
-                <input
-                  data-testid={`lineup-position-${p.key}`}
-                  className="input"
-                  type="text"
-                  list={listId}
-                  placeholder="Type or pick a name…"
-                  value={values[p.key] || ""}
-                  disabled={isLocked || saving}
-                  onChange={(e) => setValues(v => ({ ...v, [p.key]: e.target.value }))}
-                  onBlur={(e) => {
-                    const trimmed = e.target.value.trim();
-                    if (trimmed !== e.target.value) setValues(v => ({ ...v, [p.key]: trimmed }));
-                  }}
-                  style={{ padding: "6px 8px", fontSize: 14 }}
-                />
-                <datalist id={listId}>
-                  {suggestions.map(member => (
-                    <option key={member} value={member} />
-                  ))}
-                </datalist>
-              </label>
-            );
-          })}
+          {positions.map(p => (
+            <label key={p.key} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink-2)" }}>
+                {p.termId
+                  ? <TermAL name={p.termId}>{p.label}</TermAL>
+                  : p.label}
+              </span>
+              <LineupNameInput
+                value={values[p.key] || ""}
+                roster={suggestions}
+                ariaLabel={`${p.label} player`}
+                disabled={isLocked || saving}
+                onSelect={(name) => setValues(v => ({ ...v, [p.key]: name }))}
+              />
+            </label>
+          ))}
           {roster.length === 0 && (
             <div style={{ fontSize: 12, color: "var(--ink-3)", fontStyle: "italic" }}>
               This team has no registered members — type each competitor's name directly.

--- a/web-mobile/js/admin_schedule_lineup.jsx
+++ b/web-mobile/js/admin_schedule_lineup.jsx
@@ -74,7 +74,7 @@ export function pickCopySource(allMatches, currentMatchId, teamId, savedLineups)
 // teamIdOf) so there is no duplication of position-label / roster logic.
 // The helpers are read lazily on each render so module evaluation order
 // does not matter (safe in test/bundler contexts too).
-function MatchLineupSideEditor({ comp, team, match, allMatches, password, showToast, allowDuringMatch = false }) {
+export function MatchLineupSideEditor({ comp, team, match, allMatches, password, showToast, allowDuringMatch = false }) {
   const teamSize = comp?.teamSize || 5;
   const { positionsForSize: lineupPositionsForSize, rosterFor: lineupRosterFor, teamIdOf: lineupTeamIdOf } = window.AdminLineupHelpers || {};
   const positions = (typeof lineupPositionsForSize === "function")
@@ -215,7 +215,12 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
     // validator treats an absent key the same as an explicit "" — both
     // "missing". Sending explicit empties only bloats the persisted YAML.
     const positionsOut = {};
-    positions.forEach(p => { if (values[p.key]) positionsOut[p.key] = values[p.key]; });
+    positions.forEach(p => {
+      // Trim here too (not only at the picker's onSelect) so a Save can never
+      // persist leading/trailing or whitespace-only names — matches AdminLineup.
+      const v = (values[p.key] || "").trim();
+      if (v) positionsOut[p.key] = v;
+    });
     if (allowDuringMatch && matchStarted) {
       setPendingPositions(positionsOut);
       setShowLineupReasonPrompt(true);
@@ -312,7 +317,7 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
               roster={suggestions}
               ariaLabel={`${p.label} player`}
               disabled={isLocked || saving || copying}
-              onSelect={(name) => setValues(v => ({ ...v, [p.key]: name }))}
+              onSelect={(name) => setValues(v => ({ ...v, [p.key]: (name || "").trim() }))}
             />
           </label>
         ))}

--- a/web-mobile/js/admin_schedule_lineup.jsx
+++ b/web-mobile/js/admin_schedule_lineup.jsx
@@ -1,6 +1,8 @@
 // Per-match lineup components extracted from admin_schedule.jsx (mp-d7tl).
 // pickCopySource, MatchLineupSideEditor (local), MatchLineupPanel.
 
+import { LineupNameInput } from './admin_scoring_shared.jsx';
+
 const { useState: useStateA, useEffect: useEffectA } = React;
 
 // pickCopySource — pure helper that selects the most recent saved lineup
@@ -105,6 +107,9 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
     positions.forEach(p => { init[p.key] = ""; });
     return init;
   });
+  const suggestions = (window.AdminLineupHelpers && typeof window.AdminLineupHelpers.mergeRosterWithAssigned === "function")
+    ? window.AdminLineupHelpers.mergeRosterWithAssigned(roster, { positions: values })
+    : roster;
   const [lockedAt, setLockedAt] = useStateA(null);
   const [loading, setLoading] = useStateA(true);
   const [saving, setSaving] = useStateA(false);
@@ -300,26 +305,20 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 12 }}>
         {positions.map(p => (
-          <label key={p.key} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13 }}>
+          <label key={p.key} data-testid={`match-lineup-pos-${teamId}-${p.key}`} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13 }}>
             <span style={{ minWidth: 72, fontWeight: 600, color: "var(--ink-2)", fontSize: 12 }}>{p.label}</span>
-            <select
-              data-testid={`match-lineup-pos-${teamId}-${p.key}`}
-              className="input"
+            <LineupNameInput
               value={values[p.key] || ""}
+              roster={suggestions}
+              ariaLabel={`${p.label} player`}
               disabled={isLocked || saving || copying}
-              onChange={(e) => setValues(v => ({ ...v, [p.key]: e.target.value }))}
-              style={{ flex: 1, padding: "4px 6px", fontSize: 13 }}
-            >
-              <option value="">— Select —</option>
-              {roster.map(member => (
-                <option key={member} value={member}>{member}</option>
-              ))}
-            </select>
+              onSelect={(name) => setValues(v => ({ ...v, [p.key]: name }))}
+            />
           </label>
         ))}
         {roster.length === 0 && (
           <div style={{ fontSize: 12, color: "var(--ink-3)", fontStyle: "italic" }}>
-            No roster found. Add member names as metadata in the participant CSV.
+            This team has no registered members — type each competitor's name directly.
           </div>
         )}
       </div>
@@ -344,7 +343,7 @@ function MatchLineupSideEditor({ comp, team, match, allMatches, password, showTo
           <button type="button"
             className="btn btn--primary btn--sm"
             onClick={save}
-            disabled={saving || copying || roster.length === 0}
+            disabled={saving || copying}
           >
             {saving ? "Saving…" : "Save lineup"}
           </button>

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -338,7 +338,11 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
     (compMeta?.players?.length ? compMeta.players : null)
     || (compMeta?.config?.players)
     || [];
-  const rosterForSide = (side) => {
+  // lineup is this side's already-assigned positions; mergeRosterWithAssigned
+  // folds any operator-added substitute (a "+ Add …" free name not in
+  // team.metadata) back into the autocomplete so it reappears for the team's
+  // other positions instead of vanishing after a single entry.
+  const rosterForSide = (side, lineup) => {
     if (!window.AdminLineupHelpers?.rosterFor) return [];
     const sideKey = typeof side === "object" ? (side?.id || side?.name) : side;
     const teamObj = allPlayers.find(p => {
@@ -346,7 +350,10 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
       const pname = p?.name || p?.Name || "";
       return pid === sideKey || pname === sideKey;
     });
-    return window.AdminLineupHelpers.rosterFor(teamObj || null);
+    const base = window.AdminLineupHelpers.rosterFor(teamObj || null);
+    return window.AdminLineupHelpers.mergeRosterWithAssigned
+      ? window.AdminLineupHelpers.mergeRosterWithAssigned(base, lineup)
+      : base;
   };
   const teamIdForSide = (side) => {
     const sideKey = typeof side === "object" ? (side?.id || side?.name) : side;
@@ -850,8 +857,8 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
             const lineupPosKey = posKey5 || posKeyN;
             const teamIdB = teamIdForSide(m.sideB); // SHIRO = left
             const teamIdA = teamIdForSide(m.sideA); // AKA = right
-            const rosterB = rosterForSide(m.sideB);
-            const rosterA = rosterForSide(m.sideA);
+            const rosterB = rosterForSide(m.sideB, lineupB);
+            const rosterA = rosterForSide(m.sideA, lineupA);
             const pickPlayer = (teamId, lineup) => (value) => {
               const prev = (lineup?.positions || {})[lineupPosKey] || "";
               // A mid-match substitution (changing or clearing an already-recorded

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -101,6 +101,53 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         return () => { mountedRef.current = false; };
     }, []);
 
+    // mp-9h1f: the operator console is court-first AND cross-competition (the
+    // running bout stays across comps per AC7, the switch nudge watches OTHER
+    // comps on the court per AC6, Submit+Next advances within the submitted
+    // comp). It therefore sources every competition with a match on THIS court
+    // from the dedicated court feed (GET /viewer/court/:court/matches) rather
+    // than the whole-tournament aggregate. app.jsx skips its per-event aggregate
+    // refetch while this view is active (so the operator's tablet stops
+    // re-downloading all courts on every score); this page keeps itself live via
+    // its own court-scoped SSE subscription. Until the first fetch resolves it
+    // falls back to the prop aggregate so the queue is never momentarily blank.
+    const [courtComps, setCourtComps] = useStateSh(null);
+    useEffectSh(() => {
+        if (!court || !window.API || typeof window.API.fetchCourtMatches !== "function") return;
+        let cancelled = false;
+        const timers = new Set();
+        const refresh = () => {
+            window.API.fetchCourtMatches(court)
+                .then(comps => { if (!cancelled && mountedRef.current) setCourtComps(comps); })
+                .catch(err => console.error("Failed to fetch court matches", err));
+        };
+        refresh();
+        let unsub = () => {};
+        if (typeof window.API.subscribeToEvents === "function") {
+            // The feed is court-scoped server-side, so any match/schedule/comp
+            // transition may change this court's queue. Refetch (jittered to
+            // avoid a thundering herd when many operators share the venue LAN).
+            const REFRESH_EVENTS = new Set([
+                "match_updated", "schedule_updated", "competition_started",
+                "competition_completed", "draw_generated", "draw_discarded",
+                "swiss_round_generated", "competitor_status_updated", "participants_updated",
+            ]);
+            const off = window.API.subscribeToEvents((event) => {
+                if (cancelled || !event || !REFRESH_EVENTS.has(event.type)) return;
+                const id = setTimeout(() => { timers.delete(id); if (!cancelled) refresh(); }, 200 + Math.random() * 400);
+                timers.add(id);
+            });
+            unsub = () => { if (typeof off === "function") off(); };
+        }
+        return () => { cancelled = true; timers.forEach(clearTimeout); unsub(); };
+    }, [court]);
+
+    // Court-scoped competitions: the live feed once loaded, else the prop
+    // aggregate as a transient fallback. All competition/match derivations below
+    // read from this so the page operates only on THIS court's competitions.
+    const courtCompetitions = courtComps || tournament.competitions || [];
+    const courtScopedTournament = { ...tournament, competitions: courtCompetitions };
+
     // Selected match for the inline scoring panel. `calledKey` marks the match
     // the operator has announced this session (local cue only); `callingKey`
     // guards the in-flight announce request.
@@ -138,9 +185,9 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     // Same condition as courtKnown below.
     const allMatches = useMemoSh(
         () => (tournament.courts || []).includes(court)
-            ? window.filterMatchesByCourt(window.tournamentMatches(tournament).filter(hasBothSides), court)
+            ? window.filterMatchesByCourt(window.tournamentMatches({ competitions: courtCompetitions }).filter(hasBothSides), court)
             : [],
-        [tournament, court]
+        [courtCompetitions, tournament.courts, court]
     );
     const { sorted, running, scheduled, completed } = useMemoSh(
         () => partitionShiaijoMatches(allMatches),
@@ -157,12 +204,12 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         for (const m of allMatches) {
             if (!seen.has(m.compId)) {
                 seen.add(m.compId);
-                const comp = (tournament.competitions || []).find(c => c.id === m.compId);
+                const comp = courtCompetitions.find(c => c.id === m.compId);
                 out.push({ id: m.compId, name: m.compName || (comp && comp.name) || m.compId });
             }
         }
         return out;
-    }, [allMatches, tournament]);
+    }, [allMatches, courtCompetitions]);
 
     // Effective selected competition — default logic runs when selectedCompId is
     // null or no longer present (e.g. a comp was removed). Priority: running
@@ -754,7 +801,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 
                             {contextMatch && (
                                 <ShiaijoContext
-                                    match={contextMatch} tournament={tournament}
+                                    match={contextMatch} tournament={courtScopedTournament}
                                     court={court} nextPoolName={nextPoolName} tweaks={tweaks}
                                     open={contextOpen} onToggle={() => setContextOpen((v) => !v)}
                                 />

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -105,7 +105,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     // running bout stays across comps per AC7, the switch nudge watches OTHER
     // comps on the court per AC6, Submit+Next advances within the submitted
     // comp). It therefore sources every competition with a match on THIS court
-    // from the dedicated court feed (GET /viewer/court/:court/matches) rather
+    // from the dedicated court feed (GET /api/viewer/court/:court/matches) rather
     // than the whole-tournament aggregate. app.jsx skips its per-event aggregate
     // refetch while this view is active (so the operator's tablet stops
     // re-downloading all courts on every score); this page keeps itself live via

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -836,23 +836,18 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                 </div>
             )}
 
-            {/* Pre-start lineup entry for a team match. Opens the team scoresheet
-                as a modal: the per-position name pickers persist via putMatchLineup
-                independent of scoring, so the operator can set the lineup and close
-                without starting — or hit "Start match" from inside. */}
-            {lineupMatch && (
-                <ScoreEditorModal
+            {/* Pre-start lineup entry for a team match. Opens the dedicated
+                per-match lineup panel: the per-position name pickers persist
+                via putMatchLineup independent of scoring, so the operator can
+                set the lineup and close without starting. */}
+            {lineupMatch && window.MatchLineupPanel && (
+                <window.MatchLineupPanel
                     key={`lineup:${matchKey(lineupMatch)}`}
-                    variant="modal"
                     match={lineupMatch}
-                    canClose={true}
-                    onClose={() => setLineupMatch(null)}
-                    onSubmit={async (patch) => {
-                        try { await onEditScore(lineupMatch.compId, lineupMatch.id, patch, lineupMatch); }
-                        catch (_e) { /* surfaced via toast */ }
-                        if (mountedRef.current) setLineupMatch(null);
-                    }}
+                    tournament={{ competitions: courtCompetitions }}
                     password={password}
+                    showToast={typeof showToast === "function" ? showToast : undefined}
+                    onClose={() => setLineupMatch(null)}
                 />
             )}
         </div>

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -108,9 +108,12 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     // from the dedicated court feed (GET /api/viewer/court/:court/matches) rather
     // than the whole-tournament aggregate. app.jsx skips its per-event aggregate
     // refetch while this view is active (so the operator's tablet stops
-    // re-downloading all courts on every score); this page keeps itself live via
-    // its own court-scoped SSE subscription. Until the first fetch resolves it
-    // falls back to the prop aggregate so the queue is never momentarily blank.
+    // re-downloading all courts on every score); this page instead subscribes to
+    // the tournament-wide /api/events SSE stream, filters to the event TYPES that
+    // can change a court's queue (see REFRESH_EVENTS below), and refetches its
+    // court feed on those — the scoping to one court happens server-side in the
+    // feed, not in the subscription. Until the first fetch resolves it falls back
+    // to the prop aggregate so the queue is never momentarily blank.
     const [courtComps, setCourtComps] = useStateSh(null);
     useEffectSh(() => {
         if (!court || !window.API || typeof window.API.fetchCourtMatches !== "function") return;

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -146,7 +146,6 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
     // aggregate as a transient fallback. All competition/match derivations below
     // read from this so the page operates only on THIS court's competitions.
     const courtCompetitions = courtComps || tournament.competitions || [];
-    const courtScopedTournament = { ...tournament, competitions: courtCompetitions };
 
     // Selected match for the inline scoring panel. `calledKey` marks the match
     // the operator has announced this session (local cue only); `callingKey`
@@ -801,7 +800,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
 
                             {contextMatch && (
                                 <ShiaijoContext
-                                    match={contextMatch} tournament={courtScopedTournament}
+                                    match={contextMatch} competitions={courtCompetitions}
                                     court={court} nextPoolName={nextPoolName} tweaks={tweaks}
                                     open={contextOpen} onToggle={() => setContextOpen((v) => !v)}
                                 />
@@ -1033,8 +1032,8 @@ function MatchSides({ m, large }) {
 //   • pool phase  → live standings + results for the current pool (the shared
 //     read-only window.PoolsViewer), plus which pool is next on this court.
 //   • bracket phase → a bracket fragment with the current match highlighted.
-function ShiaijoContext({ match, tournament, court, nextPoolName, tweaks, open, onToggle }) {
-    const comp = (tournament.competitions || []).find((c) => c.id === match.compId);
+function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open, onToggle }) {
+    const comp = (competitions || []).find((c) => c.id === match.compId);
     const bracket = comp && (comp.bracket || (Array.isArray(comp.rounds) ? { rounds: comp.rounds } : null));
     const isPool = match.phase === "pool";
     const isLeagueComp = match.compFormat === "league";

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -923,7 +923,7 @@ function ShiaijoQueueGroup({ label, matches, subGroup, scheduled, courts, onMove
     );
 }
 
-function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCall, callingKey, calledKey, startingKey }) {
+export function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCall, callingKey, calledKey, startingKey }) {
     const isComplete = m.status === "completed";
     const scoreCell = shiaijoScoreCell(m);
     // Derive position in the full scheduled list to know when to disable ↑/↓.
@@ -951,8 +951,6 @@ function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLin
                         : ""}
                 </span>
                 <span className="shiaijo-qrow__state">
-                    {scoreCell.kind === "team" && <span className="shiaijo-row__teamscore"><abbr className="shiaijo-row__iv" title="Individual Victories">IV</abbr>{scoreCell.iv}</span>}
-                    {scoreCell.kind === "ippon" && scoreCell.ippon}
                     {isComplete && <span className="shiaijo-qrow__final">Final</span>}
                 </span>
             </div>
@@ -967,6 +965,17 @@ function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLin
                     <span className="shiaijo-qrow__name">{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</span>
                 </div>
             </div>
+            {/* Completed result on its own centred line BELOW the names — the
+                canonical "marks in the centre" position, but stacked so the
+                (often long) names keep the full-width line and never crowd. The
+                ippon string is shiro—aka, matching the Shiro-left/Aka-right
+                names above. */}
+            {isComplete && (scoreCell.kind === "ippon" || scoreCell.kind === "team") && (
+                <div className="shiaijo-qrow__result">
+                    {scoreCell.kind === "team" && <span className="shiaijo-row__teamscore"><abbr className="shiaijo-row__iv" title="Individual Victories">IV</abbr>{scoreCell.iv}</span>}
+                    {scoreCell.kind === "ippon" && scoreCell.ippon}
+                </div>
+            )}
             {showActions && (
                 <div className="shiaijo-qrow__actions" onClick={(e) => e.stopPropagation()}>
                     {onMoveCourt && courts.length > 1 && (

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -25,6 +25,21 @@
 
 import { normalizeCompetitionDetail, normalizePlayer, toBackendMatchResult, buildPlayerMetadata } from './api_serializers.jsx';
 
+// normalizeViewerCompItem maps one {config, poolMatches, bracket} item from the
+// aggregate GET /viewer/competitions or the court-scoped GET
+// /viewer/court/:court/matches into the flattened, normalized competition shape
+// the UI consumes (config fields hoisted, players + matches normalized). Shared
+// so both endpoints stay in lockstep.
+function normalizeViewerCompItem(item) {
+    const c = item.config || item;
+    return normalizeCompetitionDetail({
+        ...c,
+        poolMatches: item.poolMatches,
+        bracket: item.bracket,
+        players: (c.players || []).map(normalizePlayer),
+    });
+}
+
 // ---------------------------------------------------------------------------
 // C2: Monotonic per-match revision counter
 // ---------------------------------------------------------------------------
@@ -436,17 +451,25 @@ const API = {
         }
         const comps = await res.json();
         if (!Array.isArray(comps)) return comps;
-        return comps.map(item => {
-            const c = item.config || item;
-            const norm = {
-                ...c,
-                poolMatches: item.poolMatches,
-                bracket: item.bracket,
-                players: (c.players || []).map(normalizePlayer),
-            };
-            // Run normalization on the matches as well
-            return normalizeCompetitionDetail(norm);
-        });
+        return comps.map(normalizeViewerCompItem);
+    },
+
+    // fetchCourtMatches returns the court-scoped match feed: only the
+    // competitions that have a real match physically on `court` right now, each
+    // with its full {config, poolMatches, bracket} payload (same per-comp shape
+    // as fetchCompetitions). The operator console sources its cross-competition
+    // court view from this instead of the whole-tournament aggregate. Returns a
+    // normalized competitions array so callers can run tournamentMatches() over
+    // { competitions } exactly as they do for the aggregate.
+    async fetchCourtMatches(court) {
+        const res = await fetch(`/api/viewer/court/${encodeURIComponent(court)}/matches`);
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || `Failed to fetch court matches (Status ${res.status})`);
+        }
+        const data = await res.json();
+        const comps = Array.isArray(data.competitions) ? data.competitions : [];
+        return comps.map(normalizeViewerCompItem);
     },
     async fetchCompetitionDetails(id) {
         const res = await fetch(`/api/viewer/competitions/${id}`);

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -26,8 +26,8 @@
 import { normalizeCompetitionDetail, normalizePlayer, toBackendMatchResult, buildPlayerMetadata } from './api_serializers.jsx';
 
 // normalizeViewerCompItem maps one {config, poolMatches, bracket} item from the
-// aggregate GET /viewer/competitions or the court-scoped GET
-// /viewer/court/:court/matches into the flattened, normalized competition shape
+// aggregate GET /api/viewer/competitions or the court-scoped GET
+// /api/viewer/court/:court/matches into the flattened, normalized competition shape
 // the UI consumes (config fields hoisted, players + matches normalized). Shared
 // so both endpoints stay in lockstep.
 function normalizeViewerCompItem(item) {

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -371,6 +371,12 @@ function App() {
   }, []);
   const [viewerScreen, setViewerScreen] = useS(initialRoute.viewerScreen || "home"); // home | schedule | glossary | reset | results
   const [adminView, setAdminView] = useS(initialRoute.admin || { kind: "dashboard" });
+  // Mirror adminView into a ref so the long-lived SSE handler (deps
+  // [viewerCompId, mode]) can read the CURRENT admin view without being
+  // recreated on every navigation. Used to skip the per-event aggregate
+  // refetch while the shiaijo operator console is active (mp-9h1f).
+  const adminViewRef = useR(adminView);
+  useE(() => { adminViewRef.current = adminView; }, [adminView]);
   const [toast, setToast] = useS(null);
   // T063: SSE connection status, surfaced to display surfaces so the
   // TV / lobby / overlay can render a reconnect indicator during the
@@ -536,6 +542,16 @@ function App() {
 
   useE(() => { load(); }, []);
 
+  // mp-9h1f: while the shiaijo operator console is active the SSE handler skips
+  // its per-event aggregate refetch (the console keeps itself live via its own
+  // court-scoped feed, so the operator's tablet stops re-downloading every court
+  // on every score). Catch the admin tournament state back up when the operator
+  // navigates to any OTHER admin view, so dashboards / competition pages never
+  // render stale after a stint on the console.
+  useE(() => {
+    if (mode === "admin" && adminView.kind !== "shiaijo") load();
+  }, [adminView.kind]);
+
   useE(() => {
     window.API.fetchAnnouncements()
       .then(list => {
@@ -628,6 +644,19 @@ function App() {
         return id;
     };
 
+    // maybeLoad gates the full-aggregate refetch. While the shiaijo operator
+    // console is the active admin view, skip it: the console sources its
+    // cross-competition court view from its own GET /viewer/court/:court/matches
+    // feed and refreshes itself, so re-pulling the whole-tournament aggregate
+    // here would re-download every other court on the operator's tablet on every
+    // score for no benefit (mp-9h1f). `mode` is fresh (effect dep); the active
+    // admin view is read from the ref so this closure need not be recreated on
+    // navigation. Every other mode/view loads exactly as before.
+    const maybeLoad = () => {
+        if (mode === "admin" && adminViewRef.current && adminViewRef.current.kind === "shiaijo") return;
+        load();
+    };
+
     const unsub = window.API.subscribeToEvents((event) => {
         // P1/P4 (mp-9afd): two jitter windows.
         //   detailJitter — tight (0–500ms) for per-competition detail fetches
@@ -694,7 +723,7 @@ function App() {
             }
             // competitor_status_updated is a list-level event (eligibility
             // badges on the lobby): always refresh the full list.
-            jitteredTimeout(load, listJitter);
+            jitteredTimeout(maybeLoad, listJitter);
         } else if (event.type === "competition_started" || event.type === "match_updated" || event.type === "competition_completed") {
             // Display mode (T060) reads the full tournament tree
             // (every competition's poolMatches + bracket) and needs a
@@ -706,7 +735,7 @@ function App() {
             // thundering the server when many displays are mounted on
             // the same venue LAN.
             if (mode === "display") {
-                jitteredTimeout(load, listJitter);
+                jitteredTimeout(maybeLoad, listJitter);
             } else if (viewerCompId === event.data?.competitionId) {
                 // Apply partial update immediately (match_updated only —
                 // competition_completed has no per-match payload)
@@ -732,7 +761,7 @@ function App() {
             // Display mode is excluded because it already fires load() in the
             // `mode === "display"` block earlier in this same event handler.
             if (mode !== "display" && (event.type === "competition_started" || event.type === "competition_completed" || (event.type === "match_updated" && !viewerCompId))) {
-                jitteredTimeout(load, listJitter);
+                jitteredTimeout(maybeLoad, listJitter);
             }
         } else if (event.type === "schedule_updated") {
             // Court/time move: no competitionId in payload, so refresh the
@@ -740,7 +769,7 @@ function App() {
             if (viewerCompId) {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), detailJitter);
             }
-            jitteredTimeout(load, listJitter);
+            jitteredTimeout(maybeLoad, listJitter);
         } else if (event.type === "draw_generated" || event.type === "draw_discarded") {
             // Draw generated/discarded: refresh the selected competition's
             // details (new pools/bracket data or cleared state) and the
@@ -748,7 +777,7 @@ function App() {
             if (viewerCompId === event.data?.competitionId) {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), detailJitter);
             }
-            jitteredTimeout(load, listJitter);
+            jitteredTimeout(maybeLoad, listJitter);
         } else if (event.type === "swiss_round_generated") {
             // T192 (US13 — FR-050d): a new Swiss round's matches have been
             // generated. The payload carries competitionId + swissCurrentRound
@@ -763,7 +792,7 @@ function App() {
             // swiss_round_generated updates the tournament list (swissCurrentRound
             // counter): always do one list refresh — covers display mode, home-
             // screen viewers, and per-comp viewers alike.
-            jitteredTimeout(load, listJitter);
+            jitteredTimeout(maybeLoad, listJitter);
         } else if (event.type === "participants_updated") {
             // Check-in toggle: viewer-side badges (checked-in indicator) need
             // the updated player list. Refetch the selected competition when the
@@ -772,7 +801,7 @@ function App() {
             if (viewerCompId === event.data?.competitionId) {
                 jitteredTimeout(() => window.API.fetchCompetitionDetails(viewerCompId).then(setSelectedCompData).catch(err => console.error('SSE refresh failed:', err)), detailJitter);
             }
-            jitteredTimeout(load, listJitter);
+            jitteredTimeout(maybeLoad, listJitter);
         } else if (event.type === "lineup_updated") {
             // A team lineup was saved or deleted by an operator. The lineup
             // data is not part of the competition object, so patchCompetitionData

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -542,19 +542,24 @@ function App() {
 
   useE(() => { load(); }, []);
 
-  // mp-9h1f: while the shiaijo operator console is active the SSE handler skips
-  // its per-event aggregate refetch (the console keeps itself live via its own
-  // court-scoped feed, so the operator's tablet stops re-downloading every court
-  // on every score). Catch the admin tournament state back up ONLY when LEAVING
-  // the console for another admin view — fire on a shiaijo→other transition, not
-  // on mount (which the unconditional load() above already covers) nor on
-  // non-shiaijo↔non-shiaijo navigation (which never skipped refetches).
-  const prevAdminKindRef = useR(adminView.kind);
+  // mp-9h1f: while the shiaijo operator console is active (admin mode + shiaijo
+  // view) the SSE handler skips its per-event aggregate refetch — the console
+  // keeps itself live via its own court-scoped feed, so the operator's tablet
+  // stops re-downloading every court on every score. Catch the aggregate back up
+  // whenever we LEAVE that console state, by ANY path: navigating to another
+  // admin view (adminView.kind change) OR switching out of admin mode entirely
+  // (logout, Public-viewer, popstate to a viewer route — all change `mode` while
+  // adminView.kind can stay "shiaijo"). Tracking the combined boolean and
+  // depending on both `mode` and `adminView.kind` closes the mode-change gap. It
+  // does not fire on mount (was===is on the first run) — the unconditional
+  // load() above covers initial load.
+  const wasAdminShiaijoRef = useR(mode === "admin" && adminView.kind === "shiaijo");
   useE(() => {
-    const leftShiaijo = prevAdminKindRef.current === "shiaijo" && adminView.kind !== "shiaijo";
-    prevAdminKindRef.current = adminView.kind;
-    if (mode === "admin" && leftShiaijo) load();
-  }, [adminView.kind]);
+    const isAdminShiaijo = mode === "admin" && adminView.kind === "shiaijo";
+    const leftConsole = wasAdminShiaijoRef.current && !isAdminShiaijo;
+    wasAdminShiaijoRef.current = isAdminShiaijo;
+    if (leftConsole) load();
+  }, [adminView.kind, mode]);
 
   useE(() => {
     window.API.fetchAnnouncements()

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -650,7 +650,7 @@ function App() {
 
     // maybeLoad gates the full-aggregate refetch. While the shiaijo operator
     // console is the active admin view, skip it: the console sources its
-    // cross-competition court view from its own GET /viewer/court/:court/matches
+    // cross-competition court view from its own GET /api/viewer/court/:court/matches
     // feed and refreshes itself, so re-pulling the whole-tournament aggregate
     // here would re-download every other court on the operator's tablet on every
     // score for no benefit (mp-9h1f). `mode` is fresh (effect dep); the active

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -545,11 +545,15 @@ function App() {
   // mp-9h1f: while the shiaijo operator console is active the SSE handler skips
   // its per-event aggregate refetch (the console keeps itself live via its own
   // court-scoped feed, so the operator's tablet stops re-downloading every court
-  // on every score). Catch the admin tournament state back up when the operator
-  // navigates to any OTHER admin view, so dashboards / competition pages never
-  // render stale after a stint on the console.
+  // on every score). Catch the admin tournament state back up ONLY when LEAVING
+  // the console for another admin view — fire on a shiaijo→other transition, not
+  // on mount (which the unconditional load() above already covers) nor on
+  // non-shiaijo↔non-shiaijo navigation (which never skipped refetches).
+  const prevAdminKindRef = useR(adminView.kind);
   useE(() => {
-    if (mode === "admin" && adminView.kind !== "shiaijo") load();
+    const leftShiaijo = prevAdminKindRef.current === "shiaijo" && adminView.kind !== "shiaijo";
+    prevAdminKindRef.current = adminView.kind;
+    if (mode === "admin" && leftShiaijo) load();
   }, [adminView.kind]);
 
   useE(() => {
@@ -670,7 +674,7 @@ function App() {
         const detailJitter = Math.random() * 500;
         const listJitter = Math.random() * 2000;
         if (event.type === "tournament_updated") {
-            if (!authPromptRef.current) jitteredTimeout(load, listJitter);
+            if (!authPromptRef.current) jitteredTimeout(maybeLoad, listJitter);
         } else if (event.type === "password_reset") {
             // The admin password was rotated by someone hitting
             // POST /api/tournament/reset. Any logged-in admin's


### PR DESCRIPTION
## Summary

- **Operator console right-sized.** The shiaijo operator console now sources its cross-competition court view from a new **court-scoped feed** instead of the whole-tournament aggregate. On a multi-competition event the operator's tablet no longer re-downloads every other court on every score anywhere — it pulls only its own court's data.
- **New endpoint** `GET /api/viewer/court/:court/matches` — returns the same per-competition `{config, poolMatches, bracket}` payload as the aggregate, but only for competitions with a real match **physically placed** on that court (keyed on actual placement, so it follows an operator moving a match to another shiaijo). Full per-comp match data is preserved so pool "Match N of M" counts stay correct.
- **Endpoint rename** `GET /api/viewer/court/:court/live` → `/current` (and response `status: "live"` → `"current"`). No `/live` route remains anywhere.
- **Team lineup entry unified** (surfaced while testing the console; folded in): all three lineup surfaces share one `LineupNameInput` picker over the full team roster + free-text "+ Add"; unfilled slots use amber `--warn` (not red, which collided with Aka); the scoring console's "Enter lineup" opens the dedicated per-match panel (`MatchLineupPanel`) instead of the full scoresheet; and the comp-admin Lineups form uses the same picker so teams without member metadata can still have a lineup entered. See Screenshots.

## Why

The operator console is **court-first and cross-competition** by design — the running bout stays put across competitions (AC7), the switch nudge watches other competitions on the court (AC6), and Submit+Next advances within the submitted competition. It was reading the whole-tournament aggregate (measured at ~210–420 KB for 8–12 competitions) and `app.jsx` re-fetched that on *every* `match_updated` tournament-wide. The court feed gives the console exactly the competitions on its court and nothing else; `app.jsx` skips the per-event aggregate refetch while the console is active, and the console keeps its queue current by subscribing to the tournament-wide `/api/events` SSE stream, filtering to the event types that can change a court's queue, and refetching its court feed on those (the court-scoping is server-side in the feed, not in the subscription).

## Files changed

| File | What |
|---|---|
| `internal/mobileapp/handlers_display.go` | Rename `/live`→`/current`; new `/court/:court/matches` feed; `resolveCourt` + pure `matchesPresentOnCourt` helpers |
| `internal/mobileapp/handlers_viewer.go` | Extracted shared `buildViewerCompetitionPayload` (now takes a `courtFilter`) used by both the aggregate and the court feed |
| `internal/mobileapp/handlers_display_test.go` | Rename court tests to `/current`; new court-matches feed contract tests |
| `internal/mobileapp/coverage_gap_test.go` | Rename court coverage tests to `/current` |
| `web-mobile/js/api_client.jsx` | `fetchCourtMatches(court)` + shared `normalizeViewerCompItem` |
| `web-mobile/js/admin_shiaijo.jsx` | Console self-fetches the court feed + page-local scoped SSE; derives queue/selector/nudge from it; `ShiaijoContext` takes a `competitions` prop |
| `web-mobile/js/app.jsx` | `maybeLoad` skips the aggregate refetch while the shiaijo view is active; catch-up `load()` on shiaijo→other navigation |
| `web-mobile/js/admin_lineup.jsx` | Comp-admin Lineups: free-text combobox (was metadata-only `<select>`); `mergeRosterWithAssigned` helper; sanitized datalist id; trim on blur + in save; Save no longer gated on empty roster |
| `web-mobile/js/admin_scoring_team.jsx` | Console lineup picker unions roster with already-assigned names so added substitutes autocomplete |
| `web-mobile/js/admin_shiaijo.jsx` | Completed queue row: result on a centred line below the names (`.shiaijo-qrow__result`), corner shows only "Final"; export `ShiaijoQueueRow` for tests |
| `web-mobile/css/styles.css` | Empty lineup slot indicator: red (`--danger`) → amber (`--warn`); `.shiaijo-qrow__result` centred-result line |
| `web-mobile/js/__tests__/admin_lineup.test.jsx`, `admin_lineup_form.test.jsx` | `mergeRosterWithAssigned` unit tests; AdminLineup form render tests (combobox, Save-not-disabled, datalist suggestions, id sanitization, whitespace trim) |
| `specs/openapi.yaml`, `README.md` | Document the rename + new endpoint |

## Screenshots

![Operator console queue — Shiaijo A, sourced from the court feed](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/319/operator-console-v2.png)

Operator console queue on Shiaijo A, sourced from the court feed: Up Next, Upcoming grouped by round, and Completed. The completed bout's result is **centred on its own line below the names** (`MK—·`) with "Final" in the corner — the long names keep their full-width line.

![Live team match being scored through the console — team scoresheet (sub-bout grid, IV/PW summary, standings), sourced from the court feed](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/319/team-scoring.png)

Live **team match** being scored through the console — the team scoresheet (per-position sub-bout grid, IV/PW summary, standings) renders and scores correctly off the court feed.

### Team lineup entry — unified on one picker (folded into this PR)

All three lineup surfaces now use the **same `LineupNameInput` picker** (typeable autocomplete over the full team roster + "+ Add" free-text, amber for unfilled slots). The full roster is offered regardless of team size — a 7-member team in a 3-position match shows 3 pickers, each listing all 7 members + free-text for substitutes.

**Scoring console (Option 1)** — "Enter lineup" opens the dedicated per-match panel (`MatchLineupPanel`), both teams at once (Shiro left / Aka right), with the shared picker and amber empty slots. Replaces the heavy full scoresheet that was opened just to set names.

![Scoring console — per-match lineup panel, both teams](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/319/lineup-scoring-panel.png)

**Competition admin → Lineups (Option 2)** — single-team form using the **same picker** (identical computed style to the scoring console). Teams with no member metadata can still have a lineup entered (free-text), and Save is no longer disabled on an empty roster. Dropdown shows the roster autocomplete + "+ Add".

![Competition admin Lineups — same picker, autocomplete dropdown](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/319/lineup-comp-admin.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — `mobileapp` 85.6%
- [x] New/updated unit tests cover the change — court-matches feed contract tests (real-match listing, full-comp-data-not-court-filtered, moved-match-follows-placement, bracket-only, placeholder/preview/setup exclusion, 404/503); `/current` rename tests
- [x] Manual browser verification — drove **real scoring through the console UI off the court feed** for every match kind on one court (verified against the backend each time):
    - **Individual pool**: start → M+K → confirm → `completed`, winner persisted.
    - **Individual knockout (bracket)**: start → M+K → confirm → `completed` AND winner **advanced into round 2** (bracket propagation intact).
    - **Team**: start → team scoresheet → sub-bout scored, persisted to `subResults`.
    - Plus: selector lists all comps from the feed, pool "Match N of M" counts correct, comp-switch filters standings cleanly, a scored match propagated via **one court-feed refetch + zero aggregate refetch** (instrumented `fetch`), and **no console errors** throughout.
- [x] Team lineup unification verified in-browser: scoring console "Enter lineup" opens `MatchLineupPanel` (both teams, shared picker, amber empties); comp-admin Lineups uses the same picker (computed style identical — 36px bar, 8px radius, 13px) with roster autocomplete + "+ Add"; empty slots amber (`#fde68a`); a free-typed name persists to `lineups.yaml`. Covered by `admin_lineup.test.jsx`, `admin_lineup_form.test.jsx`, `match_lineup_side_editor_trim.test.jsx`.
- [x] Completed queue row verified: the result renders in a centred `.shiaijo-qrow__result` line below the names (not the corner, which holds only "Final"); scheduled rows keep the centre "vs" and show no result line. Covered by `admin_shiaijo.test.jsx` render tests; browser-verified.
- [x] Screenshots added above

Closes mp-9h1f

🤖 Generated with [Claude Code](https://claude.com/claude-code)






