### PR TITLE
docs: refresh documentation + fix docs-site theme (mp-i03)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Governance
 
 Before implementing features or making architectural decisions, read the project constitution:
-**`.specify/memory/constitution.md`** — defines the core principles (YAGNI, DRY, TDD, DDD, evidence-based decisions, bracket integrity, and live-tournament constraints) that all changes must comply with.
+**`.specify/memory/constitution.md`**: defines the core principles (YAGNI, DRY, TDD, DDD, evidence-based decisions, bracket integrity, and live-tournament constraints) that all changes must comply with.
 
 ## Project Overview
 
-A Go CLI and web application for generating kendo tournament brackets as Excel spreadsheets. Supports two formats: **Pools & Playoffs** (round-robin pools then knockout) and **Playoffs Only** (direct elimination). Input is CSV, output is Excel with formula-linked cells for bracket visualization. The web API is documented via an OpenAPI specification in `specs/openapi.yaml`.
+A Go CLI and web application for generating kendo tournament brackets as Excel spreadsheets. Supports multiple competition formats: **Playoffs** (direct elimination), **Mixed** (round-robin pools then knockout), **League** (full round-robin), and **Swiss** (Swiss-system across N rounds). Input is CSV, output is Excel with formula-linked cells for bracket visualization. The web API is documented via an OpenAPI specification in `specs/openapi.yaml`.
 
 ## Build & Test Commands
 
@@ -37,20 +37,20 @@ go test -cover ./internal/helper/...
 
 ### Dual Domain Model (In Transition)
 
-- **`internal/helper`** — Where the actual logic lives. Types here include Excel coordinates (`sheetName`, `cell` fields) tightly coupled to output generation. This is the primary implementation.
-- **`internal/domain`** — Clean domain models (Player, Pool, Tournament, Match, Seed) being phased in gradually. Don't confuse these with the helper types.
+- **`internal/helper`**: Where the actual logic lives. Types here include Excel coordinates (`sheetName`, `cell` fields) tightly coupled to output generation. This is the primary implementation.
+- **`internal/domain`**: Clean domain models (Player, Pool, Tournament, Match, Seed) being phased in gradually. Don't confuse these with the helper types.
 
 ### Package Responsibilities
 
-- **`cmd/`** — Cobra CLI commands. Each uses an options struct with a `run()` method. `create-pools` and `create-playoffs` share significant logic. Shared helpers (`processEntries`, `openOutputFile`, `assignPlayerNumbers`) live in `cmd/shared.go`.
-- **`internal/helper/`** — Core business logic: CSV parsing, pool/match generation, tree building, seeding algorithms, and all Excel rendering. This is the largest package.
-- **`internal/excel/`** — Excel file lifecycle (`Client`), sheet operations (`SheetManager`), style definitions.
-- **`internal/service/`** — Service layer abstraction over helper logic.
-- **`internal/resources/`** — Embedded file management. Resources flow: `main.go` embeds → `resources.NewResources()` → `cmd.ExecuteWithResources()`.
-- **`internal/mobileapp/`** — Gin HTTP handlers for the tournament app (`mobile-app` command). Routes: `handlers_competition.go`, `handlers_match.go`, `handlers_participants.go`, `handlers_tournament.go`, `handlers_decision.go` (kiken/fusenpai/daihyosen — `POST /matches/:mid/decision`), `handlers_eligibility.go` (`/competitor-status`), `handlers_lineup.go` (team lineups), `handlers_schedule.go` (`GET /schedule/estimate`, public), `handlers_reset.go` (`POST /tournament/reset`, public — for forgotten admin passwords; 404s in locked mode), `handlers_auth_config.go` (`GET /auth-config`, public — reports auth mode to the SPA). Real-time push via SSE (`hub.go`) with events: `match_updated`, `competitor_status_updated`, `competition_completed`, etc. Auth via `X-Tournament-Password` header (`middleware.go`), with two modes selected at startup by a `PasswordVerifier` (`auth_source.go`): **file mode** (default — plaintext compare against `tournament.md`) or **locked mode** (`--lock-password` flag + `TOURNAMENT_PASSWORD_HASH` env var — bcrypt compare, `POST /api/tournament/reset` returns 404; the SPA `/reset` page still renders an operator-disabled message). Consumer-boundary interfaces live in `deps.go` (NFR-002).
-- **`internal/state/`** — File-backed state store for the mobile app. Tournament and competition config lives in `tournament-data/tournament.md` and `tournament-data/competitions/<id>/config.md` (YAML front-matter). Participants are in `participants.csv` alongside each config.
-- **`internal/engine/`** — Thin adapter that drives `internal/helper` pool/bracket generation from a `state.Competition`. Called by the `POST /api/competitions/:id/start` handler.
-- **`web-mobile/`** — Preact/JSX frontend for the mobile app, served embedded in the binary. Entry point: `web-mobile/index.html`. JS modules in `web-mobile/js/` (`admin.js`, `viewer.js`, `app.js`, `api.js`, `data.js`, `bracket.js`). CSS in `web-mobile/css/styles.css`. Pre-compiled to `web-mobile/dist/` by esbuild (run automatically as part of `make go/build`). Key component: `LinedTextarea` in `admin.js` — shows numbered line gutter alongside the participant paste box.
+- **`cmd/`**: Cobra CLI commands. Each uses an options struct with a `run()` method. `create-pools` and `create-playoffs` share significant logic. Shared helpers (`processEntries`, `openOutputFile`, `assignPlayerNumbers`) live in `cmd/shared.go`.
+- **`internal/helper/`**: Core business logic: CSV parsing, pool/match generation, tree building, seeding algorithms, and all Excel rendering. This is the largest package.
+- **`internal/excel/`**: Excel file lifecycle (`Client`), sheet operations (`SheetManager`), style definitions.
+- **`internal/service/`**: Service layer abstraction over helper logic.
+- **`internal/resources/`**: Embedded file management. Resources flow: `main.go` embeds → `resources.NewResources()` → `cmd.ExecuteWithResources()`.
+- **`internal/mobileapp/`**: Gin HTTP handlers for the tournament app (`mobile-app` command). Routes: `handlers_competition.go` (including `POST /api/competitions/:id/generate-draw` [status `draw-ready`] and `DELETE /api/competitions/:id/draw` to discard the draw), `handlers_match.go`, `handlers_participants.go` (including single participant PUT updates, individual/bulk check-ins `POST /api/competitions/:id/participants/checkin-bulk`), `handlers_tournament.go`, `handlers_swiss.go` (`generate-round`, `standings`), `handlers_decision.go` (kiken/fusenpai/daihyosen: `POST /api/matches/:mid/decision`), `handlers_eligibility.go` (`/api/competitions/:id/competitor-status`), `handlers_lineup.go` (team lineups), `handlers_schedule.go` (`GET /api/schedule/estimate`, public), `handlers_reset.go` (`POST /api/tournament/reset`, public, for forgotten admin passwords; 404s in locked mode), `handlers_auth_config.go` (`GET /api/auth-config`, public, reports auth mode to the SPA). Real-time push via SSE (`hub.go`) with events: `match_updated`, `competitor_status_updated`, `competition_completed`, `swiss_round_generated`, etc. Auth via `X-Tournament-Password` header (`middleware.go`), with two modes selected at startup by a `PasswordVerifier` (`auth_source.go`): **file mode** (default, plaintext compare against `tournament.md`) or **locked mode** (`--lock-password` flag + `TOURNAMENT_PASSWORD_HASH` env var, bcrypt compare, `POST /api/tournament/reset` returns 404; the SPA `/reset` page still renders an operator-disabled message). Consumer-boundary interfaces live in `deps.go` (NFR-002).
+- **`internal/state/`**: File-backed state store for the mobile app. Tournament and competition config lives in `tournament-data/tournament.md` and `tournament-data/competitions/<id>/config.md` (YAML front-matter). Participants are in `participants.csv` alongside each config.
+- **`internal/engine/`**: Thin adapter that drives `internal/helper` pool/bracket generation from a `state.Competition`. Called by the `POST /api/competitions/:id/start` handler.
+- **`web-mobile/`**: Preact/JSX frontend for the mobile app, served embedded in the binary. Entry point: `web-mobile/index.html`. JS modules in `web-mobile/js/` are grouped by prefix: `admin_*.jsx` (the operator console: setup, participants, pools, scoring, scheduling, lineups, etc.), `viewer_*.jsx` and `display_*.jsx` (public attendee/spectator surfaces), and shared infrastructure (`app.jsx`, `api_client.jsx`, `api_serializers.jsx`, `bracket.jsx`, `data.jsx`, `patch.jsx`, `router.jsx`, `ui.jsx`, `glossary.jsx`). Run `ls web-mobile/js/` for the current set rather than relying on an enumerated list here. Note `admin_participants.jsx` holds the `LinedTextarea` gutter participant paste box and the check-in filter list. CSS in `web-mobile/css/styles.css`. Pre-compiled to `web-mobile/dist/` by esbuild (run automatically as part of `make go/build`).
 
 ### Key Algorithms
 
@@ -78,20 +78,20 @@ go test -cover ./internal/helper/...
     1. Highest number of individual winners (Victories).
     2. Highest number of points scored.
     3. If both are equal, it's a draw (Tie) in pools, or requires a play-off (Encho) in elimination matches.
-- **Tie-marking Rule**: A match (individual or sub-match) is a tie when the operator enters **'X'** (or 'x') in the "vs" column, **or when both sides finish with the same total score** (equal character-count after stripping spaces/zeros/dashes). For auto-detection, at least one score cell in that row must be non-empty. A team match is automatically a draw (T=1) when both IV and PW totals are equal.
-- **Match Colors**: White (Shiro) is always the left column and Red (Aka) is always the right column — this is fixed and not configurable. In pool matches the first-listed player (SideA) is Red; in elimination matches the upper-bracket player (`node.Left`) is Red.
+- **Tie-marking Rule**: A match (individual or sub-match) is a tie when the operator enters **'X'** (or 'x') in the "vs" column or when both sides finish with the same total score (equal character-count after stripping spaces/zeros/dashes). For auto-detection, at least one score cell in that row must be non-empty. A team match is automatically a draw (T=1) when both IV and PW totals are equal.
+- **Match Colors**: White (Shiro) is always the left column and Red (Aka) is always the right column (this is fixed and not configurable). In pool matches the first-listed player (SideA) is Red; in elimination matches the upper-bracket player (`node.Left`) is Red.
 - **Excel Layout**: Uses an **8-column per court** layout. Columns A and G (and their court-shifted counterparts) are 30 units wide; others are 5 units wide. A blank row separates pools vertically.
 - **Team Match Labels**: Summaries use **"IV"** (Individual Victories) and **"PW"** (Points Won).
 - **Court limit**: courts are labelled A–Z, so `--courts` is hard-capped at 26 and any value over that returns an error rather than silently truncating.
-- **Match Decision Types** (`internal/domain/decision.go`): 10 canonical wire values — `""` (none), `"fought"`, `"hikiwake"` (draw), `"kiken"` (legacy withdrawal, maps to kiken-voluntary on YAML load), `"kiken-voluntary"` (FIK Art. 31, permanent), `"kiken-injury"` (FIK Art. 30, reinstateable), `"fusenpai"` (no-show), `"fusensho"` (per-bout default win), `"daihyosen"` (rep bout), `"kachinuki-exhaustion"`. Use `domain.IsKikenDecision(d)` / `domain.IsKikenDecisionStr(s)` to check any kiken variant. Legacy YAML `decision: true` migrates to `"hikiwake"`, `false` to `"fought"`, `"kiken"` to `"kiken-voluntary"` (Decision.UnmarshalYAML). Visual suffixes in the UI: `Kiken`, `Fus.`, `DH`, `(E)` for encho.
+- **Match Decision Types** (`internal/domain/decision.go`): 10 canonical wire values: `""` (none), `"fought"`, `"hikiwake"` (draw), `"kiken"` (legacy withdrawal, maps to kiken-voluntary on YAML load), `"kiken-voluntary"` (FIK Art. 31, permanent), `"kiken-injury"` (FIK Art. 30, reinstateable), `"fusenpai"` (no-show), `"fusensho"` (per-bout default win), `"daihyosen"` (rep bout), `"kachinuki-exhaustion"`. Use `domain.IsKikenDecision(d)` / `domain.IsKikenDecisionStr(s)` to check any kiken variant. Legacy YAML `decision: true` migrates to `"hikiwake"`, `false` to `"fought"`, `"kiken"` to `"kiken-voluntary"` (Decision.UnmarshalYAML). Visual suffixes in the UI: `Kiken`, `Fus.`, `DH`, `(E)` for encho.
 - **Competitor Eligibility** (`internal/state/competitor_status.go`, `internal/engine/eligibility.go`): a kiken/fusenpai decision auto-writes a `CompetitorStatus{Eligible: false}` for the loser; `engine.StartMatch(compID, matchID)` is the pre-flight gate that returns `*IneligibleCompetitorError` (matches `errors.Is(err, ErrIneligibleCompetitor)`). Maps to HTTP 409. Kiken-injury (FIK Art. 30) sets `CompetitorStatus.Reinstateable: true`; the admin can call `POST /api/competitions/:cid/competitors/:pid/reinstate` to restore eligibility. Kiken-voluntary (Art. 31) and fusenpai are not reinstateable.
 - **Team Lineups & Kachinuki** (`internal/domain/team_lineup.go`, `internal/engine/kachinuki.go`): TeamLineup pins position→player for a round. FIK 5-person rule: Senpo + Taisho mandatory; 1 vacancy must be Jiho, 2 must be Jiho+Fukusho, 3+ disqualifies. Kachinuki ("winner-stays-on") dynamically appends bouts via `engine.AdvanceKachinuki` until one team is exhausted (`DecisionKachinukiExhaustion`).
 - **Schedule Estimator** (`internal/engine/schedule.go`): `EstimateSchedule(EstimateInput) ScheduleEstimate` produces total/per-court minutes from match duration × multiplier × slowest-court buffer. Exposed via stateless `GET /api/schedule/estimate` on both the CLI web server and the mobile app.
-- **Store Transactions** (`internal/state/transactions.go`): `Store.WithTransaction(compID, fn)` holds the per-comp lock once across multiple load/save operations. Use the `StoreTx` handle inside `fn` — do NOT call public Store methods (they would deadlock the non-reentrant mutex).
+- **Store Transactions** (`internal/state/transactions.go`): `Store.WithTransaction(compID, fn)` holds the per-comp lock once across multiple load/save operations. Use the `StoreTx` handle inside `fn`. Do NOT call public Store methods (they would deadlock the non-reentrant mutex).
 
 ### Excel workbook construction
 
-The workbook is built entirely from code in `internal/excel/template.go` (`NewFileFromScratch`). Each sheet (data, Time Estimator, Pool Draw, Pool Matches, Elimination Matches, Names to Print, Tree) is created and styled programmatically. Layout constants (rows-per-page, spacing, max bracket size) and sheet name constants (`SheetData`, `SheetPoolDraw`, etc.) live in `internal/helper/constants.go` — use these constants everywhere rather than string literals.
+The workbook is built entirely from code in `internal/excel/template.go` (`NewFileFromScratch`). Each sheet (data, Time Estimator, Pool Draw, Pool Matches, Elimination Matches, Names to Print, Tree) is created and styled programmatically. Layout constants (rows-per-page, spacing, max bracket size) and sheet name constants (`SheetData`, `SheetPoolDraw`, etc.) live in `internal/helper/constants.go`. Use these constants everywhere rather than string literals.
 
 ### Resource Embedding
 
@@ -103,17 +103,17 @@ Production-hardening defaults applied in the `mobile-app` command. Constants liv
 
 | Concern | Default | Override | Rationale |
 |---|---|---|---|
-| `ReadHeaderTimeout` | 10s | — | Slowloris-header defense |
-| `ReadTimeout` | 30s | — | Slow-body defense (still permits multi-MB CSV import) |
-| `IdleTimeout` | 120s | — | Bounds fd commitment per idle keep-alive client |
-| `WriteTimeout` | **0** (unbounded) | — | SSE streams are infinite; per-request cancellation runs via `Request.Context().Done()` |
-| `MaxHeaderBytes` | 1 MB | — | Header-bomb defense |
+| `ReadHeaderTimeout` | 10s | (none) | Slowloris-header defense |
+| `ReadTimeout` | 30s | (none) | Slow-body defense (still permits multi-MB CSV import) |
+| `IdleTimeout` | 120s | (none) | Bounds fd commitment per idle keep-alive client |
+| `WriteTimeout` | **0** (unbounded) | (none) | SSE streams are infinite; per-request cancellation runs via `Request.Context().Done()` |
+| `MaxHeaderBytes` | 1 MB | (none) | Header-bomb defense |
 | Body cap (admin JSON) | 1 MB | `DefaultMaxBodyBytes` const | `c.BindJSON` payloads are tiny in practice; cap is enforced by `MaxBodyBytes` middleware (returns 413) |
 | Body cap (`/tournament/import`) | 64 MB | `MaxImportBodyBytes` const | Matches `ParseMultipartForm` already in the handler |
 | SSE subscribers | 5000 | `SSE_MAX_CLIENTS` env var | Bounds fan-out cost + per-client goroutine/channel allocation (~4–10 KB resident per client); raised from 1000 → 5000 by mp-9afd for large-scale events (1000+ viewers); real hardware load test still required |
 | Graceful shutdown | 30s | `httpShutdownTimeout` const | `Hub.Close` is wired via `srv.RegisterOnShutdown` so SSE goroutines exit before the deadline |
 
