### PR TITLE
fix(participants)+feat(settings): roster fixes, clearer next step, manual-save settings

### DIFF
--- a/internal/engine/schedule_clash.go
+++ b/internal/engine/schedule_clash.go
@@ -1,0 +1,159 @@
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// MinClashFootprintMinutes is the minimum time footprint assigned to a
+// competition for court-clash detection. A competition's real duration comes
+// from its schedule estimate, which is ~0 before it has a roster; flooring at
+// this value means even empty competitions occupy a slot, so overlaps are
+// caught while the operator is still laying out the schedule. Mirrors the
+// create-form auto-stack minimum block (MIN_STACK_BLOCK_MIN in admin_setup.jsx).
+const MinClashFootprintMinutes = 30
+
+// ClashWarning describes a court (shiaijo) scheduling conflict between the
+// queried competition and another competition: they run on the same date,
+// share at least one court, and their time windows overlap.
+type ClashWarning struct {
+	OtherCompID   string   `json:"otherCompId"`
+	OtherCompName string   `json:"otherCompName"`
+	Date          string   `json:"date"`
+	SharedCourts  []string `json:"sharedCourts"`
+	OverlapStart  string   `json:"overlapStart"` // HH:MM
+	OverlapEnd    string   `json:"overlapEnd"`   // HH:MM
+}
+
+// DetectClashesForCompetition returns the court-scheduling clashes between the
+// competition identified by compID and every other competition. Two
+// competitions clash when they share a date, share at least one court, and
+// their [start, start+footprint) windows overlap. Footprint is
+// max(estimated duration, MinClashFootprintMinutes).
+//
+// Returns an empty (non-nil) slice when there are no clashes. A competition
+// that cannot be placed on a timeline — no date or an unparseable start time —
+// is skipped rather than reported. Clashes are sorted by the other
+// competition's name for a stable UI/test order.
+func (e *Engine) DetectClashesForCompetition(compID string) ([]ClashWarning, error) {
+	target, err := e.store.LoadCompetition(compID)
+	if err != nil {
+		return nil, err
+	}
+	if target == nil {
+		return nil, notFoundErrorf("competition %s not found", compID)
+	}
+
+	out := []ClashWarning{}
+
+	tStart, ok := parseHHMM(target.StartTime)
+	if !ok || strings.TrimSpace(target.Date) == "" {
+		// Target can't be placed on a timeline → nothing to compare against.
+		return out, nil
+	}
+	tEnd := tStart + e.clashFootprintMinutes(compID)
+
+	ids, err := e.store.ListCompetitions()
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		if id == compID {
+			continue
+		}
+		other, err := e.store.LoadCompetition(id)
+		if err != nil || other == nil {
+			// Skip an unreadable competition rather than failing the whole
+			// check — a single bad file shouldn't hide every other clash.
+			continue
+		}
+		if !sameDate(target.Date, other.Date) {
+			continue
+		}
+		shared := sharedCourts(target.Courts, other.Courts)
+		if len(shared) == 0 {
+			continue
+		}
+		oStart, ok := parseHHMM(other.StartTime)
+		if !ok {
+			continue
+		}
+		oEnd := oStart + e.clashFootprintMinutes(id)
+		// Half-open overlap: [tStart,tEnd) ∩ [oStart,oEnd) is non-empty.
+		if tStart < oEnd && oStart < tEnd {
+			out = append(out, ClashWarning{
+				OtherCompID:   other.ID,
+				OtherCompName: other.Name,
+				Date:          other.Date,
+				SharedCourts:  shared,
+				OverlapStart:  fmtHHMM(max(tStart, oStart)),
+				OverlapEnd:    fmtHHMM(min(tEnd, oEnd)),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].OtherCompName < out[j].OtherCompName })
+	return out, nil
+}
+
+// clashFootprintMinutes is the time a competition occupies for clash detection:
+// max(estimated total duration, MinClashFootprintMinutes). It never errors — an
+// estimate failure (config issue / missing roster) falls back to the floor so a
+// single un-estimatable competition can't break the whole clash check.
+func (e *Engine) clashFootprintMinutes(compID string) int {
+	est, err := e.EstimateScheduleForCompetition(compID)
+	if err != nil || est.TotalDurationMinutes < MinClashFootprintMinutes {
+		return MinClashFootprintMinutes
+	}
+	return est.TotalDurationMinutes
+}
+
+// parseHHMM parses a "HH:MM" clock string into minutes-since-midnight. Returns
+// ok=false for empty or malformed input (so callers can skip unplaceable
+// competitions rather than treating them as midnight).
+func parseHHMM(s string) (int, bool) {
+	parts := strings.SplitN(strings.TrimSpace(s), ":", 2)
+	if len(parts) != 2 {
+		return 0, false
+	}
+	h, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+	m, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err1 != nil || err2 != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+// fmtHHMM renders minutes-since-midnight as "HH:MM" (wrapping at 24h).
+func fmtHHMM(mins int) string {
+	if mins < 0 {
+		mins = 0
+	}
+	return fmt.Sprintf("%02d:%02d", (mins/60)%24, mins%60)
+}
+
+// sameDate is true when both dates are non-empty and equal (after trimming).
+// An empty date means the competition isn't placed on a day, so it can't clash.
+func sameDate(a, b string) bool {
+	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
+	return a != "" && a == b
+}
+
+// sharedCourts returns the sorted intersection of two court-label lists.
+func sharedCourts(a, b []string) []string {
+	inA := make(map[string]bool, len(a))
+	for _, c := range a {
+		inA[c] = true
+	}
+	seen := make(map[string]bool)
+	out := []string{}
+	for _, c := range b {
+		if inA[c] && !seen[c] {
+			out = append(out, c)
+			seen[c] = true
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/engine/schedule_clash.go
+++ b/internal/engine/schedule_clash.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
 // MinClashFootprintMinutes is the minimum time footprint assigned to a
@@ -55,6 +57,15 @@ func (e *Engine) DetectClashesForCompetition(compID string) ([]ClashWarning, err
 	}
 	tEnd := tStart + e.clashFootprintMinutes(compID)
 
+	// Resolve courts the same way the draw paths do: an empty competition
+	// court list inherits the tournament's courts (or ["A"]). Without this a
+	// legacy competition saved before court materialization — nil Courts —
+	// would silently never clash even though at draw time it occupies a real
+	// court. A LoadTournament failure leaves tourn nil; resolveClashCourts
+	// then falls back to ["A"], matching resolveCompetitionCourts.
+	tourn, _ := e.store.LoadTournament()
+	targetCourts := resolveClashCourts(target.Courts, tourn)
+
 	ids, err := e.store.ListCompetitions()
 	if err != nil {
 		return nil, err
@@ -72,7 +83,7 @@ func (e *Engine) DetectClashesForCompetition(compID string) ([]ClashWarning, err
 		if !sameDate(target.Date, other.Date) {
 			continue
 		}
-		shared := sharedCourts(target.Courts, other.Courts)
+		shared := sharedCourts(targetCourts, resolveClashCourts(other.Courts, tourn))
 		if len(shared) == 0 {
 			continue
 		}
@@ -125,12 +136,29 @@ func parseHHMM(s string) (int, bool) {
 	return h*60 + m, true
 }
 
-// fmtHHMM renders minutes-since-midnight as "HH:MM" (wrapping at 24h).
+// fmtHHMM renders minutes-since-midnight as "HH:MM". It does NOT wrap at 24h:
+// a footprint that pushes the overlap end past midnight renders as "24:15"
+// rather than a misleading "00:15", so an operator reading the warning sees
+// the next-day rollover. The value is display-only — no caller parses it back.
 func fmtHHMM(mins int) string {
 	if mins < 0 {
 		mins = 0
 	}
-	return fmt.Sprintf("%02d:%02d", (mins/60)%24, mins%60)
+	return fmt.Sprintf("%02d:%02d", mins/60, mins%60)
+}
+
+// resolveClashCourts mirrors resolveCompetitionCourts (handlers_tournament.go):
+// an empty competition court list inherits the tournament's courts, falling
+// back to ["A"] when there is no tournament. Kept as a separate engine-local
+// copy because internal/engine cannot import internal/mobileapp (import cycle).
+func resolveClashCourts(compCourts []string, tourn *state.Tournament) []string {
+	if len(compCourts) > 0 {
+		return compCourts
+	}
+	if tourn != nil && len(tourn.Courts) > 0 {
+		return append([]string(nil), tourn.Courts...)
+	}
+	return []string{"A"}
 }
 
 // sameDate is true when both dates are non-empty and equal (after trimming).
@@ -141,17 +169,18 @@ func sameDate(a, b string) bool {
 }
 
 // sharedCourts returns the sorted intersection of two court-label lists.
+// Deleting matched entries from the set as we go both de-dups (a repeated
+// label in b is only emitted once) and avoids a second bookkeeping map.
 func sharedCourts(a, b []string) []string {
-	inA := make(map[string]bool, len(a))
+	inA := make(map[string]struct{}, len(a))
 	for _, c := range a {
-		inA[c] = true
+		inA[c] = struct{}{}
 	}
-	seen := make(map[string]bool)
 	out := []string{}
 	for _, c := range b {
-		if inA[c] && !seen[c] {
+		if _, ok := inA[c]; ok {
 			out = append(out, c)
-			seen[c] = true
+			delete(inA, c)
 		}
 	}
 	sort.Strings(out)

--- a/internal/engine/schedule_clash_test.go
+++ b/internal/engine/schedule_clash_test.go
@@ -1,0 +1,128 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// emptyComp saves a roster-less competition so its clash footprint resolves to
+// the MinClashFootprintMinutes floor (estimate is ~0 with no participants).
+func emptyComp(t *testing.T, store *state.Store, id, name, date, start string, courts []string) {
+	t.Helper()
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:        id,
+		Name:      name,
+		Format:    state.CompFormatPlayoffs,
+		Kind:      "individual",
+		Date:      date,
+		StartTime: start,
+		Courts:    courts,
+		Status:    state.CompStatusSetup,
+	}))
+}
+
+func TestDetectClashes_UnknownComp(t *testing.T) {
+	eng, _, _ := setupTestEngine(t)
+	_, err := eng.DetectClashesForCompetition("nope")
+	require.Error(t, err)
+	var nfe *NotFoundError
+	assert.ErrorAs(t, err, &nfe)
+}
+
+func TestDetectClashes_OverlapSameCourt(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// Empty comps → 30-min footprint each. A 09:00 and 09:15 both on court A
+	// overlap (09:00–09:30 vs 09:15–09:45).
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", []string{"A"})
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:15", []string{"A"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	require.Len(t, clashes, 1)
+	assert.Equal(t, "b", clashes[0].OtherCompID)
+	assert.Equal(t, "Bravo", clashes[0].OtherCompName)
+	assert.Equal(t, []string{"A"}, clashes[0].SharedCourts)
+	// Overlap window = [max(09:00,09:15), min(09:30,09:45)] = 09:15–09:30.
+	assert.Equal(t, "09:15", clashes[0].OverlapStart)
+	assert.Equal(t, "09:30", clashes[0].OverlapEnd)
+}
+
+func TestDetectClashes_NoOverlapWhenSequential(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// 30-min footprints back-to-back: 09:00–09:30 and 09:30–10:00 do NOT
+	// overlap (half-open windows touch but don't intersect).
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", []string{"A"})
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:30", []string{"A"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	assert.Empty(t, clashes)
+}
+
+func TestDetectClashes_DifferentCourtsNoClash(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", []string{"A"})
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:00", []string{"B"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	assert.Empty(t, clashes, "same time + same day but disjoint courts must not clash")
+}
+
+func TestDetectClashes_DifferentDaysNoClash(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", []string{"A"})
+	emptyComp(t, store, "b", "Bravo", "02-07-2026", "09:00", []string{"A"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	assert.Empty(t, clashes, "same court + same time but different days must not clash")
+}
+
+func TestDetectClashes_PartialCourtOverlapReportsShared(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", []string{"A", "B"})
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:10", []string{"B", "C"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	require.Len(t, clashes, 1)
+	assert.Equal(t, []string{"B"}, clashes[0].SharedCourts, "only the shared court is reported")
+}
+
+func TestDetectClashes_UnplaceableTargetReturnsEmpty(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// Target has no date → cannot be placed → no clashes even though a same-time
+	// competition exists on the same court.
+	emptyComp(t, store, "a", "Alpha", "", "09:00", []string{"A"})
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:00", []string{"A"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	assert.Empty(t, clashes)
+}
+
+func TestDetectClashes_RosteredFootprintExtendsWindow(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// Alpha gets a roster so its real estimate exceeds the 30-min floor and its
+	// window stretches to overlap a competition that starts 40 min later.
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "a", Name: "Alpha", Format: state.CompFormatPlayoffs, Kind: "individual",
+		Date: "01-07-2026", StartTime: "09:00", Courts: []string{"A"},
+		PoolMatchDuration: 3, PlayoffMatchDuration: 5, Status: state.CompStatusSetup,
+	}))
+	saveTestParticipants(t, store, "a", []string{"P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"})
+	est, err := eng.EstimateScheduleForCompetition("a")
+	require.NoError(t, err)
+	require.Greater(t, est.TotalDurationMinutes, 40, "test assumes Alpha's estimate exceeds 40m")
+
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:40", []string{"A"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	require.Len(t, clashes, 1, "Alpha's rostered window must reach Bravo at 09:40")
+	assert.Equal(t, "b", clashes[0].OtherCompID)
+}

--- a/internal/engine/schedule_clash_test.go
+++ b/internal/engine/schedule_clash_test.go
@@ -105,6 +105,61 @@ func TestDetectClashes_UnplaceableTargetReturnsEmpty(t *testing.T) {
 	assert.Empty(t, clashes)
 }
 
+func TestDetectClashes_NilCourtsResolveToDefault(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// Two competitions with NO explicit courts (nil) — legacy data saved before
+	// court materialization. Both must resolve to the default ["A"] (no tournament
+	// saved) and therefore clash at the same date/time, rather than being silently
+	// skipped because their court lists are empty.
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", nil)
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:00", nil)
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	require.Len(t, clashes, 1, "nil-courts competitions must resolve to a default court and clash")
+	assert.Equal(t, []string{"A"}, clashes[0].SharedCourts)
+}
+
+func TestDetectClashes_NilCourtsInheritTournamentCourts(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// With a tournament present, nil competition courts inherit the tournament's
+	// courts (mirrors resolveCompetitionCourts at draw time).
+	require.NoError(t, store.SaveTournament(&state.Tournament{Courts: []string{"X", "Y"}}))
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "09:00", nil)
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "09:00", nil)
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	require.Len(t, clashes, 1)
+	assert.Equal(t, []string{"X", "Y"}, clashes[0].SharedCourts,
+		"nil-courts competitions must inherit the tournament's courts")
+}
+
+func TestFmtHHMM_NoMidnightWrap(t *testing.T) {
+	// Times past midnight must render as 24:xx / 25:xx, NOT wrap to 00:xx, so an
+	// operator reading the clash warning sees the next-day rollover.
+	assert.Equal(t, "24:15", fmtHHMM(24*60+15))
+	assert.Equal(t, "25:00", fmtHHMM(25*60))
+	assert.Equal(t, "00:00", fmtHHMM(0))
+	assert.Equal(t, "00:00", fmtHHMM(-5), "negative clamps to 00:00")
+	assert.Equal(t, "23:59", fmtHHMM(23*60+59))
+}
+
+func TestDetectClashes_PastMidnightOverlapEndNoWrap(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	// Both start late: 23:50 + 30-min floor = 24:20. The overlap end must render
+	// "24:10" (min(24:20, 24:15)), not a misleading "00:10".
+	emptyComp(t, store, "a", "Alpha", "01-07-2026", "23:50", []string{"A"})
+	emptyComp(t, store, "b", "Bravo", "01-07-2026", "23:45", []string{"A"})
+
+	clashes, err := eng.DetectClashesForCompetition("a")
+	require.NoError(t, err)
+	require.Len(t, clashes, 1)
+	// Windows: Alpha 23:50–24:20, Bravo 23:45–24:15. Overlap = 23:50–24:15.
+	assert.Equal(t, "23:50", clashes[0].OverlapStart)
+	assert.Equal(t, "24:15", clashes[0].OverlapEnd)
+}
+
 func TestDetectClashes_RosteredFootprintExtendsWindow(t *testing.T) {
 	eng, store, _ := setupTestEngine(t)
 	// Alpha gets a roster so its real estimate exceeds the 30-min floor and its

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -566,6 +566,30 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.JSON(http.StatusOK, estimate)
 	})
 
+	// GET /competitions/:id/schedule/clashes — court (shiaijo) scheduling
+	// conflicts between this competition and every other one (same day, shared
+	// court, overlapping time windows). Read-only, main-password gated. Returns
+	// a (possibly empty) ClashWarning array; 404 for an unknown competition.
+	// Non-blocking by design: the SPA surfaces these as a warning after a
+	// settings save / create, it does not reject the save. (mp-4a52)
+	r.GET("/competitions/:id/schedule/clashes", func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+		clashes, err := eng.DetectClashesForCompetition(id)
+		if err != nil {
+			var notFound *engine.NotFoundError
+			if errors.As(err, &notFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, clashes)
+	})
+
 	r.PUT("/competitions/:id", func(c *gin.Context) {
 		id, ok := requireValidCompID(c)
 		if !ok {

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -341,9 +341,13 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		}
 
 		// POST /competitions can land with an embedded roster via
-		// saveCompetitionWithPlayers — same length caps as the
-		// PUT roster-PUT branch and POST /participants.
+		// saveCompetitionWithPlayers — same required-field and length
+		// caps as the roster-PUT branch and POST /participants.
 		for i, p := range comp.Players {
+			if err := validatePlayerRequired(p.Name, p.Dojo); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: %s", i, err.Error())})
+				return
+			}
 			if err := validatePlayerLengths(p.Name, p.DisplayName, p.Dojo, p.Source, p.Metadata); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: %s", i, err.Error())})
 				return
@@ -649,6 +653,10 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// handlers_participants.go.
 		if comp.Players != nil {
 			for i, p := range comp.Players {
+				if err := validatePlayerRequired(p.Name, p.Dojo); err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: %s", i, err.Error())})
+					return
+				}
 				if err := validatePlayerLengths(p.Name, p.DisplayName, p.Dojo, p.Source, p.Metadata); err != nil {
 					c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: %s", i, err.Error())})
 					return

--- a/internal/mobileapp/handlers_competition_clashes_test.go
+++ b/internal/mobileapp/handlers_competition_clashes_test.go
@@ -1,0 +1,66 @@
+package mobileapp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/engine"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGETCompetitionScheduleClashes covers the court-clash endpoint
+// GET /api/competitions/:id/schedule/clashes (mp-4a52).
+func TestGETCompetitionScheduleClashes(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer func() { require.NoError(t, os.RemoveAll(tempDir)) }()
+
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name: "Test Tournament", Password: "secret", Courts: []string{"A", "B"},
+	}))
+
+	save := func(id, name, date, start string, courts []string) {
+		require.NoError(t, store.SaveCompetition(&state.Competition{
+			ID: id, Name: name, Format: state.CompFormatPlayoffs, Kind: "individual",
+			Date: date, StartTime: start, Courts: courts, Status: state.CompStatusSetup,
+		}))
+	}
+
+	t.Run("404 for unknown competition", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/competitions/nope/schedule/clashes", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("empty array when no other competitions", func(t *testing.T) {
+		// Different day from the clash subtest below so it can't interfere
+		// (subtests share one store).
+		save("solo", "Solo", "05-07-2026", "09:00", []string{"A"})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/competitions/solo/schedule/clashes", nil)
+		r.ServeHTTP(w, req)
+		require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		var clashes []engine.ClashWarning
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &clashes))
+		assert.Empty(t, clashes)
+	})
+
+	t.Run("reports a clash on a shared court at overlapping times", func(t *testing.T) {
+		save("alpha", "Alpha", "01-07-2026", "09:00", []string{"A"})
+		save("bravo", "Bravo", "01-07-2026", "09:15", []string{"A"})
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/competitions/alpha/schedule/clashes", nil)
+		r.ServeHTTP(w, req)
+		require.Equalf(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		var clashes []engine.ClashWarning
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &clashes))
+		require.Len(t, clashes, 1)
+		assert.Equal(t, "bravo", clashes[0].OtherCompID)
+		assert.Equal(t, []string{"A"}, clashes[0].SharedCourts)
+	})
+}

