### PR TITLE
feat(mp-9ukk): court-local display hub via BroadcastChannel

### DIFF
--- a/docs/architecture/infrastructure-architecture.md
+++ b/docs/architecture/infrastructure-architecture.md
@@ -196,9 +196,12 @@ flowchart LR
 This local hub needs no internet, no secure context, and no extra software, and it works in
 every topology (cloud-hosted, on-prem, or bare-IP HTTP). It **complements** the network fixes
 above rather than replacing them: the operator's writes are still queued locally and synced to
-the server once the link returns, so the authoritative record stays correct. The one limit: it
-is per machine and per court, so reloading the display tab during an outage leaves it blank until
-the server is reachable again.
+the server once the link returns, so the authoritative record stays correct. It is per machine
+and per court. Reloading the **display** tab during an outage is fine: it cold-starts from the
+operator tab's snapshot over the same channel, as long as an operator tab is still open on that
+machine to answer (it only stays blank if none is). The genuine gap is reloading the **operator**
+tab itself mid-outage, since it holds the court's working data while offline and would have
+nothing to fetch from the down server.
 
 ## 4. Persistence model
 

--- a/docs/architecture/infrastructure-architecture.md
+++ b/docs/architecture/infrastructure-architecture.md
@@ -140,7 +140,7 @@ flowchart TB
 | Device | What it runs | Notes |
 |---|---|---|
 | Operator console (1 per court) | admin scoring SPA | tablet/desktop surface; authenticates with the tournament password; scores its own shiaijo |
-| Display screen (1 per court, optional) | public display / scoreboard view | a browser at a display URL (smart-TV browser, or a mini-PC/laptop driving a TV); read-only, no auth |
+| Display screen (1 per court, optional) | public display / scoreboard view | a browser at a display URL; read-only, no auth. **Preferred: drive it from the operator console's own machine** via an HDMI cable to a TV or monitor, so the board survives a Wi-Fi outage (see [Keep the court scoreboard alive on the same machine](#keep-the-court-scoreboard-alive-on-the-same-machine-hdmi) below). A standalone smart-TV browser or separate mini-PC also works but loses that offline path |
 | Spectator phones | public viewer (mobile-first) | can be on cellular; they don't need venue Wi-Fi when the app is cloud-hosted |
 
 **Per-client load.** Every console, display, and phone holds **one SSE stream** plus its REST
@@ -159,8 +159,46 @@ clients, comfortably within `SSE_MAX_CLIENTS`, but every live update fans out to
 
 **The network is the real fix.** Client resilience (offline write queue, SSE resync, silence
 watchdog) keeps the app usable across blips. For a smooth event, **wire the operator consoles**
-where you can, put operators on a **dedicated AP** separate from spectator guest Wi-Fi, and
-prefer the **on-prem** pattern when the venue's internet is unreliable.
+where you can, put operators on a **dedicated AP** separate from spectator guest Wi-Fi, prefer
+the **on-prem** pattern when the venue's internet is unreliable, and **drive each court's display
+from the operator's own machine over HDMI** so the scoreboard keeps moving even when the network
+does not (next section).
+
+### Keep the court scoreboard alive on the same machine (HDMI)
+
+Each court's display screen can be rendered two ways, and the choice decides whether the
+scoreboard freezes during a Wi-Fi outage:
+
+- **Same machine as the operator console (recommended).** Connect a TV or monitor to the
+  operator's laptop or mini-PC with an **HDMI cable**, extend the desktop, and open the court's
+  display URL in a second browser window on that same machine. The operator console and the
+  display board are then two tabs in the same browser on the same computer, so they share a
+  private same-origin channel: every score the operator records reaches the board **directly,
+  on the machine, with no network hop**. If the venue Wi-Fi drops mid-match, that court's
+  scoreboard keeps updating from the operator's entries for as long as the scoring tab stays
+  open. The board shows a small amber dot while it is running on this local feed (see
+  [the scoreboard status dot](../user-guide/mobile-app.md#scoreboards-and-court-displays)).
+- **Separate device (a smart-TV browser, or the display on its own mini-PC).** Simpler cabling,
+  but the board only ever updates over the network, so a Wi-Fi outage freezes it until the link
+  returns (the board then shows a red dot).
+
+```mermaid
+flowchart LR
+    subgraph machine["One court machine (operator's laptop / mini-PC)"]
+        op["Operator console tab<br/>(admin scoring)"]
+        disp["Display board tab<br/>(scoreboard / bracket)"]
+        op -. same-origin channel<br/>(no network) .-> disp
+    end
+    disp == HDMI cable ==> tv["Court TV / monitor"]
+    op -->|writes, queued + synced<br/>when the link returns| net["Venue network / app server"]
+```
+
+This local hub needs no internet, no secure context, and no extra software, and it works in
+every topology (cloud-hosted, on-prem, or bare-IP HTTP). It **complements** the network fixes
+above rather than replacing them: the operator's writes are still queued locally and synced to
+the server once the link returns, so the authoritative record stays correct. The one limit: it
+is per machine and per court, so reloading the display tab during an outage leaves it blank until
+the server is reachable again.
 
 ## 4. Persistence model
 

--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -94,6 +94,8 @@ Each shiai-jo runs **one digital scoreboard** on a TV or projector: a court-scop
 
 ![Single-court scoreboard for Shiai-jo A: the current match with Shiro on the left and Aka in red on the right, and the next match below.](../screenshots/display-scoreboard.png)
 
+If the venue Wi-Fi drops, the court scoreboard keeps updating as long as the scoring tab for that court stays open on the same computer: the operator's entries reach the board directly. A small status dot appears in the top corner only when the connection is degraded. Amber means the board is being fed by the court's own scoring computer while the link to the server is down. Red means no updates are getting through, so the board may be out of date until the connection returns. When everything is healthy no dot is shown.
+
 ## Admin console
 
 Click **Admin** and enter the tournament password to access the admin console. How the password is stored is set by the [authentication mode](#admin-authentication) (file or locked); *who is allowed to act* is set by the [tournament mode](#tournament-mode-officiated-or-self-run).

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -173,18 +173,20 @@ describe('applyPatchToTree', () => {
     });
 
     it('does not throw on a malformed payload and leaves the tree unchanged', () => {
-        // The absorb path logs via console.error; re-install our own spy so the
-        // setup's unexpected-error guard does not fail on this intentional log.
+        // Spy so any intentional error log here is captured, not flagged by the
+        // setup's unexpected-error guard.
         const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         const t = makeTournament();
-        // results:[null] would make the underlying applyPatch dereference null.id;
-        // applyPatchToTree must absorb it (it runs inside a React state updater,
-        // outside any handler try/catch) and return the tree unchanged.
+        // results:[null] is now handled at the SOURCE: patch.jsx applyPatch skips
+        // null/id-less entries before building its Map, so it no longer throws
+        // and applyPatchToTree's try/catch backstop is not even exercised. Either
+        // way the contract holds: no throw, tree unchanged. (The try/catch in
+        // applyPatchToTree stays as defense-in-depth for any future throw path.)
         const msg = { type: 'patch', compId: 'comp-A', payload: { results: [null] } };
         let next;
         expect(() => { next = applyPatchToTree(t, msg); }).not.toThrow();
         expect(next).toBe(t);
-        expect(errSpy).toHaveBeenCalledTimes(1);
+        expect(errSpy).not.toHaveBeenCalled();
         errSpy.mockRestore();
     });
 

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -5,6 +5,7 @@ import {
     freshnessMs,
     getLastBroadcastAt,
     setSnapshotProvider,
+    setDisplayCourt,
     openBridge,
     _tabId,
 } from '../court_bridge.jsx';
@@ -387,5 +388,108 @@ describe('openBridge', () => {
         });
         // Bridge is closed: no delivery expected.
         expect(received).toHaveLength(0);
+    });
+});
+
+// -------------------------------------------------------------------------
+// 4. setDisplayCourt: court-scoped inbound recency clock (FIX 2)
+//
+// When a display court is set, only inbound patches/snapshots for that
+// court advance _lastBroadcastAt. When null, all inbound messages advance it.
+// -------------------------------------------------------------------------
+describe('setDisplayCourt inbound recency scoping', () => {
+    let origBC;
+
+    beforeEach(() => {
+        origBC = global.BroadcastChannel;
+        global.BroadcastChannel = MockBroadcastChannel;
+        MockBroadcastChannel.reset();
+        setSnapshotProvider(null);
+        // Reset display court to null before each test.
+        setDisplayCourt(null);
+    });
+
+    afterEach(() => {
+        global.BroadcastChannel = origBC;
+        MockBroadcastChannel.reset();
+        setDisplayCourt(null);
+    });
+
+    it('does not advance _lastBroadcastAt when a patch arrives for a different court', () => {
+        setDisplayCourt('A');
+        openBridge(); // open a bridge so the channel.onmessage handler is active
+
+        const before = getLastBroadcastAt();
+
+        // Inject a patch for court B (not the display court).
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'B', compId: 'comp-1', payload: { result: { id: 'm1' } },
+        });
+
+        expect(getLastBroadcastAt()).toBe(before);
+    });
+
+    it('advances _lastBroadcastAt when a patch arrives for the display court', () => {
+        setDisplayCourt('A');
+        openBridge();
+
+        const t0 = Date.now();
+
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'A', compId: 'comp-1', payload: { result: { id: 'm1' } },
+        });
+
+        const after = getLastBroadcastAt();
+        expect(typeof after).toBe('number');
+        expect(after).toBeGreaterThanOrEqual(t0);
+    });
+
+    it('advances _lastBroadcastAt for any court when setDisplayCourt(null) is called', () => {
+        setDisplayCourt(null);
+        openBridge();
+
+        const t0 = Date.now();
+
+        // Court B patch should advance the clock when no display court is set.
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'B', compId: 'comp-2', payload: { result: { id: 'm2' } },
+        });
+
+        const after = getLastBroadcastAt();
+        expect(typeof after).toBe('number');
+        expect(after).toBeGreaterThanOrEqual(t0);
+    });
+
+    it('does not advance _lastBroadcastAt for snapshot of a different court', () => {
+        setDisplayCourt('A');
+        openBridge();
+
+        const before = getLastBroadcastAt();
+
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'snapshot', origin: 'other-tab-id',
+            court: 'C', compId: '', payload: [],
+        });
+
+        expect(getLastBroadcastAt()).toBe(before);
+    });
+
+    it('advances _lastBroadcastAt for snapshot matching the display court', () => {
+        setDisplayCourt('A');
+        openBridge();
+
+        const t0 = Date.now();
+
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'snapshot', origin: 'other-tab-id',
+            court: 'A', compId: '', payload: [],
+        });
+
+        const after = getLastBroadcastAt();
+        expect(typeof after).toBe('number');
+        expect(after).toBeGreaterThanOrEqual(t0);
     });
 });

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    deriveLinkState,
+    applyPatchToTree,
+    freshnessMs,
+    getLastBroadcastAt,
+    setSnapshotProvider,
+    openBridge,
+    _tabId,
+} from '../court_bridge.jsx';
+
+// court_bridge.jsx: mp-9ukk Phase 2 unit tests.
+//
+// Three logical suites:
+//   1. deriveLinkState: pure truth-table (boundary at freshnessMs)
+//   2. applyPatchToTree: tree adapter (right competition updated, others
+//      untouched, new reference returned)
+//   3. openBridge: publish/subscribe, snapshot handshake, self-echo suppression
+//      (all via a BroadcastChannel mock so no real browser channel is needed)
+
+// -------------------------------------------------------------------------
+// 1. deriveLinkState truth table
+// -------------------------------------------------------------------------
+describe('deriveLinkState', () => {
+    const now = 1_000_000;
+
+    it('returns connected when sseConnected is true, regardless of lastBroadcastAt', () => {
+        expect(deriveLinkState({ sseConnected: true, lastBroadcastAt: null, now })).toBe('connected');
+        expect(deriveLinkState({ sseConnected: true, lastBroadcastAt: now - 1, now })).toBe('connected');
+        expect(deriveLinkState({ sseConnected: true, lastBroadcastAt: now - freshnessMs * 2, now })).toBe('connected');
+    });
+
+    it('returns stale when sseConnected is false and lastBroadcastAt is null', () => {
+        expect(deriveLinkState({ sseConnected: false, lastBroadcastAt: null, now })).toBe('stale');
+    });
+
+    it('returns local when server down and broadcast is 1ms under the threshold (just-under)', () => {
+        // just under: elapsed = freshnessMs - 1 → still fresh
+        const justUnder = now - (freshnessMs - 1);
+        expect(deriveLinkState({ sseConnected: false, lastBroadcastAt: justUnder, now })).toBe('local');
+    });
+
+    it('returns stale when server down and broadcast is exactly at the threshold', () => {
+        // elapsed = freshnessMs → NOT < freshnessMs, so stale
+        const exactly = now - freshnessMs;
+        expect(deriveLinkState({ sseConnected: false, lastBroadcastAt: exactly, now })).toBe('stale');
+    });
+
+    it('returns stale when server down and broadcast is 1ms over the threshold (just-over)', () => {
+        const justOver = now - (freshnessMs + 1);
+        expect(deriveLinkState({ sseConnected: false, lastBroadcastAt: justOver, now })).toBe('stale');
+    });
+
+    it('accepts a custom freshnessMs override for testing', () => {
+        const customMs = 5000;
+        const recentEnough = now - (customMs - 1);
+        const tooOld = now - customMs;
+        expect(deriveLinkState({ sseConnected: false, lastBroadcastAt: recentEnough, now, freshnessMs: customMs })).toBe('local');
+        expect(deriveLinkState({ sseConnected: false, lastBroadcastAt: tooOld, now, freshnessMs: customMs })).toBe('stale');
+    });
+});
+
+// -------------------------------------------------------------------------
+// 2. applyPatchToTree: tree-level adapter
+// -------------------------------------------------------------------------
+describe('applyPatchToTree', () => {
+    function makeTournament() {
+        return {
+            name: 'Test Tournament',
+            competitions: [
+                {
+                    id: 'comp-A',
+                    config: { id: 'comp-A' },
+                    poolMatches: [
+                        { id: 'p1', status: 'scheduled', court: 'A' },
+                        { id: 'p2', status: 'scheduled', court: 'A' },
+                    ],
+                    bracket: { rounds: [] },
+                },
+                {
+                    id: 'comp-B',
+                    config: { id: 'comp-B' },
+                    poolMatches: [
+                        { id: 'b1', status: 'scheduled', court: 'B' },
+                    ],
+                    bracket: { rounds: [] },
+                },
+            ],
+        };
+    }
+
+    it('returns the original tournament reference when msg type is not patch', () => {
+        const t = makeTournament();
+        expect(applyPatchToTree(t, { type: 'snapshot', compId: 'comp-A', payload: {} })).toBe(t);
+    });
+
+    it('returns the original tournament reference when compId does not match any competition', () => {
+        const t = makeTournament();
+        const msg = { type: 'patch', compId: 'no-such-comp', payload: { result: { id: 'p1', status: 'running' } } };
+        expect(applyPatchToTree(t, msg)).toBe(t);
+    });
+
+    it('returns the original tournament reference when tournament is null', () => {
+        expect(applyPatchToTree(null, { type: 'patch', compId: 'comp-A', payload: {} })).toBeNull();
+    });
+
+    it('returns the original tournament reference when competitions is empty', () => {
+        const t = { name: 'T', competitions: [] };
+        expect(applyPatchToTree(t, { type: 'patch', compId: 'comp-A', payload: { result: { id: 'p1' } } })).toBe(t);
+    });
+
+    it('updates only the targeted competition and returns a new tournament reference', () => {
+        const t = makeTournament();
+        const compABefore = t.competitions[0];
+        const compBBefore = t.competitions[1];
+
+        const msg = {
+            type: 'patch',
+            compId: 'comp-A',
+            payload: { result: { id: 'p1', status: 'running', winner: null } },
+        };
+        const next = applyPatchToTree(t, msg);
+
+        // New tournament reference
+        expect(next).not.toBe(t);
+        // Competition A got a new reference (it was patched)
+        expect(next.competitions[0]).not.toBe(compABefore);
+        // Competition B is the same reference (untouched)
+        expect(next.competitions[1]).toBe(compBBefore);
+        // The targeted match inside comp-A was updated
+        const p1 = next.competitions[0].poolMatches.find(m => m.id === 'p1');
+        expect(p1.status).toBe('running');
+    });
+
+    it('matches competition by config.id when top-level id is absent', () => {
+        const t = {
+            competitions: [
+                {
+                    // no top-level id
+                    config: { id: 'nested-id' },
+                    poolMatches: [{ id: 'm1', status: 'scheduled' }],
+                    bracket: { rounds: [] },
+                },
+            ],
+        };
+        const msg = { type: 'patch', compId: 'nested-id', payload: { result: { id: 'm1', status: 'running' } } };
+        const next = applyPatchToTree(t, msg);
+        expect(next).not.toBe(t);
+        expect(next.competitions[0].poolMatches[0].status).toBe('running');
+    });
+
+    it('returns original reference when patch produces no change (unknown match id)', () => {
+        const t = makeTournament();
+        const msg = {
+            type: 'patch',
+            compId: 'comp-A',
+            payload: { result: { id: 'no-such-match', status: 'running' } },
+        };
+        // applyPatch returns prev when no ids match → applyPatchToTree must
+        // propagate that identity and also return the original tournament.
+        const next = applyPatchToTree(t, msg);
+        expect(next).toBe(t);
+    });
+});
+
+// -------------------------------------------------------------------------
+// 3. openBridge: BroadcastChannel mock + publish/subscribe/snapshot/self-echo
+// -------------------------------------------------------------------------
+
+// Minimal BroadcastChannel mock. Instances are tracked by channel name so
+// tests can inject cross-tab messages with a spoofed origin (bypassing the
+// self-echo guard that would otherwise silence same-module delivery).
+class MockBroadcastChannel {
+    static _instances = new Map(); // name → Set<instance>
+    // Last message sent via postMessage, for shape assertions.
+    static _lastSent = null;
+
+    constructor(name) {
+        this._name = name;
+        this.onmessage = null;
+        if (!MockBroadcastChannel._instances.has(name)) {
+            MockBroadcastChannel._instances.set(name, new Set());
+        }
+        MockBroadcastChannel._instances.get(name).add(this);
+    }
+
+    postMessage(data) {
+        MockBroadcastChannel._lastSent = data;
+        // Deliver to all OTHER channel instances (normal BroadcastChannel semantics).
+        // In tests all bridges share the same _tabId, so the bridge's own self-echo
+        // guard will drop these. Use injectFrom() below to simulate cross-tab delivery
+        // with a different origin.
+        const peers = MockBroadcastChannel._instances.get(this._name) || new Set();
+        for (const peer of peers) {
+            if (peer !== this && peer.onmessage) {
+                peer.onmessage({ data });
+            }
+        }
+    }
+
+    // injectFrom: deliver a message to all instances on this channel as if it
+    // came from a different tab (spoofed origin). Bypasses self-echo suppression
+    // so tests can verify the receive path.
+    static injectFrom(channelName, data) {
+        const peers = MockBroadcastChannel._instances.get(channelName) || new Set();
+        for (const peer of peers) {
+            if (peer.onmessage) peer.onmessage({ data });
+        }
+    }
+
+    close() {
+        const peers = MockBroadcastChannel._instances.get(this._name);
+        if (peers) peers.delete(this);
+    }
+
+    static reset() {
+        MockBroadcastChannel._instances.clear();
+        MockBroadcastChannel._lastSent = null;
+    }
+}
+
+describe('openBridge', () => {
+    let origBC;
+
+    beforeEach(() => {
+        origBC = global.BroadcastChannel;
+        global.BroadcastChannel = MockBroadcastChannel;
+        MockBroadcastChannel.reset();
+        // Clear snapshot provider between tests
+        setSnapshotProvider(null);
+    });
+
+    afterEach(() => {
+        global.BroadcastChannel = origBC;
+        MockBroadcastChannel.reset();
+    });
+
+    it('returns a no-op bridge when BroadcastChannel is unavailable', () => {
+        delete global.BroadcastChannel;
+        const b = openBridge();
+        // Should not throw and should have the expected shape
+        expect(typeof b.publish).toBe('function');
+        expect(typeof b.onMessage).toBe('function');
+        expect(typeof b.close).toBe('function');
+        // no-op: calling publish and onMessage should not throw
+        b.publish('patch', 'A', 'comp-1', {});
+        const unsub = b.onMessage(() => {});
+        expect(typeof unsub).toBe('function');
+        b.close();
+        global.BroadcastChannel = MockBroadcastChannel;
+    });
+
+    it('publishes a versioned patch message with the correct shape', () => {
+        // In this process all bridges share the same _tabId, so the self-echo
+        // guard suppresses same-module delivery. We verify the outgoing message
+        // shape directly from MockBroadcastChannel._lastSent (what postMessage
+        // actually put on the wire), then verify the receive path separately by
+        // injecting a cross-tab message with a different origin.
+        const b = openBridge();
+        const received = [];
+        b.onMessage(msg => received.push(msg));
+
+        b.publish('patch', 'A', 'comp-1', { result: { id: 'm1', status: 'running' } });
+
+        // Verify outgoing wire shape.
+        const sent = MockBroadcastChannel._lastSent;
+        expect(sent).not.toBeNull();
+        expect(sent.type).toBe('patch');
+        expect(sent.v).toBe(1);
+        expect(sent.court).toBe('A');
+        expect(sent.compId).toBe('comp-1');
+        expect(sent.payload.result.id).toBe('m1');
+
+        // Verify receive path: inject a message from a different origin so the
+        // self-echo guard passes.
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'A', compId: 'comp-1',
+            payload: { result: { id: 'm1', status: 'running' } },
+        });
+        expect(received).toHaveLength(1);
+        expect(received[0].type).toBe('patch');
+        expect(received[0].origin).toBe('other-tab-id');
+
+        b.close();
+    });
+
+    it('does not deliver a message to the sender itself (self-echo suppression)', () => {
+        // Both bridges share the same _tabId (same module instance), so any
+        // message from one will carry origin === _tabId and be dropped by the
+        // other bridge's handler when they share a tab. Here we open two bridges
+        // in the same process (same _tabId) to confirm self-echo suppression.
+        const b1 = openBridge();
+        const b2 = openBridge();
+        const received = [];
+        // b1 listens; b1 publishes. Since they share _tabId, b2 should drop it,
+        // but more importantly b1 itself should not echo. We verify via b2.
+        b2.onMessage(msg => received.push(msg));
+
+        // Manually simulate: the mock channel calls onmessage on the OTHER
+        // instance. b2's channel gets the message from b1. b2 checks origin ===
+        // _tabId and drops it.
+        b1.publish('patch', 'A', 'comp-1', {});
+
+        // b2 receives the raw postMessage but drops it because origin === _tabId
+        expect(received).toHaveLength(0);
+
+        b1.close();
+        b2.close();
+    });
+
+    it('unsubscribe function removes the handler', () => {
+        const b = openBridge();
+        const received = [];
+        const unsub = b.onMessage(msg => received.push(msg));
+        unsub(); // remove before any message arrives
+
+        // Inject a cross-tab message (different origin bypasses self-echo guard).
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'A', compId: 'comp-1', payload: null,
+        });
+        // The unsubbed handler must not fire.
+        expect(received).toHaveLength(0);
+
+        b.close();
+    });
+
+    it('auto-responds to snapshot-req with a snapshot when a provider is registered', () => {
+        const competitions = [{ id: 'comp-A', poolMatches: [] }];
+        setSnapshotProvider((court) => court === 'A' ? competitions : null);
+
+        const operatorBridge = openBridge(); // has snapshot provider
+        const displayBridge = openBridge();  // will send snapshot-req
+
+        // The operator bridge auto-responds; displayBridge.onMessage would capture it.
+        // BUT since both bridges share _tabId (same module), the reply from
+        // operatorBridge will be dropped by displayBridge due to self-echo.
+        // This test verifies the provider lookup logic: we listen on operatorBridge
+        // itself to confirm it received the snapshot-req event and called provider.
+        const reqsReceived = [];
+        operatorBridge.onMessage(msg => reqsReceived.push(msg));
+
+        displayBridge.publish('snapshot-req', 'A', '', null);
+
+        // operatorBridge received the snapshot-req (different instance,
+        // but same _tabId → DROPPED by self-echo. So this test verifies only
+        // that the inter-instance routing works when origins differ.
+        // Since our mock shares _tabId between sender and receiver, we verify
+        // the no-echo path instead: reqsReceived.length === 0 (self-echo dropped).
+        expect(reqsReceived).toHaveLength(0);
+
+        operatorBridge.close();
+        displayBridge.close();
+    });
+
+    it('getLastBroadcastAt returns null before any publish and updates after', () => {
+        // Note: getLastBroadcastAt is module-level state. Other tests that call
+        // openBridge().publish() will have already set it, so we only verify
+        // it is a number (or null) and advances monotonically.
+        const before = getLastBroadcastAt();
+        const b = openBridge();
+        const t0 = Date.now();
+        b.publish('patch', 'A', 'comp-1', {});
+        const after = getLastBroadcastAt();
+        // after must be set and >= t0
+        expect(typeof after).toBe('number');
+        expect(after).toBeGreaterThanOrEqual(t0);
+        // If before was already a number, after must be >= before
+        if (before !== null) {
+            expect(after).toBeGreaterThanOrEqual(before);
+        }
+        b.close();
+    });
+
+    it('close() stops further message delivery to registered handlers', () => {
+        const b = openBridge();
+        const received = [];
+        b.onMessage(msg => received.push(msg));
+        b.close();
+
+        // After close the channel instance is removed from MockBroadcastChannel._instances,
+        // so injectFrom no longer reaches it.
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'B', compId: 'comp-2', payload: null,
+        });
+        // Bridge is closed: no delivery expected.
+        expect(received).toHaveLength(0);
+    });
+});

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -510,6 +510,31 @@ describe('openBridge', () => {
         expect(MockBroadcastChannel._lastSent).toBeNull();
     });
 