-**`safeGo` convention.** Any goroutine spawned inside a request handler MUST use the `safeGo` helper in [internal/mobileapp/safego.go](internal/mobileapp/safego.go). Gin's Recovery middleware only catches panics on the request goroutine — a panic in a spawned goroutine crashes the entire process. The helper guarantees `wg.Done()` on panic and captures the recovered value into a shared `atomic.Pointer[recoveredPanic]` so the handler can return a single HTTP 500 without leaking internals. Pattern:
+**`safeGo` convention.** Any goroutine spawned inside a request handler MUST use the `safeGo` helper in [internal/mobileapp/safego.go](internal/mobileapp/safego.go). Gin's Recovery middleware only catches panics on the request goroutine; a panic in a spawned goroutine crashes the entire process. The helper guarantees `wg.Done()` on panic and captures the recovered value into a shared `atomic.Pointer[recoveredPanic]` so the handler can return a single HTTP 500 without leaking internals. Pattern:
 
 ```go
 var wg sync.WaitGroup
@@ -140,54 +140,54 @@ See `handlers_viewer.go` for the canonical use sites (mp-663 Phase 1).
 
 `participants.csv` stores one participant per line. Two formats are supported:
 
-**With UUIDs (new format)** — first field is a UUID v4 (lowercase hex):
+**With UUIDs (new format)**: first field is a UUID v4 (lowercase hex).
 ```
 <uuid>, Name[, Zekken/DisplayName], Dojo[, DanGrade][, source]
 ```
 
-**Without UUIDs (legacy format)** — detected automatically when first field is not a UUID:
+**Without UUIDs (legacy format)**: detected automatically when first field is not a UUID.
 ```
 Name[, Zekken/DisplayName], Dojo[, DanGrade][, source]
 ```
 
 - The zekken/display-name column is only present when `withZekkenName=true` for the competition.
 - `DanGrade` is optional; omit or leave empty.
-- `source` is the last column when present and must be one of: `manual`, `registered`, `transfer`. This is the registration provenance (admin-only). It is distinct from the competitor's "tag" (their assigned competitor number, which is the `Number`/`number` field, optionally prefixed via `numberPrefix` — e.g. "A1").
-- Seeds are stored separately in `seeds.csv` and merged at load time — do **not** include seed ranks in `participants.csv`.
+- `source` is the last column when present and must be one of: `manual`, `registered`, `transfer`. This is the registration provenance (admin-only). It is distinct from the competitor's "tag" (their assigned competitor number, which is the `Number`/`number` field, optionally prefixed via `numberPrefix`, e.g. "A1").
+- Seeds are stored separately in `seeds.csv` and merged at load time. Do **not** include seed ranks in `participants.csv`.
 - The Go parser lives in `internal/state/participants.go`; the JS parser in `web-mobile/js/data.jsx:parseParticipantLines`. Keep both in sync with this schema when changing column layout.
 
 ## Common Pitfalls
 
 - Excel coordinates matter: changing match generation requires updating cell references and formula links across sheets
 - `team-matches=0` means individual tournaments, not team tournaments
-- The `errcheck` linter is enabled (test files excepted). Don't introduce `_ =` or bare ignored returns in production code — wrap and propagate, or log via `handleExcelError`/`handleExcelDataError`
-- Web UI changes (`web/index.html`) should be validated in a running browser, not just by reading diffs — use `make run`
-- Mobile app frontend changes (`web-mobile/`) require rebuilding the binary to take effect — the files are embedded at `go build` time via `//go:embed web-mobile/*` in `main.go`. Run `make run-mobile` which rebuilds automatically, or run `make go/build` then restart.
+- The `errcheck` linter is enabled (test files excepted). Don't introduce `_ =` or bare ignored returns in production code. Wrap and propagate, or log via `handleExcelError`/`handleExcelDataError`
+- Web UI changes (`web/index.html`) should be validated in a running browser, not just by reading diffs. Use `make run`
+- Mobile app frontend changes (`web-mobile/`) require rebuilding the binary to take effect. The files are embedded at `go build` time via `//go:embed web-mobile/*` in `main.go`. Run `make run-mobile` which rebuilds automatically, or run `make go/build` then restart.
 - Duplicate participant names in the CSV are rejected up front by `helper.CheckDuplicateEntries`; the web handler surfaces these to the user
-- Chained match navigation in the admin score editor (Prev/Next buttons, Finish + Start Next, ←/→ keys) must stay on the current match's shiaijo — operators run matches per-court, so hopping courts mid-flow breaks the workflow. See `AdminScoreEditor` in `web-mobile/js/admin_schedule.jsx`: filter to `(m.court || "") === (openMatch.court || "")` so empty/undefined courts share one "unassigned" bucket.
+- Chained match navigation in the admin score editor (Prev/Next buttons, Finish + Start Next, ←/→ keys) must stay on the current match's shiaijo. Operators run matches per-court, so hopping courts mid-flow breaks the workflow. See `AdminScoreEditor` in `web-mobile/js/admin_schedule.jsx`: filter to `(m.court || "") === (openMatch.court || "")` so empty/undefined courts share one "unassigned" bucket.
 
 ## PR Workflow
 
-- **Build the PR body from the repo template.** When creating a PR, populate the description from `.github/pull_request_template.md` and fill every section — `gh pr create --body-file <filled-template>` (the bare `gh pr create` / `--fill` does NOT apply the template). Set the `Closes mp-xxxx` bead reference.
-- **Embed screenshots via the `pr-assets` side branch, not gists** (`gh gist create` rejects binaries). Push the PNG to the `pr-assets` branch (never merged to main): `gh api --method PUT .../contents/pr-assets/<pr>/shot.png -f branch=pr-assets -f content="$(base64 < shot.png | tr -d '\n')"`, then embed `![](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/<pr>/shot.png)`. A real browser/MCP screenshot is MANDATORY for any UI change — there is NO textual/DOM/geometry substitute. If you have not captured one, the PR is not review-ready: capture it first, then fill the Screenshots section. Full verified recipe: the `/pr-screenshots` skill. **Capture only via the browser/MCP screenshot tools — NEVER a desktop or full-screen grab (`screencapture`, `scrot`, OS shortcuts), which exposes the user's private screen.**
-- **Test plan is a gate, not a formality.** Before requesting review on a PR, check off EVERY item in the PR description's test plan. Do not mark a PR ready while any checkbox is unverified. Manual/browser steps are not optional — execute them, then check them.
+- **Build the PR body from the repo template.** When creating a PR, populate the description from `.github/pull_request_template.md` and fill every section: `gh pr create --body-file <filled-template>` (the bare `gh pr create` / `--fill` does NOT apply the template). Set the `Closes mp-xxxx` bead reference.
+- **Embed screenshots via the `pr-assets` side branch, not gists** (`gh gist create` rejects binaries). Push the PNG to the `pr-assets` branch (never merged to main): `gh api --method PUT .../contents/pr-assets/<pr>/shot.png -f branch=pr-assets -f content="$(base64 < shot.png | tr -d '\n')"`, then embed `![](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/<pr>/shot.png)`. A real browser/MCP screenshot is MANDATORY for any UI change. There is NO textual/DOM/geometry substitute. If you have not captured one, the PR is not review-ready: capture it first, then fill the Screenshots section. Full verified recipe: the `/pr-screenshots` skill. **Capture only via the browser/MCP screenshot tools, NEVER a desktop or full-screen grab (`screencapture`, `scrot`, OS shortcuts), which exposes the user's private screen.**
+- **Test plan is a gate, not a formality.** Before requesting review on a PR, check off EVERY item in the PR description's test plan. Do not mark a PR ready while any checkbox is unverified. Manual/browser steps are not optional; execute them, then check them.
 - **Keep the bead `in_progress` until the PR actually merges.** A green review is not a merge. Only `bd close <id>` after the merge lands, with a reason referencing the merge commit/PR.
 - **After a merge, run the full `/cleanup` sequence** (close bead → fast-forward main → remove worktree → delete local + remote branch → prune). Don't wait to be asked for each step. See the `/cleanup` skill.
-- **Verify the worktree/branch before any edit.** This repo uses a git worktree per PR; edits applied to the wrong worktree (or directly to the `main` checkout) force patch-and-revert recovery. When there is any ambiguity, confirm with `pwd` and `git branch --show-current` before the first Edit/Write, and never edit the main checkout directly — always work inside a worktree.
+- **Verify the worktree/branch before any edit.** This repo uses a git worktree per PR; edits applied to the wrong worktree (or directly to the `main` checkout) force patch-and-revert recovery. When there is any ambiguity, confirm with `pwd` and `git branch --show-current` before the first Edit/Write. Never edit the main checkout directly; always work inside a worktree.
 
 ## Code Review (Copilot)
 
 - **Never report a review round "clean" until a fresh fetch shows zero unresolved threads.** State the total unresolved count first, give every thread an explicit disposition (fix or dismissal with a reason), then re-verify the count is zero. The `/review-loop` skill encodes the full loop.
-- **Re-request Copilot via the GraphQL `requestReviews` mutation with the bot node id** — both `gh pr edit --add-reviewer Copilot` (lowercases the login, fails) and REST `POST .../requested_reviewers -f "reviewers[]=Copilot"` (silently no-ops; that array is users-only and Copilot is a Bot) are broken. Full recipe + verification step in the `/review-loop` skill (rule 4).
-- Run `make go/test` after fixes and before pushing — a red gate means fix-or-revert, never push.
+- **Re-request Copilot via the GraphQL `requestReviews` mutation with the bot node id**: both `gh pr edit --add-reviewer Copilot` (lowercases the login, fails) and REST `POST .../requested_reviewers -f "reviewers[]=Copilot"` (silently no-ops; that array is users-only and Copilot is a Bot) are broken. Full recipe + verification step in the `/review-loop` skill (rule 4).
+- Run `make go/test` after fixes and before pushing. A red gate means fix-or-revert, never push.
 
 ## Testing & Verification
 
-- **Verify in the browser, never substitute API/curl calls.** Manual test-plan items and UAT must be executed through the actual UI.
-- **Test self-run / public features from the PUBLIC page, not the admin UI** — the public flow is what users hit; admin-side scoring proves nothing about it.
+- **Verify in the browser; never substitute API/curl calls.** Manual test-plan items and UAT must be executed through the actual UI.
+- **Test self-run / public features from the PUBLIC page, not the admin UI**: the public flow is what users hit. Admin-side scoring proves nothing about it.
 - **File gap/UX issues incrementally as you find them**, not batched at the end of a UAT pass.
 - Frontend changes under `web-mobile/` require a rebuild to take effect (`//go:embed`); use `make run-mobile` or rebuild + restart.
-- **Diagnose failures from evidence, never fabricate a cause.** When a test, build, or CI step fails (Codecov, GPG, lint, etc.), read the actual logs before explaining it. Do not invent "known bugs", version-specific regressions, or other rationalizations to justify a workaround — if the root cause isn't established, say so and keep investigating.
+- **Diagnose failures from evidence, never fabricate a cause.** When a test, build, or CI step fails (Codecov, GPG, lint, etc.), read the actual logs before explaining it. Do not invent "known bugs", version-specific regressions, or other rationalizations to justify a workaround. If the root cause isn't established, say so and keep investigating.
 - **Test coverage gate: every package that has test files must maintain ≥85% statement coverage.** Verify before any PR with:
   ```bash
   go test -race -cover . ./cmd/... ./internal/... ./tests/...
@@ -199,8 +199,8 @@ Name[, Zekken/DisplayName], Dojo[, DanGrade][, source]
 
 When rebasing or resolving conflicts, watch for these recurring breakages:
 - Duplicate declarations introduced by the rebase (same symbol defined twice after a merge).
-- UUID-vs-name-string mismatches in player/entity maps — match on id OR name, and use participant UUIDs (not display names) for bracket-highlight IDs.
-- Missed call sites when removing or renaming a symbol — `grep -r` the name across **all** packages **including `_test.go` files** before committing; a refactor that compiles can still leave stale test references or skip-test code pointing at dead paths.
+- UUID-vs-name-string mismatches in player/entity maps: match on id OR name, and use participant UUIDs (not display names) for bracket-highlight IDs.
+- Missed call sites when removing or renaming a symbol: `grep -r` the name across **all** packages **including `_test.go` files** before committing. A refactor that compiles can still leave stale test references or skip-test code pointing at dead paths.
 - Re-run `make go/test` after every rebase; a clean rebase that compiles must not be semantically broken.
 
 
@@ -231,9 +231,9 @@ bd close <id>         # Complete work if the PR is merged
 
 ### Rules
 
-- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Use `bd` for ALL task tracking. Do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use `bd remember` for persistent knowledge. Do NOT use MEMORY.md files
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 

--- a/docs/architecture/infrastructure-architecture.md
+++ b/docs/architecture/infrastructure-architecture.md
@@ -2,7 +2,7 @@
 
 How bracket-creator is built, packaged, deployed, and persisted. The whole product is a
 **single self-contained Go binary** (web assets embedded) running behind a TLS proxy, with
-tournament state on a plain disk — deployable from a laptop to a free-tier cloud VM.
+tournament state on a plain disk; deployable from a laptop to a free-tier cloud VM.
 
 > Related: [Software architecture](software-architecture.md) · [Network architecture](network-architecture.md)
 
@@ -31,10 +31,10 @@ flowchart LR
     gobuild --> img
 ```
 
-- `dist/` and `vendor/` are build artifacts (gitignored except `keep` placeholders); esbuild
+- `dist/` and `vendor/` are build artifacts (gitignored except `keep` placeholders). esbuild
   regenerates `dist/` on every build, then `go:embed` bakes the served assets into the binary.
 - The published image adds LibreOffice so the `print` PDF exports work in a container.
-- **One artifact, no runtime asset directory** — the binary serves everything from its embedded FS.
+- **One artifact, no runtime asset directory**: the binary serves everything from its embedded FS.
 
 ## 2. Runtime composition (container + proxy + disk)
 
@@ -57,7 +57,7 @@ flowchart TB
 ```
 
 - App runs as **non-root (uid 65534)**; the data volume must be owned by that uid or the app
-  refuses to start. App port 8080 is `expose`d to the proxy only — never published to the host.
+  refuses to start. App port 8080 is `expose`d to the proxy only, never published to the host.
 - `restart: unless-stopped` (compose) / auto-restart (cloud) brings the app back after reboots.
 
 ## 3. Deployment options
@@ -75,8 +75,8 @@ flowchart TD
 |---|---|---|
 | **Bare binary** | run the binary, bring your own TLS proxy | local / dev / custom hosts |
 | **Docker Compose** (`deploy/docker/`) | `app` + `caddy` services, host volume for data | self-managed VMs / on-prem |
-| **GCP Always Free** (`deploy/gcp/`) | Terraform → `e2-micro` + firewall + persistent disk + Caddy auto-HTTPS | club / regional events (~≤50–300 viewers) |
-| **Oracle Always Free** (`deploy/oracle/`) | Terraform, larger free allowance | large events (1000+ concurrent viewers) |
+| **GCP Always Free** (`deploy/gcp/`) | Terraform; `e2-micro` + firewall + persistent disk + Caddy auto-HTTPS | club / regional events (~≤50–300 viewers) |
+| **Oracle Always Free** (`deploy/oracle/`) | Terraform; larger free allowance | large events (1000+ concurrent viewers) |
 
 ### Cloud topology (GCP Always-Free example)
 
@@ -89,16 +89,16 @@ flowchart TB
             caddy["Caddy :443 (Let's Encrypt)"]
             app["app container :8080"]
         end
-        pd[("30 GB boot disk — free-tier cap<br/>OS + Docker + image + /opt/tournament-data")]
+        pd[("30 GB boot disk (free-tier cap)<br/>OS + Docker + image + /opt/tournament-data")]
     end
     fw --> caddy --> app --> pd
 ```
 
 Terraform provisions the instance, network, and firewall, then installs Docker, prepares the