--- a/internal/mobileapp/handlers_competition_test.go
+++ b/internal/mobileapp/handlers_competition_test.go
@@ -617,6 +617,59 @@ func TestCompetitionHandlers_Extended(t *testing.T) {
 		}
 	})
 
+	// Tri-review finding: an embedded roster on POST /competitions and the
+	// roster-PUT branch of PUT /competitions/:id only ran validatePlayerLengths
+	// (max-length) — never the blank-name/dojo guard that POST /participants
+	// has. A two-column "Name, Dojo" paste in a zekken competition maps to
+	// {displayName: dojo, dojo: ""}, so a blank dojo persisted a corrupted
+	// competitor while the UI reported success. Both paths now share
+	// validatePlayerRequired and must reject the blank field with 400.
+	t.Run("Embedded Roster Rejects Blank Name Or Dojo With 400", func(t *testing.T) {
+		blankCases := []struct {
+			label   string
+			player  domain.Player
+			wantMsg string
+		}{
+			{"blank dojo", domain.Player{Name: "Alice", Dojo: "   "}, "dojo must not be blank"},
+			{"blank name", domain.Player{Name: "  ", Dojo: "Dojo A"}, "name must not be blank"},
+		}
+		for _, bc := range blankCases {
+			// POST /competitions with an embedded roster.
+			comp := state.Competition{
+				ID:      "blank-roster-post",
+				Name:    "Blank Roster POST",
+				Players: []domain.Player{bc.player},
+			}
+			body, _ := json.Marshal(comp)
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("POST", "/api/competitions", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			assert.Equalf(t, http.StatusBadRequest, w.Code,
+				"POST embedded roster with %s must return 400 (got %d: %s)", bc.label, w.Code, w.Body.String())
+			assert.Containsf(t, w.Body.String(), bc.wantMsg, "POST %s error message", bc.label)
+			stored, _ := store.LoadCompetition("blank-roster-post")
+			assert.Nilf(t, stored, "POST with %s must not persist", bc.label)
+
+			// PUT /competitions/:id roster branch (Players != nil).
+			seed := state.Competition{ID: "blank-roster-put", Name: "Blank Roster PUT", Status: state.CompStatusSetup}
+			require.NoError(t, store.SaveCompetition(&seed))
+			update := state.Competition{
+				ID:      "blank-roster-put",
+				Name:    "Blank Roster PUT",
+				Players: []domain.Player{bc.player},
+			}
+			body, _ = json.Marshal(update)
+			w = httptest.NewRecorder()
+			req, _ = http.NewRequest("PUT", "/api/competitions/blank-roster-put", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+			assert.Equalf(t, http.StatusBadRequest, w.Code,
+				"PUT roster with %s must return 400 (got %d: %s)", bc.label, w.Code, w.Body.String())
+			assert.Containsf(t, w.Body.String(), bc.wantMsg, "PUT %s error message", bc.label)
+		}
+	})
+
 	// Path-traversal guard. ValidateCompetitionID was only called at 2 of
 	// the 14 :id handler sites pre-fix; the requireValidCompID helper now
 	// gates every site. A compID like "../../../etc/passwd" would

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -173,12 +173,8 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		// the whole batch on the first offender (matches the all-or-nothing
 		// semantics SaveParticipants already enforces on write).
 		for i, p := range req.Players {
-			if strings.TrimSpace(p.Name) == "" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: name must not be blank", i)})
-				return
-			}
-			if strings.TrimSpace(p.Dojo) == "" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: dojo must not be blank", i)})
+			if err := validatePlayerRequired(p.Name, p.Dojo); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: %s", i, err.Error())})
 				return
 			}
 			if err := validatePlayerLengths(p.Name, p.DisplayName, p.Dojo, p.Source, p.Metadata); err != nil {

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -163,11 +163,24 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			return
 		}
 
-		// Per-player length caps — defense-in-depth against unbounded
-		// participants.csv inflation. Reject the whole batch on the
-		// first offender (matches the all-or-nothing semantics
-		// SaveParticipants already enforces on write).
+		// Required-field + length validation. Name and dojo must be non-blank
+		// (after trimming) — mirrors the single-add path above. Without this the
+		// batch path silently accepts a misformatted roster row (e.g. a
+		// two-column "Name, Dojo" line in a zekken competition, which the SPA
+		// parser maps to {displayName: dojo, dojo: ""}), persisting a competitor
+		// with no dojo while the UI reports success. Length caps are
+		// defense-in-depth against unbounded participants.csv inflation. Reject
+		// the whole batch on the first offender (matches the all-or-nothing
+		// semantics SaveParticipants already enforces on write).
 		for i, p := range req.Players {
+			if strings.TrimSpace(p.Name) == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: name must not be blank", i)})
+				return
+			}
+			if strings.TrimSpace(p.Dojo) == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: dojo must not be blank", i)})
+				return
+			}
 			if err := validatePlayerLengths(p.Name, p.DisplayName, p.Dojo, p.Source, p.Metadata); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("players[%d]: %s", i, err.Error())})
 				return

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -380,6 +380,60 @@ func TestBatchPostDuplicateNameDojo_409(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "same name at different dojos must be accepted in a batch")
 }
 