+    it('never forwards snapshot-req to onMessage subscribers, with or without a provider', () => {
+        // snapshot-req is always fully handled inside the channel.onmessage
+        // responder; no subscriber (app.jsx only acts on 'patch'/'snapshot')
+        // should ever see it, whether or not a provider happens to be
+        // registered for the requesting court.
+        setSnapshotProvider(null); // no provider registered
+        const b = openBridge();
+        const received = [];
+        b.onMessage(msg => received.push(msg));
+
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'snapshot-req', origin: 'other-tab-id',
+            court: 'A', compId: '', payload: null,
+        });
+        expect(received).toHaveLength(0);
+
+        // Same assertion with a provider registered (and a court it can answer).
+        setSnapshotProvider((court) => (court === 'A' ? [{ id: 'comp-A', poolMatches: [] }] : null));
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'snapshot-req', origin: 'other-tab-id',
+            court: 'A', compId: '', payload: null,
+        });
+        expect(received).toHaveLength(0);
+    });
+
     it('getLastBroadcastAt returns null before any publish and updates after', () => {
         // Note: getLastBroadcastAt is module-level state. Other tests that call
         // openBridge().publish() will have already set it, so we only verify

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
     deriveLinkState,
     applyPatchToTree,
@@ -162,6 +162,28 @@ describe('applyPatchToTree', () => {
         // propagate that identity and also return the original tournament.
         const next = applyPatchToTree(t, msg);
         expect(next).toBe(t);
+    });
+
+    it('treats a patch with no payload as a no-op (returns original reference)', () => {
+        const t = makeTournament();
+        expect(applyPatchToTree(t, { type: 'patch', compId: 'comp-A', payload: null })).toBe(t);
+        expect(applyPatchToTree(t, { type: 'patch', compId: 'comp-A' })).toBe(t);
+    });
+
+    it('does not throw on a malformed payload and leaves the tree unchanged', () => {
+        // The absorb path logs via console.error; re-install our own spy so the
+        // setup's unexpected-error guard does not fail on this intentional log.
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const t = makeTournament();
+        // results:[null] would make the underlying applyPatch dereference null.id;
+        // applyPatchToTree must absorb it (it runs inside a React state updater,
+        // outside any handler try/catch) and return the tree unchanged.
+        const msg = { type: 'patch', compId: 'comp-A', payload: { results: [null] } };
+        let next;
+        expect(() => { next = applyPatchToTree(t, msg); }).not.toThrow();
+        expect(next).toBe(t);
+        expect(errSpy).toHaveBeenCalledTimes(1);
+        errSpy.mockRestore();
     });
 });
 
@@ -511,5 +533,38 @@ describe('setDisplayCourt inbound recency scoping', () => {
         const after = getLastBroadcastAt();
         expect(typeof after).toBe('number');
         expect(after).toBeGreaterThanOrEqual(t0);
+    });
+
+    it('resets _lastBroadcastAt when the display court actually changes', () => {
+        setDisplayCourt('A');
+        openBridge();
+
+        // Court A becomes fresh.
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'A', compId: 'comp-A', payload: { result: { id: 'm1' } },
+        });
+        expect(typeof getLastBroadcastAt()).toBe('number');
+
+        // Switching to a new court must clear the recency clock so the new
+        // court's dot starts 'stale' until its own operator broadcasts.
+        setDisplayCourt('B');
+        expect(getLastBroadcastAt()).toBeNull();
+    });
+
+    it('does not reset _lastBroadcastAt when setDisplayCourt is called with the same court', () => {
+        setDisplayCourt('A');
+        openBridge();
+
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'patch', origin: 'other-tab-id',
+            court: 'A', compId: 'comp-A', payload: { result: { id: 'm1' } },
+        });
+        const before = getLastBroadcastAt();
+        expect(typeof before).toBe('number');
+
+        // Re-asserting the same court is a no-op for the recency clock.
+        setDisplayCourt('A');
+        expect(getLastBroadcastAt()).toBe(before);
     });
 });

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
     deriveLinkState,
     applyPatchToTree,
+    mergeSnapshotIntoTree,
+    resolveCompId,
     freshnessMs,
     getLastBroadcastAt,
     setSnapshotProvider,
@@ -184,6 +186,110 @@ describe('applyPatchToTree', () => {
         expect(next).toBe(t);
         expect(errSpy).toHaveBeenCalledTimes(1);
         errSpy.mockRestore();
+    });
+
+    it('does not match an id-less competition when compId is empty', () => {
+        const t = { competitions: [{ poolMatches: [{ id: 'm1' }], bracket: { rounds: [] } }] };
+        // An id-less comp resolves to '' but an empty compId must not target it.
+        expect(applyPatchToTree(t, { type: 'patch', compId: '', payload: { result: { id: 'm1' } } })).toBe(t);
+    });
+});
+
+// -------------------------------------------------------------------------
+// 2b. resolveCompId: shape-tolerant competition id reader
+// -------------------------------------------------------------------------
+describe('resolveCompId', () => {
+    it('reads the top-level id when present', () => {
+        expect(resolveCompId({ id: 'top', config: { id: 'nested' } })).toBe('top');
+    });
+    it('falls back to config.id when top-level id is absent', () => {
+        expect(resolveCompId({ config: { id: 'nested' } })).toBe('nested');
+    });
+    it('falls back to the legacy config.Id arm', () => {
+        expect(resolveCompId({ config: { Id: 'legacy' } })).toBe('legacy');
+    });
+    it('returns empty string for null, primitives, and id-less objects', () => {
+        expect(resolveCompId(null)).toBe('');
+        expect(resolveCompId(undefined)).toBe('');
+        expect(resolveCompId('x')).toBe('');
+        expect(resolveCompId(42)).toBe('');
+        expect(resolveCompId({})).toBe('');
+        expect(resolveCompId({ config: {} })).toBe('');
+    });
+});
+
+// -------------------------------------------------------------------------
+// 2c. mergeSnapshotIntoTree: snapshot fold policy (bootstrap / drop / merge)
+// -------------------------------------------------------------------------
+describe('mergeSnapshotIntoTree', () => {
+    it('returns prev unchanged when the payload is not an array', () => {
+        const prev = { name: 'T', competitions: [] };
+        expect(mergeSnapshotIntoTree(prev, null, { connected: false })).toBe(prev);
+        expect(mergeSnapshotIntoTree(prev, { not: 'array' }, { connected: false })).toBe(prev);
+        expect(mergeSnapshotIntoTree(prev, undefined, { connected: false })).toBe(prev);
+    });
+
+    it('bootstraps a minimal tournament when prev is null (cold start)', () => {
+        const comps = [{ id: 'c1' }, { id: 'c2' }];
+        const out = mergeSnapshotIntoTree(null, comps, { connected: false });
+        expect(out).toEqual({ name: '', courts: [], competitions: comps });
+        expect(out.competitions).toBe(comps);
+    });
+
+    it('bootstraps even when connected (an outage at load must not be starved)', () => {
+        const comps = [{ id: 'c1' }];
+        const out = mergeSnapshotIntoTree(null, comps, { connected: true });
+        expect(out.competitions).toBe(comps);
+    });
+
+    it('drops the snapshot (returns prev) when prev exists and SSE is connected', () => {
+        const prev = { name: 'T', competitions: [{ id: 'c1', tag: 'server' }] };
+        const out = mergeSnapshotIntoTree(prev, [{ id: 'c1', tag: 'operator' }], { connected: true });
+        expect(out).toBe(prev);
+        expect(out.competitions[0].tag).toBe('server');
+    });
+
+    it('replaces an existing competition by id when offline', () => {
+        const prev = { name: 'T', courts: ['A'], competitions: [{ id: 'c1', tag: 'server' }, { id: 'c2', tag: 'server' }] };
+        const out = mergeSnapshotIntoTree(prev, [{ id: 'c1', tag: 'operator' }], { connected: false });
+        expect(out).not.toBe(prev);
+        expect(out.name).toBe('T');           // surrounding fields preserved
+        expect(out.courts).toEqual(['A']);
+        expect(out.competitions.find(c => c.id === 'c1').tag).toBe('operator'); // replaced
+        expect(out.competitions.find(c => c.id === 'c2').tag).toBe('server');   // untouched
+    });
+
+    it('appends a competition not already present when offline', () => {
+        const prev = { competitions: [{ id: 'c1' }] };
+        const out = mergeSnapshotIntoTree(prev, [{ id: 'c2', tag: 'new' }], { connected: false });
+        expect(out.competitions.map(c => c.id)).toEqual(['c1', 'c2']);
+    });
+
+    it('matches existing competitions by config.id (detail-endpoint shape)', () => {
+        const prev = { competitions: [{ config: { id: 'c1' }, tag: 'server' }] };
+        const out = mergeSnapshotIntoTree(prev, [{ config: { id: 'c1' }, tag: 'operator' }], { connected: false });
+        expect(out.competitions).toHaveLength(1);
+        expect(out.competitions[0].tag).toBe('operator');
+    });
+
+    it('skips null, primitive, and id-less elements in the payload', () => {
+        const prev = { competitions: [{ id: 'c1', tag: 'server' }] };
+        const out = mergeSnapshotIntoTree(prev, [null, 'x', {}, { config: {} }, { id: 'c2', tag: 'ok' }], { connected: false });
+        expect(out.competitions.map(c => c.id || 'none')).toEqual(['c1', 'c2']);
+        expect(out.competitions.find(c => c.id === 'c1').tag).toBe('server');
+    });
+
+    it('treats a missing prev.competitions as an empty list when offline', () => {
+        const prev = { name: 'T' };
+        const out = mergeSnapshotIntoTree(prev, [{ id: 'c1' }], { connected: false });
+        expect(out.competitions.map(c => c.id)).toEqual(['c1']);
+    });
+
+    it('defaults connected to falsey when the options object is omitted', () => {
+        const prev = { competitions: [{ id: 'c1', tag: 'server' }] };
+        const out = mergeSnapshotIntoTree(prev, [{ id: 'c1', tag: 'operator' }]);
+        // No options → connected is undefined (falsey) → offline merge runs.
+        expect(out.competitions[0].tag).toBe('operator');
     });
 });
 

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -8,6 +8,7 @@ import {
     setDisplayCourt,
     openBridge,
     _tabId,
+    _resetModuleStateForTests,
 } from '../court_bridge.jsx';
 
 // court_bridge.jsx: mp-9ukk Phase 2 unit tests.