-data dir, writes the app + Caddy config, and starts the app — reachable over HTTPS within minutes
+data dir, writes the app + Caddy config, and starts the app. Reachable over HTTPS within minutes
 of `terraform apply`. `terraform destroy` removes everything (run it after the event).
 
-### Venue connectivity — a four-court event
+### Venue connectivity: a four-court event
 
 The cloud/host above is only half the picture. On the venue floor, every operator console,
 display screen, and spectator phone is just a **browser** reaching that one app over the network.
@@ -106,7 +106,7 @@ A typical four-court (shiaijo A–D) layout:
 
 ```mermaid
 flowchart TB
-    subgraph floor["Venue floor — 4 courts"]
+    subgraph floor["Venue floor (4 courts)"]
         subgraph cA["Court A"]
             opA["Operator console<br/>tablet / laptop (admin)"]
             dA["Display screen<br/>scoreboard / bracket"]
@@ -126,7 +126,7 @@ flowchart TB
         spec["Spectator phones<br/>public viewer"]
     end
 
-    net["Venue network<br/>router + Wi-Fi AP(s)<br/>wire operators where possible;<br/>dedicated AP for operators"]
+    net["Venue network<br/>router + Wi-Fi AP(s)<br/>wire operators where possible,<br/>dedicated AP for operators"]
 
     opA & opB & opC & opD --> net
     dA & dB & dC & dD --> net
@@ -139,29 +139,28 @@ flowchart TB
 
 | Device | What it runs | Notes |
 |---|---|---|
-| Operator console — 1 per court | admin scoring SPA | tablet/desktop surface; authenticates with the tournament password; scores its own shiaijo |
-| Display screen — 1 per court (optional) | public display / scoreboard view | just a browser at a display URL (smart-TV browser, or a mini-PC/laptop driving a TV); read-only, no auth |
-| Spectator phones | public viewer (mobile-first) | can be on cellular — they don't need venue Wi-Fi when the app is cloud-hosted |
+| Operator console (1 per court) | admin scoring SPA | tablet/desktop surface; authenticates with the tournament password; scores its own shiaijo |
+| Display screen (1 per court, optional) | public display / scoreboard view | just a browser at a display URL (smart-TV browser, or a mini-PC/laptop driving a TV); read-only, no auth |
+| Spectator phones | public viewer (mobile-first) | can be on cellular; they don't need venue Wi-Fi when the app is cloud-hosted |
 
 **Per-client load.** Every console, display, and phone holds **one SSE stream** plus its REST
 calls. A four-court event is roughly 4 operators + 4 displays + N spectators of concurrent SSE
-clients — comfortably within `SSE_MAX_CLIENTS`, but every live update fans out to all of them
+clients, comfortably within `SSE_MAX_CLIENTS`, but every live update fans out to all of them
 (see [Capacity & scaling](#5-capacity--scaling)).
 
 **Two venue patterns:**
 
-- **Cloud-hosted** (topology above) — venue devices reach the cloud app over the venue's internet
+- **Cloud-hosted** (topology above): venue devices reach the cloud app over the venue's internet
   uplink; spectators can use cellular and skip venue Wi-Fi entirely. Needs a working uplink for
   the operators and displays.
-- **On-prem / local** — run the single `mobile-app` binary on a laptop or mini-PC **on the venue
-  LAN**; operators and displays hit it locally, so **scoring keeps working with no internet at
+- **On-prem / local**: run the single `mobile-app` binary on a laptop or mini-PC **on the venue
+  LAN**. Operators and displays hit it locally, so **scoring keeps working with no internet at
   all**. Put a local TLS proxy in front for secure-context features, or serve plain HTTP on the LAN.
 
 **The network is the real fix.** Client resilience (offline write queue, SSE resync, silence
-watchdog) keeps the app
-usable across blips, but for a smooth event: **wire the operator consoles** where you can, put
-operators on a **dedicated AP** separate from spectator guest Wi-Fi, and prefer the **on-prem**
-pattern when the venue's internet is unreliable.
+watchdog) keeps the app usable across blips. For a smooth event, **wire the operator consoles**
+where you can, put operators on a **dedicated AP** separate from spectator guest Wi-Fi, and
+prefer the **on-prem** pattern when the venue's internet is unreliable.
 
 ## 4. Persistence model
 
@@ -176,12 +175,12 @@ flowchart LR
     end
 ```
 
-- **No database.** State is human-readable Markdown + CSV on disk; multi-file changes are made
+- **No database.** State is human-readable Markdown + CSV on disk. Multi-file changes are made
   durable via a write-ahead log replayed on startup. The disk survives reboots and stop/start.
-- Backups are trivial — snapshot the disk or copy `tournament-data/` elsewhere.
-- **Disk sizing is not about data volume.** Tournament state is tiny (KB–MB). The cloud disks —
-  30 GB on GCP, 50 GB on Oracle — are the free-tier **boot-disk** allowances (they hold the OS,
-  Docker, and the app image, with `tournament-data/` alongside); the module simply uses the free
+- Backups are trivial: snapshot the disk or copy `tournament-data/` elsewhere.
+- **Disk sizing is not about data volume.** Tournament state is tiny (KB–MB). The cloud disks
+  (30 GB on GCP, 50 GB on Oracle) are the free-tier **boot-disk** allowances (they hold the OS,
+  Docker, and the app image, with `tournament-data/` alongside). The module simply uses the free
   cap rather than provisioning a separate data disk.
 
 ## 5. Capacity & scaling
@@ -212,19 +211,19 @@ flowchart TB
 | `PORT` | `-p/--port` | 8080 | listen port |
 | `BIND_ADDRESS` | `-b/--bind` | localhost | listen address |
 | `LOCK_PASSWORD` | `--lock-password` | false | enable locked (bcrypt) auth; disables reset endpoint |
-| `TOURNAMENT_PASSWORD_HASH` | — | — | bcrypt hash for locked mode (root-owned, never in the image) |
-| `SSE_MAX_CLIENTS` | — | 5000 | SSE subscriber cap |
-| `ENABLE_TOURNAMENT_SCHEDULE` | — | off | feature flag for the schedule UI |
+| `TOURNAMENT_PASSWORD_HASH` | (none) | (none) | bcrypt hash for locked mode (root-owned, never in the image) |
+| `SSE_MAX_CLIENTS` | (none) | 5000 | SSE subscriber cap |
+| `ENABLE_TOURNAMENT_SCHEDULE` | (none) | off | feature flag for the schedule UI |
 
 Generate the bcrypt hash with `bracket-creator hash-password`. In cloud deployments the secrets
-are written to a protected, root-owned file on the instance — never baked into the container image.
+are written to a protected, root-owned file on the instance, never baked into the container image.
 
 ## 7. Operational properties
 
-- **Stateless app, stateful disk** — the container can be recreated freely; only the data volume
+- **Stateless app, stateful disk**: the container can be recreated freely. Only the data volume
   matters. Auto-restart + a persistent disk = self-healing after reboots.
-- **Zero-dependency runtime** — no DB, no cache, no message broker; just the binary, a TLS proxy,
+- **Zero-dependency runtime**: no DB, no cache, no message broker. Just the binary, a TLS proxy,
   and a disk.
-- **Graceful shutdown** (30s) lets in-flight writes finish and SSE goroutines exit cleanly before
+- **Graceful shutdown** (30s): lets in-flight writes finish and SSE goroutines exit cleanly before
   a container restart.
-- **Teardown is one command** (`terraform destroy`) so no stray paid resources linger.
+- **Teardown is one command** (`terraform destroy`), so no stray paid resources linger.

--- a/docs/architecture/network-architecture.md
+++ b/docs/architecture/network-architecture.md
@@ -33,8 +33,8 @@ flowchart LR
 | Port | Where | Purpose |
 |---|---|---|
 | 443 | Caddy (public) | HTTPS for REST + SSE |
-| 80 | Caddy (public) | ACME challenge + redirect to 443 |
-| 8080 | app (internal) | plain HTTP; **never published directly** — Caddy proxies it |
+| 80 | Caddy (public) | ACME challenge; redirect to 443 |
+| 8080 | app (internal) | plain HTTP; **never published directly** (Caddy proxies it) |
 | 22 | host (optional) | SSH (restrict to your IP) |
 
 > **Proxy must stream, not buffer.** SSE is a long-lived response; the Caddyfiles deliberately
@@ -61,9 +61,9 @@ flowchart TB
     hub ==>|SSE id + data frames| sse
 ```
 
-- **REST** — score/decision/lineup writes, config, participants. Auth via the
+- **REST**: score/decision/lineup writes, config, participants. Auth via the
   `X-Tournament-Password` header (two modes, §5).
-- **SSE** — one stream per client carrying `match_updated`, `competition_started/completed`,
+- **SSE**: one stream per client carrying `match_updated`, `competition_started/completed`,
   `competitor_status_updated`, `draw_generated`, `schedule_updated`, plus the resilience control
   events `resync_required` and `heartbeat`. Every real event is stamped with a monotonic `seq`
   written as the SSE `id:` line, so the browser's `Last-Event-ID` advances automatically.
@@ -81,7 +81,7 @@ sequenceDiagram
     C->>H: proxied (unbuffered)
     H-->>B: id: N · data: event   (live, as matches change)
     Note over H: each event stamped seq=N,<br/>retained in a 100-event ring
-    B--xH: Wi-Fi blip — connection drops
+    B--xH: Wi-Fi blip, connection drops
     B->>C: auto-reconnect, Last-Event-ID: N
     C->>H: proxied
     alt gap satisfiable from ring
@@ -92,29 +92,29 @@ sequenceDiagram
     H-->>B: heartbeat every 15s (observable frame)
 ```
 
-- **Replay ring** — `DefaultHistorySize` (100) recent events; `Last-Event-ID` replays the gap.
-- **`resync_required`** — emitted when a gap-free replay is impossible (ring eviction, or a
-  server restart that reset `seq`); the client resets its `lastSeq` and full-refetches. Emitted
+- **Replay ring**: `DefaultHistorySize` (100) recent events. `Last-Event-ID` replays the gap.
+- **`resync_required`**: emitted when a gap-free replay is impossible (ring eviction or a
+  server restart that reset `seq`). The client resets its `lastSeq` and full-refetches. Emitted
   **without** an `id:` line when head seq is 0 so it can't force `Last-Event-ID` to "0".
-- **Observable heartbeat** — a real `{"type":"heartbeat"}` frame (no `id:`) every 15s, so the
+- **Observable heartbeat**: a real `{"type":"heartbeat"}` frame (no `id:`) every 15s, so the
   client can tell "quiet" from "dead".
 - **Per-client buffered channel**; a stalled client that can't drain is dropped (non-blocking
   send). Subscriber cap `SSE_MAX_CLIENTS` (default 5000).
 
 ## 4. Client resilience on flaky Wi-Fi
 
-The client treats the link as unreliable by default — the flows below show how.
+The client treats the link as unreliable by default; the flows below show how.
 
 ```mermaid
 flowchart TD
     submit["Operator submits a score / decision / lineup"] --> try{"fetch (12s AbortController timeout)"}
-    try -->|2xx| done["Confirmed — UI advances"]
+    try -->|2xx| done["Confirmed, UI advances"]
     try -->|transient or offline| q["Enqueue in outbox<br/>(localStorage, 6h TTL)"]
-    q --> banner["Editor shows 'Not saved yet — will retry'"]
+    q --> banner["Editor shows 'Not saved yet (will retry)'"]
     q --> flush["Background flush<br/>(exp. backoff + jitter)"]
     flush -->|2xx| cleared["Banner clears (saved)"]
-    flush -->|non-retryable 4xx| failed["Permanent fail →<br/>subscribeTerminalWriteFailed →<br/>red 'Not saved — re-enter' banner"]
-    online["browser 'online' event / tab visible again"] --> flush
+    flush -->|non-retryable 4xx| failed["Permanent fail:<br/>subscribeTerminalWriteFailed:<br/>red 'Not saved (re-enter)' banner"]
+    online["browser 'online' event, tab visible again"] --> flush
 ```
 
 ```mermaid
@@ -131,8 +131,8 @@ Key client mechanisms (all in `web-mobile/js/api_client.jsx` + consumers):
 
 | Concern | Mechanism |
 |---|---|
-| Half-open / stalled sockets | 12s write timeouts; 35s SSE silence watchdog (armed at connect, not just `onopen`) |
-| Reconnect storms | exponential backoff + jitter (vs a fixed delay) |
+| Half-open / stalled sockets | 12s write timeouts, 35s SSE silence watchdog (armed at connect, not just `onopen`) |
+| Reconnect storms | exponential backoff + jitter (vs. a fixed delay) |
 | Lost writes | durable outbox persisted to `localStorage` (6h TTL), retried; survives tab refresh |
 | Missed events | `Last-Event-ID` replay + `checkSeqGap` on every event → scoped refetch; `resync_required` |
 | Tab resume | `visibilitychange` → force reconnect + refetch |
@@ -151,9 +151,9 @@ flowchart TD
     note["locked mode also 404s POST /api/tournament/reset"]
 ```
 
-- **File mode** (default) — plaintext compare against `tournament.md`; `POST /api/tournament/reset`
+- **File mode** (default): plaintext compare against `tournament.md`. `POST /api/tournament/reset`
   is available (for a forgotten admin password).
-- **Locked mode** (`--lock-password` / `LOCK_PASSWORD=true` + `TOURNAMENT_PASSWORD_HASH`) — bcrypt
+- **Locked mode** (`--lock-password` / `LOCK_PASSWORD=true` + `TOURNAMENT_PASSWORD_HASH`): bcrypt
   compare; reset endpoint returns 404. `GET /api/auth-config` reports the mode to the SPA.
 
 ## 6. Server-side network hardening (`cmd/mobile_app.go`)

--- a/docs/architecture/software-architecture.md
+++ b/docs/architecture/software-architecture.md
@@ -14,7 +14,7 @@ flowchart TB
     viewer["Competitors & spectators<br/>(phones)"]
     cli["CLI user<br/>(terminal)"]
 
-    subgraph bin["bracket-creator — single Go binary"]
+    subgraph bin["bracket-creator (single Go binary)"]
         cliCmds["CLI commands<br/>create-pools · create-playoffs · print"]
         serveCmd["serve<br/>(one-shot Excel web form)"]
         mobile["mobile-app<br/>(live tournament server)"]
@@ -43,10 +43,10 @@ flowchart LR
     root["bracket-creator (root, Cobra)"]
     root --> cp["create-pools"]
     root --> cpp["create-playoffs"]
-    root --> srv["serve — Excel web form :8080"]
-    root --> ma["mobile-app — live server :8080"]
-    root --> hp["hash-password — bcrypt for locked mode"]
-    root --> pr["print — PDF generation"]
+    root --> srv["serve (Excel web form :8080)"]
+    root --> ma["mobile-app (live server :8080)"]
+    root --> hp["hash-password (bcrypt for locked mode)"]
+    root --> pr["print (PDF generation)"]
     root --> mn["man / version"]
 ```
 
@@ -89,17 +89,17 @@ flowchart TD
     cmd --> pdf
 ```
 
-**Dual domain model (in transition).** `internal/helper` is where the real algorithms live —
-its types carry Excel coordinates (`sheetName`, `cell`) tightly coupled to output generation.
+**Dual domain model (in transition).** `internal/helper` is where the real algorithms live.
+Its types carry Excel coordinates (`sheetName`, `cell`) tightly coupled to output generation.
 `internal/domain` holds clean models being phased in gradually. Don't confuse the two.
 
 | Package | Responsibility |
 |---|---|
-| `cmd` | Cobra commands; each an options struct with `run()` |
+| `cmd` | Cobra commands (each an options struct with `run()`) |
 | `internal/helper` | CSV parsing, pool/match generation, binary-tree brackets, seeding, Excel rendering |
 | `internal/domain` | Clean models + canonical decision/lineup rules |
-| `internal/engine` | Thin adapter that drives `helper` generation from a `state.Competition`; scoring, eligibility, kachinuki, schedule estimate |
-| `internal/state` | File-backed store (`tournament.md`, `competitions/<id>/config.md`, `participants.csv`); transactions + write-ahead log; per-competition locks |
+| `internal/engine` | Thin adapter that drives `helper` generation from a `state.Competition`; handles scoring, eligibility, kachinuki, schedule estimate |
+| `internal/state` | File-backed store (`tournament.md`, `competitions/<id>/config.md`, `participants.csv`). Transactions + write-ahead log, per-competition locks |
 | `internal/excel` | Excel lifecycle + `NewFileFromScratch` |
 | `internal/pdf` | PDF exports (LibreOffice-backed) |
 | `internal/mobileapp` | Gin HTTP handlers, SSE hub, auth middleware, `safeGo` |