+// TestBatchPostBlankDojo_400 covers the batch (players array) POST path: a row
+// with a blank dojo must be rejected with 400, mirroring the single-add path
+// (which already returns "dojo must not be blank"). Without this, a misformatted
+// roster paste — e.g. a two-column "Name, Dojo" line in a zekken competition,
+// which parseParticipantLines maps to {displayName: dojo, dojo: ""} — would be
+// silently accepted, persisting a competitor with no dojo while the UI reports
+// success. (invalid-submission acceptance bug)
+func TestBatchPostBlankDojo_400(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	compID := "comp-batch-blank-dojo"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     compID,
+		Name:   "Batch Blank Dojo Test",
+		Status: state.CompStatusSetup,
+	}))
+
+	// A blank dojo on any row must reject the whole batch with 400.
+	blank, _ := json.Marshal(map[string]any{"players": []map[string]string{
+		{"name": "Alice Smith", "dojo": "Wakaba"},
+		{"name": "Bob Jones", "dojo": ""},
+	}})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants", bytes.NewBuffer(blank))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "batch POST with a blank dojo must return 400")
+
+	// A whitespace-only dojo is equally invalid (trimmed to empty).
+	ws, _ := json.Marshal(map[string]any{"players": []map[string]string{
+		{"name": "Carol White", "dojo": "   "},
+	}})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/competitions/"+compID+"/participants", bytes.NewBuffer(ws))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "batch POST with a whitespace-only dojo must return 400")
+
+	// A blank name is likewise rejected.
+	blankName, _ := json.Marshal(map[string]any{"players": []map[string]string{
+		{"name": "  ", "dojo": "Wakaba"},
+	}})
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/competitions/"+compID+"/participants", bytes.NewBuffer(blankName))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code, "batch POST with a blank name must return 400")
+
+	// Nothing should have been persisted by any of the rejected batches.
+	players := mustLoad(t, store, compID)
+	assert.Empty(t, players, "no participants should be saved when a batch is rejected")
+}
+
 // TestReplaceDoesNotInheritOldDisplayName ensures that replacing a participant
 // with displayName:"" (the corrected JS payload) writes a clean 2-column CSV
 // row, not a 3-column row that carries the old slot's stale SanitizeName value.

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -1825,8 +1825,11 @@ func TestParticipantHandlers(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	os.RemoveAll(path)
 
-	// POST /api/competitions/:id/participants
-	req, _ = http.NewRequest("POST", "/api/competitions/c1/participants", bytes.NewBufferString(`{"players": [{"name": "P1"}]}`))
+	// POST /api/competitions/:id/participants — dojo is required (matches the
+	// single-add path and the documented CSV schema), so the smoke payload
+	// supplies one. A blank dojo is rejected with 400; see
+	// TestBatchPostBlankDojo_400.
+	req, _ = http.NewRequest("POST", "/api/competitions/c1/participants", bytes.NewBufferString(`{"players": [{"name": "P1", "dojo": "Dojo A"}]}`))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -274,6 +274,23 @@ func validateBulkScoreLengths(r *state.MatchResult) error {
 	return nil
 }
 
+// validatePlayerRequired rejects a roster entry with a blank name or dojo.
+// A blank dojo is the silent-corruption signature of a misformatted roster
+// row (e.g. a two-column "Name, Dojo" line in a zekken competition, which the
+// SPA parser maps to {displayName: dojo, dojo: ""}). Shared by every endpoint
+// that persists an embedded roster — POST /participants (batch), POST
+// /competitions, and the roster-PUT branch of PUT /competitions/:id — so the
+// same malformed payload is rejected identically regardless of entry point.
+func validatePlayerRequired(name, dojo string) error {
+	if strings.TrimSpace(name) == "" {
+		return &ValidationError{Message: "name must not be blank"}
+	}
+	if strings.TrimSpace(dojo) == "" {
+		return &ValidationError{Message: "dojo must not be blank"}
+	}
+	return nil
+}
+
 // validatePlayerLengths enforces caps on every persisted string of a
 // participant. Shared between the participants handler (live UI write)
 // and the import handler (manifest upload) so a malformed CSV or JSON

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -3418,6 +3418,24 @@ button.pool-match-row {
   position: sticky;
   top: 70px;
 }
+/* Competition left rail: stacks the per-competition nav and the
+   "Other competitions" switcher as separate cards. The RAIL is the single
+   sticky unit (align-self:start leaves grid-track travel room), so both cards
+   pin together at top:70px — otherwise the second card scrolls up and slides
+   UNDER the sticky first card (whose surface background hides it). The inner
+   cards must therefore NOT stick individually. */
+.comp-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: sticky;
+  top: 70px;
+  align-self: start;
+}
+.comp-rail .side-nav {
+  position: static;
+  top: auto;
+}
 
 .side-nav button {
   display: flex;
@@ -5509,6 +5527,12 @@ button.pool-match-row {
   }
 
   .side-nav {
+    position: static;
+  }
+
+  /* Single-column layout: the rail stacks above the content and must scroll
+     away normally rather than pin over it. */
+  .comp-rail {
     position: static;
   }
 

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -634,7 +634,28 @@ describe('AdminSettings saveNow stale-snapshot fix (Copilot round-15)', () => {
         m[2],
         `${handler} must write localRef.current = next inside its setLocal updater so saveNow sees the latest staged value even when the operator clicks Save immediately after editing`
       ).toContain('localRef.current = next');
+      // Copilot finding (PR #320 round 4): the post-save clash banner says the
+      // change "was saved" — it goes stale the moment new edits are staged (the
+      // edit may even resolve the clash). Each staging handler must clear it.
+      expect(
+        m[2],
+        `${handler} must clear clashWarnings on edit so the stale "saved" clash banner isn't shown while the form is dirty`
+      ).toContain('setClashWarnings(null)');
     }
+  });
+
+  it('toggleCourt computes from localRef.current.courts, not the stale render closure', () => {
+    // Copilot finding (PR #320 round 4): deriving nextCourts from the render-
+    // closure `local.courts` drops a toggle when the operator clicks faster than
+    // React commits. localRef.current is kept authoritative by update().
+    const m = src.match(/const toggleCourt = \(cc\) => \{([\s\S]*?)\n {2}\};/);
+    expect(m, 'expected `const toggleCourt = (cc) => { ... };` block').not.toBeNull();
+    const body = m[1];
+    expect(body).toContain('localRef.current.courts');
+    // The stale-closure compute patterns must be gone (match on CODE, not the
+    // comment that quotes `local.courts` for explanation).
+    expect(body).not.toMatch(/local\.courts\.(includes|filter)/);
+    expect(body).not.toMatch(/\[\.\.\.local\.courts/);
   });
 
   it('sync effect uses editedFieldsRef.has guard, not blanket debounceRef gate', () => {

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -550,7 +550,7 @@ describe('AdminSettings.saveNow payload whitelist', () => {
 //   1. saveLater takes NO snapshot arg — it relies on refs at fire time.
 //   2. saveNow builds an `effective` object by overlaying `localRef.current`
 //      values onto `cRef.current` for each field in `editedFieldsRef`.
-//   3. update / updateNow / updateNumber call `editedFieldsRef.current.add(k)`
+//   3. update / updateNumber call `editedFieldsRef.current.add(k)`
 //      before scheduling the save.
 //
 // Behavioral tests for the full lifecycle are blocked by vitest.setup's
@@ -579,8 +579,8 @@ describe('AdminSettings saveNow stale-snapshot fix (Copilot round-15)', () => {
     // An explicit Save control wired to saveNow.
     expect(src).toMatch(/onClick=\{saveNow\}/);
     // The edit handlers must NOT auto-persist: no save call inside update/
-    // updateNow/updateNumber bodies.
-    for (const handler of ['update', 'updateNow', 'updateNumber']) {
+    // updateNumber bodies.
+    for (const handler of ['update', 'updateNumber']) {
       const re = new RegExp(`const ${handler} = \\(([^)]*)\\) => \\{([\\s\\S]*?)\\n {2}\\};`);
       const m = src.match(re);
       expect(m, `expected \`const ${handler} = (...) => { ... };\``).not.toBeNull();
@@ -603,7 +603,7 @@ describe('AdminSettings saveNow stale-snapshot fix (Copilot round-15)', () => {
     // Each handler that mutates `local` must mark the edited field
     // BEFORE scheduling the save, so the sync effect preserves it
     // when SSE arrives during the debounce window.
-    for (const handler of ['update', 'updateNow', 'updateNumber']) {
+    for (const handler of ['update', 'updateNumber']) {
       const re = new RegExp(`const ${handler} = \\(([^)]*)\\) => \\{([\\s\\S]*?)\\n {2}\\};`);
       const m = src.match(re);
       expect(m, `expected \`const ${handler} = (...) => { ... };\` declaration`).not.toBeNull();

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -611,6 +611,15 @@ describe('AdminSettings saveNow stale-snapshot fix (Copilot round-15)', () => {
         m[2],
         `${handler} must call editedFieldsRef.current.add(...) so the sync effect preserves the user's edit during the debounce window`
       ).toContain('editedFieldsRef.current.add');
+      // Copilot finding (PR #320 round 4): saveNow reads localRef.current at
+      // click time. The useEffect that syncs localRef from `local` is async,
+      // so a rapid edit-then-Save click can land before the effect runs and
+      // miss the latest edit. Each handler must therefore write localRef.current
+      // synchronously inside the setLocal updater.
+      expect(
+        m[2],
+        `${handler} must write localRef.current = next inside its setLocal updater so saveNow sees the latest staged value even when the operator clicks Save immediately after editing`
+      ).toContain('localRef.current = next');
     }
   });
 

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -569,14 +569,23 @@ describe('AdminSettings saveNow stale-snapshot fix (Copilot round-15)', () => {
     expect(src).toContain('function AdminSettings');
   });
 
-  it('saveLater takes no snapshot argument', () => {
-    // Pre-fix: `const saveLater = (next) => { ... saveNow(next); }`
-    // Post-fix: `const saveLater = () => { ... saveNow(); }`
-    // The argument-less form proves the timer reads refs at fire time
-    // instead of capturing a snapshot.
-    const m = src.match(/const saveLater = \(([^)]*)\) =>/);
-    expect(m, 'expected `const saveLater = (...) =>` declaration').not.toBeNull();
-    expect(m[1].trim()).toBe('');
+  it('uses manual save — no debounced autosave timer (mp-3xn6)', () => {
+    // Competition Settings was converted from debounced autosave to explicit
+    // "Save changes" (matching the Tournament Edit-details page). The old
+    // `saveLater` debounce must be gone, and saveNow must be reachable from an
+    // explicit Save button rather than fired from the edit handlers.
+    expect(src).not.toContain('saveLater');
+    expect(src).not.toContain('debounceRef');
+    // An explicit Save control wired to saveNow.
+    expect(src).toMatch(/onClick=\{saveNow\}/);
+    // The edit handlers must NOT auto-persist: no save call inside update/
+    // updateNow/updateNumber bodies.
+    for (const handler of ['update', 'updateNow', 'updateNumber']) {
+      const re = new RegExp(`const ${handler} = \\(([^)]*)\\) => \\{([\\s\\S]*?)\\n {2}\\};`);
+      const m = src.match(re);
+      expect(m, `expected \`const ${handler} = (...) => { ... };\``).not.toBeNull();
+      expect(m[2], `${handler} must not save automatically`).not.toContain('saveNow(');
+    }
   });
 
   it('saveNow builds effective from cRef + editedFieldsRef overlay', () => {

--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -599,6 +599,20 @@ describe('AdminSettings saveNow stale-snapshot fix (Copilot round-15)', () => {
     expect(body).toContain('editedFieldsRef.current.forEach');
   });
 
+  it('clears a persisted field only if its staged value is unchanged (re-edit race)', () => {
+    // Copilot finding (PR #320): a name-only Set snapshot couldn't tell an
+    // in-flight-persisted field from one RE-EDITED during the save, so the
+    // unconditional `persistingFields.forEach(delete)` would drop the user's
+    // latest change and let the SSE sync effect overwrite it. The fix snapshots
+    // VALUES and clears conditionally on value equality. These tokens are unique
+    // to saveNow, so file-level assertions are robust without carving the body.
+    expect(src).toContain('persistingValues');
+    // The fragile name-only Set snapshot must be gone.
+    expect(src).not.toContain('new Set(editedFieldsRef.current)');
+    // Conditional clear: only delete when the staged value still matches.
+    expect(src).toMatch(/if\s*\(localRef\.current\[k\]\s*===\s*persistingValues\[k\]\)\s*editedFieldsRef\.current\.delete\(k\)/);
+  });
+
   it('user-edit handlers mark fields via editedFieldsRef.add', () => {
     // Each handler that mutates `local` must mark the edited field
     // BEFORE scheduling the save, so the sync effect preserves it

--- a/web-mobile/js/__tests__/admin_participants.test.jsx
+++ b/web-mobile/js/__tests__/admin_participants.test.jsx
@@ -318,11 +318,32 @@ describe('generateRosterText', () => {
       expect(parts[2]).toBe('Gyokusen');
     });
 
-    it('derived zekken is non-empty', () => {
-      const players = [{ name: 'Alice Smith', displayName: '', dojo: 'Gyokusen', danGrade: null }];
+    it('falls back when displayName is null (legacy roster shape)', () => {
+      const players = [{ name: 'Alice Smith', displayName: null, dojo: 'Gyokusen', danGrade: null }];
       const line = generateRosterText(players, true);
       const parts = line.split(',').map(s => s.trim());
-      expect(parts[1]).not.toBe('');
+      expect(parts[1]).toBe('SMITH');
+    });
+
+    it('preserves an intentional empty zekken (does NOT synthesize one)', () => {
+      // Copilot finding (PR #320 round 3): the prior `p.displayName || …`
+      // swapped any falsy displayName for a derived value, including the
+      // operator's intentional empty zekken. The new `??` form only falls
+      // back for null/undefined, so `""` round-trips verbatim and the
+      // rosterDirty diff stays stable across saves.
+      const players = [{ name: 'Alice Smith', displayName: '', dojo: 'Gyokusen', danGrade: null }];
+      const line = generateRosterText(players, true);
+      expect(line).toBe('Alice Smith, , Gyokusen');
+    });
+
+    it('trailing-whitespace name derives a non-empty zekken', () => {
+      // Copilot finding (PR #320 round 3): `name.split(' ').pop()` on
+      // "Alice " returns "" because the last token is empty. Tokenising on
+      // /\s+/ after trim filters that out and the fallback stays useful.
+      const players = [{ name: 'Alice Smith ', displayName: undefined, dojo: 'Gyokusen', danGrade: null }];
+      const line = generateRosterText(players, true);
+      const parts = line.split(',').map(s => s.trim());
+      expect(parts[1]).toBe('SMITH');
     });
   });
 });

--- a/web-mobile/js/__tests__/admin_participants.test.jsx
+++ b/web-mobile/js/__tests__/admin_participants.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mintParticipantIds, findSeedMatchIndex, participantSearchTarget } from '../admin_participants.jsx';
+import { mintParticipantIds, findSeedMatchIndex, participantSearchTarget, generateRosterText, validateRosterRows } from '../admin_participants.jsx';
 
 // Helper: parsed rows arrive from parseParticipantLines as
 // { name, displayName, dojo, danGrade, tag } objects. Test rows omit the
@@ -277,5 +277,105 @@ describe('participantSearchTarget', () => {
   it('does not match a query that is not a substring of any field', () => {
     const target = participantSearchTarget(p('Alice', null, 'Tokyo'));
     expect(target.includes('bob')).toBe(false);
+  });
+});
+
+describe('generateRosterText', () => {
+  describe('withZekkenName=false', () => {
+    it('formats as Name, Dojo', () => {
+      const players = [{ name: 'Alice Smith', dojo: 'Gyokusen', danGrade: null, displayName: null }];
+      expect(generateRosterText(players, false)).toBe('Alice Smith, Gyokusen');
+    });
+
+    it('appends dan grade when present', () => {
+      const players = [{ name: 'Alice Smith', dojo: 'Gyokusen', danGrade: '3', displayName: null }];
+      expect(generateRosterText(players, false)).toBe('Alice Smith, Gyokusen, 3');
+    });
+  });
+
+  describe('withZekkenName=true — existing players with displayName', () => {
+    it('formats as Name, Zekken, Dojo when displayName is set', () => {
+      const players = [{ name: 'Alice Smith', displayName: 'SMITH', dojo: 'Gyokusen', danGrade: null }];
+      expect(generateRosterText(players, true)).toBe('Alice Smith, SMITH, Gyokusen');
+    });
+
+    it('appends dan grade when present', () => {
+      const players = [{ name: 'Alice Smith', displayName: 'SMITH', dojo: 'Gyokusen', danGrade: '3' }];
+      expect(generateRosterText(players, true)).toBe('Alice Smith, SMITH, Gyokusen, 3');
+    });
+  });
+
+  describe('withZekkenName=true — sample players without displayName', () => {
+    it('falls back to derived zekken so line has three columns (not two)', () => {
+      // makePlayer does not set displayName; without a fallback the line is
+      // "Name, Dojo" which parseParticipantLines(withZekken=true) misreads as
+      // zekken=Dojo, dojo="" — silently corrupting the saved roster.
+      const players = [{ name: 'Alice Smith', displayName: undefined, dojo: 'Gyokusen', danGrade: null }];
+      const line = generateRosterText(players, true);
+      const parts = line.split(',').map(s => s.trim());
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toBe('Alice Smith');
+      expect(parts[2]).toBe('Gyokusen');
+    });
+
+    it('derived zekken is non-empty', () => {
+      const players = [{ name: 'Alice Smith', displayName: '', dojo: 'Gyokusen', danGrade: null }];
+      const line = generateRosterText(players, true);
+      const parts = line.split(',').map(s => s.trim());
+      expect(parts[1]).not.toBe('');
+    });
+  });
+});
+
+describe('validateRosterRows', () => {
+  const row = (name, dojo, displayName = '') => ({ name, dojo, displayName });
+
+  it('returns no problems for a valid non-zekken roster', () => {
+    const parsed = [row('Alice Smith', 'Gyokusen'), row('Bob Jones', 'Tora')];
+    expect(validateRosterRows(parsed, false)).toEqual([]);
+  });
+
+  it('returns no problems for a valid zekken roster (three columns)', () => {
+    const parsed = [row('Alice Smith', 'Gyokusen', 'SMITH')];
+    expect(validateRosterRows(parsed, true)).toEqual([]);
+  });
+
+  it('flags a zekken-comp row whose dojo is empty (the two-column misparse)', () => {
+    // "Alice Smith, Gyokusen" in a zekken comp parses as
+    // {name:"Alice Smith", displayName:"Gyokusen", dojo:""}.
+    const parsed = [{ name: 'Alice Smith', displayName: 'Gyokusen', dojo: '' }];
+    const problems = validateRosterRows(parsed, true);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].name).toBe('Alice Smith');
+    expect(problems[0].reason).toMatch(/dojo/i);
+    expect(problems[0].reason).toMatch(/zekken/i);
+  });
+
+  it('flags an empty dojo in a non-zekken comp without the zekken hint', () => {
+    const parsed = [row('Alice Smith', '')];
+    const problems = validateRosterRows(parsed, false);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].reason).toBe('missing dojo');
+  });
+
+  it('flags a missing name and reports its index', () => {
+    const parsed = [row('Alice Smith', 'Gyokusen'), row('', 'Tora')];
+    const problems = validateRosterRows(parsed, false);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].index).toBe(1);
+    expect(problems[0].reason).toBe('missing name');
+  });
+
+  it('treats whitespace-only fields as empty', () => {
+    const parsed = [row('   ', 'Tora'), row('Bob', '   ')];
+    const problems = validateRosterRows(parsed, false);
+    expect(problems).toHaveLength(2);
+    expect(problems[0].reason).toBe('missing name');
+    expect(problems[1].reason).toBe('missing dojo');
+  });
+
+  it('handles null/empty input defensively', () => {
+    expect(validateRosterRows(null, true)).toEqual([]);
+    expect(validateRosterRows([], false)).toEqual([]);
   });
 });

--- a/web-mobile/js/__tests__/admin_participants.test.jsx
+++ b/web-mobile/js/__tests__/admin_participants.test.jsx
@@ -374,6 +374,27 @@ describe('validateRosterRows', () => {
     expect(problems[1].reason).toBe('missing dojo');
   });
 
+  it('stores the trimmed name (so a whitespace-only name renders as line N, not "   ")', () => {
+    // Copilot finding (PR #320): the toast picks `"name"` when truthy and
+    // `line N` when falsy. Storing the raw whitespace string showed an ugly
+    // `"   " missing name` label; trimming makes the falsy branch kick in.
+    const parsed = [{ name: '   ', dojo: 'Tora' }];
+    const problems = validateRosterRows(parsed, false);
+    expect(problems).toHaveLength(1);
+    expect(problems[0].name).toBe('');
+  });
+
+  it('zekken-comp dojo-missing reason wording reads as a format hint, not a hard requirement', () => {
+    // Copilot finding (PR #320): the prior "needs Name, Zekken, Dojo" wording
+    // implied we enforced a non-empty zekken, but the validator only enforces
+    // dojo. The reason now reads as a format hint ("use" not "need").
+    const parsed = [{ name: 'Alice', displayName: 'Gyokusen', dojo: '' }];
+    const problems = validateRosterRows(parsed, true);
+    expect(problems[0].reason).toMatch(/missing dojo/);
+    expect(problems[0].reason).toMatch(/use/i);
+    expect(problems[0].reason).not.toMatch(/\bneed\b/i);
+  });
+
   it('handles null/empty input defensively', () => {
     expect(validateRosterRows(null, true)).toEqual([]);
     expect(validateRosterRows([], false)).toEqual([]);

--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -1,6 +1,55 @@
 import { describe, it, expect } from 'vitest';
-import { deriveCompetitionName, validatePoolSettings, validateSwissSettings } from '../admin_setup.jsx';
+import { deriveCompetitionName, validatePoolSettings, validateSwissSettings, pickStackPredecessor } from '../admin_setup.jsx';
 import { normalizeTheme } from '../admin_branding.jsx';
+
+describe('pickStackPredecessor', () => {
+  const day = '01-07-2026';
+  it('returns null when there are no competitions', () => {
+    expect(pickStackPredecessor([], day)).toBeNull();
+    expect(pickStackPredecessor(undefined, day)).toBeNull();
+  });
+
+  it('returns null when no competition matches the date', () => {
+    expect(pickStackPredecessor([{ id: 'a', date: '02-07-2026', startTime: '09:00' }], day)).toBeNull();
+  });
+
+  it('picks the latest-STARTING same-day competition', () => {
+    const comps = [
+      { id: 'a', date: day, startTime: '09:00' },
+      { id: 'c', date: day, startTime: '11:30' },
+      { id: 'b', date: day, startTime: '10:00' },
+    ];
+    expect(pickStackPredecessor(comps, day).id).toBe('c');
+  });
+
+  it('compares numerically, not lexicographically (un-padded "9:00" vs "10:00")', () => {
+    const comps = [
+      { id: 'ten', date: day, startTime: '10:00' },
+      { id: 'nine', date: day, startTime: '9:00' },
+    ];
+    // Lex sort would pick "9:00" > "10:00"; numeric correctly picks 10:00.
+    expect(pickStackPredecessor(comps, day).id).toBe('ten');
+  });
+
+  it('Copilot finding: drops competitions with a malformed start time', () => {
+    // A legacy/imported competition with an unparseable StartTime must not
+    // become `latest` — otherwise addMinutes() would emit "NaN:NaN".
+    const comps = [
+      { id: 'good', date: day, startTime: '09:00' },
+      { id: 'bad', date: day, startTime: 'garbage' },
+    ];
+    expect(pickStackPredecessor(comps, day).id).toBe('good');
+  });
+
+  it('returns null when ALL same-day start times are malformed', () => {
+    const comps = [
+      { id: 'x', date: day, startTime: 'garbage' },
+      { id: 'y', date: day, startTime: '' },
+      { id: 'z', date: day, startTime: null },
+    ];
+    expect(pickStackPredecessor(comps, day)).toBeNull();
+  });
+});
 
 describe('deriveCompetitionName', () => {
   // Copilot round-8 finding: AdminCreateCompetition.create used

--- a/web-mobile/js/__tests__/api.test.jsx
+++ b/web-mobile/js/__tests__/api.test.jsx
@@ -954,6 +954,62 @@ describe('API Utils', () => {
       });
     });
 
+    describe('getScheduleClashes', () => {
+      it('GETs /api/competitions/:id/schedule/clashes and returns the clash array', async () => {
+        const payload = [
+          { otherCompId: 'b', otherCompName: 'Bravo', date: '01-07-2026', sharedCourts: ['A'], overlapStart: '09:15', overlapEnd: '09:30' },
+        ];
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => payload });
+        const result = await API.getScheduleClashes('comp-abc', 'pw');
+        expect(result).toEqual(payload);
+        expect(global.fetch).toHaveBeenCalledWith(
+          '/api/competitions/comp-abc/schedule/clashes',
+          expect.objectContaining({
+            headers: expect.objectContaining({ 'X-Tournament-Password': 'pw' }),
+          })
+        );
+      });
+
+      it('returns an empty array when there are no clashes', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+        const result = await API.getScheduleClashes('c1', 'pw');
+        expect(result).toEqual([]);
+      });
+
+      it('sends X-Tournament-Password header', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+        await API.getScheduleClashes('c1', 'secret-pw');
+        const [, opts] = global.fetch.mock.calls[0];
+        expect(opts.headers['X-Tournament-Password']).toBe('secret-pw');
+      });
+
+      it('forwards AbortSignal to fetch', async () => {
+        global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+        const controller = new AbortController();
+        await API.getScheduleClashes('c1', 'pw', controller.signal);
+        const [, opts] = global.fetch.mock.calls[0];
+        expect(opts.signal).toBe(controller.signal);
+      });
+
+      it('throws with server error message on non-ok response', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({ error: 'competition not found' }),
+        });
+        await expect(API.getScheduleClashes('bad-id', 'pw'))
+          .rejects.toThrow('competition not found');
+      });
+
+      it('throws default message if json parse fails on error response', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => { throw new Error('parse error'); },
+        });
+        await expect(API.getScheduleClashes('c1', 'pw'))
+          .rejects.toThrow('Failed to check schedule clashes');
+      });
+    });
+
     describe('estimateSchedule', () => {
       it('GETs /api/schedule/estimate with required params in query string', async () => {
         global.fetch = vi.fn().mockResolvedValue({

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -568,6 +568,16 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       onCreate={async (c) => {
         try {
           const created = await addCompetition(c);
+          // Non-blocking court-clash check: warn if the new competition lands
+          // on a shiaijo already in use at the same time. The create still
+          // proceeds; the operator can adjust its start time / courts after.
+          try {
+            const clashes = await window.API.getScheduleClashes(created.id, password);
+            if (Array.isArray(clashes) && clashes.length > 0) {
+              const names = clashes.map((w) => w.otherCompName).join(", ");
+              showToast(`Heads up: court clash with ${names} — adjust start time or courts in Settings`, "error");
+            }
+          } catch { /* clash check is best-effort; never block creation */ }
           setView({ kind: "competition", id: created.id, section: "participants" });
         } catch {
           // error already alerted inside addCompetition

--- a/web-mobile/js/admin.jsx
+++ b/web-mobile/js/admin.jsx
@@ -575,6 +575,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       }}
       onLogout={onLogout}
       onViewerMode={onViewerMode}
+      password={password}
     />;
   }
 
@@ -702,6 +703,7 @@ function AdminApp({ tournament, onUpdate, onLogout, onViewerMode, onPasswordChan
       onSection={(section) => setView({ ...view, section })}
       onBack={() => setView({ kind: "dashboard" })}
       onOpenCompetition={(id, section) => setView({ kind: "competition", id, section: section || "overview" })}
+      onCreateCompetition={() => setView({ kind: "createComp" })}
       onUpdate={(next) => updateCompetition(c.id, next)}
       onRefreshCompetition={() => window.API.fetchCompetitionDetails(c.id).then(setAdminCompData).catch(err => console.error("refresh failed:", err))}
       onMoveCourt={moveMatchCourt}

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -297,9 +297,10 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
         <div className="workspace">
           {/* Left column stacks the per-competition nav and, as a SEPARATE
               card below it, the switcher to other competitions (mp-xsc1).
-              The Other-competitions card is position:static so it doesn't
-              fight the sticky nav above it. */}
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              The .comp-rail wrapper is the single sticky unit so both cards
+              pin together — if only the top card sticks, the lower one scrolls
+              up and disappears beneath it. */}
+          <div className="comp-rail">
             <div className="side-nav">
               {sections.map((sec) => (
                 <div key={sec.sec}>
@@ -319,7 +320,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             {/* Other-competitions switcher + a quick "Add competition" action.
                 Rendered even with no other competitions so the operator can
                 always start a new one without going back to the dashboard. */}
-            <div className="side-nav" style={{ position: "static" }}>
+            <div className="side-nav">
               <div className="side-nav__sec">Other competitions</div>
               {otherComps.map((cc) => (
                 <button type="button" key={cc.id} disabled={navBusy} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -41,7 +41,7 @@ const AdminSettings = window.AdminSettings;
 const AdminBracket = window.AdminBracket;
 const AdminSwissRounds = window.AdminSwissRounds;
 
-function AdminCompetition({ tournament, competition, pools, poolMatches, standings, bracket, section, onSection, onBack, onOpenCompetition, onUpdate, onRefreshCompetition, onMoveCourt, onEditScore, onLogout, onViewerMode, tweaks, password, showToast }) {
+function AdminCompetition({ tournament, competition, pools, poolMatches, standings, bracket, section, onSection, onBack, onOpenCompetition, onCreateCompetition, onUpdate, onRefreshCompetition, onMoveCourt, onEditScore, onLogout, onViewerMode, tweaks, password, showToast }) {
   const c = competition;
   const t = tournament;
   const [starting, setStarting] = useStateA(false);
@@ -316,18 +316,25 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
                 </div>
               ))}
             </div>
-            {otherComps.length > 0 && (
-              <div className="side-nav" style={{ position: "static" }}>
-                <div className="side-nav__sec">Other competitions</div>
-                {otherComps.map((cc) => (
-                  <button type="button" key={cc.id} disabled={navBusy} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
-                ))}
-              </div>
-            )}
+            {/* Other-competitions switcher + a quick "Add competition" action.
+                Rendered even with no other competitions so the operator can
+                always start a new one without going back to the dashboard. */}
+            <div className="side-nav" style={{ position: "static" }}>
+              <div className="side-nav__sec">Other competitions</div>
+              {otherComps.map((cc) => (
+                <button type="button" key={cc.id} disabled={navBusy} onClick={() => onOpenCompetition(cc.id)}>{cc.name}</button>
+              ))}
+              {otherComps.length === 0 && (
+                <div className="side-nav__hint" style={{ fontSize: 12, color: "var(--ink-3)", padding: "4px 8px" }}>No other competitions yet.</div>
+              )}
+              {onCreateCompetition && (
+                <button type="button" className="side-nav__add" disabled={navBusy} onClick={onCreateCompetition} style={{ fontWeight: 600, color: "var(--accent)" }}>+ Add competition</button>
+              )}
+            </div>
           </div>
           <div>
             {section === "overview" && <AdminCompOverview c={c} tournament={t} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} password={password} />}
-            {section === "participants" && <AdminParticipants c={c} tournament={t} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} />}
+            {section === "participants" && <AdminParticipants c={c} tournament={t} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} onBack={onBack} />}
             {section === "lineups" && window.AdminTeamLineupsList && <window.AdminTeamLineupsList comp={c} password={password} showToast={showToast} />}
             {section === "settings" && <AdminSettings c={c} tournament={t} onUpdate={onUpdate} onBack={onBack} password={password} showToast={showToast} onStatusChange={setLocalStatus} />}
             {section === "awards" && <FightingSpiritAwardsEditor c={c} password={password} showToast={showToast} />}

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -360,7 +360,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   // before, just over a longer window).
   const update = (k, v) => {
     editedFieldsRef.current.add(k);
-    setLocal({ ...local, [k]: v });
+    // Functional updater so back-to-back edits (e.g. fast successive
+    // toggles / paste-driven multi-field updates) don't clobber each other
+    // by spreading a stale closure-captured `local`. Mirrors the sync
+    // effect above which also uses the prev form.
+    setLocal((prev) => ({ ...prev, [k]: v }));
     setIsDirty(true);
     // Clear a stale inline error once the user edits again.
     if (saveErr) setSaveErr(null);
@@ -371,7 +375,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   // separate name only to avoid churning the ~20 JSX call sites.
   const updateNow = (k, v) => {
     editedFieldsRef.current.add(k);
-    setLocal({ ...local, [k]: v });
+    setLocal((prev) => ({ ...prev, [k]: v }));
     setIsDirty(true);
     if (saveErr) setSaveErr(null);
   };
@@ -391,7 +395,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   const updateNumber = (k, raw, min = 1) => {
     const { value } = decideNumericUpdate(raw, min);
     editedFieldsRef.current.add(k);
-    setLocal({ ...local, [k]: value });
+    setLocal((prev) => ({ ...prev, [k]: value }));
     setIsDirty(true);
     if (saveErr) setSaveErr(null);
   };

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -295,19 +295,26 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       // `mirror` above to preserve the stored value.
       teamMatchType: effective.teamMatchType || latestC.teamMatchType || "",
     };
-    // Capture the snapshot of edited fields we're about to persist. On
-    // success we clear ONLY those fields from the edited set — preserving
-    // any fields the user touched DURING the in-flight save (those need
-    // to round-trip through a subsequent save).
-    const persistingFields = new Set(editedFieldsRef.current);
+    // Snapshot the VALUE of each edited field we're about to persist (not just
+    // the field name). On success we clear a field only if its current staged
+    // value still equals what we sent — so a field RE-EDITED during the
+    // in-flight save (its value now differs) stays in the edited set and rolls
+    // into the next save. A name-only Set couldn't distinguish the original
+    // edit from a concurrent re-edit and would drop the user's latest change.
+    // localRef.current is written synchronously by the edit handlers, so it
+    // reflects any re-edit that landed while the PUT was in flight.
+    const persistingValues = {};
+    editedFieldsRef.current.forEach(k => { persistingValues[k] = localRef.current[k]; });
     setSaving(true);
     Promise.resolve(onUpdate(finalNext)).then(() => {
       if (!mountedRef.current) return;
-      // Drop the fields we just persisted from the edited set so the
-      // sync effect can absorb the server-confirmed values on the next
-      // SSE round-trip. Fields edited DURING the in-flight save stay in
-      // the set and roll into the next save.
-      persistingFields.forEach(k => editedFieldsRef.current.delete(k));
+      // Drop only the persisted fields whose staged value is unchanged, so the
+      // sync effect can absorb the server-confirmed values on the next SSE
+      // round-trip. Fields re-edited DURING the in-flight save (value differs)
+      // stay in the set and roll into the next save.
+      Object.keys(persistingValues).forEach(k => {
+        if (localRef.current[k] === persistingValues[k]) editedFieldsRef.current.delete(k);
+      });
       const now = new Date();
       setLastSaved(`${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}:${String(now.getSeconds()).padStart(2, "0")}`);
       setSaveErr(null);

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -310,7 +310,15 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       setSaving(false);
       // Only clear the dirty flag if no fields were edited DURING the
       // in-flight save. Those linger in editedFieldsRef and still need a save.
-      setIsDirty(editedFieldsRef.current.size > 0);
+      const stillDirty = editedFieldsRef.current.size > 0;
+      setIsDirty(stillDirty);
+      // Return to the dashboard on a clean save (nothing left pending) so the
+      // operator lands back on the competition list after finishing edits.
+      // A toast carries the confirmation since the on-page indicator unmounts.
+      if (!stillDirty && onBack) {
+        showToast("Competition settings saved");
+        onBack();
+      }
     }).catch((e) => {
       if (!mountedRef.current) return;
       setSaving(false);

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -388,8 +388,8 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
             fontSize: 12.5,
             padding: "4px 8px",
             borderRadius: 4,
-            background: saveErr ? "var(--red-soft)" : isDirty ? "var(--bg-2)" : lastSaved ? "var(--accent-soft)" : "transparent",
-            color: saveErr ? "var(--red)" : isDirty ? "var(--ink-2)" : "var(--accent)",
+            background: saveErr ? "var(--red-soft)" : isDirty ? "var(--warn-soft)" : lastSaved ? "var(--accent-soft)" : "transparent",
+            color: saveErr ? "var(--red)" : isDirty ? "var(--warn-ink)" : "var(--accent)",
             fontWeight: 600,
             transition: "all 300ms"
           }}>
@@ -687,7 +687,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           and disabled rules as the header button. */}
       <div style={{ marginTop: 20, display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 10 }}>
         {saveErr && <span style={{ fontSize: 12.5, color: "var(--red)", fontWeight: 600 }}>⚠ {saveErr}</span>}
-        {!saveErr && isDirty && !saving && <span style={{ fontSize: 12.5, color: "var(--ink-2)", fontWeight: 600 }}>● Unsaved changes</span>}
+        {!saveErr && isDirty && !saving && <span style={{ fontSize: 12.5, color: "var(--warn)", fontWeight: 600 }}>● Unsaved changes</span>}
         <button type="button" className="btn btn--primary" onClick={saveNow} disabled={!isDirty || saving}>
           {saving ? "Saving…" : "Save changes"}
         </button>

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -35,7 +35,12 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   const [deleting, setDeleting] = useStateA(false);
   const [invalidating, setInvalidating] = useStateA(false);
   const [local, setLocal] = useStateA({ ...c });
-  const debounceRef = useRefA(null);
+  // Manual-save model (mp-3xn6): edits only persist when the operator clicks
+  // "Save changes", matching the Tournament Edit-details page. isDirty drives
+  // the unsaved indicator + the Save button's enabled state; saving disables
+  // the button and shows "Saving…" during the in-flight PUT.
+  const [isDirty, setIsDirty] = useStateA(false);
+  const [saving, setSaving] = useStateA(false);
 
   // Schedule estimate (mp-zoh Phase 4): fetch per-competition estimate and
   // display it inline near the duration inputs. Re-fetches whenever the
@@ -62,8 +67,8 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     });
     return () => controller.abort();
   // Re-fetch when the server-confirmed competition config changes. We depend
-  // on `c` fields (not `local`) so we re-fetch after a successful debounced
-  // save, not on every keystroke. This also fires on mount and on any
+  // on `c` fields (not `local`) so we re-fetch after a successful save lands
+  // in `c`, not on every unsaved edit. This also fires on mount and on any
   // SSE-driven competition_updated / schedule_updated refresh.
   //
   // Tournament ceremony/timing fields are included so the estimate refreshes
@@ -82,9 +87,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   const mountedRef = useRefA(true);
   useEffectA(() => () => { mountedRef.current = false; }, []);
 
-  // Refs for the async saveNow timer to read fresh state at fire time
-  // (NOT closure-captured at saveLater() call time). Same shape as
-  // admin.jsx's tRef/onUpdateRef pattern from round-11.
+  // Refs so saveNow reads fresh state at click time (NOT closure-captured
+  // when the handler was defined). Same shape as admin.jsx's tRef/onUpdateRef
+  // pattern from round-11.
   const cRef = useRefA(c);
   useEffectA(() => { cRef.current = c; }, [c]);
   const localRef = useRefA(local);
@@ -97,14 +102,12 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   //  (b) saveNow's payload builder — overlay user-edited values onto a
   //      FRESH snapshot of `c` (cRef.current), so the PUT body reflects
   //      concurrent server-side changes to fields the user isn't editing
-  //      rather than stale values captured at keystroke time.
+  //      rather than stale values captured when the edit was made.
   //
-  // Without this set, the prior debounce-gate approach (`if
-  // (debounceRef.current) return prev`) had a 400ms window where a
-  // concurrent admin's settings change would land in `c` but be dropped
-  // by the sync effect AND overwritten by saveNow's stale captured
-  // snapshot — net effect: one-field edits silently revert
-  // simultaneous edits to other fields. Caught by Copilot round-15.
+  // Without this set, a concurrent admin's settings change that lands in `c`
+  // between the user's edit and their Save click would be dropped by the sync
+  // effect AND overwritten by saveNow — net effect: saving one field silently
+  // reverts simultaneous edits to other fields. Caught by Copilot round-15.
   const editedFieldsRef = useRefA(new Set());
 
   // Sync server-driven changes into local state (SSE → AdminApp → c prop).
@@ -131,14 +134,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
 
   const saveNow = () => {
     // Build `effective` from the LATEST server-known state (cRef.current)
-    // overlaid with the user's currently-edited fields. Pre-fix this
-    // function took a captured `next` arg from saveLater, which held a
-    // snapshot from the moment of the keystroke — so any SSE updates
-    // that landed during the 400ms debounce were ignored at save time,
-    // and the PUT body silently reverted concurrent admin changes to
-    // unrelated fields. Reading from refs at fire time (not closure
-    // capture) absorbs those concurrent changes naturally. Caught by
-    // Copilot round-15.
+    // overlaid with the user's currently-edited fields. Reading from refs at
+    // click time (not values captured when the handler was defined) means any
+    // SSE updates that landed since the user's last edit are absorbed, instead
+    // of the PUT silently reverting concurrent admin changes to unrelated
+    // fields. Caught by Copilot round-15.
     const latestC = cRef.current;
     const localSnap = localRef.current;
     const effective = { ...latestC };
@@ -153,10 +153,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     // Skip validation for empty date — the backend's validateDateDMY
     // accepts "" as "Date TBA" and competitions created via the import
     // path can land here with an empty Date. Without this skip, the
-    // user would be unable to change ANY unrelated setting on a
-    // date-less competition (round-robin toggle, pool size, etc.) — the
-    // first debounced saveLater fires saveNow, which rejects with
-    // "Invalid date" even though the user hasn't touched the date.
+    // user would be unable to save ANY unrelated setting on a date-less
+    // competition (round-robin toggle, pool size, etc.) — saveNow would
+    // reject with "Invalid date" even though the user hasn't touched the date.
     let dateNorm = "";
     if (effective.date && effective.date.trim() !== "") {
       const { norm, error: dateError } = validateAndNormalizeDate(effective.date);
@@ -177,10 +176,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     // Cross-file guard symmetry with the tournament edit/create paths
     // (admin_setup.jsx AdminEditTournament:80, app.jsx CreateTournament:410)
     // and with handlers_competition.go PUT (which now returns 400 on
-    // empty-after-trim Name). Without this client-side guard, every
-    // saveLater-debounced keystroke that lands on an empty Name fires a
-    // wasted PUT roundtrip and only surfaces the error in the inline
-    // .catch handler 400ms later. Keep the failure inline + immediate
+    // empty-after-trim Name). Without this client-side guard, clicking Save
+    // with an empty Name fires a wasted PUT roundtrip and only surfaces the
+    // error via the inline .catch handler. Keep the failure inline + immediate
     // like the date validation above.
     if (!trimmedName) {
       setSaveErr("Competition name is required.");
@@ -230,10 +228,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     //
     // safeInt for the numeric fields: decideNumericUpdate stores NaN in
     // local state when the user clears a number input (so the render
-    // layer can show "" instead of "0"). If the user clears poolSize
-    // and THEN edits a non-numeric field, the new field's saveLater
-    // fires saveNow with the cleared poolSize still in the edited
-    // overlay. JSON.stringify({n: NaN}) produces '{"n":null}' — Go binds
+    // layer can show "" instead of "0"). If the user clears poolSize and then
+    // clicks Save, the cleared poolSize is still NaN in the edited overlay.
+    // JSON.stringify({n: NaN}) produces '{"n":null}' — Go binds
     // JSON null to int as 0 — backend transform writes 0 to disk,
     // clobbering the prior good value. Falling back to `latestC.<field>`
     // when the effective value isn't a usable positive integer preserves
@@ -299,71 +296,61 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     // any fields the user touched DURING the in-flight save (those need
     // to round-trip through a subsequent save).
     const persistingFields = new Set(editedFieldsRef.current);
+    setSaving(true);
     Promise.resolve(onUpdate(finalNext)).then(() => {
       if (!mountedRef.current) return;
       // Drop the fields we just persisted from the edited set so the
       // sync effect can absorb the server-confirmed values on the next
       // SSE round-trip. Fields edited DURING the in-flight save stay in
-      // the set and roll into the next saveLater.
+      // the set and roll into the next save.
       persistingFields.forEach(k => editedFieldsRef.current.delete(k));
       const now = new Date();
       setLastSaved(`${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}:${String(now.getSeconds()).padStart(2, "0")}`);
       setSaveErr(null);
+      setSaving(false);
+      // Only clear the dirty flag if no fields were edited DURING the
+      // in-flight save. Those linger in editedFieldsRef and still need a save.
+      setIsDirty(editedFieldsRef.current.size > 0);
     }).catch((e) => {
       if (!mountedRef.current) return;
-      // Keep edited fields in the set — the user can retry. The next
-      // saveLater will pick them up via the same edited-overlay path.
-      // updateCompetition already surfaced the error via showToast;
-      // mirror it inline next to the input so the user sees the cause
-      // next to the field they were editing without a duplicate toast.
+      setSaving(false);
+      // Keep edited fields in the set and stay dirty — the user can retry.
+      // updateCompetition already surfaced the error via showToast; mirror it
+      // inline next to the Save button so the cause is visible without a
+      // duplicate toast.
       setSaveErr(e?.message || "Save failed");
     });
   };
 
-  // saveLater takes NO snapshot arg — pre-fix it captured `next` at
-  // call time, which became stale if SSE updated `c` during the 400ms
-  // debounce. saveNow now reads cRef.current + localRef.current at
-  // fire time, so the captured-snapshot bug is gone.
-  const saveLater = () => {
-    clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      debounceRef.current = null;
-      saveNow();
-    }, 400);
-  };
-
-  // Cancel any pending debounced save on unmount so the timer can't fire
-  // saveNow() (and trigger state updates / API calls) after teardown.
-  useEffectA(() => () => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
-  }, []);
-
+  // Manual-save model: edit handlers stage the change into `local` and mark
+  // the field edited, but DO NOT persist — the operator commits all pending
+  // edits explicitly via "Save changes". editedFieldsRef is still marked so
+  // the sync effect preserves the user's in-progress edit if an SSE-driven
+  // `c` update lands before they click Save (same concurrent-edit guard as
+  // before, just over a longer window).
   const update = (k, v) => {
     editedFieldsRef.current.add(k);
-    const next = { ...local, [k]: v };
-    setLocal(next);
-    saveLater();
+    setLocal({ ...local, [k]: v });
+    setIsDirty(true);
+    // Clear a stale inline error once the user edits again.
+    if (saveErr) setSaveErr(null);
   };
 
+  // `updateNow` previously saved immediately (used by toggles / radio pills /
+  // court chips). Under manual save it is identical to `update` — kept as a
+  // separate name only to avoid churning the ~20 JSX call sites.
   const updateNow = (k, v) => {
     editedFieldsRef.current.add(k);
-    const next = { ...local, [k]: v };
-    setLocal(next);
-    // localRef syncs via useEffect; for immediate-save handlers we need
-    // saveNow to see the just-set value. Update the ref synchronously
-    // so saveNow's read happens before React's batched state flush.
-    localRef.current = next;
-    saveNow();
+    setLocal({ ...local, [k]: v });
+    setIsDirty(true);
+    if (saveErr) setSaveErr(null);
   };
 
   // Number-input variant of `update`. Stores NaN in local state for empty
   // input so the render side can keep the display empty (see
   // decideNumericUpdate's contract). Marks the field as edited so the
   // sync effect preserves the user's in-progress clear / typed value
-  // even if SSE pushes a c-update during the 400ms debounce window.
+  // even if SSE pushes a c-update before they click Save.
   //
   // safeInt in saveNow's finalNext allowlist bridges the gap: an invalid
   // value (NaN / 1.5 / -1) falls back to latestC.<field>, so the PUT is
@@ -374,9 +361,9 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   const updateNumber = (k, raw, min = 1) => {
     const { value } = decideNumericUpdate(raw, min);
     editedFieldsRef.current.add(k);
-    const next = { ...local, [k]: value };
-    setLocal(next);
-    saveLater();
+    setLocal({ ...local, [k]: value });
+    setIsDirty(true);
+    if (saveErr) setSaveErr(null);
   };
 
   const toggleCourt = (cc) => {
@@ -396,16 +383,21 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     <div className="card">
       <div className="card__head">
         <div className="card__title">Competition settings</div>
-        <div style={{
-          fontSize: 12.5,
-          padding: "4px 8px",
-          borderRadius: 4,
-          background: saveErr ? "var(--red-soft)" : lastSaved ? "var(--accent-soft)" : "transparent",
-          color: saveErr ? "var(--red)" : "var(--accent)",
-          fontWeight: 600,
-          transition: "all 300ms"
-        }}>
-          {saveErr ? `⚠ ${saveErr}` : lastSaved ? `✓ Saved at ${lastSaved}` : ""}
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <div style={{
+            fontSize: 12.5,
+            padding: "4px 8px",
+            borderRadius: 4,
+            background: saveErr ? "var(--red-soft)" : isDirty ? "var(--bg-2)" : lastSaved ? "var(--accent-soft)" : "transparent",
+            color: saveErr ? "var(--red)" : isDirty ? "var(--ink-2)" : "var(--accent)",
+            fontWeight: 600,
+            transition: "all 300ms"
+          }}>
+            {saveErr ? `⚠ ${saveErr}` : saving ? "Saving…" : isDirty ? "● Unsaved changes" : lastSaved ? `✓ Saved at ${lastSaved}` : ""}
+          </div>
+          <button type="button" className="btn btn--primary" onClick={saveNow} disabled={!isDirty || saving}>
+            {saving ? "Saving…" : "Save changes"}
+          </button>
         </div>
       </div>
       <div className="row">
@@ -466,7 +458,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           {/* admin_scoring_modal.jsx is built from the same constant, so */}
           {/* this input can't allow a value the scoring UI doesn't render. */}
           {/* Render NaN as "" so clearing the input stays empty instead of */}
-          {/* collapsing to "0"; updateNumber gates the debounced save so a */}
+          {/* collapsing to "0"; saveNow's safeInt guard means a */}
           {/* cleared/invalid value never lands on the backend as 0. */}
           {/* draw-ready lock: teamSize is output-affecting. */}
           <input
@@ -599,7 +591,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       )}
       {/* mp-zoh Phase 4: inline schedule estimate. Shown below duration inputs */}
       {/* so the operator can immediately see the impact of duration changes */}
-      {/* after the debounced save lands. Re-fetches from the server on every */}
+      {/* after the save lands. Re-fetches from the server on every */}
       {/* c-prop update (SSE schedule_updated / competition_updated). */}
       {(compEstimate || compEstimateLoading || compEstimateErr) && (
         <div style={{ padding: "10px 12px", borderRadius: 6, background: "var(--accent-soft, #f0f9ff)", border: "1px solid var(--accent, #3b82f6)", marginTop: 4 }}>
@@ -690,6 +682,16 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           </div>
         </div>
       )}
+      {/* Repeat Save at the foot of the long settings form so the operator
+          doesn't have to scroll back to the header after editing. Same handler
+          and disabled rules as the header button. */}
+      <div style={{ marginTop: 20, display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 10 }}>
+        {saveErr && <span style={{ fontSize: 12.5, color: "var(--red)", fontWeight: 600 }}>⚠ {saveErr}</span>}
+        {!saveErr && isDirty && !saving && <span style={{ fontSize: 12.5, color: "var(--ink-2)", fontWeight: 600 }}>● Unsaved changes</span>}
+        <button type="button" className="btn btn--primary" onClick={saveNow} disabled={!isDirty || saving}>
+          {saving ? "Saving…" : "Save changes"}
+        </button>
+      </div>
       <div style={{ marginTop: 24, padding: 16, borderTop: "1px solid var(--line)", display: "flex", flexDirection: "column", gap: 12 }}>
         {(local.status === "pools" || local.status === "playoffs") && (
           <div>

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -385,6 +385,10 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     setIsDirty(true);
     // Clear a stale inline error once the user edits again.
     if (saveErr) setSaveErr(null);
+    // Clear the post-save clash banner: its "saved" wording and clash list go
+    // stale the moment new unsaved edits are staged (the edit may even resolve
+    // the clash). Re-checked on the next save.
+    if (clashWarnings) setClashWarnings(null);
   };
 
   // Number-input variant of `update`. Stores NaN in local state for empty
@@ -409,10 +413,16 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     });
     setIsDirty(true);
     if (saveErr) setSaveErr(null);
+    if (clashWarnings) setClashWarnings(null);
   };
 
   const toggleCourt = (cc) => {
-    const nextCourts = local.courts.includes(cc) ? local.courts.filter((x) => x !== cc) : [...local.courts, cc].sort();
+    // Compute from localRef.current (kept authoritative by update) rather than
+    // the render-closure `local.courts`: rapid toggles fired before React
+    // commits a re-render would otherwise both read the same stale snapshot and
+    // drop a toggle.
+    const cur = localRef.current.courts || [];
+    const nextCourts = cur.includes(cc) ? cur.filter((x) => x !== cc) : [...cur, cc].sort();
     if (nextCourts.length) update("courts", nextCourts);
   };
 

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -332,13 +332,16 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
             } else {
               setClashWarnings(null);
               showToast("Competition settings saved");
-              if (onBack) onBack();
+              // Don't navigate away if the operator started a NEW edit during
+              // the clash round-trip — that would silently discard it. Stay on
+              // the page so the pending change can be saved.
+              if (onBack && editedFieldsRef.current.size === 0) onBack();
             }
           })
           .catch(() => {
             if (!mountedRef.current) return;
             showToast("Competition settings saved");
-            if (onBack) onBack();
+            if (onBack && editedFieldsRef.current.size === 0) onBack();
           });
       }
     }).catch((e) => {
@@ -377,20 +380,6 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     if (saveErr) setSaveErr(null);
   };
 
-  // `updateNow` previously saved immediately (used by toggles / radio pills /
-  // court chips). Under manual save it is identical to `update` — kept as a
-  // separate name only to avoid churning the ~20 JSX call sites.
-  const updateNow = (k, v) => {
-    editedFieldsRef.current.add(k);
-    setLocal((prev) => {
-      const next = { ...prev, [k]: v };
-      localRef.current = next;
-      return next;
-    });
-    setIsDirty(true);
-    if (saveErr) setSaveErr(null);
-  };
-
   // Number-input variant of `update`. Stores NaN in local state for empty
   // input so the render side can keep the display empty (see
   // decideNumericUpdate's contract). Marks the field as edited so the
@@ -417,7 +406,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
 
   const toggleCourt = (cc) => {
     const nextCourts = local.courts.includes(cc) ? local.courts.filter((x) => x !== cc) : [...local.courts, cc].sort();
-    if (nextCourts.length) updateNow("courts", nextCourts);
+    if (nextCourts.length) update("courts", nextCourts);
   };
 
   // draw-ready lock: output-affecting fields — those that reach the Excel
@@ -573,8 +562,8 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
             <label className="field__label">Pool size is a</label>
             {/* draw-ready lock: poolSizeMode, poolSize, poolWinners are output-affecting. */}
             <div className="radio-group">
-              <button className={`radio-pill ${local.poolSizeMode === "max" ? "is-active" : ""}`} type="button" onClick={() => updateNow("poolSizeMode", "max")} disabled={isDrawReady}>maximum</button>
-              <button className={`radio-pill ${local.poolSizeMode === "min" ? "is-active" : ""}`} type="button" onClick={() => updateNow("poolSizeMode", "min")} disabled={isDrawReady}>minimum</button>
+              <button className={`radio-pill ${local.poolSizeMode === "max" ? "is-active" : ""}`} type="button" onClick={() => update("poolSizeMode", "max")} disabled={isDrawReady}>maximum</button>
+              <button className={`radio-pill ${local.poolSizeMode === "min" ? "is-active" : ""}`} type="button" onClick={() => update("poolSizeMode", "min")} disabled={isDrawReady}>minimum</button>
             </div>
           </div>
           <div className="row">
@@ -707,17 +696,17 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {/* draw-ready lock: roundRobin is output-affecting. */}
-        <label className="checkbox"><input type="checkbox" checked={local.roundRobin} onChange={(e) => updateNow("roundRobin", e.target.checked)} disabled={isDrawReady} /> Round-robin in pools</label>
+        <label className="checkbox"><input type="checkbox" checked={local.roundRobin} onChange={(e) => update("roundRobin", e.target.checked)} disabled={isDrawReady} /> Round-robin in pools</label>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label className="checkbox"><input type="checkbox" checked={local.withZekkenName} onChange={(e) => updateNow("withZekkenName", e.target.checked)} disabled={isDrawReady || local.kind === "team"} /> Use Zekken display name</label>
+          <label className="checkbox"><input type="checkbox" checked={local.withZekkenName} onChange={(e) => update("withZekkenName", e.target.checked)} disabled={isDrawReady || local.kind === "team"} /> Use Zekken display name</label>
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>{local.kind === "team" ? "(Only applicable for individual competitions)" : "When enabled, participant CSV uses three columns: Name, Zekken, Dojo."}</div>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label className="checkbox"><input type="checkbox" checked={!!local.naginata} onChange={(e) => updateNow("naginata", e.target.checked)} /> Naginata competition</label>
+          <label className="checkbox"><input type="checkbox" checked={!!local.naginata} onChange={(e) => update("naginata", e.target.checked)} /> Naginata competition</label>
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>Adds the Sune (S) ippon button to the score editor. Use for Naginata divisions.</div>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <label className="checkbox"><input type="checkbox" checked={!!local.checkInEnabled} onChange={(e) => updateNow("checkInEnabled", e.target.checked)} /> Check-in tracking</label>
+          <label className="checkbox"><input type="checkbox" checked={!!local.checkInEnabled} onChange={(e) => update("checkInEnabled", e.target.checked)} /> Check-in tracking</label>
           <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>Show check-in column and counter. Disable for competitions that don't need attendance tracking.</div>
         </div>
       </div>
@@ -730,19 +719,19 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
               <button
                 className={`radio-pill ${(local.leagueTiebreakTopN || 0) === 0 || local.leagueTiebreakTopN === 3 ? "is-active" : ""}`}
                 type="button"
-                onClick={() => updateNow("leagueTiebreakTopN", 3)}
+                onClick={() => update("leagueTiebreakTopN", 3)}
               >Top 3</button>
               <button
                 className={`radio-pill ${local.leagueTiebreakTopN === 4 ? "is-active" : ""}`}
                 type="button"
-                onClick={() => updateNow("leagueTiebreakTopN", 4)}
+                onClick={() => update("leagueTiebreakTopN", 4)}
               >Top 4</button>
             </div>
             <div className="field__hint">Tied teams within this finishing band require an operator-run tie-breaker before standings are finalised.</div>
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             <label className="checkbox">
-              <input type="checkbox" checked={!!local.leagueTwoThirdPlaces} onChange={(e) => updateNow("leagueTwoThirdPlaces", e.target.checked)} />
+              <input type="checkbox" checked={!!local.leagueTwoThirdPlaces} onChange={(e) => update("leagueTwoThirdPlaces", e.target.checked)} />
               {" "}Award two joint 3rd places
             </label>
             <div className="field__hint" style={{ fontSize: 11, paddingLeft: 22 }}>When enabled, teams tied entirely at 3rd place share bronze — no 3rd-vs-4th tie-breaker is needed. Standard kendo convention.</div>

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -41,6 +41,10 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   // the button and shows "Saving…" during the in-flight PUT.
   const [isDirty, setIsDirty] = useStateA(false);
   const [saving, setSaving] = useStateA(false);
+  // Court-clash warnings surfaced after a save (mp-4a52). Non-blocking: the
+  // save already committed; when present we stay on the page to show them
+  // instead of returning to the dashboard.
+  const [clashWarnings, setClashWarnings] = useStateA(null);
 
   // Schedule estimate (mp-zoh Phase 4): fetch per-competition estimate and
   // display it inline near the duration inputs. Re-fetches whenever the
@@ -312,12 +316,30 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       // in-flight save. Those linger in editedFieldsRef and still need a save.
       const stillDirty = editedFieldsRef.current.size > 0;
       setIsDirty(stillDirty);
-      // Return to the dashboard on a clean save (nothing left pending) so the
-      // operator lands back on the competition list after finishing edits.
-      // A toast carries the confirmation since the on-page indicator unmounts.
-      if (!stillDirty && onBack) {
-        showToast("Competition settings saved");
-        onBack();
+      // On a clean save (nothing left pending), check whether the change put
+      // this competition on a court (shiaijo) at the same time as another. The
+      // save has already committed — this is a non-blocking warning. If clashes
+      // exist we surface them and STAY on the page; otherwise we return to the
+      // dashboard. A clash-check failure must not strand the operator, so it
+      // falls through to the normal saved-and-return path.
+      if (!stillDirty) {
+        window.API.getScheduleClashes(c.id, password)
+          .then((clashes) => {
+            if (!mountedRef.current) return;
+            if (Array.isArray(clashes) && clashes.length > 0) {
+              setClashWarnings(clashes);
+              showToast(`Saved — ${clashes.length} court clash${clashes.length > 1 ? "es" : ""} detected, review below`, "error");
+            } else {
+              setClashWarnings(null);
+              showToast("Competition settings saved");
+              if (onBack) onBack();
+            }
+          })
+          .catch(() => {
+            if (!mountedRef.current) return;
+            showToast("Competition settings saved");
+            if (onBack) onBack();
+          });
       }
     }).catch((e) => {
       if (!mountedRef.current) return;
@@ -408,6 +430,24 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
           </button>
         </div>
       </div>
+      {clashWarnings && clashWarnings.length > 0 && (
+        <div className="alert alert--warn" style={{ marginBottom: 12 }} data-testid="clash-banner">
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>
+            ⚠ Court clash — this competition overlaps {clashWarnings.length === 1 ? "another" : `${clashWarnings.length} other`} on a shared shiaijo:
+          </div>
+          <ul style={{ margin: "0 0 8px 16px", padding: 0 }}>
+            {clashWarnings.map((w, i) => (
+              <li key={i}>
+                <strong>{w.otherCompName}</strong> — shiaijo {(w.sharedCourts || []).join(", ")} · {w.overlapStart}–{w.overlapEnd}
+              </li>
+            ))}
+          </ul>
+          <div style={{ fontSize: 12, color: "var(--ink-3)", marginBottom: 8 }}>
+            The change was saved. Two competitions can't run on the same court at the same time — adjust the start time or assigned courts here or on the other competition.
+          </div>
+          <button type="button" className="btn btn--sm" onClick={() => { setClashWarnings(null); if (onBack) onBack(); }}>Dismiss & return to dashboard</button>
+        </div>
+      )}
       <div className="row">
         <div className="field"><label className="field__label">Display name</label><input className="input" value={local.name} onChange={(e) => update("name", e.target.value)} /></div>
         <div className="field">

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -362,9 +362,16 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
     editedFieldsRef.current.add(k);
     // Functional updater so back-to-back edits (e.g. fast successive
     // toggles / paste-driven multi-field updates) don't clobber each other
-    // by spreading a stale closure-captured `local`. Mirrors the sync
-    // effect above which also uses the prev form.
-    setLocal((prev) => ({ ...prev, [k]: v }));
+    // by spreading a stale closure-captured `local`. We also write the
+    // result to localRef synchronously: saveNow reads localRef.current when
+    // the operator clicks Save, and the useEffect that syncs localRef from
+    // `local` is async — a rapid edit-then-click could otherwise land before
+    // the effect runs and the latest edit would be missing from the PUT.
+    setLocal((prev) => {
+      const next = { ...prev, [k]: v };
+      localRef.current = next;
+      return next;
+    });
     setIsDirty(true);
     // Clear a stale inline error once the user edits again.
     if (saveErr) setSaveErr(null);
@@ -375,7 +382,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   // separate name only to avoid churning the ~20 JSX call sites.
   const updateNow = (k, v) => {
     editedFieldsRef.current.add(k);
-    setLocal((prev) => ({ ...prev, [k]: v }));
+    setLocal((prev) => {
+      const next = { ...prev, [k]: v };
+      localRef.current = next;
+      return next;
+    });
     setIsDirty(true);
     if (saveErr) setSaveErr(null);
   };
@@ -395,7 +406,11 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
   const updateNumber = (k, raw, min = 1) => {
     const { value } = decideNumericUpdate(raw, min);
     editedFieldsRef.current.add(k);
-    setLocal((prev) => ({ ...prev, [k]: value }));
+    setLocal((prev) => {
+      const next = { ...prev, [k]: value };
+      localRef.current = next;
+      return next;
+    });
     setIsDirty(true);
     if (saveErr) setSaveErr(null);
   };

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -232,14 +232,13 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   const [showAllPreview, setShowAllPreview] = useStateA(false);
   const [seedImportResult, setSeedImportResult] = useStateA(null);
   const [importSummary, setImportSummary] = useStateA(null);
-  const [text, setText] = useStateA(() => (c.players || []).map((p) => {
-    if (c.withZekkenName && p.displayName) {
-      const base = `${p.name ?? ""}, ${p.displayName ?? ""}, ${p.dojo ?? ""}`;
-      return p.danGrade ? `${base}, ${p.danGrade}` : base;
-    }
-    const base = `${p.name ?? ""}, ${p.dojo ?? ""}`;
-    return p.danGrade ? `${base}, ${p.danGrade}` : base;
-  }).join("\n"));
+  // Initialise from the SAME generator that rosterDirty diffs against
+  // (generateRosterText), not the old inline 3-col-only-when-displayName
+  // logic. Otherwise a zekken competition whose players lack a displayName
+  // starts with "Name, Dojo" while rosterDirty computes "Name, LASTNAME,
+  // Dojo" → a false "Unsaved changes" flash on mount before the
+  // c.players/withZekkenName effect re-syncs text.
+  const [text, setText] = useStateA(() => generateRosterText(c.players || [], c.withZekkenName));
   const [dragOver, setDragOver] = useStateA(false);
   const fileRef = useRefA(null);
   const seedFileRef = useRefA(null);

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -172,25 +172,30 @@ function generateRosterText(playersList, withZekkenName) {
   }).join("\n");
 }
 