@@ -227,8 +228,9 @@ describe('openBridge', () => {
         origBC = global.BroadcastChannel;
         global.BroadcastChannel = MockBroadcastChannel;
         MockBroadcastChannel.reset();
-        // Clear snapshot provider between tests
-        setSnapshotProvider(null);
+        // Reset all module-level state (lastBroadcastAt, displayCourt,
+        // snapshotProvider) so tests do not depend on execution order.
+        _resetModuleStateForTests();
     });
 
     afterEach(() => {
@@ -327,32 +329,51 @@ describe('openBridge', () => {
         b.close();
     });
 
-    it('auto-responds to snapshot-req with a snapshot when a provider is registered', () => {
+    it('auto-responds to snapshot-req from a different origin with a snapshot for the right court', () => {
+        // The self-echo guard drops messages whose origin === _tabId, so a
+        // same-module publish() never reaches the responder. Inject the
+        // snapshot-req from a spoofed different origin to bypass that guard
+        // and actually exercise the auto-reply path.
         const competitions = [{ id: 'comp-A', poolMatches: [] }];
         setSnapshotProvider((court) => court === 'A' ? competitions : null);
 
-        const operatorBridge = openBridge(); // has snapshot provider
-        const displayBridge = openBridge();  // will send snapshot-req
+        openBridge(); // activate the onmessage responder
 
-        // The operator bridge auto-responds; displayBridge.onMessage would capture it.
-        // BUT since both bridges share _tabId (same module), the reply from
-        // operatorBridge will be dropped by displayBridge due to self-echo.
-        // This test verifies the provider lookup logic: we listen on operatorBridge
-        // itself to confirm it received the snapshot-req event and called provider.
-        const reqsReceived = [];
-        operatorBridge.onMessage(msg => reqsReceived.push(msg));
+        MockBroadcastChannel._lastSent = null;
 
-        displayBridge.publish('snapshot-req', 'A', '', null);
+        // Inject a snapshot-req from a different tab for court 'A'.
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'snapshot-req', origin: 'other-tab-id',
+            court: 'A', compId: '', payload: null,
+        });
 
-        // operatorBridge received the snapshot-req (different instance,
-        // but same _tabId → DROPPED by self-echo. So this test verifies only
-        // that the inter-instance routing works when origins differ.
-        // Since our mock shares _tabId between sender and receiver, we verify
-        // the no-echo path instead: reqsReceived.length === 0 (self-echo dropped).
-        expect(reqsReceived).toHaveLength(0);
+        // The responder should have called postMessage with a snapshot reply.
+        const sent = MockBroadcastChannel._lastSent;
+        expect(sent).not.toBeNull();
+        expect(sent.type).toBe('snapshot');
+        expect(sent.court).toBe('A');
+        expect(sent.compId).toBe('');
+        expect(sent.origin).toBe(_tabId);
+        expect(sent.payload).toBe(competitions);
+    });
 
-        operatorBridge.close();
-        displayBridge.close();
+    it('does not reply to a snapshot-req when the provider has no data for the requested court', () => {
+        // Provider only has data for court 'A'; request for court 'B' should
+        // produce no reply (last-sent stays null).
+        const competitions = [{ id: 'comp-A', poolMatches: [] }];
+        setSnapshotProvider((court) => court === 'A' ? competitions : null);
+
+        openBridge();
+
+        MockBroadcastChannel._lastSent = null;
+
+        MockBroadcastChannel.injectFrom('bc-court-hub-v1', {
+            v: 1, type: 'snapshot-req', origin: 'other-tab-id',
+            court: 'B', compId: '', payload: null,
+        });
+
+        // No data for court B: the responder must not call postMessage.
+        expect(MockBroadcastChannel._lastSent).toBeNull();
     });
 
     it('getLastBroadcastAt returns null before any publish and updates after', () => {
@@ -404,9 +425,8 @@ describe('setDisplayCourt inbound recency scoping', () => {
         origBC = global.BroadcastChannel;
         global.BroadcastChannel = MockBroadcastChannel;
         MockBroadcastChannel.reset();
-        setSnapshotProvider(null);
-        // Reset display court to null before each test.
-        setDisplayCourt(null);
+        // Reset all module-level state so tests do not depend on execution order.
+        _resetModuleStateForTests();
     });
 
     afterEach(() => {

--- a/web-mobile/js/__tests__/court_bridge.test.jsx
+++ b/web-mobile/js/__tests__/court_bridge.test.jsx
@@ -233,13 +233,17 @@ describe('mergeSnapshotIntoTree', () => {
         const comps = [{ id: 'c1' }, { id: 'c2' }];
         const out = mergeSnapshotIntoTree(null, comps, { connected: false });
         expect(out).toEqual({ name: '', courts: [], competitions: comps });
-        expect(out.competitions).toBe(comps);
     });
 
     it('bootstraps even when connected (an outage at load must not be starved)', () => {
         const comps = [{ id: 'c1' }];
         const out = mergeSnapshotIntoTree(null, comps, { connected: true });
-        expect(out.competitions).toBe(comps);
+        expect(out.competitions.map(c => c.id)).toEqual(['c1']);
+    });
+
+    it('filters null/primitive/id-less elements out of the cold-start bootstrap too', () => {
+        const out = mergeSnapshotIntoTree(null, [null, 'x', {}, { config: {} }, { id: 'c1' }], { connected: false });
+        expect(out.competitions).toEqual([{ id: 'c1' }]);
     });
 
     it('drops the snapshot (returns prev) when prev exists and SSE is connected', () => {

--- a/web-mobile/js/__tests__/link_dot.test.jsx
+++ b/web-mobile/js/__tests__/link_dot.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { LinkDot } from '../display_scoreboard.jsx';
+
+// LinkDot: the 3-state connection indicator on the TV scoreboard (mp-9ukk
+// Phase 2). JSX compiles to the non-reactive global React stub from
+// vitest.setup.js, so calling LinkDot(props) returns a { type, props, children }
+// vnode whose props we assert directly. No mount needed (the component is a
+// single self-closing <span>).
+//
+// State contract:
+//   connected -> invisible (visibility:hidden, transparent bg, aria-hidden) so
+//                the header reserves the dot's space and does not reflow.
+//   local     -> amber dot (var(--warn)), no ring, role=status.
+//   stale     -> red dot (var(--danger)) WITH a dark ring (boxShadow), role=status.
+// The two degraded states are distinguished by TREATMENT (the ring), not hue
+// alone (DESIGN.md principle 2), so the meaning survives projector glare and
+// colour-blindness.
+
+function render(linkState) {
+    return LinkDot({ linkState });
+}
+
+describe('LinkDot', () => {
+    it('renders a span tagged with the link state via data-link-state', () => {
+        for (const state of ['connected', 'local', 'stale']) {
+            const v = render(state);
+            expect(v.type).toBe('span');
+            expect(v.props['data-link-state']).toBe(state);
+            expect(v.props['data-testid']).toBe('display-link-dot');
+        }
+    });
+
+    it('connected: invisible, transparent, aria-hidden, no status role', () => {
+        const v = render('connected');
+        expect(v.props.style.visibility).toBe('hidden');
+        expect(v.props.style.background).toBe('transparent');
+        expect(v.props['aria-hidden']).toBe('true');
+        expect(v.props.role).toBeUndefined();
+        expect(v.props['aria-label']).toBeUndefined();
+        expect(v.props.style.boxShadow).toBe('none');
+    });
+
+    it('local: amber dot, visible, status role, no ring', () => {
+        const v = render('local');
+        expect(v.props.style.visibility).toBe('visible');
+        expect(v.props.style.background).toContain('--warn');
+        expect(v.props.style.boxShadow).toBe('none');
+        expect(v.props.role).toBe('status');
+        expect(v.props['aria-hidden']).toBeUndefined();
+        expect(v.props['aria-label']).toBe('Operator broadcast (server offline)');
+    });
+
+    it('stale: red dot, visible, status role, dark ring (boxShadow)', () => {
+        const v = render('stale');
+        expect(v.props.style.visibility).toBe('visible');
+        expect(v.props.style.background).toContain('--danger');
+        expect(v.props.style.boxShadow).toContain('--ink-1');
+        expect(v.props.role).toBe('status');
+        expect(v.props['aria-label']).toBe('No data feed');
+    });
+
+    it('distinguishes local and stale by treatment (ring), not hue alone', () => {
+        // The ring is the colour-independent differentiator required by DESIGN.md.
+        expect(render('local').props.style.boxShadow).toBe('none');
+        expect(render('stale').props.style.boxShadow).not.toBe('none');
+    });
+});

--- a/web-mobile/js/__tests__/patch.test.jsx
+++ b/web-mobile/js/__tests__/patch.test.jsx
@@ -37,6 +37,18 @@ describe('applyPatch', () => {
     expect(next).toBe(prev);
   });
 
+  it('does not throw on null / id-less entries in results and ignores them', () => {
+    const prev = makeState();
+    // A malformed event (e.g. results:[null]) must not crash the Map build;
+    // the bad entries are skipped and a valid sibling result still applies.
+    let next;
+    expect(() => {
+      next = applyPatch(prev, { data: { results: [null, "x", {}, { winner: "X" }, { id: "p1", status: "completed", winner: "X" }] } });
+    }).not.toThrow();
+    expect(next.poolMatches.find(m => m.id === "p1").status).toBe("completed");
+    expect(next.poolMatches.find(m => m.id === "p2").status).toBe("scheduled");
+  });
+
   it('applies a single result to the matching poolMatch', () => {
     const prev = makeState();
     const next = applyPatch(prev, { data: { result: { id: "p1", winner: "Alice", status: "completed" } } });

--- a/web-mobile/js/__tests__/router.test.jsx
+++ b/web-mobile/js/__tests__/router.test.jsx
@@ -58,4 +58,16 @@ describe('parseSearch', () => {
         expect(() => { out2 = parseSearch('?%=x'); }).not.toThrow();
         expect(out2['%']).toBe('x');
     });
+
+    it('does not throw on a non-string truthy input; returns an empty object', () => {
+        // parseSearch is on the public surface (ES export + window.AppRouter).
+        // A truthy non-string (object, number, boolean, array) passes the old
+        // `!search` falsy check but lacks .startsWith/.slice, which would throw
+        // downstream for any caller that passes the wrong shape.
+        for (const bad of [{}, 42, true, [], { court: 'A' }]) {
+            let out;
+            expect(() => { out = parseSearch(bad); }).not.toThrow();
+            expect(out).toEqual({});
+        }
+    });
 });

--- a/web-mobile/js/__tests__/router.test.jsx
+++ b/web-mobile/js/__tests__/router.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { parseSearch } from '../router.jsx';
+
+// parseSearch: the single canonical query-string parser in router.jsx, exposed
+// via the ES export and window.AppRouter. app.jsx (parseCourtFromSearch) and
+// router's own useQuery both delegate to it, so it is worth covering directly.
+
+describe('parseSearch', () => {
+    it('returns an empty object for empty / too-short input', () => {
+        expect(parseSearch('')).toEqual({});
+        expect(parseSearch('?')).toEqual({});
+        expect(parseSearch(undefined)).toEqual({});
+        expect(parseSearch(null)).toEqual({});
+    });
+
+    it('parses a single key=value pair, stripping a leading ?', () => {
+        expect(parseSearch('?court=A')).toEqual({ court: 'A' });
+    });
+
+    it('parses without a leading ?', () => {
+        expect(parseSearch('court=B')).toEqual({ court: 'B' });
+    });
+
+    it('parses multiple pairs', () => {
+        expect(parseSearch('?court=A&overlay=true&position=top')).toEqual({
+            court: 'A', overlay: 'true', position: 'top',
+        });
+    });
+
+    it('maps a key with no value to an empty string', () => {
+        expect(parseSearch('?flag')).toEqual({ flag: '' });
+        expect(parseSearch('?a=1&flag&b=2')).toEqual({ a: '1', flag: '', b: '2' });
+    });
+
+    it('percent-decodes keys and values', () => {
+        expect(parseSearch('?name=Akira%20Tanaka')).toEqual({ name: 'Akira Tanaka' });
+        expect(parseSearch('?a%20b=c')).toEqual({ 'a b': 'c' });
+    });
+
+    it('keeps the last value when a key repeats', () => {
+        expect(parseSearch('?court=A&court=B')).toEqual({ court: 'B' });
+    });
+
+    it('skips empty segments from doubled separators', () => {
+        expect(parseSearch('?court=A&&overlay=1')).toEqual({ court: 'A', overlay: '1' });
+    });
+});

--- a/web-mobile/js/__tests__/router.test.jsx
+++ b/web-mobile/js/__tests__/router.test.jsx
@@ -44,4 +44,18 @@ describe('parseSearch', () => {
     it('skips empty segments from doubled separators', () => {
         expect(parseSearch('?court=A&&overlay=1')).toEqual({ court: 'A', overlay: '1' });
     });
+
+    it('does not throw on malformed percent-encoding; falls back to the raw substring', () => {
+        // A stray '%' makes decodeURIComponent throw; parseSearch is on the
+        // public surface and runs at state init, so it must never propagate that.
+        let out;
+        expect(() => { out = parseSearch('?court=%E0%A4%A'); }).not.toThrow();
+        expect(out.court).toBe('%E0%A4%A');
+        // A valid pair alongside a malformed one still parses.
+        expect(parseSearch('?court=A&bad=%')).toEqual({ court: 'A', bad: '%' });
+        // A malformed key is tolerated too.
+        let out2;
+        expect(() => { out2 = parseSearch('?%=x'); }).not.toThrow();
+        expect(out2['%']).toBe('x');
+    });
 });

--- a/web-mobile/js/__tests__/router.test.jsx
+++ b/web-mobile/js/__tests__/router.test.jsx
@@ -59,6 +59,19 @@ describe('parseSearch', () => {
         expect(out2['%']).toBe('x');
     });
 
+    it('stores a __proto__ key as an own property instead of hitting the Object.prototype accessor', () => {
+        // On a plain {} literal, params['__proto__'] = 'x' hits the special
+        // accessor on Object.prototype and no-ops for a string value, silently
+        // dropping the key. params must be Object.create(null) so the key is
+        // stored as a normal own property, and Object.prototype methods are
+        // absent (confirming the null prototype).
+        const out = parseSearch('?__proto__=malicious&court=A');
+        expect(out.__proto__).toBe('malicious');
+        expect(Object.getPrototypeOf(out)).toBeNull();
+        expect(out.court).toBe('A');
+        expect(Object.keys(out).sort()).toEqual(['__proto__', 'court']);
+    });
+
     it('does not throw on a non-string truthy input; returns an empty object', () => {
         // parseSearch is on the public surface (ES export + window.AppRouter).
         // A truthy non-string (object, number, boolean, array) passes the old

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -31,12 +31,7 @@
 //   F5: Terminal writes (decision, completed score, lineup) durable via queue.
 
 import { normalizeCompetitionDetail, normalizePlayer, toBackendMatchResult, buildPlayerMetadata } from './api_serializers.jsx';
-import { openBridge } from './court_bridge.jsx';
-
-// Module-level bridge singleton. Opened once so all recordScore calls in
-// this tab share one BroadcastChannel handle. The bridge auto-degrades to
-// a no-op when BroadcastChannel is unavailable (graceful degrade).
-const _bridge = openBridge();
+import { bridge as _bridge } from './court_bridge.jsx';
 
 // ---------------------------------------------------------------------------
 // F1: fetch with per-request timeout via AbortController
@@ -1061,16 +1056,23 @@ const API = {
         // court-local BroadcastChannel so the display tab can update without
         // a server round-trip during offline periods.
         //
-        // The payload shape mirrors the SSE match_updated data envelope:
-        //   { result: { id: matchID, ...backendFields } }
-        // applyPatch (patch.jsx) reads result.id to locate the match.
-        // We strip rev/revSession from the broadcast so the display tab's
-        // applyPatch does not propagate internal write-ordering metadata.
-        // court is sourced from the match object passed by the score editor.
+        // The envelope mirrors the SSE match_updated shape including sideAId and
+        // sideBId so the display tab's normalizeMatch can resolve participants by
+        // UUID rather than falling back to name-key lookup (which can mis-resolve
+        // same-name participants). winnerId is already in rest when present.
+        // rev/revSession are stripped so internal write-ordering metadata is not
+        // propagated to the display tab.
         const _broadcastPatch = (fields) => {
             const { rev: _r, revSession: _rs, ...rest } = fields || {};
             const court = (match && match.court) || '';
-            _bridge.publish('patch', court, compID, { result: { id: matchID, ...rest } });
+            _bridge.publish('patch', court, compID, {
+                result: {
+                    id: matchID,
+                    ...(match && match.sideA && match.sideA.id ? { sideAId: match.sideA.id } : {}),
+                    ...(match && match.sideB && match.sideB.id ? { sideBId: match.sideB.id } : {}),
+                    ...rest,
+                },
+            });
         };
 
         const scoreUrl = `/api/competitions/${compID}/matches/${matchID}/score`;
@@ -1143,10 +1145,13 @@ const API = {
                 _matchRevCounters.delete(_revKey(compID, matchID));
             }
             // A stale running write is signalled by HTTP 200 {stale:true}
-            // (the server's rev-guard no-ops it). Returned as-is; the
+            // (the server's rev-guard no-ops it). Do not broadcast it: pushing
+            // a superseded running score to the display would overwrite the
+            // authoritative newer state already there. Return as-is; the
             // fire-and-forget autosave caller ignores the value.
-            // mp-9ukk: broadcast the confirmed server response so the display
-            // tab gets authoritative data even when the SSE link is slow/down.
+            // mp-9ukk: broadcast only confirmed, non-stale responses so the
+            // display tab gets authoritative data when the SSE link is slow/down.
+            if (data && data.stale) return data;
             _broadcastPatch(payload);
             return data;
         }

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -31,6 +31,12 @@
 //   F5: Terminal writes (decision, completed score, lineup) durable via queue.
 
 import { normalizeCompetitionDetail, normalizePlayer, toBackendMatchResult, buildPlayerMetadata } from './api_serializers.jsx';
+import { openBridge } from './court_bridge.jsx';
+
+// Module-level bridge singleton. Opened once so all recordScore calls in
+// this tab share one BroadcastChannel handle. The bridge auto-degrades to
+// a no-op when BroadcastChannel is unavailable (graceful degrade).
+const _bridge = openBridge();
 
 // ---------------------------------------------------------------------------
 // F1: fetch with per-request timeout via AbortController
@@ -1051,6 +1057,22 @@ const API = {
             _recomputeSyncStatus();
         }
 
+        // mp-9ukk Phase 2: broadcast helper. Publishes a match patch on the
+        // court-local BroadcastChannel so the display tab can update without
+        // a server round-trip during offline periods.
+        //
+        // The payload shape mirrors the SSE match_updated data envelope:
+        //   { result: { id: matchID, ...backendFields } }
+        // applyPatch (patch.jsx) reads result.id to locate the match.
+        // We strip rev/revSession from the broadcast so the display tab's
+        // applyPatch does not propagate internal write-ordering metadata.
+        // court is sourced from the match object passed by the score editor.
+        const _broadcastPatch = (fields) => {
+            const { rev: _r, revSession: _rs, ...rest } = fields || {};
+            const court = (match && match.court) || '';
+            _bridge.publish('patch', court, compID, { result: { id: matchID, ...rest } });
+        };
+
         const scoreUrl = `/api/competitions/${compID}/matches/${matchID}/score`;
         let res;
         try {
@@ -1073,6 +1095,9 @@ const API = {
                 // failures so they are not silently lost on a wifi gap.
                 if (isRunning) {
                     enqueueRunningWrite(compID, matchID, payload, password);
+                    // mp-9ukk: broadcast even on enqueue so the display tab gets
+                    // the optimistic overlay while the server is unreachable.
+                    _broadcastPatch(payload);
                     // Return a DISCRIMINATED { queued: true } result. The write was
                     // NOT confirmed by the server: only enqueued for async delivery
                     // via _flushQueue (last-write-wins). Fire-and-forget callers
@@ -1090,6 +1115,8 @@ const API = {
                     _revKey(compID, matchID), 'score', 'PUT', scoreUrl,
                     payload, password, compID, matchID
                 );
+                // mp-9ukk: broadcast the terminal write for offline display update.
+                _broadcastPatch(payload);
                 return { queued: true };
             }
         } finally {
@@ -1118,6 +1145,9 @@ const API = {
             // A stale running write is signalled by HTTP 200 {stale:true}
             // (the server's rev-guard no-ops it). Returned as-is; the
             // fire-and-forget autosave caller ignores the value.
+            // mp-9ukk: broadcast the confirmed server response so the display
+            // tab gets authoritative data even when the SSE link is slow/down.
+            _broadcastPatch(payload);
             return data;
         }
         // A running write that failed with a RETRYABLE server error (5xx / 429)
@@ -1128,6 +1158,8 @@ const API = {
         // latest state.
         if (isRunning && (res.status >= 500 || res.status === 429)) {
             enqueueRunningWrite(compID, matchID, payload, password);
+            // mp-9ukk: broadcast the queued state for offline display update.
+            _broadcastPatch(payload);
             // Discriminated { queued: true }: not server-confirmed; see the
             // network-error branch above for the full caller contract.
             return { queued: true };
@@ -1139,6 +1171,8 @@ const API = {
                 _revKey(compID, matchID), 'score', 'PUT', scoreUrl,
                 payload, password, compID, matchID
             );
+            // mp-9ukk: broadcast the queued terminal state for offline display.
+            _broadcastPatch(payload);
             return { queued: true };
         }
         // mp-dc52 Phase 3: the simultaneity gate returns 409 ineligible_competitor

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1154,10 +1154,19 @@ const API = {
             // A stale running write is signalled by HTTP 200 {stale:true}
             // (the server's rev-guard no-ops it). Do not broadcast it: pushing
             // a superseded running score to the display would overwrite the
-            // authoritative newer state already there. Return as-is; the
-            // fire-and-forget autosave caller ignores the value.
-            // mp-9ukk: broadcast only confirmed, non-stale responses so the
-            // display tab gets authoritative data when the SSE link is slow/down.
+            // newer state already there. Return as-is; the fire-and-forget
+            // autosave caller ignores the value.
+            // mp-9ukk: echo the operator's patch to the court display
+            // peer-to-peer so the board keeps updating when the SSE link is
+            // slow or down. This is an OPTIMISTIC overlay, not the
+            // authoritative source: the request payload already carries the
+            // display-critical fields (id, side ids, winner, scores, status)
+            // in the same envelope every other broadcast path uses, and the
+            // fully server-normalized state arrives via SSE (or the reconnect
+            // full refetch), which replaces the overlay. Broadcasting the
+            // request payload (not the server `data`) keeps one consistent
+            // shape across the confirmed and offline paths. Skip a rejected
+            // stale write above so a superseded score is never pushed.
             if (data && data.stale) return data;
             _broadcastPatch(payload);
             return data;

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1065,6 +1065,13 @@ const API = {
         const _broadcastPatch = (fields) => {
             const { rev: _r, revSession: _rs, ...rest } = fields || {};
             const court = (match && match.court) || '';
+            // Do not emit an unscoped (court-less) broadcast: a display can only
+            // safely apply a patch it can attribute to its court, and the display
+            // guard drops court-less messages anyway. In production every
+            // recordScore caller passes the match (so court is set); the
+            // court-less case is test-only (match=null), where no broadcast is
+            // expected.
+            if (!court) return;
             _bridge.publish('patch', court, compID, {
                 result: {
                     id: matchID,

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -606,12 +606,16 @@ function App() {
 
     const unsub = bridge.onMessage((msg) => {
       if (msg.type === 'patch') {
-        if (msg.court && msg.court !== court) return;
+        // Strict court match: a message with no court (unscoped) or a
+        // different court is dropped, never applied to this court's board.
+        if (msg.court !== court) return;
         setTournament(prev => applyPatchToTree(prev, msg));
         return;
       }
       if (msg.type === 'snapshot' && msg.payload) {
-        if (msg.court && msg.court !== court) return;
+        // Strict court match: a message with no court (unscoped) or a
+        // different court is dropped, never applied to this court's board.
+        if (msg.court !== court) return;
         // Bootstrap or fill gap from the operator tab's court snapshot.
         // We build a minimal tournament wrapper: the display only reads
         // tournament.name/courts for the header and tournament.competitions

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -286,6 +286,26 @@ export function diffAnnouncementSnapshot(seenRef, list) {
   return additions;
 }
 
+// parseCourtFromSearch: read the normalized display court from the URL query
+// string ('?court=A' → 'A', 'all' → 'ALL', default 'A'). Used by the display
+// consumer so the bridge re-scopes when the court param changes (mp-9ukk).
+function parseCourtFromSearch() {
+  const s = typeof window !== 'undefined' ? (window.location.search || '') : '';
+  let raw = 'A';
+  if (s.length >= 2) {
+    const trimmed = s.startsWith('?') ? s.slice(1) : s;
+    for (const pair of trimmed.split('&')) {
+      if (!pair) continue;
+      const eq = pair.indexOf('=');
+      if (eq !== -1 && decodeURIComponent(pair.slice(0, eq)) === 'court') {
+        raw = decodeURIComponent(pair.slice(eq + 1));
+        break;
+      }
+    }
+  }
+  return raw.toLowerCase() === 'all' ? 'ALL' : raw.toUpperCase();
+}
+
 function App() {
   const [tournament, setTournament] = useS(undefined);
   const [loading, setLoading] = useS(true);
@@ -390,6 +410,10 @@ function App() {
   // Derived from sseConnected + the bridge's last-broadcast recency in a tick.
   // The boolean sseConnected is kept for LobbyDisplay (unchanged scope).
   const [linkState, setLinkState] = useS('connected');
+  // mp-9ukk Phase 2: the display court parsed from ?court=. Tracked as state
+  // (updated on popstate) so the display consumer effect re-runs and re-scopes
+  // the bridge when the court changes without a full reload.
+  const [displayCourt, setDisplayCourtParam] = useS(() => parseCourtFromSearch());
   // Ref kept in sync with sseConnected so the 5 s display-mode ticker can
   // read the current value without closing over a stale copy from the effect
   // that has [mode] as its only dep. See the sync effect below.
@@ -504,6 +528,9 @@ function App() {
         if (route.admin) setAdminView(route.admin);
       } else if (route.mode === "display") {
         setMode("display");
+        // Re-read the court so an in-place back/forward to a different
+        // ?court= re-scopes the bridge (the display effect depends on it).
+        setDisplayCourtParam(parseCourtFromSearch());
       } else {
         setMode("viewer");
         setViewerCompId(route.viewerCompId || null);
@@ -583,22 +610,10 @@ function App() {
   useE(() => {
     if (mode !== 'display') return;
 
-    // Read the court from the URL query string. DisplayRoute also reads
-    // it via useQuery: we replicate the parse here to scope the snapshot-req.
-    const rawCourt = (() => {
-      const s = typeof window !== 'undefined' ? (window.location.search || '') : '';
-      if (s.length < 2) return 'A';
-      const trimmed = s.startsWith('?') ? s.slice(1) : s;
-      for (const pair of trimmed.split('&')) {
-        if (!pair) continue;
-        const eq = pair.indexOf('=');
-        if (eq !== -1 && decodeURIComponent(pair.slice(0, eq)) === 'court') {
-          return decodeURIComponent(pair.slice(eq + 1));
-        }
-      }
-      return 'A';
-    })();
-    const court = rawCourt.toLowerCase() === 'all' ? 'ALL' : rawCourt.toUpperCase();
+    // The display court is tracked as state (parseCourtFromSearch, updated on
+    // popstate) and is a dependency of this effect, so the bridge re-scopes
+    // when ?court= changes without a full reload.
+    const court = displayCourt;
 
     // Scope the inbound recency clock to this display court so a patch for
     // a different court does not falsely advance the local dot to 'local'.
@@ -677,11 +692,12 @@ function App() {
       setDisplayCourt(null);
       clearInterval(ticker);
     };
-    // mode is in deps so the effect re-runs if the user navigates away from
-    // display mode (unlikely but possible via popstate). sseConnected is NOT
-    // in deps deliberately: re-opening the bridge on every SSE flip would
-    // drop all in-flight snapshot replies.
-  }, [mode]);
+    // mode + displayCourt are in deps so the effect re-runs (re-scoping the
+    // bridge: snapshot-req, recency clock, and the inbound court guard) when
+    // the user leaves display mode or switches ?court= in place. sseConnected
+    // is NOT in deps deliberately: re-opening the bridge on every SSE flip
+    // would drop all in-flight snapshot replies.
+  }, [mode, displayCourt]);
 
   // mp-9ukk Phase 2: ref sync + linkState re-derivation on every sseConnected
   // or mode change. sseConnectedRef is updated first (before the mode guard)
@@ -1179,6 +1195,37 @@ function App() {
     return <window.LoadingSpinner text="Loading..." />;
   }
 
+  // T060: /display family: public, read-only TV / lobby / overlay
+  // surfaces. Short-circuit BEFORE the CreateTournament null-check and
+  // before viewer/admin so no auth prompt is shown, no admin chrome leaks
+  // in, and a public TV never falls through to the admin create-tournament
+  // form during an outage. The DisplayRoute owns its own query-param
+  // routing (court=, overlay=, position=). `connected` is the SSE-status
+  // boolean from T063 (for LobbyDisplay). `linkState` is the 3-state dot
+  // value for TvDisplay (mp-9ukk Phase 2): 'connected' | 'local' | 'stale'.
+  if (mode === "display") {
+    const DisplayRoute = window.DisplayRoute;
+    if (!DisplayRoute) {
+      // Defensive: display.js bundle is part of the standard build, so
+      // this should never fire in production. Render a minimal message
+      // rather than a blank screen if it does.
+      return <div className="loading" style={{ background: '#000', color: '#fff', padding: 40 }}>Display module not loaded.</div>;
+    }
+    // tournament is null when the initial fetch failed (outage). Pass a safe
+    // empty wrapper so the board renders its own loading/empty state instead
+    // of the admin create form; the snapshot bootstrap may still populate it
+    // from an operator tab, and load() replaces it on reconnect.
+    const displayTournament = tournament || { name: '', competitions: [] };
+    return (
+      <DisplayRoute
+        tournament={displayTournament}
+        competitions={displayTournament.competitions || []}
+        connected={sseConnected}
+        linkState={linkState}
+      />
+    );
+  }
+
   if (tournament === null) {
     return (
       <CreateTournament
@@ -1189,32 +1236,6 @@ function App() {
           setMode("admin");
           setPassword(p);
         }}
-      />
-    );
-  }
-
-  // T060: /display family: public, read-only TV / lobby / overlay
-  // surfaces. Short-circuit before viewer/admin so no auth prompt is
-  // shown, no admin chrome leaks in, and the DisplayRoute owns its
-  // own query-param routing (court=, overlay=, position=). The
-  // tournament prop carries .competitions already (load() merges
-  // them), and `connected` is the SSE-status boolean from T063 (for
-  // LobbyDisplay). `linkState` is the 3-state dot value for TvDisplay
-  // (mp-9ukk Phase 2): 'connected' | 'local' | 'stale'.
-  if (mode === "display") {
-    const DisplayRoute = window.DisplayRoute;
-    if (!DisplayRoute) {
-      // Defensive: display.js bundle is part of the standard build, so
-      // this should never fire in production. Render a minimal message
-      // rather than a blank screen if it does.
-      return <div className="loading" style={{ background: '#000', color: '#fff', padding: 40 }}>Display module not loaded.</div>;
-    }
-    return (
-      <DisplayRoute
-        tournament={tournament}
-        competitions={tournament.competitions || []}
-        connected={sseConnected}
-        linkState={linkState}
       />
     );
   }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -733,7 +733,7 @@ function App() {
         if (c.poolMatches && c.poolMatches.some(m => m.court === court)) return true;
         if (c.bracket && Array.isArray(c.bracket.rounds)) {
           for (const round of c.bracket.rounds) {
-            if (round.some(m => m.court === court)) return true;
+            if (Array.isArray(round) && round.some(m => m.court === court)) return true;
           }
         }
         return false;

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -606,16 +606,18 @@ function App() {
 
     const unsub = bridge.onMessage((msg) => {
       if (msg.type === 'patch') {
+        if (msg.court && msg.court !== court) return;
         setTournament(prev => applyPatchToTree(prev, msg));
         return;
       }
       if (msg.type === 'snapshot' && msg.payload) {
+        if (msg.court && msg.court !== court) return;
         // Bootstrap or fill gap from the operator tab's court snapshot.
         // We build a minimal tournament wrapper: the display only reads
         // tournament.name/courts for the header and tournament.competitions
         // for match rendering.
         setTournament(prev => {
-          if (!msg.payload || !Array.isArray(msg.payload)) return prev;
+          if (!Array.isArray(msg.payload)) return prev;
           const incomingComps = msg.payload;
           if (!prev) {
             // No server data yet: bootstrap entirely from the snapshot.
@@ -672,10 +674,14 @@ function App() {
     // drop all in-flight snapshot replies.
   }, [mode]);
 
-  // mp-9ukk Phase 2: linkState re-derivation on every sseConnected change.
-  // This catches the moment SSE reconnects (sseConnected flips true) so the
-  // dot goes green immediately without waiting for the 5 s ticker.
+  // mp-9ukk Phase 2: ref sync + linkState re-derivation on every sseConnected
+  // or mode change. sseConnectedRef is updated first (before the mode guard)
+  // so the ref stays in sync in all modes, not just display mode. The
+  // linkState derivation then fires only in display mode: this catches the
+  // moment SSE reconnects (sseConnected flips true) so the dot goes green
+  // immediately without waiting for the 5 s ticker.
   useE(() => {
+    sseConnectedRef.current = sseConnected;
     if (mode !== 'display') return;
     setLinkState(deriveLinkState({
       sseConnected,
@@ -684,10 +690,6 @@ function App() {
       freshnessMs,
     }));
   }, [sseConnected, mode]);
-
-  // Keep sseConnectedRef in sync with sseConnected so the display-mode 5 s
-  // ticker can read the current value without the interval closure going stale.
-  useE(() => { sseConnectedRef.current = sseConnected; }, [sseConnected]);
 
   // mp-9ukk Phase 2: operator-tab snapshot provider.
   //
@@ -717,7 +719,7 @@ function App() {
         // exposes a courts[] array use it; otherwise scan poolMatches.
         if (c.courts && Array.isArray(c.courts) && c.courts.includes(court)) return true;
         if (c.poolMatches && c.poolMatches.some(m => m.court === court)) return true;
-        if (c.bracket && c.bracket.rounds) {
+        if (c.bracket && Array.isArray(c.bracket.rounds)) {
           for (const round of c.bracket.rounds) {
             if (round.some(m => m.court === court)) return true;
           }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -4,7 +4,7 @@
 import { applyPatch as patchCompetitionData, checkSeqGap } from './patch.jsx';
 import { setCachedAuthConfig } from './admin_helpers.jsx';
 import { LS_NOTIFICATIONS_ENABLED } from './notification_keys.jsx';
-import { bridge, setSnapshotProvider, setDisplayCourt, getLastBroadcastAt, applyPatchToTree, deriveLinkState, freshnessMs } from './court_bridge.jsx';
+import { bridge, setSnapshotProvider, setDisplayCourt, getLastBroadcastAt, applyPatchToTree, mergeSnapshotIntoTree, deriveLinkState, freshnessMs } from './court_bridge.jsx';
 
 const { useState: useS, useEffect: useE, useRef: useR, useCallback: useC } = React;
 
@@ -641,40 +641,11 @@ function App() {
         // tournament.name/courts for the header and tournament.competitions
         // for match rendering.
         setTournament(prev => {
+          // Pure merge policy lives in court_bridge.mergeSnapshotIntoTree (so it
+          // is unit-testable apart from this effect). The try/catch is a backstop
+          // so a future malformed snapshot can never crash the display board.
           try {
-            if (!Array.isArray(msg.payload)) return prev;
-            const incomingComps = msg.payload;
-            if (!prev) {
-              // No server data yet: bootstrap entirely from the snapshot. This
-              // path is unconditional (even if sseConnected is still its
-              // optimistic mount default) so a cold start during an outage is
-              // never starved of the operator snapshot.
-              return { name: '', courts: [], competitions: incomingComps };
-            }
-            // Server data already loaded AND the SSE feed is up: the server is
-            // authoritative, so drop a late-arriving snapshot rather than let it
-            // overwrite the loaded server competitions with the operator tab's copy.
-            if (sseConnectedRef.current) return prev;
-            // Offline: merge the operator snapshot into the existing tournament.
-            // Existing competitions ARE replaced by the operator snapshot (the
-            // operator tab is the court authority during an outage). The
-            // reconnect full-refetch restores server truth.
-            const existing = prev.competitions || [];
-            const merged = existing.slice();
-            for (const comp of incomingComps) {
-              if (!comp || typeof comp !== 'object') continue;
-              const id = comp.id || (comp.config && (comp.config.id || comp.config.Id));
-              if (!id) continue;
-              const idx = merged.findIndex(c =>
-                c.id === id || (c.config && (c.config.id === id || c.config.Id === id))
-              );
-              if (idx === -1) {
-                merged.push(comp);
-              } else {
-                merged[idx] = comp;
-              }
-            }
-            return { ...prev, competitions: merged };
+            return mergeSnapshotIntoTree(prev, msg.payload, { connected: sseConnectedRef.current });
           } catch (e) {
             console.error('court_bridge: snapshot merge failed:', e);
             return prev;

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -289,20 +289,17 @@ export function diffAnnouncementSnapshot(seenRef, list) {
 // parseCourtFromSearch: read the normalized display court from the URL query
 // string ('?court=A' → 'A', 'all' → 'ALL', default 'A'). Used by the display
 // consumer so the bridge re-scopes when the court param changes (mp-9ukk).
+//
+// Delegates the query-string parse to the shared AppRouter.parseSearch (the one
+// canonical implementation in router.jsx) rather than re-rolling the loop.
+// router.js is script-tagged before app.js in index.html, so window.AppRouter
+// is always present by the time the App renders; the {} fallback only guards a
+// non-browser/never-rendered context and degrades to the default court.
 function parseCourtFromSearch() {
   const s = typeof window !== 'undefined' ? (window.location.search || '') : '';
-  let raw = 'A';
-  if (s.length >= 2) {
-    const trimmed = s.startsWith('?') ? s.slice(1) : s;
-    for (const pair of trimmed.split('&')) {
-      if (!pair) continue;
-      const eq = pair.indexOf('=');
-      if (eq !== -1 && decodeURIComponent(pair.slice(0, eq)) === 'court') {
-        raw = decodeURIComponent(pair.slice(eq + 1));
-        break;
-      }
-    }
-  }
+  const router = (typeof window !== 'undefined' && window.AppRouter) || null;
+  const query = router && router.parseSearch ? router.parseSearch(s) : {};
+  const raw = query.court || 'A';
   return raw.toLowerCase() === 'all' ? 'ALL' : raw.toUpperCase();
 }
 

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -291,14 +291,14 @@ export function diffAnnouncementSnapshot(seenRef, list) {
 // consumer so the bridge re-scopes when the court param changes (mp-9ukk).
 //
 // Delegates the query-string parse to the shared AppRouter.parseSearch (the one
-// canonical implementation in router.jsx) rather than re-rolling the loop.
+// canonical implementation in router.jsx) rather than re-rolling the loop, via
+// the module-level AppRouter binding (same pattern as AppRouter.route() below).
 // router.js is script-tagged before app.js in index.html, so window.AppRouter
-// is always present by the time the App renders; the {} fallback only guards a
+// is always set by the time this module evaluates; the fallback only guards a
 // non-browser/never-rendered context and degrades to the default court.
 function parseCourtFromSearch() {
   const s = typeof window !== 'undefined' ? (window.location.search || '') : '';
-  const router = (typeof window !== 'undefined' && window.AppRouter) || null;
-  const query = router && router.parseSearch ? router.parseSearch(s) : {};
+  const query = AppRouter && AppRouter.parseSearch ? AppRouter.parseSearch(s) : {};
   const raw = query.court || 'A';
   return raw.toLowerCase() === 'all' ? 'ALL' : raw.toUpperCase();
 }
@@ -614,7 +614,19 @@ function App() {
 
     // Scope the inbound recency clock to this display court so a patch for
     // a different court does not falsely advance the local dot to 'local'.
+    // setDisplayCourt resets the recency clock when the court actually changed.
     setDisplayCourt(court);
+
+    // Re-derive linkState immediately (rather than waiting up to 5 s for the
+    // ticker below) so switching ?court= does not keep showing the PREVIOUS
+    // court's dot state. This reads the recency clock setDisplayCourt just
+    // reset above, so a fresh court starts from its own (blank) state.
+    setLinkState(deriveLinkState({
+      sseConnected: sseConnectedRef.current,
+      lastBroadcastAt: getLastBroadcastAt(),
+      now: Date.now(),
+      freshnessMs,
+    }));
 
     // Use the module-level singleton (shared with api_client's publisher in
     // the same tab) so only one BroadcastChannel is opened per tab.

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -4,7 +4,7 @@
 import { applyPatch as patchCompetitionData, checkSeqGap } from './patch.jsx';
 import { setCachedAuthConfig } from './admin_helpers.jsx';
 import { LS_NOTIFICATIONS_ENABLED } from './notification_keys.jsx';
-import { openBridge, setSnapshotProvider, getLastBroadcastAt, applyPatchToTree, deriveLinkState, freshnessMs } from './court_bridge.jsx';
+import { bridge, setSnapshotProvider, setDisplayCourt, getLastBroadcastAt, applyPatchToTree, deriveLinkState, freshnessMs } from './court_bridge.jsx';
 
 const { useState: useS, useEffect: useE, useRef: useR, useCallback: useC } = React;
 
@@ -390,6 +390,10 @@ function App() {
   // Derived from sseConnected + the bridge's last-broadcast recency in a tick.
   // The boolean sseConnected is kept for LobbyDisplay (unchanged scope).
   const [linkState, setLinkState] = useS('connected');
+  // Ref kept in sync with sseConnected so the 5 s display-mode ticker can
+  // read the current value without closing over a stale copy from the effect
+  // that has [mode] as its only dep. See the sync effect below.
+  const sseConnectedRef = useR(sseConnected);
   // Per-tab client ID, generated once on mount. Used as the originator
   // identifier on password-reset POSTs so the SSE broadcast can be
   // ignored in the originating tab. Without this, the tab that just
@@ -591,8 +595,12 @@ function App() {
     })();
     const court = rawCourt.toLowerCase() === 'all' ? 'ALL' : rawCourt.toUpperCase();
 
-    const bridge = openBridge();
+    // Scope the inbound recency clock to this display court so a patch for
+    // a different court does not falsely advance the local dot to 'local'.
+    setDisplayCourt(court);
 
+    // Use the module-level singleton (shared with api_client's publisher in
+    // the same tab) so only one BroadcastChannel is opened per tab.
     // Post snapshot-req so any open operator tab can reply with court data.
     bridge.publish('snapshot-req', court, '', null);
 
@@ -602,8 +610,7 @@ function App() {
         return;
       }
       if (msg.type === 'snapshot' && msg.payload) {
-        // Bootstrap: if tournament is not yet loaded (undefined/null) OR
-        // if this snapshot carries more up-to-date data, merge it.
+        // Bootstrap or fill gap from the operator tab's court snapshot.
         // We build a minimal tournament wrapper: the display only reads
         // tournament.name/courts for the header and tournament.competitions
         // for match rendering.
@@ -614,8 +621,10 @@ function App() {
             // No server data yet: bootstrap entirely from the snapshot.
             return { name: '', courts: [], competitions: incomingComps };
           }
-          // Server data is already loaded: merge the snapshot's competitions
-          // for the court into the existing tournament to fill any gap.
+          // Server data is already loaded: merge the operator snapshot into
+          // the existing tournament. Existing competitions ARE replaced by the
+          // operator snapshot (the operator tab is the court authority during
+          // an outage). The reconnect full-refetch restores server truth.
           const existing = prev.competitions || [];
           const merged = existing.slice();
           for (const comp of incomingComps) {
@@ -624,7 +633,11 @@ function App() {
             const idx = merged.findIndex(c =>
               c.id === id || (c.config && (c.config.id === id || c.config.Id === id))
             );
-            if (idx === -1) merged.push(comp);
+            if (idx === -1) {
+              merged.push(comp);
+            } else {
+              merged[idx] = comp;
+            }
           }
           return { ...prev, competitions: merged };
         });
@@ -633,9 +646,13 @@ function App() {
 
     // Tick: re-derive linkState every 5 s so the dot transitions promptly
     // when the broadcast recency crosses the freshnessMs threshold.
+    // The ticker reads sseConnectedRef.current (a ref kept in sync by a
+    // dedicated effect) so the interval closure is never stale. sseConnected
+    // is intentionally left OUT of this effect's deps so re-opening the bridge
+    // does not drop in-flight snapshot replies.
     const ticker = setInterval(() => {
       setLinkState(deriveLinkState({
-        sseConnected,
+        sseConnected: sseConnectedRef.current,
         lastBroadcastAt: getLastBroadcastAt(),
         now: Date.now(),
         freshnessMs,
@@ -644,14 +661,15 @@ function App() {
 
     return () => {
       unsub();
-      bridge.close();
+      // Do NOT close the shared bridge here: it is shared with api_client's
+      // publisher in the same tab. Only unsubscribe the display listener.
+      setDisplayCourt(null);
       clearInterval(ticker);
     };
     // mode is in deps so the effect re-runs if the user navigates away from
     // display mode (unlikely but possible via popstate). sseConnected is NOT
     // in deps deliberately: re-opening the bridge on every SSE flip would
-    // drop all in-flight snapshot replies. The ticker reads sseConnected via
-    // setLinkState which always captures fresh state.
+    // drop all in-flight snapshot replies.
   }, [mode]);
 
   // mp-9ukk Phase 2: linkState re-derivation on every sseConnected change.
@@ -666,6 +684,10 @@ function App() {
       freshnessMs,
     }));
   }, [sseConnected, mode]);
+
+  // Keep sseConnectedRef in sync with sseConnected so the display-mode 5 s
+  // ticker can read the current value without the interval closure going stale.
+  useE(() => { sseConnectedRef.current = sseConnected; }, [sseConnected]);
 
   // mp-9ukk Phase 2: operator-tab snapshot provider.
   //

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -394,6 +394,11 @@ function App() {
   // read the current value without closing over a stale copy from the effect
   // that has [mode] as its only dep. See the sync effect below.
   const sseConnectedRef = useR(sseConnected);
+  // mp-9ukk Phase 2: holds the latest competitions so the snapshot provider
+  // can be registered ONCE (keyed on [mode]) and read current data through the
+  // ref, instead of re-registering on every tournament update (which would
+  // churn the provider and open a transient unregistered window).
+  const compsRef = useR(null);
   // Per-tab client ID, generated once on mount. Used as the originator
   // identifier on password-reset POSTs so the SSE broadcast can be
   // ignored in the originating tab. Without this, the tab that just
@@ -695,28 +700,31 @@ function App() {
     }));
   }, [sseConnected, mode]);
 
+  // Keep compsRef in sync with the latest competitions so the snapshot
+  // provider (registered once below) always answers with current data.
+  useE(() => { compsRef.current = (tournament && tournament.competitions) || null; }, [tournament]);
+
   // mp-9ukk Phase 2: operator-tab snapshot provider.
   //
-  // When the app is in admin or viewer mode (i.e. NOT display mode) and
-  // has tournament data loaded, register a snapshot provider so the bridge
-  // can auto-reply to display-tab snapshot-req messages.
+  // When the app is in admin or viewer mode (i.e. NOT display mode) register a
+  // snapshot provider so the bridge can auto-reply to display-tab snapshot-req
+  // messages. It is registered ONCE per mode and reads the live competitions
+  // through compsRef, so a tournament update never transiently unregisters it
+  // (which could drop a snapshot-req landing during a re-register window).
   //
-  // The provider returns only the competitions for the requested court so
-  // the payload is bounded (one court's slice rather than all courts).
-  // When no court match is found it returns null and the bridge stays silent.
+  // The provider returns only the competitions for the requested court so the
+  // payload is bounded (one court's slice rather than all courts). When there
+  // is no data yet, or no court match, it returns null and the bridge stays
+  // silent.
   useE(() => {
     if (mode === 'display') {
       // Display tabs do not answer snapshot requests.
       setSnapshotProvider(null);
       return;
     }
-    if (!tournament || !tournament.competitions) {
-      setSnapshotProvider(null);
-      return;
-    }
-    const comps = tournament.competitions;
     setSnapshotProvider((court) => {
-      if (!court) return null;
+      const comps = compsRef.current;
+      if (!court || !comps) return null;
       const slice = comps.filter(c => {
         // A competition belongs to a court when ANY of its pool or bracket
         // matches are assigned to that court. Quick check: if the comp
@@ -733,7 +741,7 @@ function App() {
       return slice.length > 0 ? slice : null;
     });
     return () => setSnapshotProvider(null);
-  }, [mode, tournament]);
+  }, [mode]);
 
   // mp-9h1f: while the shiaijo operator console is active (admin mode + shiaijo
   // view) the SSE handler skips its per-event aggregate refetch: the console

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -4,6 +4,7 @@
 import { applyPatch as patchCompetitionData, checkSeqGap } from './patch.jsx';
 import { setCachedAuthConfig } from './admin_helpers.jsx';
 import { LS_NOTIFICATIONS_ENABLED } from './notification_keys.jsx';
+import { openBridge, setSnapshotProvider, getLastBroadcastAt, applyPatchToTree, deriveLinkState, freshnessMs } from './court_bridge.jsx';
 
 const { useState: useS, useEffect: useE, useRef: useR, useCallback: useC } = React;
 
@@ -384,6 +385,11 @@ function App() {
   // EventSource itself lives inside subscribeToEvents; the second
   // callback hands status events up here.
   const [sseConnected, setSseConnected] = useS(true);
+  // mp-9ukk Phase 2: 3-state link indicator for the TV board.
+  // 'connected' = SSE up; 'local' = operator broadcast fresh; 'stale' = no feed.
+  // Derived from sseConnected + the bridge's last-broadcast recency in a tick.
+  // The boolean sseConnected is kept for LobbyDisplay (unchanged scope).
+  const [linkState, setLinkState] = useS('connected');
   // Per-tab client ID, generated once on mount. Used as the originator
   // identifier on password-reset POSTs so the SSE broadcast can be
   // ignored in the originating tab. Without this, the tab that just
@@ -541,6 +547,165 @@ function App() {
   };
 
   useE(() => { load(); }, []);
+
+  // mp-9ukk Phase 2: display-mode BroadcastChannel consumer.
+  //
+  // When mode === "display" this effect:
+  //   1. Opens a bridge and posts a snapshot-req for the display's court so
+  //      any open operator tab can reply with the competition data.
+  //   2. Subscribes to broadcast messages:
+  //      - 'patch'    : apply the match patch into the in-memory tournament
+  //                     tree via the tree-level adapter (applyPatchToTree).
+  //      - 'snapshot' : bootstrap tournament.competitions when the display
+  //                     loaded offline or before the server fetch resolved.
+  //   3. Runs a 5 s interval tick that re-derives linkState from sseConnected
+  //      + the bridge's last-broadcast recency.
+  //
+  // On reconnect the existing SSE match_updated handler fires maybeLoad()
+  // which wholesale replaces the in-memory tree with server truth: the
+  // optimistic broadcast overlay is discarded by construction.
+  //
+  // Snapshot fallback: the standard load() above already runs on mount
+  // and populates tournament. If the server is unreachable on first load,
+  // load() catches and sets tournament=null. The snapshot handler below
+  // bootstraps from the operator tab's reply instead, using the court
+  // slice of competitions. We set a synthetic tournament so the display
+  // can render.
+  useE(() => {
+    if (mode !== 'display') return;
+
+    // Read the court from the URL query string. DisplayRoute also reads
+    // it via useQuery: we replicate the parse here to scope the snapshot-req.
+    const rawCourt = (() => {
+      const s = typeof window !== 'undefined' ? (window.location.search || '') : '';
+      if (s.length < 2) return 'A';
+      const trimmed = s.startsWith('?') ? s.slice(1) : s;
+      for (const pair of trimmed.split('&')) {
+        if (!pair) continue;
+        const eq = pair.indexOf('=');
+        if (eq !== -1 && decodeURIComponent(pair.slice(0, eq)) === 'court') {
+          return decodeURIComponent(pair.slice(eq + 1));
+        }
+      }
+      return 'A';
+    })();
+    const court = rawCourt.toLowerCase() === 'all' ? 'ALL' : rawCourt.toUpperCase();
+
+    const bridge = openBridge();
+
+    // Post snapshot-req so any open operator tab can reply with court data.
+    bridge.publish('snapshot-req', court, '', null);
+
+    const unsub = bridge.onMessage((msg) => {
+      if (msg.type === 'patch') {
+        setTournament(prev => applyPatchToTree(prev, msg));
+        return;
+      }
+      if (msg.type === 'snapshot' && msg.payload) {
+        // Bootstrap: if tournament is not yet loaded (undefined/null) OR
+        // if this snapshot carries more up-to-date data, merge it.
+        // We build a minimal tournament wrapper: the display only reads
+        // tournament.name/courts for the header and tournament.competitions
+        // for match rendering.
+        setTournament(prev => {
+          if (!msg.payload || !Array.isArray(msg.payload)) return prev;
+          const incomingComps = msg.payload;
+          if (!prev) {
+            // No server data yet: bootstrap entirely from the snapshot.
+            return { name: '', courts: [], competitions: incomingComps };
+          }
+          // Server data is already loaded: merge the snapshot's competitions
+          // for the court into the existing tournament to fill any gap.
+          const existing = prev.competitions || [];
+          const merged = existing.slice();
+          for (const comp of incomingComps) {
+            const id = comp.id || (comp.config && (comp.config.id || comp.config.Id));
+            if (!id) continue;
+            const idx = merged.findIndex(c =>
+              c.id === id || (c.config && (c.config.id === id || c.config.Id === id))
+            );
+            if (idx === -1) merged.push(comp);
+          }
+          return { ...prev, competitions: merged };
+        });
+      }
+    });
+
+    // Tick: re-derive linkState every 5 s so the dot transitions promptly
+    // when the broadcast recency crosses the freshnessMs threshold.
+    const ticker = setInterval(() => {
+      setLinkState(deriveLinkState({
+        sseConnected,
+        lastBroadcastAt: getLastBroadcastAt(),
+        now: Date.now(),
+        freshnessMs,
+      }));
+    }, 5000);
+
+    return () => {
+      unsub();
+      bridge.close();
+      clearInterval(ticker);
+    };
+    // mode is in deps so the effect re-runs if the user navigates away from
+    // display mode (unlikely but possible via popstate). sseConnected is NOT
+    // in deps deliberately: re-opening the bridge on every SSE flip would
+    // drop all in-flight snapshot replies. The ticker reads sseConnected via
+    // setLinkState which always captures fresh state.
+  }, [mode]);
+
+  // mp-9ukk Phase 2: linkState re-derivation on every sseConnected change.
+  // This catches the moment SSE reconnects (sseConnected flips true) so the
+  // dot goes green immediately without waiting for the 5 s ticker.
+  useE(() => {
+    if (mode !== 'display') return;
+    setLinkState(deriveLinkState({
+      sseConnected,
+      lastBroadcastAt: getLastBroadcastAt(),
+      now: Date.now(),
+      freshnessMs,
+    }));
+  }, [sseConnected, mode]);
+
+  // mp-9ukk Phase 2: operator-tab snapshot provider.
+  //
+  // When the app is in admin or viewer mode (i.e. NOT display mode) and
+  // has tournament data loaded, register a snapshot provider so the bridge
+  // can auto-reply to display-tab snapshot-req messages.
+  //
+  // The provider returns only the competitions for the requested court so
+  // the payload is bounded (one court's slice rather than all courts).
+  // When no court match is found it returns null and the bridge stays silent.
+  useE(() => {
+    if (mode === 'display') {
+      // Display tabs do not answer snapshot requests.
+      setSnapshotProvider(null);
+      return;
+    }
+    if (!tournament || !tournament.competitions) {
+      setSnapshotProvider(null);
+      return;
+    }
+    const comps = tournament.competitions;
+    setSnapshotProvider((court) => {
+      if (!court) return null;
+      const slice = comps.filter(c => {
+        // A competition belongs to a court when ANY of its pool or bracket
+        // matches are assigned to that court. Quick check: if the comp
+        // exposes a courts[] array use it; otherwise scan poolMatches.
+        if (c.courts && Array.isArray(c.courts) && c.courts.includes(court)) return true;
+        if (c.poolMatches && c.poolMatches.some(m => m.court === court)) return true;
+        if (c.bracket && c.bracket.rounds) {
+          for (const round of c.bracket.rounds) {
+            if (round.some(m => m.court === court)) return true;
+          }
+        }
+        return false;
+      });
+      return slice.length > 0 ? slice : null;
+    });
+    return () => setSnapshotProvider(null);
+  }, [mode, tournament]);
 
   // mp-9h1f: while the shiaijo operator console is active (admin mode + shiaijo
   // view) the SSE handler skips its per-event aggregate refetch: the console
@@ -997,7 +1162,9 @@ function App() {
   // shown, no admin chrome leaks in, and the DisplayRoute owns its
   // own query-param routing (court=, overlay=, position=). The
   // tournament prop carries .competitions already (load() merges
-  // them), and `connected` is the SSE-status boolean from T063.
+  // them), and `connected` is the SSE-status boolean from T063 (for
+  // LobbyDisplay). `linkState` is the 3-state dot value for TvDisplay
+  // (mp-9ukk Phase 2): 'connected' | 'local' | 'stale'.
   if (mode === "display") {
     const DisplayRoute = window.DisplayRoute;
     if (!DisplayRoute) {
@@ -1011,6 +1178,7 @@ function App() {
         tournament={tournament}
         competitions={tournament.competitions || []}
         connected={sseConnected}
+        linkState={linkState}
       />
     );
   }

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -413,7 +413,7 @@ function App() {
   // mp-9ukk Phase 2: the display court parsed from ?court=. Tracked as state
   // (updated on popstate) so the display consumer effect re-runs and re-scopes
   // the bridge when the court changes without a full reload.
-  const [displayCourt, setDisplayCourtParam] = useS(() => parseCourtFromSearch());
+  const [displayCourt, setDisplayCourtState] = useS(() => parseCourtFromSearch());
   // Ref kept in sync with sseConnected so the 5 s display-mode ticker can
   // read the current value without closing over a stale copy from the effect
   // that has [mode] as its only dep. See the sync effect below.
@@ -530,7 +530,7 @@ function App() {
         setMode("display");
         // Re-read the court so an in-place back/forward to a different
         // ?court= re-scopes the bridge (the display effect depends on it).
-        setDisplayCourtParam(parseCourtFromSearch());
+        setDisplayCourtState(parseCourtFromSearch());
       } else {
         setMode("viewer");
         setViewerCompId(route.viewerCompId || null);
@@ -641,31 +641,44 @@ function App() {
         // tournament.name/courts for the header and tournament.competitions
         // for match rendering.
         setTournament(prev => {
-          if (!Array.isArray(msg.payload)) return prev;
-          const incomingComps = msg.payload;
-          if (!prev) {
-            // No server data yet: bootstrap entirely from the snapshot.
-            return { name: '', courts: [], competitions: incomingComps };
-          }
-          // Server data is already loaded: merge the operator snapshot into
-          // the existing tournament. Existing competitions ARE replaced by the
-          // operator snapshot (the operator tab is the court authority during
-          // an outage). The reconnect full-refetch restores server truth.
-          const existing = prev.competitions || [];
-          const merged = existing.slice();
-          for (const comp of incomingComps) {
-            const id = comp.id || (comp.config && (comp.config.id || comp.config.Id));
-            if (!id) continue;
-            const idx = merged.findIndex(c =>
-              c.id === id || (c.config && (c.config.id === id || c.config.Id === id))
-            );
-            if (idx === -1) {
-              merged.push(comp);
-            } else {
-              merged[idx] = comp;
+          try {
+            if (!Array.isArray(msg.payload)) return prev;
+            const incomingComps = msg.payload;
+            if (!prev) {
+              // No server data yet: bootstrap entirely from the snapshot. This
+              // path is unconditional (even if sseConnected is still its
+              // optimistic mount default) so a cold start during an outage is
+              // never starved of the operator snapshot.
+              return { name: '', courts: [], competitions: incomingComps };
             }
+            // Server data already loaded AND the SSE feed is up: the server is
+            // authoritative, so drop a late-arriving snapshot rather than let it
+            // overwrite the loaded server competitions with the operator tab's copy.
+            if (sseConnectedRef.current) return prev;
+            // Offline: merge the operator snapshot into the existing tournament.
+            // Existing competitions ARE replaced by the operator snapshot (the
+            // operator tab is the court authority during an outage). The
+            // reconnect full-refetch restores server truth.
+            const existing = prev.competitions || [];
+            const merged = existing.slice();
+            for (const comp of incomingComps) {
+              if (!comp || typeof comp !== 'object') continue;
+              const id = comp.id || (comp.config && (comp.config.id || comp.config.Id));
+              if (!id) continue;
+              const idx = merged.findIndex(c =>
+                c.id === id || (c.config && (c.config.id === id || c.config.Id === id))
+              );
+              if (idx === -1) {
+                merged.push(comp);
+              } else {
+                merged[idx] = comp;
+              }
+            }
+            return { ...prev, competitions: merged };
+          } catch (e) {
+            console.error('court_bridge: snapshot merge failed:', e);
+            return prev;
           }
-          return { ...prev, competitions: merged };
         });
       }
     });

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -407,6 +407,18 @@ function App() {
   // Derived from sseConnected + the bridge's last-broadcast recency in a tick.
   // The boolean sseConnected is kept for LobbyDisplay (unchanged scope).
   const [linkState, setLinkState] = useS('connected');
+  // Shared by the display-consumer effect (on mount/court-change and its 5 s
+  // ticker) and the sseConnected-sync effect below, all of which re-derive
+  // linkState from the same shape. Stable identity (no deps): freshnessMs is
+  // a module import, getLastBroadcastAt/setLinkState never change.
+  const refreshLinkState = useC((connected) => {
+    setLinkState(deriveLinkState({
+      sseConnected: connected,
+      lastBroadcastAt: getLastBroadcastAt(),
+      now: Date.now(),
+      freshnessMs,
+    }));
+  }, []);
   // mp-9ukk Phase 2: the display court parsed from ?court=. Tracked as state
   // (updated on popstate) so the display consumer effect re-runs and re-scopes
   // the bridge when the court changes without a full reload.
@@ -621,12 +633,7 @@ function App() {
     // ticker below) so switching ?court= does not keep showing the PREVIOUS
     // court's dot state. This reads the recency clock setDisplayCourt just
     // reset above, so a fresh court starts from its own (blank) state.
-    setLinkState(deriveLinkState({
-      sseConnected: sseConnectedRef.current,
-      lastBroadcastAt: getLastBroadcastAt(),
-      now: Date.now(),
-      freshnessMs,
-    }));
+    refreshLinkState(sseConnectedRef.current);
 
     // Use the module-level singleton (shared with api_client's publisher in
     // the same tab) so only one BroadcastChannel is opened per tab.
@@ -670,12 +677,7 @@ function App() {
     // is intentionally left OUT of this effect's deps so re-opening the bridge
     // does not drop in-flight snapshot replies.
     const ticker = setInterval(() => {
-      setLinkState(deriveLinkState({
-        sseConnected: sseConnectedRef.current,
-        lastBroadcastAt: getLastBroadcastAt(),
-        now: Date.now(),
-        freshnessMs,
-      }));
+      refreshLinkState(sseConnectedRef.current);
     }, 5000);
 
     return () => {
@@ -701,12 +703,7 @@ function App() {
   useE(() => {
     sseConnectedRef.current = sseConnected;
     if (mode !== 'display') return;
-    setLinkState(deriveLinkState({
-      sseConnected,
-      lastBroadcastAt: getLastBroadcastAt(),
-      now: Date.now(),
-      freshnessMs,
-    }));
+    refreshLinkState(sseConnected);
   }, [sseConnected, mode]);
 
   // Keep compsRef in sync with the latest competitions so the snapshot

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -160,6 +160,15 @@ export function setSnapshotProvider(fn) {
     _snapshotProvider = typeof fn === 'function' ? fn : null;
 }
 
+// Testing only: reset all module-level state so test suites that assert on
+// _lastBroadcastAt, _displayCourt, or _snapshotProvider do not depend on
+// test-execution order. Call in beforeEach of any suite that touches these.
+export function _resetModuleStateForTests() {
+    _lastBroadcastAt = null;
+    _displayCourt = null;
+    _snapshotProvider = null;
+}
+
 // -----------------------------------------------------------------------
 // openBridge: create a BroadcastChannel handle.
 //
@@ -196,24 +205,30 @@ export function openBridge() {
         // the requested court, reply with the court's competitions slice.
         if (msg.type === 'snapshot-req' && _snapshotProvider) {
             const court = msg.court || '';
-            const slice = _snapshotProvider(court);
-            if (slice && slice.length > 0) {
-                // Reply with one snapshot message per competition in the slice
-                // so the display can apply each one individually. We also send
-                // an aggregate snapshot (compId empty, payload = full slice) so
-                // the display can bootstrap its whole court view in one message.
-                channel.postMessage({
-                    v: 1,
-                    type: 'snapshot',
-                    origin: _tabId,
-                    court,
-                    compId: '',
-                    payload: slice,
-                });
-                _lastBroadcastAt = Date.now();
+            try {
+                const slice = _snapshotProvider(court);
+                if (slice && slice.length > 0) {
+                    // Reply with one aggregate snapshot (compId empty, payload = the
+                    // court's competitions slice) so the display bootstraps its whole
+                    // court view in one message.
+                    try {
+                        channel.postMessage({
+                            v: 1,
+                            type: 'snapshot',
+                            origin: _tabId,
+                            court,
+                            compId: '',
+                            payload: slice,
+                        });
+                        _lastBroadcastAt = Date.now();
+                    } catch (postErr) {
+                        console.error('court_bridge: snapshot postMessage failed:', postErr);
+                    }
+                }
+            } catch (providerErr) {
+                console.error('court_bridge: _snapshotProvider threw:', providerErr);
             }
-            // No return: also deliver the snapshot-req to registered handlers
-            // in case the caller wants to observe it.
+            return; // snapshot-req is fully handled here; do not forward to subscriber handlers
         }
 
         for (const h of handlers) {
@@ -228,17 +243,21 @@ export function openBridge() {
         //   compId : competition id (may be '' for snapshot-req)
         //   payload: message body
         publish(type, court, compId, payload) {
-            if (type === 'patch' || type === 'snapshot') {
-                _lastBroadcastAt = Date.now();
+            try {
+                channel.postMessage({
+                    v: 1,
+                    type,
+                    origin: _tabId,
+                    court: court || '',
+                    compId: compId || '',
+                    payload: payload || null,
+                });
+                if (type === 'patch' || type === 'snapshot') {
+                    _lastBroadcastAt = Date.now();
+                }
+            } catch (err) {
+                console.error('court_bridge: postMessage failed:', err);
             }
-            channel.postMessage({
-                v: 1,
-                type,
-                origin: _tabId,
-                court: court || '',
-                compId: compId || '',
-                payload: payload || null,
-            });
         },
 
         // onMessage: register an inbound message handler.

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -163,15 +163,19 @@ export function applyPatchToTree(tournament, msg) {
 // -----------------------------------------------------------------------
 export function mergeSnapshotIntoTree(prev, incomingComps, { connected } = {}) {
     if (!Array.isArray(incomingComps)) return prev;
+    // Keep only well-formed competitions (a resolvable id) up front, so BOTH the
+    // cold-start and the offline-merge paths are protected: a malformed or rogue
+    // same-origin snapshot can never inject null/primitive/id-less values into
+    // tournament.competitions.
+    const valid = incomingComps.filter(c => resolveCompId(c));
     if (!prev) {
-        return { name: '', courts: [], competitions: incomingComps };
+        return { name: '', courts: [], competitions: valid };
     }
     if (connected) return prev;
     const existing = prev.competitions || [];
     const merged = existing.slice();
-    for (const comp of incomingComps) {
+    for (const comp of valid) {
         const id = resolveCompId(comp);
-        if (!id) continue;
         const idx = merged.findIndex(c => resolveCompId(c) === id);
         if (idx === -1) {
             merged.push(comp);
@@ -291,7 +295,9 @@ export function openBridge() {
         if (msg.type === 'snapshot-req' && _snapshotProvider) {
             const court = msg.court || '';
             // One try/catch covers both the provider call and postMessage: either
-            // failing just logs and continues (the requester re-requests on its tick).
+            // failing just logs and continues. A dropped reply is recovered the
+            // next time the display publishes snapshot-req (on its effect mount or
+            // a court change); there is no periodic re-request.
             try {
                 const slice = _snapshotProvider(court);
                 if (slice && slice.length > 0) {

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -73,6 +73,19 @@ export function deriveLinkState({ sseConnected, lastBroadcastAt, now, freshnessM
 }
 
 // -----------------------------------------------------------------------
+// resolveCompId: read a competition's id regardless of shape.
+//
+// competitions[] entries carry their id at different depths depending on the
+// source: top-level `id` for the viewer aggregate, nested under `config` for
+// the detail endpoint (and a legacy capital-`Id` arm is tolerated). Returns ''
+// for a null/primitive entry or one with no id, so callers can `if (!id)`-skip.
+// -----------------------------------------------------------------------
+export function resolveCompId(c) {
+    if (!c || typeof c !== 'object') return '';
+    return c.id || (c.config && (c.config.id || c.config.Id)) || '';
+}
+
+// -----------------------------------------------------------------------
 // applyPatchToTree: tree-level adapter.
 //
 // Takes the full in-memory `tournament` (with `tournament.competitions[]`)
@@ -92,12 +105,9 @@ export function applyPatchToTree(tournament, msg) {
     if (!competitions || competitions.length === 0) return tournament;
 
     const compId = msg.compId;
-    const idx = competitions.findIndex(c => {
-        // competitions[] entries can have id at different depths depending
-        // on whether they come from the viewer aggregate or the detail endpoint.
-        return c.id === compId
-            || (c.config && (c.config.id === compId || c.config.Id === compId));
-    });
+    const idx = compId
+        ? competitions.findIndex(c => resolveCompId(c) === compId)
+        : -1;
     if (idx === -1) return tournament;
 
     const prevComp = competitions[idx];
@@ -123,6 +133,53 @@ export function applyPatchToTree(tournament, msg) {
     const nextCompetitions = competitions.slice();
     nextCompetitions[idx] = nextComp;
     return { ...tournament, competitions: nextCompetitions };
+}
+
+// -----------------------------------------------------------------------
+// mergeSnapshotIntoTree: fold an operator-tab court snapshot into the
+// display's in-memory tournament. Pure (and exported) so the merge policy
+// is unit-testable apart from the React effect that drives it.
+//
+//   prev          : current tournament (null/undefined before the first load)
+//   incomingComps : the snapshot payload (expected: array of competitions)
+//   connected     : whether the SSE feed is currently up
+//
+// Policy:
+//   - non-array payload          -> prev unchanged
+//   - no prev (cold start)       -> bootstrap a minimal tournament wrapper.
+//                                   UNCONDITIONAL by design: an outage AT LOAD
+//                                   must not be starved of the snapshot even
+//                                   when `connected` is still its optimistic
+//                                   mount default.
+//   - prev present AND connected -> prev unchanged: the server feed is
+//                                   authoritative, so a late snapshot is dropped
+//                                   rather than allowed to overwrite server data.
+//   - prev present AND offline   -> replace existing competitions by id, append
+//                                   any new ones (the operator tab is the court
+//                                   authority during an outage; the reconnect
+//                                   full-refetch later restores server truth).
+//
+// Null/primitive elements and elements with no resolvable id are skipped.
+// -----------------------------------------------------------------------
+export function mergeSnapshotIntoTree(prev, incomingComps, { connected } = {}) {
+    if (!Array.isArray(incomingComps)) return prev;
+    if (!prev) {
+        return { name: '', courts: [], competitions: incomingComps };
+    }
+    if (connected) return prev;
+    const existing = prev.competitions || [];
+    const merged = existing.slice();
+    for (const comp of incomingComps) {
+        const id = resolveCompId(comp);
+        if (!id) continue;
+        const idx = merged.findIndex(c => resolveCompId(c) === id);
+        if (idx === -1) {
+            merged.push(comp);
+        } else {
+            merged[idx] = comp;
+        }
+    }
+    return { ...prev, competitions: merged };
 }
 
 // -----------------------------------------------------------------------

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -117,10 +117,13 @@ export function applyPatchToTree(tournament, msg) {
         type: 'match_updated',
         data: msg.payload,
     };
-    // A malformed payload (e.g. results:[null]) can make _applyPatch throw.
-    // This runs inside a React state updater (deferred, outside any handler
-    // try/catch), so a throw here would crash the display board into the error
-    // boundary. Absorb it: a bad patch leaves the tree unchanged.
+    // patch.jsx's applyPatch filters null/id-less result entries before
+    // building its lookup Map, so a payload like results:[null] no longer
+    // throws. This try/catch is kept as defense-in-depth: it runs inside a
+    // React state updater (deferred, outside any handler try/catch) fed by
+    // arbitrary same-origin BroadcastChannel messages, so any future throw
+    // path in _applyPatch is still absorbed rather than crashing the display
+    // board into the error boundary.
     let nextComp;
     try {
         nextComp = _applyPatch(prevComp, syntheticEvent);
@@ -290,34 +293,40 @@ export function openBridge() {
             _lastBroadcastAt = Date.now();
         }
 
-        // Automatic snapshot-req responder: if this tab has a provider for
-        // the requested court, reply with the court's competitions slice.
-        if (msg.type === 'snapshot-req' && _snapshotProvider) {
-            const court = msg.court || '';
-            // One try/catch covers both the provider call and postMessage: either
-            // failing just logs and continues. A dropped reply is recovered the
-            // next time the display publishes snapshot-req (on its effect mount or
-            // a court change); there is no periodic re-request.
-            try {
-                const slice = _snapshotProvider(court);
-                if (slice && slice.length > 0) {
-                    // Reply with one aggregate snapshot (compId empty, payload = the
-                    // court's competitions slice) so the display bootstraps its whole
-                    // court view in one message.
-                    channel.postMessage({
-                        v: 1,
-                        type: 'snapshot',
-                        origin: _tabId,
-                        court,
-                        compId: '',
-                        payload: slice,
-                    });
-                    _lastBroadcastAt = Date.now();
+        // snapshot-req is always fully handled here (never forwarded to
+        // subscriber handlers below), whether or not this tab happens to have
+        // a provider registered: an unanswered snapshot-req has no meaning to
+        // any current subscriber (they only act on 'patch'/'snapshot'), so
+        // there is nothing to gain by passing it through.
+        if (msg.type === 'snapshot-req') {
+            if (_snapshotProvider) {
+                const court = msg.court || '';
+                // One try/catch covers both the provider call and postMessage:
+                // either failing just logs and continues. A dropped reply is
+                // recovered the next time the display publishes snapshot-req
+                // (on its effect mount or a court change); there is no
+                // periodic re-request.
+                try {
+                    const slice = _snapshotProvider(court);
+                    if (slice && slice.length > 0) {
+                        // Reply with one aggregate snapshot (compId empty, payload
+                        // = the court's competitions slice) so the display
+                        // bootstraps its whole court view in one message.
+                        channel.postMessage({
+                            v: 1,
+                            type: 'snapshot',
+                            origin: _tabId,
+                            court,
+                            compId: '',
+                            payload: slice,
+                        });
+                        _lastBroadcastAt = Date.now();
+                    }
+                } catch (err) {
+                    console.error('court_bridge: snapshot-req responder failed:', err);
                 }
-            } catch (err) {
-                console.error('court_bridge: snapshot-req responder failed:', err);
             }
-            return; // snapshot-req is fully handled here; do not forward to subscriber handlers
+            return;
         }
 
         for (const h of handlers) {

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -121,6 +121,21 @@ export function applyPatchToTree(tournament, msg) {
 // -----------------------------------------------------------------------
 let _lastBroadcastAt = null;
 
+// -----------------------------------------------------------------------
+// Court-scope filter for inbound recency tracking (FIX 2).
+//
+// When a display court is set, only patches/snapshots for that court
+// advance the recency clock. This prevents a court-B patch from making
+// the court-A display dot falsely show 'local'.
+// When null (operator tabs, no specific display court), all inbound
+// messages advance the clock.
+// -----------------------------------------------------------------------
+let _displayCourt = null;
+
+export function setDisplayCourt(c) {
+    _displayCourt = c || null;
+}
+
 // getLastBroadcastAt: read the module-level recency timestamp.
 // Called by app.jsx in its linkState-derivation tick.
 export function getLastBroadcastAt() {
@@ -169,8 +184,11 @@ export function openBridge() {
         // Self-echo suppression.
         if (msg.origin === _tabId) return;
 
-        // Update recency tracker on any inbound patch or snapshot data.
-        if (msg.type === 'patch' || msg.type === 'snapshot') {
+        // Update recency tracker on inbound patch or snapshot data.
+        // When a display court is set, only messages for that court advance
+        // the clock; when null (operator tabs) all inbound messages advance it.
+        if ((msg.type === 'patch' || msg.type === 'snapshot') &&
+            (!_displayCourt || msg.court === _displayCourt)) {
             _lastBroadcastAt = Date.now();
         }
 
@@ -238,3 +256,12 @@ export function openBridge() {
 
     return bridge;
 }
+
+// -----------------------------------------------------------------------
+// Singleton bridge: one shared BroadcastChannel handle per tab.
+// Both api_client.jsx (publisher) and app.jsx (display subscriber) import
+// this same reference so only one BroadcastChannel is opened per tab.
+// The no-op-degrade path inside openBridge() runs exactly once at module
+// load time.
+// -----------------------------------------------------------------------
+export const bridge = openBridge();

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -172,19 +172,30 @@ export function _resetModuleStateForTests() {
 // -----------------------------------------------------------------------
 // openBridge: create a BroadcastChannel handle.
 //
-// Returns a no-op object when BroadcastChannel is unavailable so all callers
-// work without guards.
+// Returns a no-op object when BroadcastChannel is unavailable OR when
+// constructing it throws (e.g. a SecurityError in a sandboxed/blocked
+// context), so all callers work without guards. This must not throw: the
+// module-level `bridge` singleton is created at import time, so a throw here
+// would crash the whole app instead of degrading to the SSE-only path.
 // -----------------------------------------------------------------------
+const _noopBridge = {
+    publish: () => {},
+    onMessage: () => () => {},
+    close: () => {},
+};
+
 export function openBridge() {
     if (typeof BroadcastChannel === 'undefined') {
-        return {
-            publish: () => {},
-            onMessage: () => () => {},
-            close: () => {},
-        };
+        return _noopBridge;
     }
 
-    const channel = new BroadcastChannel(CHANNEL_NAME);
+    let channel;
+    try {
+        channel = new BroadcastChannel(CHANNEL_NAME);
+    } catch (err) {
+        console.error('court_bridge: BroadcastChannel unavailable, degrading to SSE-only:', err);
+        return _noopBridge;
+    }
     const handlers = new Set();
 
     channel.onmessage = (evt) => {

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -85,7 +85,9 @@ export function deriveLinkState({ sseConnected, lastBroadcastAt, now, freshnessM
 // Returns the original `tournament` reference when nothing matched.
 // -----------------------------------------------------------------------
 export function applyPatchToTree(tournament, msg) {
-    if (!tournament || !msg || msg.type !== 'patch') return tournament;
+    // A patch with no payload is a no-op: bail before the findIndex scan and
+    // before _applyPatch can dereference a missing payload.
+    if (!tournament || !msg || msg.type !== 'patch' || !msg.payload) return tournament;
     const competitions = tournament.competitions;
     if (!competitions || competitions.length === 0) return tournament;
 
@@ -105,7 +107,17 @@ export function applyPatchToTree(tournament, msg) {
         type: 'match_updated',
         data: msg.payload,
     };
-    const nextComp = _applyPatch(prevComp, syntheticEvent);
+    // A malformed payload (e.g. results:[null]) can make _applyPatch throw.
+    // This runs inside a React state updater (deferred, outside any handler
+    // try/catch), so a throw here would crash the display board into the error
+    // boundary. Absorb it: a bad patch leaves the tree unchanged.
+    let nextComp;
+    try {
+        nextComp = _applyPatch(prevComp, syntheticEvent);
+    } catch (err) {
+        console.error('court_bridge: applyPatch failed for a malformed payload:', err);
+        return tournament;
+    }
     if (nextComp === prevComp) return tournament;
 
     const nextCompetitions = competitions.slice();
@@ -133,7 +145,12 @@ let _lastBroadcastAt = null;
 let _displayCourt = null;
 
 export function setDisplayCourt(c) {
-    _displayCourt = c || null;
+    const next = c || null;
+    // Reset the recency clock when the court actually changes so the dot does
+    // not inherit the previous court's freshness: after a ?court= switch the
+    // new court starts 'stale' until its own operator broadcasts.
+    if (_displayCourt !== next) _lastBroadcastAt = null;
+    _displayCourt = next;
 }
 
 // getLastBroadcastAt: read the module-level recency timestamp.
@@ -216,28 +233,26 @@ export function openBridge() {
         // the requested court, reply with the court's competitions slice.
         if (msg.type === 'snapshot-req' && _snapshotProvider) {
             const court = msg.court || '';
+            // One try/catch covers both the provider call and postMessage: either
+            // failing just logs and continues (the requester re-requests on its tick).
             try {
                 const slice = _snapshotProvider(court);
                 if (slice && slice.length > 0) {
                     // Reply with one aggregate snapshot (compId empty, payload = the
                     // court's competitions slice) so the display bootstraps its whole
                     // court view in one message.
-                    try {
-                        channel.postMessage({
-                            v: 1,
-                            type: 'snapshot',
-                            origin: _tabId,
-                            court,
-                            compId: '',
-                            payload: slice,
-                        });
-                        _lastBroadcastAt = Date.now();
-                    } catch (postErr) {
-                        console.error('court_bridge: snapshot postMessage failed:', postErr);
-                    }
+                    channel.postMessage({
+                        v: 1,
+                        type: 'snapshot',
+                        origin: _tabId,
+                        court,
+                        compId: '',
+                        payload: slice,
+                    });
+                    _lastBroadcastAt = Date.now();
                 }
-            } catch (providerErr) {
-                console.error('court_bridge: _snapshotProvider threw:', providerErr);
+            } catch (err) {
+                console.error('court_bridge: snapshot-req responder failed:', err);
             }
             return; // snapshot-req is fully handled here; do not forward to subscriber handlers
         }
@@ -245,6 +260,12 @@ export function openBridge() {
         for (const h of handlers) {
             try { h(msg); } catch (err) { console.error('court_bridge handler error:', err); }
         }
+    };
+
+    // Surface structured-clone deserialization failures (otherwise the browser
+    // swallows them silently) so a bad cross-tab message is visible in DevTools.
+    channel.onmessageerror = (evt) => {
+        console.error('court_bridge: message deserialization error:', evt);
     };
 
     const bridge = {

--- a/web-mobile/js/court_bridge.jsx
+++ b/web-mobile/js/court_bridge.jsx
@@ -1,0 +1,240 @@
+// court_bridge.jsx: BroadcastChannel-based court-local data hub.
+//
+// Phase 2 of the mp-gpra flaky-wifi hardening initiative (mp-9ukk). When
+// the server link is down, the operator tab becomes the display tab's local
+// data hub: match patches are broadcast on confirm or enqueue, and the
+// display tab can bootstrap from the operator tab's competition snapshot on
+// cold load.
+//
+// ## Message schema (versioned)
+//
+//   { v: 1, type: 'patch'|'snapshot-req'|'snapshot',
+//     origin: <string tabId>,
+//     court:  <string, e.g. "A">,
+//     compId: <string>,          // patch + snapshot; empty for snapshot-req
+//     payload: <object|null> }   // match-patch event data | court slice of competitions
+//
+// ## Self-echo suppression
+//
+// Each tab generates a random `_tabId` on first import. Outbound messages
+// carry `origin: _tabId`. Inbound messages where `msg.origin === _tabId`
+// are silently dropped so no tab reacts to its own broadcasts.
+//
+// ## Snapshot handshake
+//
+// On load, the display tab publishes `snapshot-req` for its court. Any
+// operator tab that has registered a snapshot provider via
+// `setSnapshotProvider(fn)` replies with a `snapshot` containing that
+// court's competitions slice. If multiple operator tabs answer, the display
+// uses the first reply (the update is idempotent: same court data).
+//
+// ## Graceful degrade
+//
+// When BroadcastChannel is unavailable (very old browser) openBridge()
+// returns a no-op handle. Behavior degrades to today's SSE-only flow with
+// no regression.
+
+import { applyPatch as _applyPatch } from './patch.jsx';
+
+// freshnessMs: the amber->red dot threshold.
+// 20 s sits below the 35 s SSE silence watchdog and above the 15 s SSE
+// heartbeat, so a quiet (but open) operator tab does NOT flap to stale
+// between matches, yet a crashed/closed operator tab becomes stale promptly.
+// Exported as a named constant so tests and callers share one value.
+export const freshnessMs = 20000;
+
+// BroadcastChannel name. All same-origin tabs share one channel; messages
+// are scoped by the `court` field inside each message payload.
+const CHANNEL_NAME = 'bc-court-hub-v1';
+
+// Module-level tab identity. Stable for the lifetime of this module instance
+// (one per tab). crypto.randomUUID is available in modern browsers and jsdom.
+export const _tabId = (typeof crypto !== 'undefined' && crypto.randomUUID)
+    ? crypto.randomUUID()
+    : `t${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+// -----------------------------------------------------------------------
+// deriveLinkState: pure exported function so vitest can test it without
+// mounting any component.
+//
+// Returns:
+//   'connected' : SSE to server is up (sseConnected === true)
+//   'local'     : server down, but operator-tab broadcast is fresh
+//                 (lastBroadcastAt within freshnessMs of now)
+//   'stale'     : no server AND no recent operator broadcast
+//
+// `fm` defaults to the module constant so callers can pass a custom value
+// for testing without altering the module-level default.
+// -----------------------------------------------------------------------
+export function deriveLinkState({ sseConnected, lastBroadcastAt, now, freshnessMs: fm = freshnessMs }) {
+    if (sseConnected) return 'connected';
+    if (lastBroadcastAt !== null && (now - lastBroadcastAt) < fm) return 'local';
+    return 'stale';
+}
+
+// -----------------------------------------------------------------------
+// applyPatchToTree: tree-level adapter.
+//
+// Takes the full in-memory `tournament` (with `tournament.competitions[]`)
+// plus one broadcast `msg` (type: 'patch', compId, payload), locates the
+// competition by `compId`, delegates the single-competition merge to the
+// existing `applyPatch` from patch.jsx, and returns a new tournament object.
+//
+// Only the touched competition changes reference; all other competitions
+// and the surrounding tournament fields are preserved by shallow spread.
+// Returns the original `tournament` reference when nothing matched.
+// -----------------------------------------------------------------------
+export function applyPatchToTree(tournament, msg) {
+    if (!tournament || !msg || msg.type !== 'patch') return tournament;
+    const competitions = tournament.competitions;
+    if (!competitions || competitions.length === 0) return tournament;
+
+    const compId = msg.compId;
+    const idx = competitions.findIndex(c => {
+        // competitions[] entries can have id at different depths depending
+        // on whether they come from the viewer aggregate or the detail endpoint.
+        return c.id === compId
+            || (c.config && (c.config.id === compId || c.config.Id === compId));
+    });
+    if (idx === -1) return tournament;
+
+    const prevComp = competitions[idx];
+    // Wrap the broadcast payload in a synthetic SSE match_updated envelope
+    // so applyPatch (which expects {type, data}) can process it directly.
+    const syntheticEvent = {
+        type: 'match_updated',
+        data: msg.payload,
+    };
+    const nextComp = _applyPatch(prevComp, syntheticEvent);
+    if (nextComp === prevComp) return tournament;
+
+    const nextCompetitions = competitions.slice();
+    nextCompetitions[idx] = nextComp;
+    return { ...tournament, competitions: nextCompetitions };
+}
+
+// -----------------------------------------------------------------------
+// Module-level recency tracker. Shared across all bridge instances in this
+// tab (there should only ever be one open bridge per tab in normal use).
+// Updated on every outbound patch/snapshot AND every inbound patch/snapshot,
+// so the display tab's recency clock also advances when it receives a reply.
+// -----------------------------------------------------------------------
+let _lastBroadcastAt = null;
+
+// getLastBroadcastAt: read the module-level recency timestamp.
+// Called by app.jsx in its linkState-derivation tick.
+export function getLastBroadcastAt() {
+    return _lastBroadcastAt;
+}
+
+// -----------------------------------------------------------------------
+// Module-level snapshot provider registry.
+//
+// The operator tab calls setSnapshotProvider(fn) after loading its
+// competition data. When a snapshot-req arrives, openBridge replies
+// automatically using this provider. Only one provider is registered at a
+// time; re-registering replaces the previous one (correct because one
+// operator tab drives one court).
+//
+// fn signature: (court: string) => competitions[] | null
+//   Return null when the tab has no data for the requested court.
+// -----------------------------------------------------------------------
+let _snapshotProvider = null;
+
+export function setSnapshotProvider(fn) {
+    _snapshotProvider = typeof fn === 'function' ? fn : null;
+}
+
+// -----------------------------------------------------------------------
+// openBridge: create a BroadcastChannel handle.
+//
+// Returns a no-op object when BroadcastChannel is unavailable so all callers
+// work without guards.
+// -----------------------------------------------------------------------
+export function openBridge() {
+    if (typeof BroadcastChannel === 'undefined') {
+        return {
+            publish: () => {},
+            onMessage: () => () => {},
+            close: () => {},
+        };
+    }
+
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    const handlers = new Set();
+
+    channel.onmessage = (evt) => {
+        const msg = evt.data;
+        if (!msg || msg.v !== 1) return;
+        // Self-echo suppression.
+        if (msg.origin === _tabId) return;
+
+        // Update recency tracker on any inbound patch or snapshot data.
+        if (msg.type === 'patch' || msg.type === 'snapshot') {
+            _lastBroadcastAt = Date.now();
+        }
+
+        // Automatic snapshot-req responder: if this tab has a provider for
+        // the requested court, reply with the court's competitions slice.
+        if (msg.type === 'snapshot-req' && _snapshotProvider) {
+            const court = msg.court || '';
+            const slice = _snapshotProvider(court);
+            if (slice && slice.length > 0) {
+                // Reply with one snapshot message per competition in the slice
+                // so the display can apply each one individually. We also send
+                // an aggregate snapshot (compId empty, payload = full slice) so
+                // the display can bootstrap its whole court view in one message.
+                channel.postMessage({
+                    v: 1,
+                    type: 'snapshot',
+                    origin: _tabId,
+                    court,
+                    compId: '',
+                    payload: slice,
+                });
+                _lastBroadcastAt = Date.now();
+            }
+            // No return: also deliver the snapshot-req to registered handlers
+            // in case the caller wants to observe it.
+        }
+
+        for (const h of handlers) {
+            try { h(msg); } catch (err) { console.error('court_bridge handler error:', err); }
+        }
+    };
+
+    const bridge = {
+        // publish: send a versioned message on the channel.
+        //   type   : 'patch' | 'snapshot-req' | 'snapshot'
+        //   court  : court label e.g. "A"
+        //   compId : competition id (may be '' for snapshot-req)
+        //   payload: message body
+        publish(type, court, compId, payload) {
+            if (type === 'patch' || type === 'snapshot') {
+                _lastBroadcastAt = Date.now();
+            }
+            channel.postMessage({
+                v: 1,
+                type,
+                origin: _tabId,
+                court: court || '',
+                compId: compId || '',
+                payload: payload || null,
+            });
+        },
+
+        // onMessage: register an inbound message handler.
+        // Returns an unsubscribe function.
+        onMessage(handler) {
+            handlers.add(handler);
+            return () => handlers.delete(handler);
+        },
+
+        close() {
+            handlers.clear();
+            channel.close();
+        },
+    };
+
+    return bridge;
+}

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -43,23 +43,20 @@ import {
 // hiding the layout on outage. app.jsx owns both values and feeds them down.
 function DisplayRoute({ tournament, competitions, connected = true, linkState = 'connected' }) {
     const useQuery = window.AppRouter?.useQuery;
-    const query = useQuery ? useQuery() : (() => {
-        if (typeof window === 'undefined') return {};
-        const s = window.location.search || '';
-        const out = {};
-        if (s.length < 2) return out;
-        // decodeURIComponent throws on malformed percent-encoding; fall back to
-        // the raw substring so a crafted ?court= cannot crash the display board.
-        const dec = (v) => { try { return decodeURIComponent(v); } catch (_e) { return v; } };
-        const trimmed = s.startsWith('?') ? s.slice(1) : s;
-        for (const pair of trimmed.split('&')) {
-            if (!pair) continue;
-            const eq = pair.indexOf('=');
-            if (eq === -1) out[dec(pair)] = '';
-            else out[dec(pair.slice(0, eq))] = dec(pair.slice(eq + 1));
-        }
-        return out;
-    })();
+    // Prefer the reactive useQuery hook (re-renders on popstate). If
+    // window.AppRouter hasn't been set yet (e.g. a component test that renders
+    // DisplayRoute without loading router.jsx as a script), fall back to a
+    // one-time parse via the SAME canonical AppRouter.parseSearch rather than a
+    // second hand-rolled copy of the query-string loop, which would otherwise
+    // drift from router.jsx's implementation over time. useQuery and
+    // parseSearch are set together on window.AppRouter (router.jsx), so if
+    // AppRouter is present at all, parseSearch is present too; only a fully
+    // absent AppRouter (or a non-browser context) degrades to {}.
+    const query = useQuery
+        ? useQuery()
+        : (typeof window !== 'undefined' && window.AppRouter?.parseSearch
+            ? window.AppRouter.parseSearch(window.location.search || '')
+            : {});
     const courtRaw = (query.court || 'A');
     const overlay = query.overlay === 'true' || query.overlay === '1';
     const position = query.position === 'top' ? 'top' : 'bottom';

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -48,12 +48,15 @@ function DisplayRoute({ tournament, competitions, connected = true, linkState = 
         const s = window.location.search || '';
         const out = {};
         if (s.length < 2) return out;
+        // decodeURIComponent throws on malformed percent-encoding; fall back to
+        // the raw substring so a crafted ?court= cannot crash the display board.
+        const dec = (v) => { try { return decodeURIComponent(v); } catch (_e) { return v; } };
         const trimmed = s.startsWith('?') ? s.slice(1) : s;
         for (const pair of trimmed.split('&')) {
             if (!pair) continue;
             const eq = pair.indexOf('=');
-            if (eq === -1) out[decodeURIComponent(pair)] = '';
-            else out[decodeURIComponent(pair.slice(0, eq))] = decodeURIComponent(pair.slice(eq + 1));
+            if (eq === -1) out[dec(pair)] = '';
+            else out[dec(pair.slice(0, eq))] = dec(pair.slice(eq + 1));
         }
         return out;
     })();

--- a/web-mobile/js/display.jsx
+++ b/web-mobile/js/display.jsx
@@ -36,10 +36,12 @@ import {
 // position → "bottom". Both "true" and "1" toggle overlay mode so the
 // OBS muscle-memory ?overlay=1 form works alongside ?overlay=true.
 //
-// `connected` is forwarded so the per-court / lobby surfaces can show
-// the SSE reconnect indicator. app.jsx owns the EventSource lifecycle
-// and feeds the boolean down through the AppRouter props.
-function DisplayRoute({ tournament, competitions, connected = true }) {
+// `connected` (boolean) is forwarded to LobbyDisplay for the SSE reconnect
+// indicator. `linkState` (3-state: 'connected'|'local'|'stale') is forwarded
+// to TvDisplay (mp-9ukk Phase 2): the per-court board shows a small coloured
+// dot that distinguishes server-fresh vs operator-broadcast vs no feed, without
+// hiding the layout on outage. app.jsx owns both values and feeds them down.
+function DisplayRoute({ tournament, competitions, connected = true, linkState = 'connected' }) {
     const useQuery = window.AppRouter?.useQuery;
     const query = useQuery ? useQuery() : (() => {
         if (typeof window === 'undefined') return {};
@@ -68,7 +70,7 @@ function DisplayRoute({ tournament, competitions, connected = true }) {
     if (court === 'ALL') {
         return <LobbyDisplay tournament={tournament} competitions={competitions} connected={connected} />;
     }
-    return <TvDisplay court={court} tournament={tournament} competitions={competitions} connected={connected} />;
+    return <TvDisplay court={court} tournament={tournament} competitions={competitions} linkState={linkState} />;
 }
 
 export {

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -33,8 +33,9 @@ function emptyStateHeadline(allCompleted, noMatches) {
 // LinkDot: 3-state connection indicator (mp-9ukk Phase 2).
 // 'connected' renders NOTHING (a healthy, server-fresh board shows no dot);
 // 'local' → amber dot (operator broadcast fresh, server down); 'stale' → red
-// dot (no feed). A small static circle with no label keeps the board
-// uncluttered; the colour alone conveys the degraded state to venue staff.
+// dot WITH a dark ring (no feed). A small static circle keeps the board
+// uncluttered; the two degraded states are told apart by treatment (the ring),
+// not hue alone, and each carries an aria-label for assistive tech.
 function LinkDot({ linkState }) {
     if (linkState === 'connected') return null;
     const isStale = linkState === 'stale';

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -743,4 +743,4 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, linkState 
     );
 }
 
-export { TvDisplay, TvWhiteBoard, TvIndividualBoard, gatherIndividualGroup, findNextPoolOnCourt, emptyStateHeadline };
+export { TvDisplay, TvWhiteBoard, TvIndividualBoard, gatherIndividualGroup, findNextPoolOnCourt, emptyStateHeadline, LinkDot };

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -37,17 +37,22 @@ function emptyStateHeadline(allCompleted, noMatches) {
 // uncluttered; the two degraded states are told apart by treatment (the ring),
 // not hue alone, and each carries an aria-label for assistive tech.
 function LinkDot({ linkState }) {
-    if (linkState === 'connected') return null;
+    const connected = linkState === 'connected';
     const isStale = linkState === 'stale';
     // 'local' uses var(--warn, #b45309); 'stale' uses var(--danger, #dc2626).
     // Per DESIGN.md principle 2, the two degraded states are distinguished by
     // TREATMENT, not hue alone (so the meaning survives projector glare and
     // colour-blindness): 'stale' carries a dark ring, 'local' is a plain dot.
+    // When connected we keep the element but make it invisible (visibility
+    // hidden, aria-hidden) so the header reserves the dot's space and the
+    // subtitle does not shift horizontally as the state toggles.
     const bg = isStale ? 'var(--danger, #dc2626)' : 'var(--warn, #b45309)';
     const label = isStale ? 'No data feed' : 'Operator broadcast (server offline)';
     return (
-        <span data-testid="display-link-dot" data-link-state={linkState} role="status" aria-label={label}
-            style={{ width: '1.4vh', height: '1.4vh', borderRadius: '50%', background: bg, display: 'inline-block', flexShrink: 0, boxShadow: isStale ? '0 0 0 0.3vh var(--ink-1, #111827)' : 'none' }} />
+        <span data-testid="display-link-dot" data-link-state={linkState}
+            role={connected ? undefined : 'status'} aria-label={connected ? undefined : label}
+            aria-hidden={connected ? 'true' : undefined}
+            style={{ width: '1.4vh', height: '1.4vh', borderRadius: '50%', background: connected ? 'transparent' : bg, display: 'inline-block', flexShrink: 0, boxShadow: isStale ? '0 0 0 0.3vh var(--ink-1, #111827)' : 'none', visibility: connected ? 'hidden' : 'visible' }} />
     );
 }
 

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -37,12 +37,16 @@ function emptyStateHeadline(allCompleted, noMatches) {
 // uncluttered; the colour alone conveys the degraded state to venue staff.
 function LinkDot({ linkState }) {
     if (linkState === 'connected') return null;
-    // 'local' uses var(--warn, #b45309); 'stale' uses var(--danger, #dc2626)
-    const bg = linkState === 'local' ? 'var(--warn, #b45309)' : 'var(--danger, #dc2626)';
-    const label = linkState === 'local' ? 'Operator broadcast (server offline)' : 'No data feed';
+    const isStale = linkState === 'stale';
+    // 'local' uses var(--warn, #b45309); 'stale' uses var(--danger, #dc2626).
+    // Per DESIGN.md principle 2, the two degraded states are distinguished by
+    // TREATMENT, not hue alone (so the meaning survives projector glare and
+    // colour-blindness): 'stale' carries a dark ring, 'local' is a plain dot.
+    const bg = isStale ? 'var(--danger, #dc2626)' : 'var(--warn, #b45309)';
+    const label = isStale ? 'No data feed' : 'Operator broadcast (server offline)';
     return (
         <span data-testid="display-link-dot" data-link-state={linkState} role="status" aria-label={label}
-            style={{ width: '1.4vh', height: '1.4vh', borderRadius: '50%', background: bg, display: 'inline-block', flexShrink: 0 }} />
+            style={{ width: '1.4vh', height: '1.4vh', borderRadius: '50%', background: bg, display: 'inline-block', flexShrink: 0, boxShadow: isStale ? '0 0 0 0.3vh var(--ink-1, #111827)' : 'none' }} />
     );
 }
 

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -30,7 +30,24 @@ function emptyStateHeadline(allCompleted, noMatches) {
 // and a single "Next" line. Individual matches, empty states and the lobby
 // keep the existing dark surface (no mockup for those).
 
-function TvWhiteBoard({ tournament, court, connected, promoted, isTeamMatch, subResults, lineupA, lineupB, teamSize, showDH, queueMatches, zekken }) {
+// LinkDot: 3-state connection indicator (mp-9ukk Phase 2).
+// 'connected' → green dot (server reachable); 'local' → amber dot (operator
+// broadcast fresh, server down); 'stale' → red dot (no feed). A small
+// static circle with no label keeps the board uncluttered; the colour
+// alone conveys the state to venue staff. Hidden when linkState is
+// 'connected' so a server-fresh board shows nothing.
+function LinkDot({ linkState }) {
+    if (linkState === 'connected') return null;
+    // 'local' uses var(--warn, #b45309); 'stale' uses var(--danger, #dc2626)
+    const bg = linkState === 'local' ? 'var(--warn, #b45309)' : 'var(--danger, #dc2626)';
+    const label = linkState === 'local' ? 'Operator broadcast (server offline)' : 'No data feed';
+    return (
+        <span data-testid="display-link-dot" data-link-state={linkState} role="status" aria-label={label}
+            style={{ width: '1.4vh', height: '1.4vh', borderRadius: '50%', background: bg, display: 'inline-block', flexShrink: 0 }} />
+    );
+}
+
+function TvWhiteBoard({ tournament, court, linkState = 'connected', promoted, isTeamMatch, subResults, lineupA, lineupB, teamSize, showDH, queueMatches, zekken }) {
     const shiroTeam = sideLabel(promoted.match.sideB, zekken);
     const akaTeam = sideLabel(promoted.match.sideA, zekken);
     // Daihyosen / tiebreaker rep bout (mp-62vr): SideA/SideB are TEAM names, but
@@ -65,15 +82,11 @@ function TvWhiteBoard({ tournament, court, connected, promoted, isTeamMatch, sub
                 </div>
                 <div style={{ display: "flex", gap: "1.5vw", alignItems: "center", fontSize: "2.2vh", color: "var(--ink-3)" }}>
                     <span>{headerSubtitle}</span>
-                    {/* mp-13y #9: no "UP NEXT" badge: the promoted match is shown
+                    {/* mp-9ukk Phase 2: 3-state dot. Hidden when connected;
+                        amber when operator-broadcast is fresh; red when stale.
+                        mp-13y #9: no "UP NEXT" badge: the promoted match is shown
                         plainly (the NEXT line below still lists what follows). */}
-                    {!connected && (
-                        <span data-testid="display-reconnect" role="status" aria-label="Reconnecting"
-                            style={{ display: "inline-flex", alignItems: "center", gap: "0.6vw", background: "#fef3c7", color: "#b45309", padding: "0.4vh 1vw", borderRadius: "0.4vw", fontSize: "1.6vh", fontWeight: 700 }}>
-                            <span style={{ width: "1.2vh", height: "1.2vh", borderRadius: "50%", background: "#b45309", display: "inline-block" }} />
-                            RECONNECTING
-                        </span>
-                    )}
+                    <LinkDot linkState={linkState} />
                 </div>
             </div>
 
@@ -295,7 +308,7 @@ function windowAroundCurrent(all, currentIdx, max) {
 // pool phase as completed → current → scheduled, so the current match sits
 // among its upcoming matches; windowAroundCurrent keeps it on screen when the
 // group overflows the visible cap (no animation). FIK §263.
-function TvIndividualBoard({ tournament, court, connected, promoted, queueMatches, zekken }) {
+function TvIndividualBoard({ tournament, court, linkState = 'connected', promoted, queueMatches, zekken }) {
     const all = gatherIndividualGroup(promoted, court);
     const currentIdx = all.findIndex(m => m.id === promoted.match.id || m.status === "running");
     // A league is one big round-robin table: showing its whole match list would
@@ -342,13 +355,9 @@ function TvIndividualBoard({ tournament, court, connected, promoted, queueMatche
                 </div>
                 <div style={{ display: "flex", gap: "1.5vw", alignItems: "center", fontSize: "2.2vh", color: "var(--ink-3)" }}>
                     <span>{promoted.competition?.name || ""}</span>
-                    {!connected && (
-                        <span data-testid="display-reconnect" role="status" aria-label="Reconnecting"
-                            style={{ display: "inline-flex", alignItems: "center", gap: "0.6vw", background: "#fef3c7", color: "#b45309", padding: "0.4vh 1vw", borderRadius: "0.4vw", fontSize: "1.6vh", fontWeight: 700 }}>
-                            <span style={{ width: "1.2vh", height: "1.2vh", borderRadius: "50%", background: "#b45309", display: "inline-block" }} />
-                            RECONNECTING
-                        </span>
-                    )}
+                    {/* mp-9ukk Phase 2: 3-state dot. Hidden when connected;
+                        amber when operator-broadcast is fresh; red when stale. */}
+                    <LinkDot linkState={linkState} />
                 </div>
             </div>
 
@@ -483,7 +492,7 @@ function TvIndividualBoard({ tournament, court, connected, promoted, queueMatche
 // EventSource. When it flips false we render a small amber pill so the
 // venue knows the screen has gone stale; the rest of the layout stays
 // put so reconnect doesn't flash the layout.
-function TvDisplay({ court, tournament, competitions, withZekkenName, connected = true }) {
+function TvDisplay({ court, tournament, competitions, withZekkenName, linkState = 'connected' }) {
     const running = useMD(() => findRunningOnCourt(competitions, court), [competitions, court]);
     const upcoming = useMD(() => findUpcomingOnCourt(competitions, court, running ? 2 : 3), [competitions, court, running]);
     const counts = useMD(() => countCourtMatches(competitions, court), [competitions, court]);
@@ -605,7 +614,7 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
     if (promoted) {
         if (isTeamMatch) {
             return <TvWhiteBoard
-                tournament={tournament} court={court} connected={connected}
+                tournament={tournament} court={court} linkState={linkState}
                 promoted={promoted} isTeamMatch={isTeamMatch}
                 subResults={subResults} lineupA={lineupA} lineupB={lineupB} teamSize={teamSize}
                 showDH={showDH} queueMatches={queueMatches} zekken={zekken}
@@ -618,14 +627,14 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
         // the rep bout's ippon slots).
         if (supplementaryBout && isTeamComp) {
             return <TvWhiteBoard
-                tournament={tournament} court={court} connected={connected}
+                tournament={tournament} court={court} linkState={linkState}
                 promoted={promoted} isTeamMatch={false}
                 subResults={subResults} lineupA={lineupA} lineupB={lineupB} teamSize={teamSize}
                 showDH={false} queueMatches={queueMatches} zekken={zekken}
             />;
         }
         return <TvIndividualBoard
-            tournament={tournament} court={court} connected={connected}
+            tournament={tournament} court={court} linkState={linkState}
             promoted={promoted} queueMatches={queueMatches} zekken={zekken}
         />;
     }
@@ -659,13 +668,9 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, connected 
             {/* Court header + black rule */}
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "3px solid #111", paddingBottom: "1.4vh", marginBottom: "2.4vh", fontSize: "2.6vh", fontWeight: 700, letterSpacing: "0.08em" }}>
                 <div>{tournament?.name ? tournament.name + " · " : ""}SHIAIJO {court}</div>
-                {!connected && (
-                    <span data-testid="display-reconnect" role="status" aria-label="Reconnecting"
-                        style={{ display: "inline-flex", alignItems: "center", gap: "0.6vw", background: "#fef3c7", color: "#b45309", padding: "0.4vh 1vw", borderRadius: "0.4vw", fontSize: "1.6vh", fontWeight: 700 }}>
-                        <span style={{ width: "1.2vh", height: "1.2vh", borderRadius: "50%", background: "#b45309", display: "inline-block" }} />
-                        RECONNECTING
-                    </span>
-                )}
+                {/* mp-9ukk Phase 2: 3-state dot on empty-state board. Hidden
+                    when connected; amber when operator-broadcast fresh; red stale. */}
+                <LinkDot linkState={linkState} />
             </div>
 
             {/* Centre block: anchored slightly above dead-centre */}

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -31,11 +31,13 @@ function emptyStateHeadline(allCompleted, noMatches) {
 // keep the existing dark surface (no mockup for those).
 
 // LinkDot: 3-state connection indicator (mp-9ukk Phase 2).
-// 'connected' renders NOTHING (a healthy, server-fresh board shows no dot);
-// 'local' → amber dot (operator broadcast fresh, server down); 'stale' → red
-// dot WITH a dark ring (no feed). A small static circle keeps the board
-// uncluttered; the two degraded states are told apart by treatment (the ring),
-// not hue alone, and each carries an aria-label for assistive tech.
+// 'connected' renders an INVISIBLE span (visibility:hidden + transparent), not
+// nothing: it still reserves the dot's layout space so the header does not
+// reflow when the state changes, but a healthy, server-fresh board shows no
+// visible dot. 'local' → amber dot (operator broadcast fresh, server down);
+// 'stale' → red dot WITH a dark ring (no feed). A small static circle keeps
+// the board uncluttered; the two degraded states are told apart by treatment
+// (the ring), not hue alone, and each carries an aria-label for assistive tech.
 function LinkDot({ linkState }) {
     const connected = linkState === 'connected';
     const isStale = linkState === 'stale';

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -31,11 +31,10 @@ function emptyStateHeadline(allCompleted, noMatches) {
 // keep the existing dark surface (no mockup for those).
 
 // LinkDot: 3-state connection indicator (mp-9ukk Phase 2).
-// 'connected' → green dot (server reachable); 'local' → amber dot (operator
-// broadcast fresh, server down); 'stale' → red dot (no feed). A small
-// static circle with no label keeps the board uncluttered; the colour
-// alone conveys the state to venue staff. Hidden when linkState is
-// 'connected' so a server-fresh board shows nothing.
+// 'connected' renders NOTHING (a healthy, server-fresh board shows no dot);
+// 'local' → amber dot (operator broadcast fresh, server down); 'stale' → red
+// dot (no feed). A small static circle with no label keeps the board
+// uncluttered; the colour alone conveys the degraded state to venue staff.
 function LinkDot({ linkState }) {
     if (linkState === 'connected') return null;
     // 'local' uses var(--warn, #b45309); 'stale' uses var(--danger, #dc2626)
@@ -487,11 +486,12 @@ function TvIndividualBoard({ tournament, court, linkState = 'connected', promote
 // These are mutually exclusive: completed > 0 AND no running/scheduled →
 // "completed"; otherwise zero matches at all → "nothing".
 //
-// Reconnect indicator (T063 / FR-011 scenario 4): the `connected` prop
-// (defaults to true) is wired from app.jsx which owns the SSE
-// EventSource. When it flips false we render a small amber pill so the
-// venue knows the screen has gone stale; the rest of the layout stays
-// put so reconnect doesn't flash the layout.
+// Link indicator (mp-9ukk): the `linkState` prop ('connected' | 'local' |
+// 'stale'), wired from app.jsx which owns both the SSE EventSource and the
+// court broadcast recency, drives the discreet LinkDot in the header. The dot
+// is hidden when connected, amber when court-local (server down but the
+// operator broadcast is fresh), and red when stale. The rest of the layout
+// stays put so a state change doesn't reflow the board.
 function TvDisplay({ court, tournament, competitions, withZekkenName, linkState = 'connected' }) {
     const running = useMD(() => findRunningOnCourt(competitions, court), [competitions, court]);
     const upcoming = useMD(() => findUpcomingOnCourt(competitions, court, running ? 2 : 3), [competitions, court, running]);

--- a/web-mobile/js/patch.jsx
+++ b/web-mobile/js/patch.jsx
@@ -340,7 +340,14 @@ function applyPatch(prev, event) {
     const resultsToApply = results || (result ? [result] : []);
     if (resultsToApply.length === 0) return prev;
 
-    const resultMap = new Map(resultsToApply.map(r => [r.id, r]));
+    // Skip null/primitive/id-less entries before building the lookup: a
+    // malformed event (e.g. results:[null], whether from a rogue same-origin
+    // BroadcastChannel patch or a bad server payload) would otherwise throw on
+    // r.id inside the Map constructor. Such entries can never match a real
+    // match id anyway, so dropping them is behaviour-preserving for valid input.
+    const resultMap = new Map(
+        resultsToApply.filter(r => r && r.id != null).map(r => [r.id, r]),
+    );
     const next = { ...prev };
     let changed = false;
     // Track whether any pool patch changed a match's scheduled state;

--- a/web-mobile/js/router.jsx
+++ b/web-mobile/js/router.jsx
@@ -91,6 +91,18 @@ function route(url, replace = false) {
     return false;
 }
 
+// decodeURIComponent throws on malformed percent-encoding (e.g. a stray "%").
+// parseSearch is on the public surface (ES export + window.AppRouter) and is
+// called during state init (useQuery, app.jsx's parseCourtFromSearch), so it
+// must never throw on a crafted/truncated URL: fall back to the raw substring.
+function safeDecode(s) {
+    try {
+        return decodeURIComponent(s);
+    } catch (_e) {
+        return s;
+    }
+}
+
 // Pure parse of a search string into a plain object. Extracted so the
 // useQuery hook below stays trivial and so the parser can be unit-tested
 // without a DOM.
@@ -102,10 +114,10 @@ function parseSearch(search) {
         if (!pair) continue;
         const eq = pair.indexOf('=');
         if (eq === -1) {
-            params[decodeURIComponent(pair)] = '';
+            params[safeDecode(pair)] = '';
         } else {
-            const k = decodeURIComponent(pair.slice(0, eq));
-            const v = decodeURIComponent(pair.slice(eq + 1));
+            const k = safeDecode(pair.slice(0, eq));
+            const v = safeDecode(pair.slice(eq + 1));
             params[k] = v;
         }
     }

--- a/web-mobile/js/router.jsx
+++ b/web-mobile/js/router.jsx
@@ -107,7 +107,12 @@ function safeDecode(s) {
 // useQuery hook below stays trivial and so the parser can be unit-tested
 // without a DOM.
 function parseSearch(search) {
-    const params = {};
+    // Null-prototype: query-string keys are attacker-controlled (URL params),
+    // so a key literally named "__proto__" must not silently no-op against the
+    // special accessor on Object.prototype (matches the Object.create(null)
+    // pattern used elsewhere for user-controlled keys, e.g. viewer_utils.jsx,
+    // admin_participants.jsx).
+    const params = Object.create(null);
     // parseSearch is on the public surface (see the module-level comment above
     // safeDecode: "must never throw"). A non-string truthy input (e.g. an
     // object passed by mistake by some future/external caller) would pass the

--- a/web-mobile/js/router.jsx
+++ b/web-mobile/js/router.jsx
@@ -108,7 +108,12 @@ function safeDecode(s) {
 // without a DOM.
 function parseSearch(search) {
     const params = {};
-    if (!search || search.length < 2) return params;
+    // parseSearch is on the public surface (see the module-level comment above
+    // safeDecode: "must never throw"). A non-string truthy input (e.g. an
+    // object passed by mistake by some future/external caller) would pass the
+    // old `!search` check yet lack .startsWith/.slice, throwing downstream;
+    // guard on the actual type so the invariant holds for any caller input.
+    if (typeof search !== 'string' || search.length < 2) return params;
     const trimmed = search.startsWith('?') ? search.slice(1) : search;
     for (const pair of trimmed.split('&')) {
         if (!pair) continue;

--- a/web-mobile/js/router.jsx
+++ b/web-mobile/js/router.jsx
@@ -140,8 +140,8 @@ function getCurrentUrl() {
 
 const Link = _Link || ((props) => React.createElement('a', props, props.children));
 
-export { Router, Route, route, Link, useQuery, getCurrentUrl };
+export { Router, Route, route, Link, useQuery, getCurrentUrl, parseSearch };
 
 if (typeof window !== 'undefined') {
-    window.AppRouter = { Router, Route, route, Link, useQuery, getCurrentUrl };
+    window.AppRouter = { Router, Route, route, Link, useQuery, getCurrentUrl, parseSearch };
 }


### PR DESCRIPTION
## Summary

- Keeps a shiaijo's TV display board updating during a server-link outage, on the same laptop, **as long as the operator tab stays open**. The operator tab becomes the court's local data hub over a same-origin `BroadcastChannel`; the display merges patches and can cold-start from the operator tab's snapshot when the server fetch fails.
- Replaces the `RECONNECTING` pill on the TV board with a discreet **3-state link dot**: green (server reachable, shown only via absence: the dot is hidden when connected), amber (server down but the operator broadcast is fresh, court-local), red (no server and no operator feed, stale).
- Works across all deployment topologies (cloud+TLS, venue-local+TLS, bare-IP HTTP), because `BroadcastChannel` needs no secure context. No server/Go change.

## Why

Part of the `mp-gpra` flaky-wifi hardening initiative (phase 1 = #321). Phase 1 hardened the client/server flow (durable write outbox, SSE resync, silence watchdog). Phase 2 (this PR) addresses the remaining gap: during a venue Wi-Fi outage, the court's TV board would freeze. Now the operator's scores keep flowing to the board peer-to-peer on the same machine.

Reconciliation model: **overlay-while-offline, refetch-replaces-on-reconnect** (no per-match `rev`, no Go change). When SSE returns, the display's existing full refetch wholesale replaces the optimistic overlay, so double-apply is structurally impossible. Knockout advancement stays option A (the next-round slot remains a server-side placeholder offline). Operator-tab cold-start (a reload during an outage) is an accepted non-goal, deferred to `mp-wm4e` (the loopback "satellite").

## Files changed

| File | What |
|---|---|
| `web-mobile/js/court_bridge.jsx` (new) | BroadcastChannel hub: versioned message schema, self-echo suppression, snapshot handshake, court-scoped recency clock, `deriveLinkState` (pure 3-state), `applyPatchToTree` (non-throwing tree adapter delegating to `patch.jsx` `applyPatch`), `mergeSnapshotIntoTree` (pure snapshot-fold policy: bootstrap / drop-when-connected / offline-merge), shared `resolveCompId`, `freshnessMs=20000`, recency reset on court change, `onmessageerror` handler, single shared-bridge singleton, try/catch hardened sends |
| `web-mobile/js/api_client.jsx` | Broadcast the match patch on every `recordScore` confirm and durable enqueue; envelope mirrors the SSE shape (incl. `sideAId/sideBId`); skip broadcast on a server-rejected `{stale:true}` write; use the shared bridge singleton |
| `web-mobile/js/app.jsx` | Display-mode consumer (court-guarded snapshot bootstrap + patch merge via the tree adapter, both wrapped in a try/catch backstop); operator-tab snapshot provider; derive `linkState` from `sseConnected` (via a synced ref) + court-scoped broadcast recency; `parseCourtFromSearch` delegates to the shared `AppRouter.parseSearch` |
| `web-mobile/js/router.jsx` | Expose `parseSearch` on the ES export and `window.AppRouter` so consumers share one query-string parser (no new ES-import edge, avoiding the double module-eval trap) |
| `web-mobile/js/display.jsx` | Thread `linkState` to `TvDisplay`; `LobbyDisplay` keeps its boolean `connected` |
| `web-mobile/js/display_scoreboard.jsx` | `LinkDot` 3-state indicator replaces the `RECONNECTING` pill at the 3 board sites; `LinkDot` exported for render tests |
| `web-mobile/js/__tests__/court_bridge.test.jsx` (new) | Unit tests for `deriveLinkState`, `applyPatchToTree` (incl. malformed-payload non-throw + empty-compId), `resolveCompId`, `mergeSnapshotIntoTree` (every branch), court-scoped recency + reset-on-court-change, snapshot-req auto-reply handshake (foreign-origin injection) + negative case |
| `web-mobile/js/__tests__/link_dot.test.jsx` (new) | `LinkDot` render tests for all three states (connected hidden + aria-hidden; local amber; stale red with the dark ring) and the treatment-not-hue-alone differentiator |
| `web-mobile/js/__tests__/router.test.jsx` (new) | `parseSearch` unit tests (empty, leading `?`, multi-pair, valueless key, percent-decode, repeat-key, doubled separator) |
| `docs/user-guide/mobile-app.md` | Court-scoreboard connection-dot note (amber court-local / red stale / no dot when healthy) |
| `docs/architecture/infrastructure-architecture.md` | Recommend driving each court display from the operator console's own machine over HDMI so the scoreboard survives a Wi-Fi outage; new section with a mini diagram and the trade-offs/limits |

## Review

Reviewed with three full `/tri-review` passes (3 lenses each + adversarial per-finding verification) on top of the Copilot loop. Pass 1: 11 confirmed (incl. a HIGH stale-closure bug in the link-state ticker), all fixed. Pass 2: 13 confirmed (2 medium + hardening), 10 fixed. Pass 3: 10 confirmed (1 medium + 9 low), 8 fixed (display-board crash-guard against malformed BroadcastChannel messages, snapshot-merge hardening, recency reset on court change, plus simplifications), 2 DRY items addressed in follow-ups. The remaining DRY items were then closed: the snapshot-merge policy was extracted into the pure, fully-tested `mergeSnapshotIntoTree`, and the duplicated query-string parser was deduped onto the shared `AppRouter.parseSearch`. Net result: the highest-risk logic (where the pass-3 bugs lived) is now pure and unit-tested, and the display board cannot crash on a malformed peer message.

## Screenshots

Captured on the real `/display?court=A` board (1600x900) driving the actual three states. The server was killed to produce a genuine outage; the operator score was delivered over BroadcastChannel with no server.

**1. Connected** (server reachable): no dot, board is server-fresh.

![Connected: court A board, no status dot](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/325/dot-1-connected.png)

**2. Court-local** (server down, operator broadcast fresh): amber dot, and the operator's "M" reached the board over BroadcastChannel with the server dead.

![Court-local: amber dot, operator score applied offline](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/325/dot-2-local.png)

![Court-local dot close-up (amber)](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/325/dot-2-local-crop.png)

**3. Stale** (no server and no operator feed for >20s): red dot.

![Stale: red dot](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/325/dot-3-stale.png)

![Stale dot close-up (red)](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/325/dot-3-stale-crop.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — green, coverage >=85% all packages (no Go changed; confirms no regression)
- [x] New/updated unit tests cover the change — `court_bridge.test.jsx`, `link_dot.test.jsx`, `router.test.jsx`; full JS suite (2024) + render-smoke + eslint clean
- [x] Manual browser verification (real `/display?court=A`, seeded competition): connected board renders with no dot; killed the server -> dot goes red; posted an operator patch over BroadcastChannel for court A -> board applied the "M" score with the server dead and the dot went amber; waited >20s -> dot went red again. Court-scoping confirmed (court-A board only reacts to court-A messages).
- [x] Screenshots added above (REQUIRED for UI change)
- [x] Docs updated under `docs/` — court-scoreboard connection-dot note in `docs/user-guide/mobile-app.md`, and an HDMI same-machine display recommendation in `docs/architecture/infrastructure-architecture.md`; `make docs/build` passes strict (both new anchors resolve in the built HTML)
- [x] No new console errors or warnings — zero JS errors in the connected state; the only console output during the outage is `ERR_CONNECTION_REFUSED` from the deliberately killed server (the simulated outage), not application errors

<!-- Bead reference: -->
Refs mp-gpra
Closes mp-9ukk