@@ -113,7 +113,7 @@ flowchart TB
         mw["middleware.go<br/>X-Tournament-Password auth · body caps"]
         authsrc["auth_source.go<br/>PasswordVerifier (file | locked/bcrypt)"]
         handlers["handlers_*.go<br/>competition · match · participants · tournament<br/>decision · eligibility · lineup · schedule · reset · auth-config"]
-        hub["hub.go — SSE hub<br/>seq stamping · 100-event replay ring · resync · heartbeat"]
+        hub["hub.go (SSE hub)<br/>seq stamping · 100-event replay ring · resync · heartbeat"]
         safego["safego.go<br/>panic-safe goroutines"]
         engine["engine adapter"]
         store[("state.Store<br/>WithTransaction + WAL")]
@@ -129,12 +129,12 @@ flowchart TB
 ```
 
 Server hardening (constants in `cmd/mobile_app.go`): `ReadHeaderTimeout 10s`, `ReadTimeout 30s`,
-`IdleTimeout 120s`, `MaxHeaderBytes 1 MB`, **`WriteTimeout 0`** (SSE streams are infinite —
-per-request cancellation runs via the request context), graceful shutdown 30s with
+`IdleTimeout 120s`, `MaxHeaderBytes 1 MB`, **`WriteTimeout 0`** (SSE streams are infinite;
+per-request cancellation runs via the request context). Graceful shutdown 30s with
 `Hub.Close` wired through `RegisterOnShutdown`. Every handler-spawned goroutine uses `safeGo`
 (Gin Recovery only catches the request goroutine).
 
-## 5. Write path — recording a score (ACID + broadcast)
+## 5. Write path: recording a score (ACID + broadcast)
 
 ```mermaid
 sequenceDiagram
@@ -160,7 +160,7 @@ sequenceDiagram
     H-->>SPA: 200 result
 ```
 
-Core invariant (project constitution): **persist then broadcast** — a write is durable
+Core invariant (project constitution): **persist then broadcast**. A write is durable
 (`fsync` + atomic rename, WAL for multi-file changes) before the 200 and before any SSE
 fan-out. Scoring is ACID; a legitimate operator change is never dropped.
 
@@ -204,5 +204,5 @@ The operator console is a tablet/desktop surface; the viewer is mobile-first. Th
 
 - **Persist before broadcast**; scoring is ACID; never drop a legitimate operator change.
 - **Use layout/sheet constants** (`internal/helper/constants.go`), never string literals.
-- **`errcheck` is enforced** in production code — propagate or log, never `_ =`.
+- **`errcheck` is enforced** in production code: propagate or log, never `_ =`.
 - **Aka (Red) / Shiro (White) are positional**, distinguished by treatment, not hue alone.

--- a/docs/assets/javascripts/mermaid-init.js
+++ b/docs/assets/javascripts/mermaid-init.js
@@ -1,24 +1,24 @@
 // Render Mermaid diagrams in the MkDocs Material site.
 //
 // Material 8.5's built-in Mermaid loader does not fire reliably from the
-// superfences custom fence, so we load Mermaid explicitly (extra_javascript in
+// superfences custom fence; we load Mermaid explicitly (extra_javascript in
 // mkdocs.yaml) and run it here.
 //
 // IMPORTANT: pymdownx superfences emits `<pre class="mermaid"><code>…</code></pre>`.
 // Vanilla mermaid.run() chokes on that nested `<code>` (every diagram fails with
-// "Syntax error in text"). We unwrap it first — replacing the host's content with
-// the `<code>`'s decoded text — so each `.mermaid` holds the raw diagram source,
+// "Syntax error in text"). We unwrap it first; replacing the host's content with
+// the `<code>`'s decoded text; so each `.mermaid` holds the raw diagram source,
 // the structure mermaid expects.
 //
-// `navigation.instant` is enabled (XHR page swaps, no full reload), so we re-run
-// on Material's `document$` observable — it emits on first load AND every instant
-// navigation — rather than once on DOMContentLoaded, else diagrams are blank after
+// `navigation.instant` is enabled (XHR page swaps, no full reload); we re-run
+// on Material's `document$` observable. It emits on first load AND every instant
+// navigation, rather than once on DOMContentLoaded, else diagrams are blank after
 // an in-site link click. We only process not-yet-rendered nodes to avoid
 // re-running mermaid over already-drawn SVGs (which throws during page swaps).
 (function () {
   function render() {
     if (!window.mermaid) return;
-    // Our own "attempted" marker — NOT mermaid's `data-processed`. mermaid.run()
+    // Our own "attempted" marker; NOT mermaid's `data-processed`. mermaid.run()
     // is async and skips any node already flagged `data-processed` (even an
     // explicit `nodes` list), so touching that attribute ourselves would race its
     // per-node rendering and blank later diagrams. A separate attribute lets us
@@ -39,7 +39,7 @@
     try {
       window.mermaid.run({ nodes: pending });
     } catch (e) {
-      // A single bad diagram shouldn't blank the page; mermaid logs its own error.
+      // A single bad diagram should not blank the page; mermaid logs its own error.
       console.error("mermaid.run failed:", e);
     }
   }

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,5 +1,84 @@
-:root {
+/* bracket-creator docs theme overrides.
+ *
+ * Color is scoped PER SCHEME. Material derives link/interactive colors from
+ * these tokens; an unscoped `:root` override (the previous approach) forced
+ * one value into both light and dark, which made dark-mode links #333 on a
+ * navy background (1.03:1, invisible). Each scheme now gets its own values.
+ *
+ * Accent = the web-mobile app's brand navy (--accent #1d3557, see DESIGN.md) so
+ * the docs and the product share one interactive color. The slate scheme uses a
+ * lightened navy of the same hue; links stay legible on the dark surface. */
+
+/* Light scheme */
+[data-md-color-scheme="default"] {
 	--md-primary-fg-color: #333333;
-	--md-primary-fg-color--light: #333333;
-	--md-primary-fg-color--dark: #333333;
+	--md-primary-fg-color--light: #4a4a4a;
+	--md-primary-fg-color--dark: #1f1f1f;
+
+	/* Brand navy: hover/focus/active states + in-prose links. 12.3:1 on white. */
+	--md-accent-fg-color: #1d3557;
+	--md-typeset-a-color: #1d3557;
+
+	/* Paper is a near-white tinted a whisper toward the brand navy (hue ~225),
+	 * rather than pure #fff, so the reading surface reads as the product's own
+	 * rather than a default white. Body text still clears ~16:1. */
+	--md-default-bg-color: #fbfcfe;
+}
+
+/* Dark (slate) scheme */
+[data-md-color-scheme="slate"] {
+	--md-primary-fg-color: #333333;
+	--md-primary-fg-color--light: #5a5a5a;
+	--md-primary-fg-color--dark: #1f1f1f;
+
+	/* Lightened navy (same hue) so links/accent clear 4.5:1 on the slate bg.
+	 * #93b3e0 on the default slate surface measures ~6.1:1. */
+	--md-accent-fg-color: #93b3e0;
+	--md-typeset-a-color: #93b3e0;
+}
+
+/* In-prose links are underlined by default. On a high-link-density docs site
+ * the navy hue alone is only ~1.3:1 against body text; the underline (not
+ * the color) is what marks a link. Structural/anchor links opt out. */
+.md-typeset a {
+	text-decoration: underline;
+	text-underline-offset: 0.15em;
+	text-decoration-thickness: 1px;
+}
+
+.md-typeset a:hover {
+	text-decoration-thickness: 2px;
+}
+
+/* Permalink anchors (¶) and buttons are not prose links; no underline. */
+.md-typeset a.headerlink,
+.md-typeset .md-button {
+	text-decoration: none;
+}
+
+/* Image-only links (e.g. shields.io badges). Kept in a SEPARATE rule: a
+ * comma-list is non-forgiving, so grouping `:has(img)` with the selectors
+ * above would invalidate the whole list (and re-underline headerlinks/buttons)
+ * in browsers without :has() support. */
+.md-typeset a:has(img) {
+	text-decoration: none;
+}
+
+/* Mobile table polish. Inline code in table cells (commands, env vars, flags
+ * like `create-pools` / `TOURNAMENT_DATA_DIR`) must not break mid-token; on a
+ * phone they were fragmenting into "create-\npools". Keep each token whole... */
+.md-typeset table:not([class]) td code,
+.md-typeset table:not([class]) th code {
+	white-space: nowrap;
+}
+
+/* ...and let the table wrapper scroll horizontally when a row gets wider than
+ * the viewport. The wrapper must be a block constrained to the content column
+ * (max-width: 100%) for overflow-x to scroll the inner table; otherwise it
+ * sizes to content and spills past the column. Material wraps every table in
+ * .md-typeset__table. */
+.md-typeset__table {
+	display: block;
+	max-width: 100%;
+	overflow-x: auto;
 }

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -55,7 +55,7 @@ make run          # starts on localhost:8080
 PORT=8081 make run
 ```
 
-Open the browser and walk through bracket generation manually — type checking and unit tests do not exercise the UI rendering path.
+Open the browser and walk through bracket generation manually. Type checking and unit tests do not exercise the UI rendering path.
 
 ### Testing the mobile / live tournament app
 
@@ -73,13 +73,13 @@ TOURNAMENT_DATA_DIR=/path PORT=8082 ./bin/bracket-creator mobile-app
 
 An explicit `--folder`, `--port`, or `--bind` flag still overrides the env var.
 
-**Important:** `web-mobile/` is a Preact/JSX frontend compiled by esbuild into `web-mobile/dist/` and then embedded into the Go binary at build time. Any change to `web-mobile/js/*.js` or `web-mobile/css/*.css` requires:
+**Important:** `web-mobile/` is a Preact/JSX frontend compiled by esbuild into `web-mobile/dist/` and then embedded into the Go binary at build time. Any change to `web-mobile/js/*.js` or `web-mobile/css/*.css` requires the following:
 
-1. Rebuild the JS bundle: `cd web-mobile && npm run build` (or `npx esbuild ...` — see the project `Makefile`)
+1. Rebuild the JS bundle: `cd web-mobile && npm run build` (or `npx esbuild ...`; see the project `Makefile`)
 2. Rebuild the binary: `make go/build`
 3. Restart the server: `make run-mobile`
 
-Simply editing `.js` files and refreshing the browser will **not** pick up changes — the browser is served the embedded bundle baked into the last binary build.
+Simply editing `.js` files and refreshing the browser will **not** pick up changes; the browser is served the embedded bundle baked into the last binary build.
 
 ## Create a commit
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,8 @@ Open `tournament.xlsx` in Excel or LibreOffice and print.
 
 ## What you need on tournament day
 
-- **A3 printer** — for team/player name sheets
-- **A4 printer** — for the bracket trees
+- **A3 printer**: for team/player name sheets
+- **A4 printer**: for the bracket trees
 - Scoreboards, whiteboard markers, scissors, tasuki
 
 ### Keeping courts in sync