-// validateRosterRows checks parsed roster rows for missing required columns
+// validateRosterRows checks parsed roster rows for the required columns
 // before they are sent to the server. Name and dojo are mandatory for every
-// competition. In a zekken competition a row needs Name, Zekken, Dojo — a
-// two-column "Name, Dojo" paste is parsed as {displayName: dojo, dojo: ""},
-// so an empty dojo is the tell-tale of a row that is missing its zekken column.
+// competition. Note that an EMPTY zekken is NOT enforced here: only name + dojo
+// are. In a zekken competition the expected three-column format is
+// Name, Zekken, Dojo — a two-column "Name, Dojo" paste is misparsed into
+// {displayName: dojo, dojo: ""}, so an empty dojo on a zekken competition is
+// the tell-tale of that misparse rather than a missing zekken value, and the
+// reason text surfaces the expected format as a hint.
 // Returns an array of { index, name, reason } for each offending row (empty
-// when the roster is valid).
+// when the roster is valid). The stored `name` is the TRIMMED value (not the
+// raw input), so whitespace-only names render as the falsy "line N" branch in
+// the apply() toast rather than a literal "   " label.
 function validateRosterRows(parsed, withZekkenName) {
   const problems = [];
   (parsed || []).forEach((p, i) => {
     const name = (p.name || "").trim();
     const dojo = (p.dojo || "").trim();
     if (!name) {
-      problems.push({ index: i, name: p.name || "", reason: "missing name" });
+      problems.push({ index: i, name, reason: "missing name" });
       return;
     }
     if (!dojo) {
       const reason = withZekkenName
-        ? "missing dojo (zekken competitions need Name, Zekken, Dojo)"
+        ? "missing dojo (zekken competitions use Name, Zekken, Dojo)"
         : "missing dojo";
       problems.push({ index: i, name, reason });
     }

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -156,6 +156,48 @@ function levenshtein(a, b) {
   return prev[n];
 }
 
+function generateRosterText(playersList, withZekkenName) {
+  return (playersList || []).map((p) => {
+    if (withZekkenName) {
+      // Fall back to uppercase last name when displayName is absent (e.g. sample
+      // roster from makePlayer). Without a fallback the line has only two columns
+      // which parseParticipantLines(withZekken=true) misreads — mapping dojo into
+      // the zekken slot and leaving dojo blank.
+      const zekken = p.displayName || (p.name ?? "").split(" ").pop().toUpperCase();
+      const base = `${p.name ?? ""}, ${zekken}, ${p.dojo ?? ""}`;
+      return p.danGrade ? `${base}, ${p.danGrade}` : base;
+    }
+    const base = `${p.name ?? ""}, ${p.dojo ?? ""}`;
+    return p.danGrade ? `${base}, ${p.danGrade}` : base;
+  }).join("\n");
+}
+
+// validateRosterRows checks parsed roster rows for missing required columns
+// before they are sent to the server. Name and dojo are mandatory for every
+// competition. In a zekken competition a row needs Name, Zekken, Dojo — a
+// two-column "Name, Dojo" paste is parsed as {displayName: dojo, dojo: ""},
+// so an empty dojo is the tell-tale of a row that is missing its zekken column.
+// Returns an array of { index, name, reason } for each offending row (empty
+// when the roster is valid).
+function validateRosterRows(parsed, withZekkenName) {
+  const problems = [];
+  (parsed || []).forEach((p, i) => {
+    const name = (p.name || "").trim();
+    const dojo = (p.dojo || "").trim();
+    if (!name) {
+      problems.push({ index: i, name: p.name || "", reason: "missing name" });
+      return;
+    }
+    if (!dojo) {
+      const reason = withZekkenName
+        ? "missing dojo (zekken competitions need Name, Zekken, Dojo)"
+        : "missing dojo";
+      problems.push({ index: i, name, reason });
+    }
+  });
+  return problems;
+}
+
 function AdminParticipants({ c, tournament: _tournament, onUpdate, password, showToast, onSection }) {
   const [showOnlyUnchecked, setShowOnlyUnchecked] = useStateA(false);
   const [replaceTarget, setReplaceTarget] = useStateA(null);
@@ -198,14 +240,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   useEffectA(() => () => { mountedRef.current = false; }, []);
   const textFocusRef = useRefA(false);
 
-  const generateText = (playersList) => (playersList || []).map((p) => {
-    if (c.withZekkenName && p.displayName) {
-      const base = `${p.name ?? ""}, ${p.displayName ?? ""}, ${p.dojo ?? ""}`;
-      return p.danGrade ? `${base}, ${p.danGrade}` : base;
-    }
-    const base = `${p.name ?? ""}, ${p.dojo ?? ""}`;
-    return p.danGrade ? `${base}, ${p.danGrade}` : base;
-  }).join("\n");
+  const generateText = (playersList) => generateRosterText(playersList, c.withZekkenName);
 
   // Fill the roster textarea with a generated sample roster of `count`
   // competitors. This lives in the Participants view (not the create form)
@@ -616,6 +651,19 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
       const withZekken = c.withZekkenName;
       const parsed = window.parseParticipantLines(lines, withZekken);
 
+      // Reject rows missing a required column before sending. Catches a
+      // misformatted paste (e.g. a two-column "Name, Dojo" line in a zekken
+      // competition, parsed as {displayName: dojo, dojo: ""}) up front with an
+      // actionable message, instead of relying on the server 400 round-trip.
+      const rowProblems = validateRosterRows(parsed, withZekken);
+      if (rowProblems.length > 0) {
+        const first = rowProblems[0];
+        const label = first.name ? `"${first.name}"` : `line ${first.index + 1}`;
+        const more = rowProblems.length > 1 ? ` (and ${rowProblems.length - 1} more)` : "";
+        showToast(`Cannot save: ${label} ${first.reason}${more}`, "error");
+        return;
+      }
+
       // Tier-1: Duplicate detection — reject on perfect (normalizedName,
       // normalizedDojo) collision.  Uses name+dojo so two people from
       // different clubs with the same name are allowed.
@@ -757,15 +805,25 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
         <div className="card" style={{ marginBottom: 16, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
           <div>
             <div className="card__title" style={{ marginBottom: 2 }}>
-              {players.length >= 2 ? "Roster ready" : "Add your roster to begin"}
+              {players.length >= 2 ? "Roster ready — next: generate the draw" : "Add your roster to begin"}
             </div>
             <div className="card__sub">
               {players.length >= 2
-                ? `${players.length} ${c.kind === "team" ? "teams" : "participants"} added. Assign seeds (optional), then use “Generate draw” in the header to build the bracket.`
+                ? `${players.length} ${c.kind === "team" ? "teams" : "participants"} added. Optionally assign seeds, then continue to Overview to generate the draw.`
                 : `Add at least 2 ${c.kind === "team" ? "teams" : "participants"}, then you can generate the draw.`}
             </div>
           </div>
-          <button type="button" className="btn" onClick={() => onSection("overview")}>View setup steps →</button>
+          {/* When the roster is ready the next action is generating the draw,
+              which lives on the Overview page. Make that a primary CTA so the
+              next step is obvious; before the roster is ready, keep a low-key
+              link to the full setup checklist. */}
+          <button
+            type="button"
+            className={players.length >= 2 ? "btn btn--primary" : "btn"}
+            onClick={() => onSection("overview")}
+          >
+            {players.length >= 2 ? "Continue to draw setup →" : "View setup steps →"}
+          </button>
         </div>
       )}
       <div className="row" style={{ alignItems: "start", ...(emptyRoster ? { gridTemplateColumns: "1fr" } : {}) }}>
@@ -1151,6 +1209,14 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               </div>
             );
           })()}
