### PR TITLE
docs(mp-fx9b): clarify bulk-score error field is not a stable code

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1836,6 +1836,10 @@ paths:
                           type: string
                         error:
                           type: string
+                          description: >
+                            Human-readable failure reason. Not a stable machine-readable
+                            code; callers needing to branch on error class should use the
+                            single-result PUT /score endpoint instead.
 
   /api/competitions/{id}/matches/{mid}/quick-score:
     put:


### PR DESCRIPTION
## Summary

- Documented that the `error` field in the bulk-score partial-success response (`POST /api/competitions/:id/matches/bulk-score`) is a human-readable string, not a stable machine-readable code, and points callers who need to branch on error class to the single-result `PUT /score` endpoint instead.

## Why

Bead mp-fx9b asked whether bulk-score should get structured per-item error codes like the single-score handler's `errors.As` switch (`IneligibleCompetitorError`, `AlreadyIneligibleError`, etc.). Investigation found:
- Zero frontend callers parse the bulk-score `errors[]` field (`grep` across `web-mobile/js/` and `web-mobile/dist/` returns no hits).
- The handler is explicitly documented as an admin batch-import/correction tool, not a live scoring path (it bypasses court exclusivity and `StartMatchTx` on purpose).
- The single-score `PUT /score` endpoint already has the full structured-error mapping for any caller that needs to branch on error class.

Building the structured-code machinery now would be speculative work for a caller that doesn't exist (YAGNI). Instead, this documents the trade-off explicitly in the OpenAPI spec so future readers don't rediscover the same question.

## Files changed

| File | What |
|---|---|
| `specs/openapi.yaml` | Added a `description` to the bulk-score response `error` field clarifying it is not a stable machine-readable code |

## Screenshots

No UI impact; this is a documentation-only change to the OpenAPI spec.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change — N/A, doc-only YAML change with no behavior change
- [x] Manual browser verification (for `web-mobile/` or `web/` changes): N/A, no `web-mobile/` or `web/` changes
- [x] Screenshots added above (REQUIRED for any UI-affecting change): N/A, no UI impact
- [x] Docs updated under `docs/` for any new or changed user-facing feature, flag, command, or behavior (`make docs/build` passes): N/A, this is an internal API contract clarification in `specs/openapi.yaml`, not a `docs/`-facing behavior change
- [x] No new console errors or warnings

Closes mp-fx9b