@@ -60,11 +60,11 @@ If you have multiple shiai-jo, upload the Excel file to Google Drive (or similar
 
 ## Before the tournament
 
-1. **Collect participants** — one name per line in a CSV file ([input format](user-guide/input-format.md))
-2. **Generate the bracket** — run `create-pools` or `create-playoffs` ([commands](user-guide/commands/create-pools.md))
+1. **Collect participants**: one name per line in a CSV file ([input format](user-guide/input-format.md))
+2. **Generate the bracket**: run `create-pools` or `create-playoffs` ([commands](user-guide/commands/create-pools.md))
 3. **Optionally seed** top competitors so they land in separate pools/sides of the bracket ([seeding](user-guide/commands/create-pools.md#seeding))
-4. **Print** — the Excel file is laid out to print cleanly on A4/A3
+4. **Print**: the Excel file is laid out to print cleanly on A4/A3
 
 ## On the day
 
-Use the **live tournament app** to manage pools and scores in real time across all devices on your network — no Excel required on the day. See the [mobile app guide](user-guide/mobile-app.md).
+Use the **live tournament app** to manage pools and scores in real time across all devices on your network (no Excel required on the day). See the [mobile app guide](user-guide/mobile-app.md).

--- a/docs/user-guide/commands/create-playoffs.md
+++ b/docs/user-guide/commands/create-playoffs.md
@@ -10,16 +10,16 @@ bracket-creator create-playoffs [flags]
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--file` | `-f` | — | CSV file with participants **(required)** |
-| `--output` | `-o` | — | Output `.xlsx` path **(required)** |
+| `--file` | `-f` | (none) | CSV file with participants **(required)** |
+| `--output` | `-o` | (none) | Output `.xlsx` path **(required)** |
 | `--courts` | `-c` | `2` | Number of shiai-jo (courts) to split the tree across |
 | `--team-matches` | `-t` | `0` | Players per team (0 = individual tournament) |
 | `--with-zekken-name` | `-z` | `false` | Use second CSV column as zekken display name |
-| `--seeds` | — | — | CSV file with seed rankings |
+| `--seeds` | (none) | (none) | CSV file with seed rankings |
 | `--determined` | `-d` | `false` | Do not shuffle input order |
-| `--single-tree` | — | `false` | Produce one tree sheet instead of one per court |
+| `--single-tree` | (none) | `false` | Produce one tree sheet instead of one per court |
 | `--number-prefix` | `-n` | `""` | Assign consecutive numbers with this letter prefix (e.g. `K` produces K1, K2, …) |
-| `--title-prefix` | — | `""` | Prefix added to sheet titles |
+| `--title-prefix` | (none) | `""` | Prefix added to sheet titles |
 
 ## Examples
 
@@ -47,7 +47,7 @@ bracket-creator create-playoffs \
 
 ## Seeding
 
-Works the same as `create-pools` — top seeds are placed on opposite sides of the bracket so they can only meet in the final. See the [input format](../input-format.md#seeds-file) for the seeds CSV layout.
+Works the same as `create-pools`; top seeds are placed on opposite sides of the bracket so they can only meet in the final. See the [input format](../input-format.md#seeds-file) for the seeds CSV layout.
 
 ## Output sheets
 

--- a/docs/user-guide/commands/create-pools.md
+++ b/docs/user-guide/commands/create-pools.md
@@ -10,24 +10,24 @@ bracket-creator create-pools [flags]
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--file` | `-f` | — | CSV file with participants **(required)** |
-| `--output` | `-o` | — | Output `.xlsx` path **(required)** |
+| `--file` | `-f` | (none) | CSV file with participants **(required)** |
+| `--output` | `-o` | (none) | Output `.xlsx` path **(required)** |
 | `--courts` | `-c` | `2` | Number of shiai-jo (courts) to distribute pools across |
 | `--players` | `-p` | `3` | Minimum players per pool |
-| `--max-players` | `-m` | — | Maximum players per pool |
+| `--max-players` | `-m` | (none) | Maximum players per pool |
 | `--pool-winners` | `-w` | `2` | Players that qualify from each pool |
 | `--round-robin` | `-r` | `false` | Force full round-robin in every pool |
 | `--team-matches` | `-t` | `0` | Players per team (0 = individual tournament) |
 | `--with-zekken-name` | `-z` | `false` | Use second CSV column as zekken display name |
-| `--seeds` | — | — | CSV file with seed rankings |
+| `--seeds` | (none) | (none) | CSV file with seed rankings |
 | `--determined` | `-d` | `false` | Do not shuffle input order |
-| `--single-tree` | — | `false` | Produce one tree sheet instead of one per court |
+| `--single-tree` | (none) | `false` | Produce one tree sheet instead of one per court |
 | `--number-prefix` | `-n` | `""` | Assign consecutive numbers with this letter prefix (e.g. `K` produces K1, K2, …) |
-| `--title-prefix` | — | `""` | Prefix added to sheet titles |
+| `--title-prefix` | (none) | `""` | Prefix added to sheet titles |
 
 ## Examples
 
-Minimal — two courts, random draw:
+Minimal: two courts, random draw:
 
 ```bash
 bracket-creator create-pools -f participants.csv -o tournament.xlsx

--- a/docs/user-guide/commands/hash-password.md
+++ b/docs/user-guide/commands/hash-password.md
@@ -10,14 +10,14 @@ bracket-creator hash-password [plaintext]
 
 The command reads the plaintext from one of two sources, in this order:
 
-1. **Positional argument** — `bracket-creator hash-password mysecret`. Convenient for ad-hoc use, but the password is recorded in shell history. Suitable for development.
-2. **Standard input** (when no argument is supplied) — read one line of stdin. The terminal echoes what the operator types (the command does **not** disable echo or print a prompt). For production rotation, pipe from a secrets manager or here-doc rather than typing the password interactively. Recommended path because it avoids shell-history leakage.
+1. **Positional argument**: `bracket-creator hash-password mysecret`. Convenient for ad-hoc use, but the password is recorded in shell history. Suitable for development.
+2. **Standard input** (when no argument is supplied): read one line of stdin. The terminal echoes what the operator types (the command does **not** disable echo or print a prompt). For production rotation, pipe from a secrets manager or here-doc rather than typing the password interactively. Recommended path because it avoids shell-history leakage.
 
 Bcrypt has a hard 72-byte limit on the input. Passwords longer than that are rejected up-front rather than silently truncated.
 
 ## Output
 
-Single line on stdout: the bcrypt hash (e.g. `$2a$10$tq9jkGYsf1ttx0ZM.UUrxezVBcO4aZaS.dVRY73xC5lwEvTJLcMc6`). Cost is `bcrypt.DefaultCost` (10) — fine for admin-facing endpoints (~50–100 ms per verify) and not worth tuning until a real load problem appears.
+Single line on stdout: the bcrypt hash (e.g. `$2a$10$tq9jkGYsf1ttx0ZM.UUrxezVBcO4aZaS.dVRY73xC5lwEvTJLcMc6`). Cost is `bcrypt.DefaultCost` (10), fine for admin-facing endpoints (~50-100 ms per verify) and not worth tuning until a real load problem appears.
 
 ## Examples
 
@@ -25,7 +25,7 @@ Single line on stdout: the bcrypt hash (e.g. `$2a$10$tq9jkGYsf1ttx0ZM.UUrxezVBcO
 # Quick generation via argument (leaves password in shell history)
 bracket-creator hash-password mysecret
 
-# Stdin path — pipe from another command
+# Stdin path: pipe from another command
 echo -n "$MY_SECRET" | bracket-creator hash-password
 
 # Capture into a shell variable for the mobile-app server

--- a/docs/user-guide/commands/mobile-app.md
+++ b/docs/user-guide/commands/mobile-app.md
@@ -15,7 +15,7 @@ See the [Mobile Tournament App guide](../mobile-app.md) for a full walkthrough o
 | `--folder` | `-f` | `.` | Folder containing `tournament.md` and `competitions/`. Created on first save. |
 | `--port` | `-p` | `8080` (or `$PORT`) | Port to listen on |
 | `--bind` | `-b` | `localhost` (or `$BIND_ADDRESS`) | Address to bind to. Use `0.0.0.0` to reach the server from other devices on the LAN. |
-| `--lock-password` | — | unset (or `$LOCK_PASSWORD=true`) | Switch to locked authentication mode. Requires `TOURNAMENT_PASSWORD_HASH`. See [Authentication](#authentication) below. |
+| `--lock-password` | (none) | unset (or `$LOCK_PASSWORD=true`) | Switch to locked authentication mode. Requires `TOURNAMENT_PASSWORD_HASH`. See [Authentication](#authentication) below. |
 
 ## Environment variables
 
@@ -34,7 +34,7 @@ The server has two authentication modes for the admin console; viewer routes are
 
 The admin password is stored plaintext in `tournament-data/tournament.md` and compared by exact-string match. Set the password during the in-app **Create tournament** flow, or edit `tournament.md` directly.
 
-- `POST /api/tournament/reset` is enabled and unauthenticated — browse to `http://<host>/reset` from any device on the same network to set a new password if you've forgotten the current one.
+- `POST /api/tournament/reset` is enabled and unauthenticated; browse to `http://<host>/reset` from any device on the same network to set a new password if you've forgotten the current one.
 - `GET /api/auth-config` returns `{"mode": "file", "resetEnabled": true}`.
 
 ### Locked mode (`--lock-password`)
@@ -42,7 +42,7 @@ The admin password is stored plaintext in `tournament-data/tournament.md` and co
 The on-disk password is ignored. Authentication compares the `X-Tournament-Password` header against a bcrypt hash supplied via the `TOURNAMENT_PASSWORD_HASH` environment variable.
 
 ```bash
-# Generate the hash (pipe the secret — bare invocation waits for stdin with no
+# Generate the hash (pipe the secret; bare invocation waits for stdin with no
 # prompt or echo-off, so always use printf/pipe to avoid shell history leakage)
 printf '%s' "$MY_ADMIN_SECRET" | bracket-creator hash-password
 
@@ -61,13 +61,13 @@ TOURNAMENT_PASSWORD_HASH='$2a$10$...' \
 #### Operational caveats
 
 - **`POST /api/tournament/reset` has no rate limiting.** The endpoint is unauthenticated and the server does not throttle calls. For internet-exposed deployments, run with `--lock-password` (which 404s `POST /api/tournament/reset`) OR front the server with a reverse proxy that rate-limits that path.
-- **Locked mode has no bcrypt brute-force protection.** The server runs a full bcrypt comparison (`bcrypt.DefaultCost` ≈ 50–100 ms) on every `X-Tournament-Password` header, but does not throttle repeated failed attempts. For internet-exposed locked-mode deployments, add a reverse proxy that rate-limits authenticated routes (e.g. nginx's `limit_req`) in addition to `POST /api/tournament/reset`.
-- **Mode switching preserves the stored password.** Switching from file mode to locked mode does NOT erase `tournament.md`'s `password` field — auth just stops consulting it. A later switch back to file mode resurrects the original password. This is a deliberate rollback feature, but anyone with filesystem access can still read the value. To fully retire a file-mode credential before going locked, `POST /api/tournament/reset` it to a one-time throwaway first.
+- **Locked mode has no bcrypt brute-force protection.** The server runs a full bcrypt comparison (`bcrypt.DefaultCost` approx 50-100 ms) on every `X-Tournament-Password` header, but does not throttle repeated failed attempts. For internet-exposed locked-mode deployments, add a reverse proxy that rate-limits authenticated routes (e.g. nginx's `limit_req`) in addition to `POST /api/tournament/reset`.
+- **Mode switching preserves the stored password.** Switching from file mode to locked mode does NOT erase `tournament.md`'s `password` field; auth just stops consulting it. A later switch back to file mode resurrects the original password. This is a deliberate rollback feature, but anyone with filesystem access can still read the value. To fully retire a file-mode credential before going locked, `POST /api/tournament/reset` it to a one-time throwaway first.
 
 ## Examples
 
 ```bash
-# Local LAN — file mode, default port
+# Local LAN: file mode, default port
 bracket-creator mobile-app -f ./tournament-data
 
 # Bind to all interfaces, custom port
@@ -75,7 +75,7 @@ bracket-creator mobile-app -f ./tournament-data -b 0.0.0.0 -p 8082
 
 # Locked mode for a public deployment.
 # Note: `hash-password` reads ONE line from stdin without prompting or
-# disabling terminal echo — pipe the password in from a secrets manager
+# disabling terminal echo; pipe the password in from a secrets manager
 # or a here-doc rather than typing it directly, so it never lands in
 # shell history or the terminal scrollback.
 HASH=$(printf '%s' "$MY_ADMIN_SECRET" | bracket-creator hash-password)

--- a/docs/user-guide/commands/serve.md
+++ b/docs/user-guide/commands/serve.md
@@ -16,7 +16,7 @@ bracket-creator serve [flags]
 ## Usage
 
 ```bash
-# Default — available at http://localhost:8080
+# Default: available at http://localhost:8080
 bracket-creator serve
 
 # Different port

--- a/docs/user-guide/input-format.md
+++ b/docs/user-guide/input-format.md
@@ -1,6 +1,6 @@
 # Input Format
 
-Participants are provided as a plain CSV file — one participant per line, no header row.
+Participants are provided as a plain CSV file (one participant per line, no header row).
 
 ## Basic format
 
@@ -25,11 +25,11 @@ Eddard Stark, STARK, Team Epsilon
 
 ## Team matches
 
-For team tournaments (`--team-matches N`), each row still represents an individual fighter — the application groups them into teams of N. The dojo column is used to keep team-mates out of the same pool.
+For team tournaments (`--team-matches N`), each row still represents an individual fighter. The application groups them into teams of N. The dojo column is used to keep team-mates out of the same pool.
 
 ## Constraints
 
-- Names must be **unique** — duplicate entries are rejected before any bracket is generated.
+- Names must be **unique**: duplicate entries are rejected before any bracket is generated.
 - Names in a [seeds file](commands/create-pools.md#seeding) must match the CSV exactly (case-sensitive).
 
 ## Seeds file

--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -1,6 +1,6 @@
 # Mobile Tournament App
 
-The `mobile-app` command starts a real-time tournament management server for use **on the day of the tournament**. Any device on the same network can open the URL to view real-time results or — with the admin password — manage pools and scores.
+The `mobile-app` command starts a real-time tournament management server for use **on the day of the tournament**. Any device on the same network can open the URL to view real-time results or (with the admin password) manage pools and scores.
 
 ## Starting the server
 
@@ -8,7 +8,7 @@ The `mobile-app` command starts a real-time tournament management server for use
 bracket-creator mobile-app --folder ./tournament-data
 ```
 
-The `--folder` and `--port` flags can also be supplied via environment variables — useful for systemd units, Docker, or any deploy that doesn't run via `make`:
+The `--folder` and `--port` flags can also be supplied via environment variables (useful for systemd units, Docker, or any deploy that doesn't run via `make`):
 
 ```bash
 TOURNAMENT_DATA_DIR=/path/to/data PORT=8082 bracket-creator mobile-app
@@ -44,22 +44,22 @@ The default view requires no password. It shows:
 
 ## Admin console
 
-Click **Admin** and enter the tournament password to access the admin console. The server runs in one of two authentication modes — see [Admin authentication](#admin-authentication) below.
+Click **Admin** and enter the tournament password to access the admin console. The server runs in one of two authentication modes; see [Admin authentication](#admin-authentication) below.
 
 ### Admin authentication
 
-**File mode** (default — local / private LAN use):
+**File mode** (default: local / private LAN use):
 
-The admin password lives plaintext in `tournament-data/tournament.md`. Set it during the **Create tournament** flow, or edit the file directly. If you forget the password, browse to `http://<host>/reset` from any device on the same network and choose a new one — no old password required. The reset endpoint is intentionally unauthenticated and is the documented recovery path; for trusted networks this is convenient, and for internet-exposed deployments use locked mode below.
+The admin password lives plaintext in `tournament-data/tournament.md`. Set it during the **Create tournament** flow, or edit the file directly. If you forget the password, browse to `http://<host>/reset` from any device on the same network and choose a new one (no old password required). The reset endpoint is intentionally unauthenticated and is the documented recovery path; for trusted networks this is convenient, and for internet-exposed deployments use locked mode below.
 
 **Locked mode** (recommended for any deployment reachable over the internet):
 
 ```bash
 # 1) generate a bcrypt hash for your chosen password.
-# hash-password reads from stdin without a prompt or echo masking —
+# hash-password reads from stdin without a prompt or echo masking;
 # pipe from a secrets manager or here-doc rather than typing interactively.
 printf '%s' "$MY_ADMIN_SECRET" | bracket-creator hash-password
-# (the hash is printed on stdout — copy it)
+# (the hash is printed on stdout; copy it)
 
 # 2) start the server with --lock-password and the hash in the env
 TOURNAMENT_PASSWORD_HASH='$2a$10$...' \
@@ -72,7 +72,7 @@ In locked mode:
 - `POST /api/tournament/reset` returns 404. The SPA's `/reset` page still loads (it's part of the embedded SPA bundle) but renders an "operator-disabled" message instead of the form, and the AuthModal hides the "Forgot password?" link.
 - Authentication compares the `X-Tournament-Password` header against the env-var bcrypt hash.
 - Rotating the credential requires restarting the server with a new hash; the runtime never reads the env var twice.
-- If `--lock-password` is set but `TOURNAMENT_PASSWORD_HASH` is empty or malformed, the server **refuses to start** — fail-closed, so a misconfigured deployment can't silently fall through to file mode.
+- If `--lock-password` is set but `TOURNAMENT_PASSWORD_HASH` is empty or malformed, the server **refuses to start** (fail-closed, so a misconfigured deployment can't silently fall through to file mode).
 
 The public `GET /api/auth-config` endpoint reports `{mode: "file"|"locked", resetEnabled: bool, elevatedRequired: bool, elevatedConfigured: bool, elevatedEditable: bool}` so SPAs and external monitoring can see the active mode (and whether the destructive-ops password gate is active) without authenticating.
 
@@ -96,7 +96,7 @@ password each time (no session is cached); the value is sent in an
 password**. The current value is never displayed (write-only) and is stored in
 `tournament-data/tournament.md` under `admin_password`. Changing it once set
 requires entering the current destructive-ops password. While unset, the
-feature is off and destructive actions are gated by the main password only —
+feature is off and destructive actions are gated by the main password only.
 so existing file-mode deployments are unaffected until you opt in.
 
 **Locked mode.** The destructive-ops password is the bcrypt hash in the
@@ -115,8 +115,8 @@ TOURNAMENT_PASSWORD_HASH='$2a$10$...main...' \
 > **always active and fail-closed**: if `TOURNAMENT_ADMIN_PASSWORD_HASH` is
 > unset (or malformed), the gated endpoints return **503 "admin password not
 > configured"** rather than allowing the action with the main password alone.
-> A malformed/empty hash does **not** prevent startup — the server boots and
-> only the destructive endpoints 503 — so set the env var if your operators
+> A malformed/empty hash does **not** prevent startup; the server boots and
+> only the destructive endpoints 503, so set the env var if your operators
 > need to delete competitions or edit rosters on a locked deployment.
 
 **Scope of protection.** This is a privilege-separation speed bump for
@@ -128,7 +128,7 @@ network boundary, run behind TLS and/or `--lock-password`.
 ### Operational notes
 
 - **No rate limiting on `/reset`.** The reset endpoint is unauthenticated by design and the server does not throttle calls to it. On a trusted LAN this is fine (the legitimate operator is the only person at the keyboard); on any network where untrusted clients can reach the server, an attacker can grief the deployment by repeatedly POSTing new passwords and locking the operator out. **Always run with `--lock-password` for internet-exposed deployments**, or front the server with a reverse proxy that rate-limits `/api/tournament/reset`.
-- **Mode switching preserves the stored password.** When you switch from file mode to locked mode, the password on disk in `tournament.md` is **not** erased — it's just ignored at auth time. If you later switch back to file mode (drop `--lock-password`), the original password authenticates again. Treat this as a feature for rollback experimentation, but be aware that the on-disk credential remains discoverable by anyone with filesystem access. If you want to fully retire a file-mode password, run `POST /api/tournament/reset` to a value you don't intend to use before switching to locked mode.
+- **Mode switching preserves the stored password.** When you switch from file mode to locked mode, the password on disk in `tournament.md` is **not** erased; it's just ignored at auth time. If you later switch back to file mode (drop `--lock-password`), the original password authenticates again. Treat this as a feature for rollback experimentation, but be aware that the on-disk credential remains discoverable by anyone with filesystem access. If you want to fully retire a file-mode password, run `POST /api/tournament/reset` to a value you don't intend to use before switching to locked mode.
 
 ### Dashboard
 
@@ -136,27 +136,64 @@ The dashboard lists all competitions. Each card shows the competition type, numb
 
 ### Setting up a competition
 
-Each competition goes through a **Setup → Pools → Playoffs** lifecycle.
+Each competition goes through a **Setup → Draw Preview (status `draw-ready`) → Live play (status `pools` or `playoffs`)** lifecycle. "Swiss" is a *format*, not a separate status; Swiss-format competitions run live under the `pools` status.
 
-1. **Participants & seeds** — Paste or upload a CSV. The participant textarea shows numbered lines for easy error spotting. Format:
-   - Without zekken: `Name, Dojo[, Dan grade]`
-   - With zekken: `Name, Zekken display name, Dojo[, Dan grade]`
+#### The Participant Setup View
 
-   Enable **Use Zekken display name** in Settings first when using the 4-column format.
+The participant setup view places two panels side by side:
 
-   After pasting, click **Apply** to save. Optionally import a seeds CSV or type seed numbers per row.
+* **Check-in & Seeding panel** (titled **Seeding** when check-in is off, **Check-in & Seeding** when it is on): the working roster of all saved players.
+    * When **Enable check-in** is turned on in the competition settings, each row gains a check-in check-box, and the panel adds a "Show unchecked" / "Show all" filter toggle plus a "Check in all" button.
+    * The roster is drag-and-drop enabled: drag rows to assign seeding ranks, or type ranks manually in the seed column. A "Shuffle unseeded" button randomizes the starting positions of unseeded competitors, and "Import seeds (CSV)" / "Clear seeds" manage ranks in bulk.
+* **Participant list panel** (titled **Team list** for team competitions): contains a `LinedTextarea` with line numbers where operators paste newline-separated CSV participant rosters, plus a "Paste clipboard" helper that converts tab-separated values (for example, from Excel) to CSV.
 
-2. **Settings** — Adjust pool size, winners per pool, shiai-jo assignment, start time, round-robin mode, and zekken display.
+Format for bulk paste:
+* Without Zekken: `Name, Dojo[, Dan grade]`
+* With Zekken: `Name, Zekken display name, Dojo[, Dan grade]`
 
-3. **Start competition** — Click **Start competition →** to draw pools. The status moves to `pools`.
+To save the bulk import, click the **Apply changes** button at the bottom of the Participant list panel.
+
+#### Participant Edit Modal
+
+To edit details of a single competitor (for spelling corrections, dojo transfers, or dan grade updates) without wiping the bulk list:
+1. Click the edit pencil icon next to the participant's name in the Check-in & Seeding panel. Editing is available during setup only; once the draw is generated (status `draw-ready`) the pencil is disabled, so discard the draw first to make corrections.
+2. In the modal that appears, modify the name, dojo, dan grade, or display name.
+3. Click **Save changes** to commit. The edits are persisted atomically to `participants.csv` without disrupting existing check-in or seeding states. Seed ranks are managed in the same Check-in & Seeding panel described above, via drag-and-drop or the seed-rank input, not in a separate tab.
+
+#### Optional Check-in Workflow
+
+You can enable check-in for any competition in its **Settings** tab. When check-in is enabled:
+- A check-in panel displays in the viewer roster screen.
+- A **Check-in window** (configurable via tournament settings as `Check-in window start/end`) displays a status banner indicating if the window is pending, open, or closed.
+- Operators can check in players individually by checking their checkbox, bulk check in all players from a specific dojo, or click **Check in all** to check in everyone.
+- Check-in affects the draw with **opt-in semantics**: when you click **Generate draw**, if at least one participant is checked in, only checked-in participants are included (unchecked no-shows are automatically excluded, and their seed assignments dropped); if nobody has checked in yet, everyone is included, so simply enabling the panel never shrinks the field on its own. (When check-in is disabled for the competition, check-in markers are ignored entirely.)
+
+#### The Draw-Preview (status `draw-ready`) Workflow
+
+To prevent mistakes and allow manual inspection of the draw before matches are locked and started, the application uses a multi-step **Draw-Preview** workflow:
+
+1. Under the setup tab, after importing and checking in all players, click **Generate draw**.
+2. The competition transitions to the **`draw-ready`** status.
+3. An interactive draw preview appears, showing the generated pools, bracket structure, or Swiss Round 1 pairings. 
+4. While a draw is in the `draw-ready` status, **participant roster edits are locked** to prevent TOCTOU data corruption. Check-in toggles remain available during this phase.
+5. If the draw is satisfactory, click **Start competition**. This transitions the status to `pools` (for mixed and Swiss formats) or `playoffs` (for playoffs-only) and exposes the matches to scorers and the public viewer.
+6. If the draw needs changes (e.g., a late-arriving player needs to be added, or a seed rank must be corrected), click **Discard draw**. This deletes the draft pools and bracket files, unlocks the participant list, and returns the competition to the `setup` phase so you can edit and regenerate.
 
 ### Pools
 
-Once pools are drawn, the **Pools** tab shows all pools and their current standings. Scorers can use the **Scores — edit** tab or the dedicated score editor to record match results.
+Once the competition has started, the **Pools** tab shows all pools and their current standings. Scorers can use the **Scores** tab or the dedicated score editor to record match results.
 
 ### Bracket
 
 After all pool matches are complete, advance the pool winners to the elimination bracket. The bracket updates in real time as scores come in.
+
+#### Swiss format tournament flow
+
+For large individual tournaments using the **Swiss** format:
+1. **Start**: Click **Start competition**. The competition transitions to `pools` status (the same lifecycle status used for mixed/league formats) and Round 1 pairings are generated. Round 1 has no prior results, so it uses **fold pairing** when seeds are present (1 vs N, 2 vs N-1, …) or a deterministic-random pairing otherwise. The "winners face winners" grouping by win record applies from Round 2 onward.
+2. **Match Completion**: Scorers record match outcomes. A Swiss round must have all matches completed before the operator can generate the next round.
+3. **Cumulative Standings**: Standings are calculated in real time based on wins, points scored, head-to-head records, and stable alphabetical sorting. This cumulative standings view is public (no authentication required) so spectators can track who is leading the field at any point.
+4. **Advancement**: Click **Generate next round** to compute pairings for the subsequent round. This increments `swissCurrentRound` and broadcasts `swiss_round_generated` SSE events to refresh all screens.
 
 ### Export & print
 

--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -164,7 +164,6 @@ To edit details of a single competitor (for spelling corrections, dojo transfers
 
 You can enable check-in for any competition in its **Settings** tab. When check-in is enabled:
 - A check-in panel displays in the viewer roster screen.
-- A **Check-in window** (configurable via tournament settings as `Check-in window start/end`) displays a status banner indicating if the window is pending, open, or closed.
 - Operators can check in players individually by checking their checkbox, bulk check in all players from a specific dojo, or click **Check in all** to check in everyone.
 - Check-in affects the draw with **opt-in semantics**: when you click **Generate draw**, if at least one participant is checked in, only checked-in participants are included (unchecked no-shows are automatically excluded, and their seed assignments dropped); if nobody has checked in yet, everyone is included, so simply enabling the panel never shrinks the field on its own. (When check-in is disabled for the competition, check-in markers are ignored entirely.)
 

--- a/docs/user-guide/web-ui.md
+++ b/docs/user-guide/web-ui.md
@@ -32,4 +32,4 @@ After confirming, the assigned seeds are shown inline next to each participant n
 
 ## Downloading the bracket
 
-Click **Generate** to produce the Excel file. The browser downloads the `.xlsx` directly — no server-side storage, no account needed.
+Click **Generate** to produce the Excel file. The browser downloads the `.xlsx` directly (no server-side storage, no account needed).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -8,10 +8,10 @@ repo_url: https://github.com/gitrgoliveira/bracket-creator
 extra_css:
   - assets/stylesheets/extra.css
 
-# Mermaid: load the library explicitly + an init that re-runs on Material's
+# Mermaid: load the library explicitly plus an init that re-runs on Material's
 # instant-navigation page swaps (see assets/javascripts/mermaid-init.js).
 extra_javascript:
-  # Pinned to the current latest (11.16.0) for reproducible builds — bump the
+  # Pinned to the current latest (11.16.0) for reproducible builds; bump the
   # version here to upgrade (check https://www.npmjs.com/package/mermaid).
   - https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.min.js
   - assets/javascripts/mermaid-init.js
@@ -35,6 +35,7 @@ markdown_extensions:
 
 theme:
   name: material
+  custom_dir: overrides
   features:
     - navigation.indexes
     - navigation.sections
@@ -43,16 +44,23 @@ theme:
     - navigation.tabs.sticky
   favicon: assets/images/favicon.ico
   logo: assets/images/logo.png
+  font:
+    # Atkinson Hyperlegible (Braille Institute) maximizes glyph separation
+    # (l/I/1, O/0/Q); chosen for legibility in bright/noisy halls per
+    # PRODUCT.md. JetBrains Mono keeps CLI examples crisp.
+    text: Atkinson Hyperlegible
+    code: JetBrains Mono
+  # Colors are driven entirely by assets/stylesheets/extra.css (the
+  # --md-primary-fg-color / --md-accent-fg-color tokens, scoped per scheme).
+  # Material's `primary`/`accent` only accept named palettes (e.g. `indigo`),
+  # not hex, so hex values here are silently ignored; they are intentionally
+  # omitted so the CSS is the single source of truth.
   palette:
     - scheme: default
-      primary: 333333
-      accent: 333333
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: "#333333"
-      accent: "#333333"
       toggle:
         icon: material/brightness-3
         name: Switch to light mode

--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+<!--
+  Custom 404. Material's default 404 renders only "404 - Not found" with no way
+  forward; broken inbound links (common for docs) land readers on a dead end.
+  This adds an apology, the most likely destinations, and a nudge to search.
+-->
+
+{% block content %}
+  <h1>Page not found</h1>
+  <p>
+    Sorry; that page doesn’t exist. It may have moved or been renamed.
+    Use the search box at the top of the page, or jump to one of these:
+  </p>
+  <ul>
+    <li><a href="{{ base_url }}/">Home</a></li>
+    <li><a href="{{ base_url }}/user-guide/getting-started/">Installation &amp; getting started</a></li>
+    <li><a href="{{ base_url }}/user-guide/mobile-app/">Live tournament app</a></li>
+    <li><a href="{{ config.repo_url }}">Project on GitHub</a></li>
+  </ul>
+{% endblock %}

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2137,7 +2137,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [error]
+                required: [error, code, round]
                 properties:
                   error:
                     type: string

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -21,6 +21,14 @@ info:
     - **`GET /api/competitions/{id}/teams/{tid}/lineups/{round}`**: public read; `PUT`/`DELETE` are protected.
     - **`GET /api/competitions/{id}/swiss/standings`**: public read; always public.
     - **`GET /api/tournament/announcement`**: public read; returns the currently active admin broadcast announcement (204 when none/expired).
+
+    **Self-run mode.** When the tournament is created with `mode: self-run`, the
+    main-password gate is bypassed for the operational play surface (scoring, check-in,
+    start/complete, generate-draw, etc.) so participants can drive their own flow without
+    an organiser at a table. Destructive routes (delete competition, invalidate, discard
+    draw, result overrides, roster mutations, import) and organiser-owned setup
+    (tournament/competition config) stay gated. In the default `officiated` mode every
+    `/api/` route keeps requiring `X-Tournament-Password` as described above.
   version: 2.1.0
 
 servers:
@@ -2871,19 +2879,6 @@ components:
             (rotation is done via `PUT /api/auth/admin-password`). In locked mode this
             field is accepted but silently ignored; the `TOURNAMENT_ADMIN_PASSWORD_HASH`
             env var is the authoritative elevated credential.
-        checkInWindowStart:
-          type: string
-          maxLength: 5
-          pattern: '^\d{2}:\d{2}$'
-          description: >
-            Global check-in window open time (HH:MM). Displayed in the viewer as a status
-            banner ("pending / open / closed"). Informational only; does not block
-            check-in API calls outside the window.
-        checkInWindowEnd:
-          type: string
-          maxLength: 5
-          pattern: '^\d{2}:\d{2}$'
-          description: Global check-in window close time (HH:MM).
 
     Competition:
       type: object

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -11,16 +11,16 @@ info:
     The Mobile/Admin API routes under `/api/` (excluding `/api/viewer/`) require the
     `X-Tournament-Password` header for authentication, with several public exceptions:
 
-    - **`GET /api/events`** — SSE stream; always public so viewers and spectator screens
+    - **`GET /api/events`**: SSE stream; always public so viewers and spectator screens
       can receive real-time updates without an admin credential.
-    - **`GET /api/auth-config`** — always public; carries no secret material.
-    - **`POST /api/tournament/reset`** — public in file mode (the recovery path for a
+    - **`GET /api/auth-config`**: always public; carries no secret material.
+    - **`POST /api/tournament/reset`**: public in file mode (the recovery path for a
       forgotten password); returns `404` in locked mode (`--lock-password`).
-    - **`GET /api/schedule/estimate`** — stateless schedule calculator; always public.
-    - **`GET /api/competitions/{id}/competitor-status`** — public read; the `POST` write is protected.
-    - **`GET /api/competitions/{id}/teams/{tid}/lineups/{round}`** — public read; `PUT`/`DELETE` are protected.
-    - **`GET /api/competitions/{id}/swiss/standings`** — public read; always public.
-    - **`GET /api/tournament/announcement`** — public read; returns the currently active admin broadcast announcement (204 when none/expired).
+    - **`GET /api/schedule/estimate`**: stateless schedule calculator; always public.
+    - **`GET /api/competitions/{id}/competitor-status`**: public read; the `POST` write is protected.
+    - **`GET /api/competitions/{id}/teams/{tid}/lineups/{round}`**: public read; `PUT`/`DELETE` are protected.
+    - **`GET /api/competitions/{id}/swiss/standings`**: public read; always public.
+    - **`GET /api/tournament/announcement`**: public read; returns the currently active admin broadcast announcement (204 when none/expired).
   version: 2.1.0
 
 servers:
@@ -219,26 +219,26 @@ paths:
         Subscribe to real-time tournament updates via SSE.
 
         Event types (canonical set defined in `internal/mobileapp/hub.go`):
-        - `match_updated` — a match's score/court/scheduledAt changed.
+        - `match_updated`: a match's score/court/scheduledAt changed.
           `data: { competitionId, matchId, ... }`.
-        - `competition_started` — a competition transitioned out of `setup`.
+        - `competition_started`: a competition transitioned out of `setup`.
           `data: { competitionId }`.
-        - `competition_completed` — a competition transitioned to `completed`
+        - `competition_completed`: a competition transitioned to `completed`
           (either via POST /complete or via the auto-complete check after the
           last pool match scored). `data: { competitionId }`.
-        - `tournament_updated` — tournament-level config change (a competition
+        - `tournament_updated`: tournament-level config change (a competition
           was created/updated/deleted, participants updated, etc.).
-          `data: null` — clients should refresh full state.
-        - `schedule_updated` — a competition's schedule was saved.
-        - `password_reset` — the admin password was changed. Emitted
+          `data: null`; clients should refresh full state.
+        - `schedule_updated`: a competition's schedule was saved.
+        - `password_reset`: the admin password was changed. Emitted
           from three sources (file mode only; never emitted in locked mode):
-          1. `POST /api/tournament/reset` — the public recovery endpoint.
+          1. `POST /api/tournament/reset`; the public recovery endpoint.
              Payload includes `originatorId` so the submitting tab can
              suppress its own broadcast: `data: { originatorId: "<opaque>" }`.
-          2. `PUT /api/tournament` — when an admin changes the password
+          2. `PUT /api/tournament`; when an admin changes the password
              via a tournament edit. Payload is `data: {}` (no originatorId;
              all sessions including the editing tab should re-authenticate).
-          3. `POST /api/tournament` — when an existing tournament is
+          3. `POST /api/tournament`; when an existing tournament is
              overwritten with a different password. Payload is `data: {}`.
           Consumers must treat `originatorId` as optional and handle both
           payload shapes. Non-originating sessions should clear their
@@ -260,7 +260,7 @@ paths:
       summary: Get tournament configuration
       description: |
         Returns the tournament record. In **locked mode** (`--lock-password` startup flag) the
-        `password` field is stripped from the response — auth comes from the env-var bcrypt hash
+        `password` field is stripped from the response; auth comes from the env-var bcrypt hash
         and the on-disk value is irrelevant. The same redaction applies to the PUT and POST
         responses below. Use `GET /api/auth-config` to discover which mode the server is in
         without authenticating.
@@ -284,19 +284,19 @@ paths:
         **File mode (default)**: allowed without the
         `X-Tournament-Password` header when no tournament has been
         configured yet (bootstrap). `password` must be non-empty
-        (`tournament password is required`) — an empty Password on
+        (`tournament password is required`); an empty Password on
         disk would let AuthMiddleware's `password != t.Password`
         check vacuously pass for any client sending an empty header.
         Once a tournament with a password exists, auth is required.
 
         **Locked mode (`--lock-password`)**: there is NO bootstrap
-        exception — the bcrypt env-var hash is the credential from
+        exception; the bcrypt env-var hash is the credential from
         the very first request. The `password` field in the request
         body is
-        accepted but **discarded** server-side — authentication uses the bcrypt hash from
+        accepted but **discarded** server-side; authentication uses the bcrypt hash from
         `TOURNAMENT_PASSWORD_HASH` env var, not the stored value. **Bootstrap requires
         `X-Tournament-Password` to match the env-var hash, even on a never-initialized
-        deployment** — anonymous bootstrap would let any network-reachable client race-claim
+        deployment**; anonymous bootstrap would let any network-reachable client race-claim
         the initial tournament record. The SPA's CreateTournament form detects locked mode
         via `GET /api/auth-config` and sends the env-var password as the header on the
         bootstrap POST. The response body's `password` field is empty.
@@ -333,13 +333,13 @@ paths:
             `tournament.md` is missing OR when the on-disk record is
             the literal default placeholder (`Name == "New Tournament"
             && Password == ""`). A real-named record with an empty
-            password is FAIL-CLOSED — rejected with 403 (`tournament
+            password is FAIL-CLOSED; rejected with 403 (`tournament
             misconfigured: password is not set`) before this handler
             runs; operator can use `POST /api/tournament/reset` or
             repair `tournament.md` out-of-band to recover. The
             empty-stored guard is disabled in locked mode (the
             on-disk password is irrelevant).
-          - Locked mode: `X-Tournament-Password` is REQUIRED — there
+          - Locked mode: `X-Tournament-Password` is REQUIRED; there
             is no bootstrap exception. The middleware verifies the
             header against the bcrypt hash from
             `TOURNAMENT_PASSWORD_HASH`. See
@@ -348,7 +348,7 @@ paths:
 
         Validation matches POST for `name` (rejected if empty after trim).
 
-        **File mode — Password preserve semantics**: when the request
+        **File mode; Password preserve semantics**: when the request
         body omits `password` or sends an empty string, the server
         preserves the currently-stored password. This matches the
         admin UI's `password: pass || undefined` pattern ("leave blank
@@ -361,7 +361,7 @@ paths:
         their stale localStorage credential and re-prompt; name-only
         edits do not.
 
-        **Locked mode — password rotation is disabled**: PUTs that
+        **Locked mode; password rotation is disabled**: PUTs that
         carry a non-empty `password` field are **rejected with 400**
         (`password rotation is disabled in locked mode; restart with
         a new TOURNAMENT_PASSWORD_HASH`). The auth credential lives
@@ -395,7 +395,7 @@ paths:
       summary: Reset the admin password (file mode only)
       description: |
         Replaces the stored admin password with the supplied value. Unauthenticated by
-        design — this is the documented recovery path for a forgotten admin password
+        design; this is the documented recovery path for a forgotten admin password
         on local / private deployments.
 
         The endpoint is disabled in **locked mode** (`--lock-password` CLI flag, with
@@ -450,12 +450,11 @@ paths:
       summary: Public auth-mode metadata
       description: |
         Reports the active authentication mode. Used by the SPA on first load to decide
-        whether to surface the password-reset UI. Public (no auth header required) —
-        the response carries no secret material, only the operator-visible toggle bits.
+        whether to surface the password-reset UI. Public (no auth header required); the response carries no secret material, only the operator-visible toggle bits.
 
         `mode` is one of:
-          * `file` — admin password lives in `tournament.md` (plaintext). Default.
-          * `locked` — admin password is a bcrypt hash read from `TOURNAMENT_PASSWORD_HASH`.
+          * `file`; admin password lives in `tournament.md` (plaintext). Default.
+          * `locked`; admin password is a bcrypt hash read from `TOURNAMENT_PASSWORD_HASH`.
             `POST /api/tournament/reset` returns 404 in this mode; the SPA `/reset`
             page is still served but renders an operator-disabled message.
       responses:
@@ -509,13 +508,13 @@ paths:
         mp-e21). Gated by the MAIN password (`X-Tournament-Password`) via the
         admin middleware.
 
-          * First-time set (no admin password yet) — trust-on-first-use: the
+          * First-time set (no admin password yet); trust-on-first-use: the
             main password authorizes it; `currentPassword` is ignored.
-          * Rotation (admin password already set) — `currentPassword` must
+          * Rotation (admin password already set); `currentPassword` must
             equal the stored value, else 401. This prevents a main-password
             holder from silently re-setting the elevated credential.
 
-        Locked mode returns 404 — the credential is the
+        Locked mode returns 404; the credential is the
         `TOURNAMENT_ADMIN_PASSWORD_HASH` env var and is not settable via the
         API. The response never echoes any password (write-only).
       security:
@@ -555,7 +554,7 @@ paths:
         '401':
           description: Wrong currentPassword on rotation (or missing/invalid main password).
         '404':
-          description: Locked mode — not settable via the API.
+          description: Locked mode; not settable via the API.
         '409':
           description: No tournament configured yet.
 
@@ -582,7 +581,7 @@ paths:
             schema:
               type: object
               description: >
-                Any number of file fields. The field names are ignored — all uploaded files are
+                Any number of file fields. The field names are ignored; all uploaded files are
                 indexed by filename. Include `manifest.yaml` plus any referenced CSV files.
               additionalProperties:
                 type: string
@@ -637,7 +636,7 @@ paths:
         and receive a router-level `404`.
 
         Response carries `Cache-Control: public, max-age=31536000, immutable`
-        because the filename is unique per upload — the bytes at a given URL
+        because the filename is unique per upload; the bytes at a given URL
         never change.
       parameters:
         - in: path
@@ -672,7 +671,7 @@ paths:
         Admin-gated (`X-Tournament-Password`). Accepts `multipart/form-data`
         with fields `name` (required, ≤80 chars), `link` (optional, must be
         an `http(s)://` URL with no user-info), and `file` (required PNG or
-        JPEG, ≤1 MB detected by content sniff — not the `Content-Type` header).
+        JPEG, ≤1 MB detected by content sniff; not the `Content-Type` header).
 
         Up to **6** sponsors per tournament. The server generates the on-disk
         filename from `crypto/rand` hex; the client-supplied filename is ignored.
@@ -760,7 +759,7 @@ paths:
       description: |
         Returns the currently active admin broadcast announcement.
         Returns `204 No Content` when there is no active announcement or the
-        last one has already expired. No authentication required — viewer screens
+        last one has already expired. No authentication required; viewer screens
         poll this endpoint on SSE connect to catch announcements they may have
         missed before subscribing.
       responses:
@@ -848,7 +847,7 @@ paths:
       tags: [competitions]
       summary: Create competition
       description: |
-        Creates a new competition. The `id` field is optional — when omitted the server
+        Creates a new competition. The `id` field is optional; when omitted the server
         derives a URL-friendly slug from `name` (lowercase, spaces to hyphens, max 64 chars).
 
         Validation (returns 400 with explanatory message):
@@ -928,7 +927,7 @@ paths:
         The server writes `participants.csv` (and clears or extracts
         `seeds.csv` from each player's `seed` field) and IGNORES all
         settings fields in the body. This is how the admin
-        participants page saves the roster — its body shape is
+        participants page saves the roster; its body shape is
         `{ ...c, players: np }` where `c` is a possibly-stale
         frontend snapshot of the competition. Treating settings
         fields as authoritative in this case would silently revert
@@ -940,13 +939,13 @@ paths:
         Returns 404 when the competition does not exist (this endpoint
         never creates).
 
-        Server-managed fields — `status`, `hasParticipantIDs` — are
+        Server-managed fields `status` and `hasParticipantIDs` are
         IGNORED in the body. Use the dedicated transition endpoints
         (`/start`, `/complete`, `/invalidate`) to change status.
 
         **Elevated password (spec 004 / mp-e21):** the ROSTER-save path
         (non-null `players`) additionally requires `X-Admin-Password`
-        when the destructive-ops gate is active — it rewrites
+        when the destructive-ops gate is active; it rewrites
         `participants.csv`, the same protected operation as the dedicated
         participant endpoints. Returns 503 if locked mode is active without
         `TOURNAMENT_ADMIN_PASSWORD_HASH`. The SETTINGS-only path
@@ -978,7 +977,7 @@ paths:
             Conflict. Output-affecting settings (format, courts, pool
             size/winners/mode, pool format, round-robin, mirror, team size,
             kind, number prefix, zekken display) were changed while the
-            competition is in `draw-ready` state — discard the draw first.
+            competition is in `draw-ready` state; discard the draw first.
             Duplicate name/number-prefix violations are returned as 400.
           content:
             application/json:
@@ -990,7 +989,7 @@ paths:
       tags: [competitions]
       summary: Delete competition
       description: |
-        Idempotent — returns 204 even when the competition does not exist.
+        Idempotent; returns 204 even when the competition does not exist.
         Allowed in any non-in-progress state (`setup`, `completed`,
         `invalid`, or unset). In-progress competitions (`pools`/`playoffs`)
         must first be invalidated via `POST /api/competitions/{id}/invalidate`.
@@ -1354,6 +1353,21 @@ paths:
           $ref: '#/components/responses/InternalError'
 
   /api/competitions/{id}/participants/{pid}:
+    parameters:
+      - $ref: '#/components/parameters/CompetitionId'
+      - in: path
+        name: pid
+        required: true
+        schema:
+          type: string
+          maxLength: 201
+        description: |
+          Participant identifier. Either the participant's stable UUID, or; for
+          legacy rosters without UUIDs; the composite `name|dojo` key the client
+          sends for ID-less rows (resolved server-side, UUID first then the
+          name|dojo fallback). The length cap covers the composite form:
+          name (≤100) + "|" + dojo (≤100); the server applies no 64-char limit
+          to this path parameter.
     put:
       tags: [participants]
       summary: Update a participant
@@ -1363,7 +1377,7 @@ paths:
         Allowed in `setup` state (no draw yet) and `draw-ready` state (draw generated
         but not started). In draw-ready state the change **cascades** through draw
         artifacts: `pools.csv`, `bracket.json`, and `pool-matches.csv` are updated
-        in place — the draw structure (pool assignments, elimination bracket) is
+        in place; the draw structure (pool assignments, elimination bracket) is
         preserved. Seeds are renamed automatically by the participant update.
 
         Returns the updated player. When the cascade detects dojo conflicts,
@@ -1373,14 +1387,6 @@ paths:
       security:
         - TournamentPassword: []
           AdminPassword: []
-      parameters:
-        - $ref: '#/components/parameters/CompetitionId'
-        - in: path
-          name: pid
-          required: true
-          schema:
-            type: string
-          description: Participant UUID.
       requestBody:
         required: true
         content:
@@ -1391,22 +1397,29 @@ paths:
               properties:
                 name:
                   type: string
+                  maxLength: 100
                   description: Participant's full name (trimmed; must not be blank).
                 dojo:
                   type: string
+                  maxLength: 100
                   description: Participant's dojo (trimmed; must not be blank).
                 displayName:
                   type: string
+                  maxLength: 50
                   description: Bib/zekken display name (only persisted for zekken-enabled competitions).
                 danGrade:
                   type: string
+                  maxLength: 200
                   description: Dan grade string (e.g. "3 Dan"). Stored in Metadata[0] when Metadata is absent.
                 metadata:
                   type: array
+                  maxItems: 16
                   items:
                     type: string
+                    maxLength: 200
                 source:
                   type: string
+                  maxLength: 200
                   enum: [manual, registered, transfer, reserved]
                   description: Registration source / provenance (case-insensitive; stored lower-case). Renamed from the former `tag` field. The legacy value `reserved` is accepted and normalized to `manual` on write; responses always emit `manual`.
       responses:
@@ -1446,6 +1459,103 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Forbidden'
+
+  /api/competitions/{id}/participants/{pid}/checkin:
+    parameters:
+      - $ref: '#/components/parameters/CompetitionId'
+      - in: path
+        name: pid
+        required: true
+        schema:
+          type: string
+          maxLength: 201
+        description: |
+          Participant identifier. Either the participant's stable UUID, or; for
+          legacy rosters without UUIDs; the composite `name|dojo` key the client
+          sends for ID-less rows (resolved server-side, UUID first then the
+          name|dojo fallback). The length cap covers the composite form:
+          name (≤100) + "|" + dojo (≤100); the server applies no 64-char limit
+          to this path parameter.
+    put:
+      tags: [participants]
+      summary: Check in a single participant
+      description: Sets checked-in status to true for the participant.
+      security:
+        - TournamentPassword: []
+      responses:
+        '200':
+          description: Participant checked in.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Player'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    delete:
+      tags: [participants]
+      summary: Undo check-in for a single participant
+      description: Resets checked-in status to false for the participant.
+      security:
+        - TournamentPassword: []
+      responses:
+        '200':
+          description: Participant check-in undone.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Player'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/competitions/{id}/participants/checkin-bulk:
+    parameters:
+      - $ref: '#/components/parameters/CompetitionId'
+    post:
+      tags: [participants]
+      summary: Bulk check-in participants
+      description: Atomically checks in multiple participants at once.
+      security:
+        - TournamentPassword: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [participantIds]
+              properties:
+                participantIds:
+                  type: array
+                  maxItems: 1000
+                  description: >
+                    Participant identifiers to check in. Each is either a stable
+                    UUID or, for legacy UUID-less rosters, the composite
+                    `name|dojo` key (the same identifier the web client builds).
+                    Unlike the single-participant `{pid}` path parameter, each
+                    entry here is capped at 64 chars and validated server-side; a legacy `name|dojo` composite longer than 64 is rejected
+                    with 400.
+                  items:
+                    type: string
+                    maxLength: 64
+      responses:
+        '200':
+          description: Bulk check-in completed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkCheckInResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -1518,7 +1628,7 @@ paths:
             out-of-order delivery (a lower rev than one already applied for that
             client session, e.g. a reconnect flush), or (b) the match is already
             completed, so a running write must not revert the final result.
-            Different client sessions are concurrent operators — the server
+            Different client sessions are concurrent operators; the server
             applies those last-write-wins, never stale.
           content:
             application/json:
@@ -1538,14 +1648,14 @@ paths:
                       stale:
                         type: boolean
                         description: >
-                          true when a running-write autosave was a no-op — either
+                          true when a running-write autosave was a no-op; either
                           dropped by the rev-guard as a same-session out-of-order
                           delivery, or rejected because the match is already
                           completed. Omitted on normal responses.
                     required: [stale]
         '409':
           description: |
-            Conflict — one of six codes returned in the `error` field:
+            Conflict; one of six codes returned in the `error` field:
             - `court_busy`: court already has a running match in this or another competition.
               Extra fields: `court`, `matchId`, `compId`, `message`.
             - `ineligible_competitor`: a participant is ineligible (kiken/fusenpai in a prior match).
@@ -1990,6 +2100,57 @@ paths:
         '204':
           description: Lineup deleted.
 
+  /api/competitions/{id}/swiss/generate-round:
+    parameters:
+      - $ref: '#/components/parameters/CompetitionId'
+    post:
+      tags: [competitions]
+      summary: Generate next Swiss round
+      description: |
+        Generates pairing and matches for the next Swiss round.
+        Returns 201 Created with the new round number and generated matches.
+      security:
+        - TournamentPassword: []
+      responses:
+        '201':
+          description: Swiss round generated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  round:
+                    type: integer
+                  swissCurrentRound:
+                    type: integer
+                  matches:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MatchResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Current Swiss round has incomplete matches.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error]
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                    enum: [round_incomplete]
+                    description: Machine-readable conflict code.
+                  round:
+                    type: integer
+                    description: The incomplete round number.
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/competitions/{id}/swiss/standings:
     parameters:
       - $ref: '#/components/parameters/CompetitionId'
@@ -1998,7 +2159,7 @@ paths:
       summary: Get Swiss-format cumulative standings
       description: >
         Returns the cumulative standings for a Swiss-format competition,
-        ranked by wins then points. Always public (no auth required) — read-only
+        ranked by wins then points. Always public (no auth required); read-only
         viewer data, same policy as pool standings.
       security: []
       responses:
@@ -2020,8 +2181,7 @@ paths:
       tags: [competitions]
       summary: List consequential league tie-breaker tied groups
       description: >
-        Returns the consequential tied groups for a team-league competition —
-        groups of teams tied on all official criteria whose finishing positions
+        Returns the consequential tied groups for a team-league competition; groups of teams tied on all official criteria whose finishing positions
         fall within the configured tie-breaker band (`leagueTiebreakTopN`, honouring
         `leagueTwoThirdPlaces`). Public read (no auth): derived from the
         already-public standings. Returns an empty list for non-team-league
@@ -2341,8 +2501,8 @@ paths:
       description: >
         Returns the same per-competition payload as GET /api/viewer/competitions
         (config + poolMatches + bracket), but ONLY for competitions that have at
-        least one real (both-sides-resolved) match — pool or non-preview bracket
-        — physically placed on the given court right now. Keyed on actual match
+        least one real (both-sides-resolved) match, pool or non-preview bracket,
+        physically placed on the given court right now. Keyed on actual match
         placement (not competition court config) so the feed stays correct after
         an operator moves a match to another shiaijo. Per-competition match data
         is full (not court-filtered) so client-side derivations like pool
@@ -2433,7 +2593,7 @@ components:
         `password` field in `tournament.md` is IGNORED for both auth
         and the GET/PUT/POST response shape (the response always
         returns `"password": ""`). The bootstrap exception above
-        does NOT apply — `POST /api/tournament` requires
+        does NOT apply; `POST /api/tournament` requires
         X-Tournament-Password from the very first request so a
         network-reachable attacker can't race-claim the initial
         tournament record on a fresh deployment. The reset endpoint
@@ -2451,7 +2611,7 @@ components:
       in: header
       name: X-Admin-Password
       description: |
-        Elevated (destructive-ops) password — spec 004 / mp-e21. Required
+        Elevated (destructive-ops) password; spec 004 / mp-e21. Required
         IN ADDITION to `X-Tournament-Password` on destructive endpoints:
         `DELETE /api/competitions/{id}`, `POST /api/competitions/{id}/invalidate`,
         `DELETE /api/competitions/{id}/draw`, `DELETE /api/competitions/{id}/overrides`,
@@ -2459,23 +2619,23 @@ components:
         `PUT /api/competitions/{id}/participants/{pid}`,
         `POST /api/tournament/import`, and
         `PUT /api/competitions/{id}` **when the body carries a non-null
-        `players` field** (the roster-save path — settings-only PUTs are not
+        `players` field** (the roster-save path; settings-only PUTs are not
         gated).
 
         Gate behavior:
-          * File mode — verified exact-string against the write-only
+          * File mode; verified exact-string against the write-only
             `admin_password` in `tournament.md`. While unset the gate is
             INACTIVE (the header is not required; the main password alone
             authorizes the action), so existing file deployments are
             unaffected until an admin password is set.
-          * Locked mode — verified via bcrypt against
+          * Locked mode; verified via bcrypt against
             `TOURNAMENT_ADMIN_PASSWORD_HASH`. The gate is always active
             (fail-closed): if the env var is unset/malformed the gated
             endpoints return 503 "admin password not configured".
 
         On a missing/incorrect header (when the gate is active and
         configured) the endpoint returns 401. Set or rotate the file-mode
-        value via `PUT /api/auth/admin-password`. There is no session — the
+        value via `PUT /api/auth/admin-password`. There is no session; the
         header is required on each gated request.
 
   parameters:
@@ -2623,7 +2783,7 @@ components:
           description: >
             Court labels (e.g. ["A", "B"]). Each label is a single
             character; 26-court cap (A–Z). Duplicate labels are rejected
-            with 400 — the frontend uses labels as identity keys (per-court
+            with 400; the frontend uses labels as identity keys (per-court
             rendering, schedule `byCourt` bucketing, filter values) and
             duplicates would collapse data structures.
         password:
@@ -2634,9 +2794,9 @@ components:
             (see `GET /api/auth-config`); the shared schema's
             "required" semantics below apply to **file mode** only.
 
-            **File mode** (default — authoritative credential stored
+            **File mode** (default; authoritative credential stored
             plaintext in `tournament.md`): required (non-empty) on POST
-            /tournament — an empty Password on disk would let
+            /tournament; an empty Password on disk would let
             AuthMiddleware's `password != t.Password` check vacuously
             pass for any client sending an empty
             `X-Tournament-Password` header. On PUT /tournament,
@@ -2644,14 +2804,14 @@ components:
             currently-stored password ("leave blank to keep current");
             sending a non-empty string updates it.
 
-            **Locked mode** (`--lock-password` — non-authoritative;
+            **Locked mode** (`--lock-password`; non-authoritative;
             bcrypt hash in `TOURNAMENT_PASSWORD_HASH` is the credential):
             POST /tournament accepts but **discards** the body's
             `password` server-side (the on-disk value is preserved for
             an existing record, or set to `""` for a fresh bootstrap);
             non-empty passwords are NOT rejected as a backward-compat
             convenience. PUT /tournament rejects any non-empty
-            `password` with 400 — rotation requires restarting the
+            `password` with 400; rotation requires restarting the
             server with a new hash. The response body's `password` is
             always empty in locked mode.
 
@@ -2679,13 +2839,13 @@ components:
           enum: [officiated, self-run]
           description: >
             Tournament auth posture. Chosen once at creation and **immutable** thereafter
-            (mp-7h7) — PUT /tournament rejects a mode change with 400.
+            (mp-7h7); PUT /tournament rejects a mode change with 400.
 
             - **officiated** (default): the full admin surface requires `X-Tournament-Password`.
               Constructive actions (scoring, check-in, start) and organiser-setup mutations
               all require the main password.
             - **self-run**: there is no dedicated table operator. Operational actions
-              (scoring, check-in, start, complete, swiss round generation) are public — no
+              (scoring, check-in, start, complete, swiss round generation) are public; no
               password required. Organiser-setup mutations (tournament/competition config,
               seeds, override edits (set/change result), announcements, schedule, court
               assignment, export) remain behind the main password. Destructive actions
@@ -2703,14 +2863,27 @@ components:
           description: >
             **Creation-only, file mode, self-run tournaments only.** Sets the elevated
             (destructive-ops) credential atomically in the same POST that creates the
-            tournament. Required when `mode` is `"self-run"` in file mode — without it the
+            tournament. Required when `mode` is `"self-run"` in file mode; without it the
             main gate is skipped and destructive routes would be unauthenticated.
 
             This field is **write-only at the API boundary**: it is never returned in any
             response (`json:"-"` on the server struct) and is ignored by PUT /tournament
             (rotation is done via `PUT /api/auth/admin-password`). In locked mode this
-            field is accepted but silently ignored — the `TOURNAMENT_ADMIN_PASSWORD_HASH`
+            field is accepted but silently ignored; the `TOURNAMENT_ADMIN_PASSWORD_HASH`
             env var is the authoritative elevated credential.
+        checkInWindowStart:
+          type: string
+          maxLength: 5
+          pattern: '^\d{2}:\d{2}$'
+          description: >
+            Global check-in window open time (HH:MM). Displayed in the viewer as a status
+            banner ("pending / open / closed"). Informational only; does not block
+            check-in API calls outside the window.
+        checkInWindowEnd:
+          type: string
+          maxLength: 5
+          pattern: '^\d{2}:\d{2}$'
+          description: Global check-in window close time (HH:MM).
 
     Competition:
       type: object
@@ -2721,9 +2894,9 @@ components:
           description: >
             Unique competition identifier. Must start with an alphanumeric
             character, contain only alphanumerics / hyphens / underscores,
-            and be at most 64 chars (same rule as the `:id` path parameter
-            — see CompetitionId).
-            Optional on POST — the server derives a slug from `name` when omitted.
+            and be at most 64 chars (same rule as the `:id` path parameter;
+            see CompetitionId).
+            Optional on POST; the server derives a slug from `name` when omitted.
         name:
           type: string
           maxLength: 200
@@ -2731,7 +2904,7 @@ components:
             Competition name. Trimmed server-side and rejected with 400
             (`competition name is required`) if empty after trim or
             longer than 200 characters.
-            Uniqueness check (case-insensitive) on POST/PUT — duplicate
+            Uniqueness check (case-insensitive) on POST/PUT; duplicate
             names return 400 (`competition name "X" already exists`).
         kind:
           type: string
@@ -2739,8 +2912,8 @@ components:
           enum: [individual, team]
         format:
           type: string
-          description: "pools or playoffs"
-          enum: [pools, playoffs]
+          description: "playoffs, mixed, league, or swiss"
+          enum: [playoffs, mixed, league, swiss]
         teamSize:
           type: integer
           minimum: 0
@@ -2768,7 +2941,7 @@ components:
             Per-competition court labels (subset of Tournament.courts).
             Each label is a single character; 26-court cap; duplicates
             rejected with 400. Empty array means "use the tournament
-            default" — the engine defaults a competition with no Courts
+            default"; the engine defaults a competition with no Courts
             to 1 court.
         startTime:
           type: string
@@ -2785,11 +2958,11 @@ components:
         status:
           type: string
           description: >
-            Lifecycle state. Set by the server — do not supply on create/update.
+            Lifecycle state. Set by the server; do not supply on create/update.
             `setup` → not yet started; `draw-ready` → draw generated and available
             for preview, not yet started; `pools` → pools phase active (for a
             mixed competition the knockout bracket is already filling in
-            incrementally as pools finish — knockout matches with both sides
+            incrementally as pools finish; knockout matches with both sides
             resolved are scoreable even in this state); `playoffs` → knockout
             phase active (for mixed: every pool has been seeded into the bracket);
             `completed` → finished; `invalid` → operator-declared invalid,
@@ -2805,11 +2978,22 @@ components:
           type: boolean
         teamMatchType:
           type: string
-          description: Team-match scoring model — `fixed` (positions) or `kachinuki` (winner-stays).
+          description: Team-match scoring model; `fixed` (positions) or `kachinuki` (winner-stays).
           enum: [fixed, kachinuki]
         maxEnchoPeriods:
           type: integer
           description: Maximum number of encho (extended time) periods permitted per match.
+        checkInEnabled:
+          type: boolean
+          description: >
+            When true, the check-in workflow is active for this competition.
+            A check-in panel is shown in the viewer roster screen and operators
+            can mark participants as checked in via the admin UI or the API.
+            When enabled, Generate Draw applies opt-in filtering: if at least one
+            participant is checked in, only checked-in participants enter the draw
+            (unchecked no-shows are excluded, and their seed assignments pruned);
+            if nobody has checked in, everyone is included. When this flag is
+            false, check-in markers are ignored and never shrink the field.
         fightingSpiritAwards:
           type: array
           description: >
@@ -2875,7 +3059,10 @@ components:
           description: Seed rank (0 = unseeded).
         number:
           type: string
-          description: The competitor's "tag" — assigned number = prefix + sequence (e.g. "K1"). Only present when numberPrefix is set.
+          description: The competitor's "tag"; assigned number = prefix + sequence (e.g. "K1"). Only present when numberPrefix is set.
+        checkedIn:
+          type: boolean
+          description: True when the participant has checked in.
 
     Participant:
       type: object
@@ -2903,6 +3090,31 @@ components:
           maxLength: 200
           enum: [manual, registered, transfer]
           description: Registration source / provenance (renamed from `tag`; stored lower-case). Responses always emit one of these canonical values. The legacy value `reserved` is accepted only on input (see `ParticipantInput`, normalized to `manual`) and is never emitted here.
+        checkedIn:
+          type: boolean
+          readOnly: true
+          description: >
+            True when the participant has checked in. Read-only in the
+            `POST /api/competitions/{id}/participants` request body; the server preserves existing check-in state on bulk import
+            and ignores any incoming `checkedIn` value. Use the dedicated
+            check-in endpoints (`PUT /…/participants/{pid}/checkin`,
+            `POST /…/participants/checkin-bulk`,
+            `DELETE /…/participants/{pid}/checkin`) to manage check-in state.
+
+    BulkCheckInResult:
+      type: object
+      required: [checkedIn, alreadyCheckedIn, notFound]
+      properties:
+        checkedIn:
+          type: integer
+        alreadyCheckedIn:
+          type: integer
+        notFound:
+          type: array
+          items:
+            type: string
+            maxLength: 64
+          description: Participant IDs from the request that did not match any roster entry (echoed back; each capped at 64 chars, matching the request-side ID limit).
 
     ParticipantInput:
       type: object
@@ -3002,13 +3214,13 @@ components:
           type: string
           description: >
             Decision code for the match outcome. Extended set:
-            `none`/`""` — no decision recorded; `fought` — resolved by scoring;
-            `hikiwake` — draw/tie; `kiken` — withdrawal (legacy, maps to kiken-voluntary);
-            `kiken-voluntary` — voluntary withdrawal (FIK Art. 31, permanent);
-            `kiken-injury` — injury withdrawal (FIK Art. 30, reinstateable);
-            `fusenpai` — forfeit loss; `fusensho` — forfeit win;
-            `daihyosen` — resolved by representative bout;
-            `kachinuki-exhaustion` — kachinuki team match ended with one side exhausted.
+            `none`/`""` (no decision recorded); `fought` (resolved by scoring);
+            `hikiwake` (draw/tie); `kiken` (withdrawal, legacy, maps to kiken-voluntary);
+            `kiken-voluntary` (voluntary withdrawal, FIK Art. 31, permanent);
+            `kiken-injury` (injury withdrawal, FIK Art. 30, reinstateable);
+            `fusenpai` (forfeit loss); `fusensho` (forfeit win);
+            `daihyosen` (resolved by representative bout);
+            `kachinuki-exhaustion` (kachinuki team match ended with one side exhausted).
           enum: [none, fought, hikiwake, kiken, kiken-voluntary, kiken-injury, fusenpai, fusensho, daihyosen, kachinuki-exhaustion]
         decisionBy:
           type: string
@@ -3037,7 +3249,7 @@ components:
           type: boolean
           description: >
             True when the winner was declared by referee hantei on a tied bout
-            (FIK Art. 7-5 / 29-6). Overtime is not required — a tied scoreline may be
+            (FIK Art. 7-5 / 29-6). Overtime is not required; a tied scoreline may be
             taken straight to a judges' decision. On a bracket-match score request,
             omitting the field preserves the stored value; sending an explicit
             true/false applies it.
@@ -3075,7 +3287,7 @@ components:
             Decision code for this individual sub-match. For numbered bouts:
             `""` (normal victory), `"hikiwake"` (draw/tie), or `"fusensho"`
             (per-bout default win). The daihyosen representative bout
-            (`position: -1`) always carries `"daihyosen"` — including when its
+            (`position: -1`) always carries `"daihyosen"`; including when its
             winner is declared by hantei on a tied bout (the frontend emits
             `decision: "daihyosen"` together with `decidedByHantei: true`). The
             server also tolerates `""` or `"fought"` alongside hantei, but
@@ -3086,11 +3298,11 @@ components:
             True when this sub-bout's winner was declared by referee hantei on a
             tied bout. Valid ONLY for the daihyosen representative bout (`position: -1`);
             regular numbered bouts have fixed regulation time and are never decided by
-            hantei. Overtime is NOT required — a tied daihyosen may be decided by judges
+            hantei. Overtime is NOT required; a tied daihyosen may be decided by judges
             directly (`encho` is optional). The accompanying `decision` is `"daihyosen"`
             (the value the frontend persists for the rep bout); the server additionally
             accepts `""` or `"fought"`. `winner` must be set and the scoreline must be
-            tied — the server rejects hantei with any other decision code.
+            tied; the server rejects hantei with any other decision code.
         encho:
           allOf:
             - $ref: '#/components/schemas/EnchoMetadata'
@@ -3200,7 +3412,7 @@ components:
         points:
           type: integer
           description: >
-            Internal weighted composite sort key — not intended for display.
+            Internal weighted composite sort key; not intended for display.
             Individual formula (×100 for integer arithmetic):
             W×100M − L×1M + D×10K + ipponsGiven×100 − ipponsTaken.
             Team formula:


### PR DESCRIPTION
## Summary

Documentation accuracy pass (features merged through May/June 2026) plus a fix to the published MkDocs Material docs site. This is the documentation half of the original combined branch, split so it stays well under Copilot's 300-file review cap and gets a real review. The repo-wide em-dash/punctuation refactor is in a separate PR (see below).

- **`docs/user-guide/mobile-app.md`** documents the draw-ready preview flow, the check-in workflow, and the participant edit modal. Corrected the participant setup view to the **real two-panel layout** ("Check-in & Seeding" + "Participant list"), replacing an inaccurate "3-column dashboard" description, and noted the edit pencil is setup-only (disabled at `draw-ready`).
- **`specs/openapi.yaml`** adds the single/bulk/undo check-in endpoints and the Swiss `generate-round` operation, tightens request-body constraints to match the Go handlers, and repairs the `decision` enum rendering.
- **`CLAUDE.md`** de-enumerates the brittle `web-mobile/js/` module list (pointer to `ls` instead).

**Docs-website theme** (`https://gitrgoliveira.github.io/bracket-creator/`)
- **P0 fix:** dark-mode content links rendered at **1.03:1** (`#333` on the navy slate background) because `extra.css` set `--md-primary-fg-color` on `:root` for both schemes. Tokens are now per-scheme; links use the app's brand navy, underlined by default (**12.36:1** light / **6.07:1** slate).
- `mkdocs.yaml`: dropped the silently-ignored palette hex (CSS is the single source of truth), set Atkinson Hyperlegible + JetBrains Mono, wired the `overrides/` dir.
- `overrides/404.html`: helpful 404 page (search + links home).

## Files changed

| File / group | What |
|---|---|
| `docs/user-guide/mobile-app.md` | Draw-preview, check-in, edit-modal; real two-panel participant layout |
| `specs/openapi.yaml` | Check-in (single/bulk/undo) + Swiss generate-round endpoints; tightened schemas |
| `CLAUDE.md` | De-enumerated the `web-mobile/js/` module list |
| `docs/assets/stylesheets/extra.css` | Per-scheme tokens; brand-navy underlined links (fixes invisible dark-mode links) |
| `mkdocs.yaml`, `overrides/404.html` | Fonts + custom 404 override |
| `docs/**` (architecture, dev-guide, commands, index) | Content refresh + theme |

## Screenshots

Docs site after the theme fix (measured dark-mode link contrast 1.03:1 → 6.07:1).

**Light mode**
![docs light mode](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/187/docs-light.png)

**Dark (slate) mode** (the P0 fix)
![docs dark mode](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/187/docs-dark.png)

**Custom 404**
![docs 404](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/187/docs-404.png)

## Test plan

- [x] `mkdocs build --strict` passes (docs site builds clean with the new theme + 404 override)
- [x] Browser verification of the docs site (light + slate): links visible + underlined, contrast measured 12.36:1 / 6.07:1; custom 404 renders; Atkinson/JetBrains fonts load
- [x] Screenshots embedded above (light, dark, 404), captured via Playwright
- [x] No Go/JS runtime changes in this PR (docs + spec + theme only)

Closes mp-i03