+          {/* Repeat Apply at the bottom so the operator doesn't have to scroll
+              back up after pasting/reviewing a long roster. Same handler and
+              disabled rules as the top button. */}
+          {lines.length > 0 && (
+            <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 12 }}>
+              <button className="btn btn--primary" type="button" onClick={apply} disabled={hasGaps || isDrawReady} title={isDrawReady ? "Discard the draw to apply roster changes" : undefined}>Apply changes</button>
+            </div>
+          )}
         </div>
       </div>
     </>
@@ -1165,4 +1231,4 @@ window.AdminParticipants = AdminParticipants;
 
 // ES export for the vitest suite — pure helpers only. Components remain
 // behind the window.* global pattern to match the rest of admin_*.jsx.
-export { mintParticipantIds, findSeedMatchIndex, participantSearchTarget };
+export { mintParticipantIds, findSeedMatchIndex, participantSearchTarget, generateRosterText, validateRosterRows };

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -198,7 +198,7 @@ function validateRosterRows(parsed, withZekkenName) {
   return problems;
 }
 
-function AdminParticipants({ c, tournament: _tournament, onUpdate, password, showToast, onSection }) {
+function AdminParticipants({ c, tournament: _tournament, onUpdate, password, showToast, onSection, onBack }) {
   const [showOnlyUnchecked, setShowOnlyUnchecked] = useStateA(false);
   const [replaceTarget, setReplaceTarget] = useStateA(null);
   const [showAddForm, setShowAddForm] = useStateA(false);
@@ -375,6 +375,14 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   const [searchQuery, setSearchQuery] = useStateA("");
   const trimmedSearch = useMemoA(() => searchQuery.trim(), [searchQuery]);
   const lines = useMemoA(() => text.split("\n").filter((l) => l.trim()), [text]);
+  // Unsaved-roster detection: the textarea has edits not yet committed via
+  // "Apply changes". Compare against the saved roster's canonical rendering,
+  // ignoring blank-line / trailing-whitespace noise so re-typing the same
+  // roster doesn't read as dirty. Mirrors the Settings unsaved indicator.
+  const rosterDirty = useMemoA(() => {
+    const norm = (s) => s.split("\n").map((l) => l.trim()).filter(Boolean).join("\n");
+    return norm(text) !== norm(generateText(c.players || []));
+  }, [text, c.players, c.withZekkenName]);
   const players = useMemoA(() => c.players || [], [c.players]);
   // First-run: with no participants yet there is nothing to seed or check in,
   // so the seeding panel is premature. Collapse it and let the roster-input
@@ -733,7 +741,12 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
       }
       showToast(msg);
       setImportSummary(null);
-      setNearDupPending(Array.isArray(warnings) && warnings.length > 0 ? { pairs: warnings } : null);
+      const hasWarnings = Array.isArray(warnings) && warnings.length > 0;
+      setNearDupPending(hasWarnings ? { pairs: warnings } : null);
+      // Return to the dashboard after a clean apply so the operator lands back
+      // on the competition list. When the save surfaced near-duplicate warnings,
+      // stay put so they can review the banner before navigating away.
+      if (!hasWarnings && onBack) onBack();
     } catch (err) {
       // PUT failure path. updateCompetition already showed an error
       // toast for the user; log here so the dev console has the stack
@@ -1106,7 +1119,8 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               </div>
             </div>
             {/* draw-ready lock: roster mutations (paste, apply, CSV import) disabled until the draw is discarded */}
-            <div style={{ display: "flex", gap: 6 }}>
+            <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+              {rosterDirty && !isDrawReady && <span style={{ fontSize: 12.5, color: "var(--warn)", fontWeight: 600 }}>● Unsaved changes</span>}
               <button className="btn btn--sm" type="button" onClick={pasteFromExcel} disabled={isDrawReady} title={isDrawReady ? "Discard the draw to edit participants" : "Reads clipboard and converts tab-separated values (e.g. from Excel) to CSV"}>Paste clipboard</button>
               <button className="btn btn--sm btn--primary" type="button" onClick={apply} disabled={hasGaps || isDrawReady} title={isDrawReady ? "Discard the draw to apply roster changes" : undefined}>Apply changes</button>
             </div>
@@ -1213,7 +1227,8 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
               back up after pasting/reviewing a long roster. Same handler and
               disabled rules as the top button. */}
           {lines.length > 0 && (
-            <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 12 }}>
+            <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 10, marginTop: 12 }}>
+              {rosterDirty && !isDrawReady && <span style={{ fontSize: 12.5, color: "var(--warn)", fontWeight: 600 }}>● Unsaved changes</span>}
               <button className="btn btn--primary" type="button" onClick={apply} disabled={hasGaps || isDrawReady} title={isDrawReady ? "Discard the draw to apply roster changes" : undefined}>Apply changes</button>
             </div>
           )}

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -159,11 +159,19 @@ function levenshtein(a, b) {
 function generateRosterText(playersList, withZekkenName) {
   return (playersList || []).map((p) => {
     if (withZekkenName) {
-      // Fall back to uppercase last name when displayName is absent (e.g. sample
-      // roster from makePlayer). Without a fallback the line has only two columns
-      // which parseParticipantLines(withZekken=true) misreads — mapping dojo into
-      // the zekken slot and leaving dojo blank.
-      const zekken = p.displayName || (p.name ?? "").split(" ").pop().toUpperCase();
+      // Fall back to uppercase last name ONLY when displayName is absent
+      // (null/undefined) — `??` not `||`, so an intentional empty zekken
+      // (displayName: "") is preserved verbatim. Without that, a saved
+      // empty-zekken row would re-render with a synthetic last-name, making
+      // the rosterDirty diff flip true on every reload. The fallback covers
+      // the sample roster from makePlayer (which never sets displayName);
+      // without it, the line would have only two columns and
+      // parseParticipantLines(withZekken=true) would misread dojo into the
+      // zekken slot and leave dojo blank. Tokenise on whitespace and filter
+      // empties so a trailing-space name like "Alice " still derives "ALICE".
+      const tokens = (p.name ?? "").trim().split(/\s+/).filter(Boolean);
+      const fallback = tokens.length ? tokens[tokens.length - 1].toUpperCase() : "";
+      const zekken = p.displayName ?? fallback;
       const base = `${p.name ?? ""}, ${zekken}, ${p.dojo ?? ""}`;
       return p.danGrade ? `${base}, ${p.danGrade}` : base;
     }

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -691,7 +691,14 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     if (startTimeEditedRef.current) return;
     const sameDay = (tournament.competitions || []).filter((cc) => cc.date === date && cc.startTime);
     if (sameDay.length === 0) return; // no predecessor → keep the 09:00 default
-    const latest = sameDay.reduce((a, b) => (b.startTime > a.startTime ? b : a));
+    // Compare numerically (minutes-since-midnight). The backend trims StartTime
+    // but does not normalise to zero-padded HH:MM, so a legacy/imported "9:00"
+    // would lex-sort AFTER "10:00" and pick the wrong predecessor.
+    const toMin = (s) => {
+      const [h, m] = String(s || "").split(":").map((n) => parseInt(n, 10));
+      return (Number.isFinite(h) ? h : 0) * 60 + (Number.isFinite(m) ? m : 0);
+    };
+    const latest = sameDay.reduce((a, b) => (toMin(b.startTime) > toMin(a.startTime) ? b : a));
     const controller = new AbortController();
     let cancelled = false;
     const applyStacked = (durMin) => {

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -635,7 +635,13 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   );
 }
 
-function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onViewerMode }) {
+// Minimum gap (minutes) stacked after the previous competition when defaulting
+// a new competition's start time. Before a competition has a roster its
+// schedule estimate is ~0, so this floor keeps successive competitions visibly
+// stacked; once a roster exists the real estimate takes over if it is larger.
+const MIN_STACK_BLOCK_MIN = 30;
+
+function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onViewerMode, password }) {
   const [name, setName] = useStateA("");
   const [kind, setKind] = useStateA("individual");
   const [gender, setGender] = useStateA("M"); // for individual: M/F/X
@@ -654,6 +660,9 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   // matches the example in spec.md US13. Only used when format=swiss.
   const [swissRounds, setSwissRounds] = useStateA(4);
   const [startTime, setStartTime] = useStateA("09:00");
+  // Once the operator types a start time, stop auto-stacking it (see the
+  // effect below) so we never clobber a deliberate choice.
+  const startTimeEditedRef = useRefA(false);
   const [date, setDate] = useStateA(tournament.date);
   const [teamSize, setTeamSize] = useStateA(5);
   const [numberPrefix, setNumberPrefix] = useStateA("");
@@ -672,6 +681,29 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     prevCourtsRef.current = tournament.courts;
   }, [tournament.courts]);
   const [error, setError] = useStateA("");
+
+  // Auto-stack the default start time after the previous competition on the
+  // same day. We take the latest-STARTING same-day competition and add its
+  // estimated duration (≈0 until it has a roster) floored at MIN_STACK_BLOCK_MIN,
+  // so back-to-back creates lay out sequentially. Skipped once the operator
+  // edits the field; re-runs when the selected day changes.
+  useEffectA(() => {
+    if (startTimeEditedRef.current) return;
+    const sameDay = (tournament.competitions || []).filter((cc) => cc.date === date && cc.startTime);
+    if (sameDay.length === 0) return; // no predecessor → keep the 09:00 default
+    const latest = sameDay.reduce((a, b) => (b.startTime > a.startTime ? b : a));
+    const controller = new AbortController();
+    let cancelled = false;
+    const applyStacked = (durMin) => {
+      if (cancelled || startTimeEditedRef.current) return;
+      const block = Math.max(Math.round(durMin || 0), MIN_STACK_BLOCK_MIN);
+      setStartTime(window.addMinutes(latest.startTime, block));
+    };
+    window.API.estimateCompetitionSchedule(latest.id, password, controller.signal)
+      .then((est) => applyStacked(est?.totalDurationMinutes))
+      .catch(() => { if (!controller.signal.aborted) applyStacked(0); });
+    return () => { cancelled = true; controller.abort(); };
+  }, [date, tournament.competitions, password]);
 
   const toggleCourt = (cc) => setSelectedCourts((sc) => sc.includes(cc) ? sc.filter((c) => c !== cc) : [...sc, cc].sort());
 
@@ -837,7 +869,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
             </div>
             <div className="field">
               <label className="field__label">Start time</label>
-              <input className="input" type="time" value={startTime} onChange={(e) => setStartTime(e.target.value)} />
+              <input className="input" type="time" value={startTime} onChange={(e) => { startTimeEditedRef.current = true; setStartTime(e.target.value); }} />
             </div>
           </div>
 

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -93,6 +93,7 @@ function validateSwissSettings(format, swissRounds) {
 // dirty-tracking snapshot here can't drift from the shape BrandingManager emits
 // (mp-sspn). Importing keeps the defaults in one place.
 import { normalizeTheme } from './admin_branding.jsx';
+import { timeToMinutes } from './admin_schedule_utils.jsx';
 
 function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerMode, authConfig, password, showToast }) {
   // In locked mode the on-disk Password is irrelevant — auth comes
@@ -697,23 +698,20 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     if (sameDay.length === 0) return; // no predecessor → keep the 09:00 default
     // Compare numerically (minutes-since-midnight). The backend trims StartTime
     // but does not normalise to zero-padded HH:MM, so a legacy/imported "9:00"
-    // would lex-sort AFTER "10:00" and pick the wrong predecessor.
-    const toMin = (s) => {
-      const [h, m] = String(s || "").split(":").map((n) => parseInt(n, 10));
-      return (Number.isFinite(h) ? h : 0) * 60 + (Number.isFinite(m) ? m : 0);
-    };
-    const latest = sameDay.reduce((a, b) => (toMin(b.startTime) > toMin(a.startTime) ? b : a));
+    // would lex-sort AFTER "10:00" and pick the wrong predecessor. timeToMinutes
+    // returns null for malformed input, but the sameDay filter guarantees a
+    // truthy startTime, so the reduce only ever compares real clock values.
+    const latest = sameDay.reduce((a, b) => ((timeToMinutes(b.startTime) || 0) > (timeToMinutes(a.startTime) || 0) ? b : a));
     const controller = new AbortController();
-    let cancelled = false;
     const applyStacked = (durMin) => {
-      if (cancelled || startTimeEditedRef.current) return;
+      if (controller.signal.aborted || startTimeEditedRef.current) return;
       const block = Math.max(Math.round(durMin || 0), MIN_STACK_BLOCK_MIN);
       setStartTime(window.addMinutes(latest.startTime, block));
     };
     window.API.estimateCompetitionSchedule(latest.id, password, controller.signal)
       .then((est) => applyStacked(est?.totalDurationMinutes))
       .catch(() => { if (!controller.signal.aborted) applyStacked(0); });
-    return () => { cancelled = true; controller.abort(); };
+    return () => { controller.abort(); };
   }, [date, tournament.competitions, password]);
 
   const toggleCourt = (cc) => setSelectedCourts((sc) => sc.includes(cc) ? sc.filter((c) => c !== cc) : [...sc, cc].sort());

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -685,8 +685,12 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   // Auto-stack the default start time after the previous competition on the
   // same day. We take the latest-STARTING same-day competition and add its
   // estimated duration (≈0 until it has a roster) floored at MIN_STACK_BLOCK_MIN,
-  // so back-to-back creates lay out sequentially. Skipped once the operator
-  // edits the field; re-runs when the selected day changes.
+  // so back-to-back creates lay out sequentially. Behaviour:
+  //  - Recomputes when the operator switches days BEFORE editing the start
+  //    time (each day has its own predecessor).
+  //  - Once the operator types a start time, startTimeEditedRef latches and
+  //    this effect short-circuits — a deliberate manual choice survives
+  //    subsequent day changes rather than being silently overwritten.
   useEffectA(() => {
     if (startTimeEditedRef.current) return;
     const sameDay = (tournament.competitions || []).filter((cc) => cc.date === date && cc.startTime);

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -43,6 +43,22 @@ function deriveCompetitionName(rawName, kind, gender) {
   return "Individual";
 }
 
+// pickStackPredecessor returns the latest-STARTING same-day competition that the
+// new competition's default start time should stack after — or null when there
+// is no usable predecessor (the caller keeps the 09:00 default).
+//
+// Entries are filtered on PARSEABLE start times (timeToMinutes !== null), not
+// just truthy ones: the backend only length-caps StartTime (no format
+// validation), so a legacy/imported competition could carry a malformed value.
+// Including such an entry could make it the `latest` and make the caller's
+// addMinutes() emit "NaN:NaN". Comparison is numeric (minutes-since-midnight)
+// so an un-zero-padded "9:00" doesn't lex-sort after "10:00".
+function pickStackPredecessor(competitions, date) {
+  const sameDay = (competitions || []).filter((cc) => cc.date === date && timeToMinutes(cc.startTime) !== null);
+  if (sameDay.length === 0) return null;
+  return sameDay.reduce((a, b) => (timeToMinutes(b.startTime) > timeToMinutes(a.startTime) ? b : a));
+}
+
 // Pure submit-time validation for AdminCreateCompetition's pool-format
 // fields. Returns { ok, error } so the caller (create) can route the
 // error string through setError without duplicating the per-field
@@ -694,14 +710,10 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
   //    subsequent day changes rather than being silently overwritten.
   useEffectA(() => {
     if (startTimeEditedRef.current) return;
-    const sameDay = (tournament.competitions || []).filter((cc) => cc.date === date && cc.startTime);
-    if (sameDay.length === 0) return; // no predecessor → keep the 09:00 default
-    // Compare numerically (minutes-since-midnight). The backend trims StartTime
-    // but does not normalise to zero-padded HH:MM, so a legacy/imported "9:00"
-    // would lex-sort AFTER "10:00" and pick the wrong predecessor. timeToMinutes
-    // returns null for malformed input, but the sameDay filter guarantees a
-    // truthy startTime, so the reduce only ever compares real clock values.
-    const latest = sameDay.reduce((a, b) => ((timeToMinutes(b.startTime) || 0) > (timeToMinutes(a.startTime) || 0) ? b : a));
+    // latest.startTime is guaranteed parseable (pickStackPredecessor filters on
+    // timeToMinutes !== null), so addMinutes() below never emits "NaN:NaN".
+    const latest = pickStackPredecessor(tournament.competitions, date);
+    if (!latest) return; // no usable predecessor → keep the 09:00 default
     const controller = new AbortController();
     const applyStacked = (durMin) => {
       if (controller.signal.aborted || startTimeEditedRef.current) return;
@@ -1264,4 +1276,4 @@ window.AdminImportPage = AdminImportPage;
 // The announcement-broadcast helpers (isSendAnnouncementDisabled /
 // sendAnnouncementLabel) moved to admin_announcement.jsx alongside the
 // AnnouncementComposer component they drive (mp-djc).
-export { deriveCompetitionName, validatePoolSettings, validateSwissSettings };
+export { deriveCompetitionName, validatePoolSettings, validateSwissSettings, pickStackPredecessor };

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -873,6 +873,20 @@ const API = {
         }
         return res.json();
     },
+    // Court (shiaijo) clashes between this competition and every other one
+    // (same day, shared court, overlapping time windows). Returns a possibly
+    // empty array of ClashWarning objects. Non-blocking — surfaced as a warning.
+    async getScheduleClashes(compID, password, signal) {
+        const res = await fetch(`/api/competitions/${compID}/schedule/clashes`, {
+            headers: { 'X-Tournament-Password': password },
+            signal,
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.error || "Failed to check schedule clashes");
+        }
+        return res.json();
+    },
     async moveMatchCourt(compID, matchID, court, password) {
         const res = await fetch(`/api/competitions/${compID}/matches/${matchID}/court`, {
             method: 'PUT',


### PR DESCRIPTION
## Summary

Roster-entry and competition-settings fixes in the mobile admin:

- **Sample roster now adapts to zekken competitions.** Picking a sample roster ("Small/Medium/Large") in a zekken comp produced two-column `Name, Dojo` lines, which the parser misread as `{zekken: Dojo, dojo: ""}` — corrupting the roster. Sample lines are now correctly `Name, ZEKKEN, Dojo`.
- **Invalid roster submissions are rejected instead of silently "saved".** A blank-dojo row previously saved with HTTP 200 and a "Saved" toast while persisting corrupt data. The server now rejects blank name/dojo on the batch path, and the client shows an actionable, format-aware error before the round-trip.
- **The next step after adding participants is now obvious** — a primary **"Continue to draw setup →"** CTA, plus the **Apply** button repeated below the preview table.
- **Competition Settings now has an explicit Save button (manual save).** It was the only admin surface that silently debounce-autosaved; every comparable surface (Tournament Edit-details, Participants, Create) commits on an explicit button. Converted to manual save with header + footer "Save changes" buttons and an "● Unsaved changes / Saving… / ✓ Saved at …" indicator.

## Why

Roster root cause: `makePlayer` never sets `displayName`, so `generateRosterText` fell through to the two-column branch for sample rosters; in a zekken comp `parseParticipantLines` maps `parts[1]`→zekken and `parts[2]`→dojo, so a two-column line lands dojo into the zekken slot and leaves dojo empty. The batch `Players[]` POST only validated max-lengths (not blank dojo), so the corrupt row saved with 200 and the success toast was truthful about the PUT while the data was wrong.

Settings: debounced autosave gave no Save affordance and no clear unsaved/saved state, inconsistent with the rest of the admin. The conversion keeps the carefully-guarded concurrent-edit machinery — `saveNow` still overlays `editedFieldsRef` onto a fresh `cRef` snapshot, so an SSE-driven change to a field the operator isn't editing is not reverted on save.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_participants.jsx` | `generateRosterText` (zekken-aware placeholder); `validateRosterRows` pre-check wired into `apply()`; second Apply button; primary next-step CTA |
| `web-mobile/js/admin_competition_settings.jsx` | Manual save: removed debounce autosave; header + footer Save buttons; dirty/saving/saved indicator; `isDirty`/`saving` state |
| `internal/mobileapp/handlers_participants.go` | Batch `Players[]` POST now rejects blank name/dojo |
| `internal/mobileapp/handlers_participants_test.go` | New `TestBatchPostBlankDojo_400` |
| `internal/mobileapp/handlers_test.go` | Updated smoke test that encoded the old blank-dojo-accepted behavior |
| `web-mobile/js/__tests__/admin_participants.test.jsx` | New `generateRosterText` + `validateRosterRows` suites |
| `web-mobile/js/__tests__/admin_competition.test.jsx` | Replaced obsolete `saveLater` structural test with manual-save invariants |

## Screenshots

**Participants — next-step CTA + zekken-aware preview table:**

![next-step CTA and zekken preview](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/next-step-cta.png)

**Participants — repeated "Apply changes" button below the preview:**

![bottom apply button](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/bottom-apply.png)

**Competition Settings — "● Unsaved changes" with the Save button enabled:**

![settings unsaved state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/settings-unsaved.png)

**Competition Settings — "✓ Saved at …" with the Save button re-disabled after save:**

![settings saved state](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/settings-saved.png)

## Competition-admin UX (mp-bd7s)

A second batch of admin UX improvements on the same branch:

- **"+ Add competition" in the competition left rail** — the "Other competitions" switcher card now always renders (even with none) and carries an add action, so you can start a new competition without going back to the dashboard.
- **Save / Apply return to the dashboard** — a clean "Save changes" (Settings) and "Apply changes" (Participants) navigate back to the competition list on success, with a confirmation toast. Participants stays put when near-duplicate warnings are surfaced so they can be reviewed first.
- **Unsaved-changes detection in the Participants paste box** — an amber "● Unsaved changes" indicator (matching Settings, `--warn`) shows by both Apply buttons when the textarea differs from the saved roster.
- **Auto-stacked default start time** — creating a competition defaults Start time to the latest same-day competition's start + its estimated duration, floored at 30m so empty competitions still stack; the real estimate takes over once a roster exists.

| | |
|---|---|
| Left rail "+ Add competition" | ![left rail](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/left-rail-add-comp.png) |
| Auto-stacked start time (09:00 + 44m estimate → 09:44) | ![stacked start time](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/create-stacked-time.png) |
| Participants unsaved indicator (amber) | ![participants unsaved](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/participants-unsaved.png) |

## Court-clash detection (mp-4a52)

Cross-competition shiaijo-clash warnings. Two competitions clash when they share a date, share a court, and their time windows overlap (window = start → start + max(estimate, 30m), so even roster-less competitions occupy a slot).

- **New backend**: `engine.DetectClashesForCompetition` + `GET /api/competitions/:id/schedule/clashes` (read-only, returns a `ClashWarning[]`).
- **Saving Competition settings** checks for clashes after the (committed) save and shows an amber banner listing the other competition, shared shiaijo, and overlap window — staying on the page so the operator can adjust. No clashes → returns to the dashboard.
- **Creating a competition** warns via toast if the new one lands on a busy court; creation still proceeds.
- Non-blocking by design ("warn", not "block").

![court clash warning](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/320/clash-warning.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — full gate green, coverage ≥85%
- [x] New/updated unit tests cover the change — `TestBatchPostBlankDojo_400`; `generateRosterText`, `validateRosterRows`; manual-save structural test
- [x] Manual browser verification — **Participants:** sample fills 3-column zekken format; bottom Apply saves; malformed two-column paste rejected with format-aware toast; saved CSV inspected (`uuid,Name,ZEKKEN,Dojo`); next-step CTA renders primary. **Settings:** editing shows "Unsaved changes" + enables Save; no PUT fires on edit (server keeps old value past the old 400ms window); clicking Save persists and flips to "Saved at …" with the button re-disabled
- [x] Screenshots added above
- [x] No new console errors or warnings
- [x] Court-clash detection (mp-4a52) — engine + handler unit tests; browser-verified: moving Bravo onto Alpha's court at an overlapping time shows the amber banner ("Alpha — shiaijo A · 09:10–09:30") + toast and holds the settings page; non-clashing save returns to dashboard
- [x] Competition-admin UX (mp-bd7s) browser-verified — left-rail add opens create form; settings save & participants apply land on dashboard with toast; roster dirty indicator amber only after edit; new competition defaulted to 09:44 (09:00 + 44m estimate)

Closes mp-3xn6
Closes mp-bd7s
Closes mp-4a52


