### PR TITLE
feat(mp-sjaz): rest-aware League match scheduling (no back-to-back)

### DIFF
--- a/internal/engine/league_allocation_test.go
+++ b/internal/engine/league_allocation_test.go
@@ -55,7 +55,7 @@ func tryStartLeague(t *testing.T, compID string, courts []string, players []stri
 
 func names(n int) []string {
 	out := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		out[i] = fmt.Sprintf("P%d", i+1)
 	}
 	return out
@@ -63,13 +63,15 @@ func names(n int) []string {
 
 // TestLeagueAllocation_EdgeCases pins how a league (single pool spanning the
 // whole roster) allocates its matches to courts across a range of roster/court
-// shapes. The core rules under test (engine/pools.go):
+// shapes. The core rules under test (engine/pools.go + engine/league_schedule.go):
 //   - a league spreads its matches across ALL assigned courts (no court idle),
 //   - a single-court league keeps everything on that one court,
 //   - every generated match gets a court when courts are configured,
-//   - the round-robin court assignment never co-locates two matches of the SAME
-//     round on the same court while another court is free (so same-round matches,
-//     which always have distinct participants, can run in parallel).
+//   - within a single time slot (matches sharing a ScheduledAt) the courts are
+//     distinct and no player is double-booked (G1), so the parallel matches in a
+//     slot can run safely. Note: matches of the same round-robin Round are
+//     deliberately NOT forced into one slot, the rest-aware scheduler spreads a
+//     player's fights out (mp-sjaz), which is what prevents back-to-back play.
 func TestLeagueAllocation_EdgeCases(t *testing.T) {
 	t.Run("single court keeps every match on that court", func(t *testing.T) {
 		matches := startLeague(t, "lg-1court", 0, []string{"A"}, names(5))
@@ -130,12 +132,10 @@ func TestLeagueAllocation_EdgeCases(t *testing.T) {
 		assert.Len(t, used, 2, "team league must use both courts")
 	})
 
-	t.Run("same-round matches are never stacked on one court while another is free", func(t *testing.T) {
-		// For every roster/court combo, within a single round the matches are
-		// assigned to DISTINCT courts up to the court count. Same-round matches
-		// always have distinct participants, so distinct-court placement lets them
-		// run in parallel safely. When a round has more matches than courts, the
-		// surplus reuses courts (sequential), which is expected.
+	t.Run("matches sharing a time slot use distinct courts and distinct players", func(t *testing.T) {
+		// Within a single time slot (all matches at the same ScheduledAt), the
+		// rest-aware scheduler places at most one match per court and never the
+		// same player twice, so the parallel matches in that slot run safely (G1).
 		cases := []struct {
 			players, courts int
 		}{
@@ -145,24 +145,23 @@ func TestLeagueAllocation_EdgeCases(t *testing.T) {
 			courtLabels := []string{"A", "B", "C", "D"}[:tc.courts]
 			id := fmt.Sprintf("lg-round-%dp-%dc", tc.players, tc.courts)
 			matches := startLeague(t, id, 0, courtLabels, names(tc.players))
-			byRound := map[int][]string{} // round -> courts used (in order)
+			bySlot := map[string][]state.MatchResult{} // ScheduledAt -> matches in that slot
 			for _, m := range matches {
-				byRound[m.Round] = append(byRound[m.Round], m.Court)
+				bySlot[m.ScheduledAt] = append(bySlot[m.ScheduledAt], m)
 			}
-			for round, used := range byRound {
-				// The first min(len(used), courts) matches of a round must be on
-				// distinct courts (a round-robin cycle), so no court is double-booked
-				// within a round before every court has one match.
-				limit := tc.courts
-				if len(used) < limit {
-					limit = len(used)
-				}
-				seen := map[string]bool{}
-				for i := 0; i < limit; i++ {
-					assert.Falsef(t, seen[used[i]],
-						"%s round %d: court %q reused within the first %d matches of the round (would idle another court)",
-						id, round, used[i], limit)
-					seen[used[i]] = true
+			for slotTime, group := range bySlot {
+				courtSeen := map[string]bool{}
+				playerSeen := map[string]bool{}
+				for _, m := range group {
+					assert.Falsef(t, courtSeen[m.Court],
+						"%s slot %s: court %q used by two matches at once", id, slotTime, m.Court)
+					courtSeen[m.Court] = true
+					assert.Falsef(t, playerSeen[m.SideA],
+						"%s slot %s: player %q double-booked (G1)", id, slotTime, m.SideA)
+					assert.Falsef(t, playerSeen[m.SideB],
+						"%s slot %s: player %q double-booked (G1)", id, slotTime, m.SideB)
+					playerSeen[m.SideA] = true
+					playerSeen[m.SideB] = true
 				}
 			}
 		}

--- a/internal/engine/league_allocation_test.go
+++ b/internal/engine/league_allocation_test.go
@@ -64,7 +64,9 @@ func names(n int) []string {
 // TestLeagueAllocation_EdgeCases pins how a league (single pool spanning the
 // whole roster) allocates its matches to courts across a range of roster/court
 // shapes. The core rules under test (engine/pools.go + engine/league_schedule.go):
-//   - a league spreads its matches across ALL assigned courts (no court idle),
+//   - a league spreads its matches across ALL assigned courts (every court
+//     carries at least one match; individual time slots may still leave a court
+//     idle when the rest-aware scheduler inserts a rest band),
 //   - a single-court league keeps everything on that one court,
 //   - every generated match gets a court when courts are configured,
 //   - within a single time slot (matches sharing a ScheduledAt) the courts are
@@ -101,7 +103,7 @@ func TestLeagueAllocation_EdgeCases(t *testing.T) {
 			"4 players with 2 courts (== floor(N/2)) must be accepted")
 	})
 
-	t.Run("multi-court league uses every assigned court (no court idle)", func(t *testing.T) {
+	t.Run("multi-court league: every assigned court carries at least one match", func(t *testing.T) {
 		matches := startLeague(t, "lg-3court", 0, []string{"A", "B", "C"}, names(6))
 		require.Len(t, matches, 15)
 		used := map[string]int{}

--- a/internal/engine/league_schedule.go
+++ b/internal/engine/league_schedule.go
@@ -33,8 +33,8 @@ func scheduleLeagueSlots(matches []state.MatchResult, courts []string) (ordered 
 	}
 	numCourts := len(courts)
 
-	// sentinel: a player not yet scheduled has lastSlot = math.MinInt/2 so
-	// (lastSlot[x] == slot-1) is false for any non-negative slot.
+	// sentinel: a player not yet scheduled reports an arbitrary large negative
+	// lastSlot so (lastSlot[x] == slot-1) is false for any non-negative slot.
 	const absent = -(1 << 30)
 	lastSlot := make(map[string]int)
 	getLastSlot := func(player string) int {

--- a/internal/engine/league_schedule.go
+++ b/internal/engine/league_schedule.go
@@ -1,0 +1,183 @@
+package engine
+
+import (
+	"sort"
+	"time"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// scheduleLeagueSlots assigns each match a global slot index and a court,
+// spreading every player's matches so they never fight two slots in a row.
+// Returns the input matches with Court set, plus a parallel slice giving the
+// slot index of each returned match (result[i] is in slot slots[i]). Players
+// are identified by SideA/SideB (names). numPlayers is the league size (n);
+// courts is the ordered court-label list (len>=1).
+//
+// Guarantees (see mp-sjaz):
+//   - G1 (no simultaneity): within any single slot, no player appears in two matches.
+//   - G2 (no back-to-back): NO player ever has matches in two adjacent slots, for
+//     ANY court count. This is a HARD invariant: when every remaining match would
+//     put a player who just fought (in slot-1) straight back in, the current slot
+//     is left empty (an idle rest band) and scheduling advances to the next slot,
+//     where the just-played players are two slots clear and eligible again.
+//   - Completeness: every match in the input appears exactly once in the output.
+//
+// Court count therefore affects only schedule LENGTH (fewer courts -> more slots,
+// i.e. more idle/rest time), never correctness. A full round-robin cannot pack
+// every player's matches non-adjacently into the minimum slot count, so idle
+// slots are the deliberate price of the rest guarantee.
+func scheduleLeagueSlots(matches []state.MatchResult, numPlayers int, courts []string) (ordered []state.MatchResult, slots []int) {
+	if len(courts) == 0 {
+		courts = []string{""}
+	}
+	numCourts := len(courts)
+
+	// sentinel: a player not yet scheduled has lastSlot = math.MinInt/2 so
+	// (lastSlot[x] == slot-1) is false for any non-negative slot.
+	const absent = -(1 << 30)
+	lastSlot := make(map[string]int, numPlayers)
+	getLastSlot := func(player string) int {
+		if v, ok := lastSlot[player]; ok {
+			return v
+		}
+		return absent
+	}
+
+	remaining := make([]state.MatchResult, len(matches))
+	copy(remaining, matches)
+
+	slot := 0
+	for len(remaining) > 0 {
+		// Candidate order for G2-aware pass:
+		// sort by (min(lastSlot[a],lastSlot[b]) asc, Round asc, ID asc)
+		sorted := make([]state.MatchResult, len(remaining))
+		copy(sorted, remaining)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			mi, mj := sorted[i], sorted[j]
+			lsi := min(getLastSlot(mi.SideA), getLastSlot(mi.SideB))
+			lsj := min(getLastSlot(mj.SideA), getLastSlot(mj.SideB))
+			if lsi != lsj {
+				return lsi < lsj
+			}
+			if mi.Round != mj.Round {
+				return mi.Round < mj.Round
+			}
+			return mi.ID < mj.ID
+		})
+
+		var slotMatches []state.MatchResult
+		used := make(map[string]bool)
+
+		// Fill this slot with matches whose players did NOT fight in slot-1
+		// (hard G2) and are not already placed in this slot (G1). Preferring
+		// the least-recently-played matches keeps every player's fights spread
+		// out. If nothing qualifies (every remaining match reuses a slot-1
+		// player), slotMatches stays empty: the slot becomes an idle rest band
+		// and we advance. On the next slot the just-played players are two
+		// slots clear, so at least one match always qualifies, guaranteeing
+		// termination.
+		for _, cand := range sorted {
+			if len(slotMatches) == numCourts {
+				break
+			}
+			a, b := cand.SideA, cand.SideB
+			if used[a] || used[b] {
+				continue // G1 violation
+			}
+			if getLastSlot(a) == slot-1 || getLastSlot(b) == slot-1 {
+				continue // G2: never place a player who fought last slot
+			}
+			slotMatches = append(slotMatches, cand)
+			used[a] = true
+			used[b] = true
+		}
+
+		// Assign courts and record slot index; update lastSlot.
+		placed := make(map[string]bool)
+		for i, m := range slotMatches {
+			m.Court = courts[i]
+			placed[m.ID] = true
+			lastSlot[m.SideA] = slot
+			lastSlot[m.SideB] = slot
+			ordered = append(ordered, m)
+			slots = append(slots, slot)
+		}
+
+		// Remove placed matches from remaining.
+		next := remaining[:0]
+		for _, m := range remaining {
+			if !placed[m.ID] {
+				next = append(next, m)
+			}
+		}
+		remaining = next
+		slot++
+	}
+
+	return ordered, slots
+}
+
+// assignLeagueSlotTimes writes ScheduledAt on each match according to its slot:
+// all matches in slot k share one start time; slot k+1 starts one match-duration
+// after slot k (lunch/opening blocks respected via the same rules as
+// assignPoolMatchSlots). Returns matches and the max end cursor.
+//
+// A single global cursor is used: slot k's start = dayStart + OpeningBlock +
+// k*perMatchMin, pushed past LunchBlock via skipCeremonyBlocks. This keeps all
+// courts in the same slot strictly time-aligned, unlike the per-court cursors of
+// assignPoolMatchSlots (which is the defect G2 scheduling is designed to fix).
+//
+// Returns the input slice with ScheduledAt populated and the cursor position
+// immediately after the last slot ends. Returns an unmodified slice and zero
+// time.Time when comp is nil.
+func assignLeagueSlotTimes(matches []state.MatchResult, slots []int, comp *state.Competition, tournament *state.Tournament) ([]state.MatchResult, time.Time) {
+	if comp == nil {
+		return matches, time.Time{}
+	}
+
+	dayStart := parseClockHHMM(comp.StartTime)
+	openingMin := 0
+	lunchMin := 0
+	var lunchStart time.Time
+	if tournament != nil {
+		openingMin = parseDurationMinutes(tournament.OpeningBlock)
+		lunchMin = parseDurationMinutes(tournament.LunchBlock)
+		lunchStart = parseClockHHMM(defaultLunchStartClock)
+	}
+
+	if len(matches) == 0 {
+		return matches, dayStart.Add(time.Duration(openingMin) * time.Minute)
+	}
+
+	perMatchMin := perMatchElapsedMinutes(comp, tournament, false /*isPlayoff*/)
+
+	// Build a map from slot index to start time by walking slot 0..maxSlot
+	// with a single cursor, skipping ceremony blocks.
+	maxSlot := 0
+	for _, s := range slots {
+		if s > maxSlot {
+			maxSlot = s
+		}
+	}
+
+	slotTime := make([]time.Time, maxSlot+1)
+	cursor := dayStart.Add(time.Duration(openingMin) * time.Minute)
+	for k := range maxSlot + 1 {
+		cursor = skipCeremonyBlocks(cursor, lunchStart, lunchMin)
+		slotTime[k] = cursor
+		cursor = cursor.Add(time.Duration(perMatchMin) * time.Minute)
+	}
+
+	for i := range matches {
+		if i < len(slots) {
+			s := slots[i]
+			if s >= 0 && s < len(slotTime) {
+				matches[i].ScheduledAt = slotTime[s].Format(scheduleClockLayout)
+			}
+		}
+	}
+
+	// Return cursor as the end time after the last slot.
+	return matches, cursor
+}

--- a/internal/engine/league_schedule.go
+++ b/internal/engine/league_schedule.go
@@ -11,8 +11,8 @@ import (
 // spreading every player's matches so they never fight two slots in a row.
 // Returns the input matches with Court set, plus a parallel slice giving the
 // slot index of each returned match (result[i] is in slot slots[i]). Players
-// are identified by SideA/SideB (names). numPlayers is the league size (n);
-// courts is the ordered court-label list (len>=1).
+// are identified by SideA/SideB (names). courts is the ordered court-label
+// list; an empty list is treated as a single unnamed court.
 //
 // Guarantees (see mp-sjaz):
 //   - G1 (no simultaneity): within any single slot, no player appears in two matches.
@@ -27,7 +27,7 @@ import (
 // i.e. more idle/rest time), never correctness. A full round-robin cannot pack
 // every player's matches non-adjacently into the minimum slot count, so idle
 // slots are the deliberate price of the rest guarantee.
-func scheduleLeagueSlots(matches []state.MatchResult, numPlayers int, courts []string) (ordered []state.MatchResult, slots []int) {
+func scheduleLeagueSlots(matches []state.MatchResult, courts []string) (ordered []state.MatchResult, slots []int) {
 	if len(courts) == 0 {
 		courts = []string{""}
 	}
@@ -36,7 +36,7 @@ func scheduleLeagueSlots(matches []state.MatchResult, numPlayers int, courts []s
 	// sentinel: a player not yet scheduled has lastSlot = math.MinInt/2 so
 	// (lastSlot[x] == slot-1) is false for any non-negative slot.
 	const absent = -(1 << 30)
-	lastSlot := make(map[string]int, numPlayers)
+	lastSlot := make(map[string]int)
 	getLastSlot := func(player string) int {
 		if v, ok := lastSlot[player]; ok {
 			return v
@@ -136,15 +136,7 @@ func assignLeagueSlotTimes(matches []state.MatchResult, slots []int, comp *state
 		return matches, time.Time{}
 	}
 
-	dayStart := parseClockHHMM(comp.StartTime)
-	openingMin := 0
-	lunchMin := 0
-	var lunchStart time.Time
-	if tournament != nil {
-		openingMin = parseDurationMinutes(tournament.OpeningBlock)
-		lunchMin = parseDurationMinutes(tournament.LunchBlock)
-		lunchStart = parseClockHHMM(defaultLunchStartClock)
-	}
+	dayStart, openingMin, lunchMin, lunchStart := parseCeremonyParams(comp, tournament)
 
 	if len(matches) == 0 {
 		return matches, dayStart.Add(time.Duration(openingMin) * time.Minute)

--- a/internal/engine/league_schedule_test.go
+++ b/internal/engine/league_schedule_test.go
@@ -146,7 +146,9 @@ func TestScheduleLeagueSlots_CompletenessG1G2(t *testing.T) {
 
 // --- Warning zone: numCourts = floor(n/2) (one above SuggestedMaxCourts) ---
 // G2 is a hard invariant (idle slots are inserted when needed), so it holds
-// here too; the higher court count only means a longer schedule.
+// here too regardless of court count. This test asserts correctness (G1/G2),
+// not schedule length; the court count changes how the matches pack into slots
+// but never whether the rest guarantee holds.
 
 func TestScheduleLeagueSlots_WarningZone_StillG2(t *testing.T) {
 	t.Parallel()

--- a/internal/engine/league_schedule_test.go
+++ b/internal/engine/league_schedule_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
 	"github.com/gitrgoliveira/bracket-creator/internal/state"
@@ -358,11 +359,12 @@ func TestGeneratePools_League_G1G2(t *testing.T) {
 				}
 			}
 
-			// G2: no player has two matches closer than two slots apart. Recompute
-			// the slot duration exactly as generatePools did (load + apply
-			// defaults). A correct schedule keeps every player's matches at least
-			// two slots (2*perMatch) apart; a lunch skip only widens the gap, so
-			// the >= check stays correct across the lunch boundary.
+			// G2: no player appears in two adjacent slots. Wall-clock minute gaps
+			// cannot detect this across a lunch/ceremony boundary (a skip inflates
+			// the gap of an adjacent pair), so map each ScheduledAt back to its
+			// slot INDEX by replaying the same cursor loop assignLeagueSlotTimes
+			// uses (parseCeremonyParams + skipCeremonyBlocks + perMatch steps),
+			// then assert no player has two matches in consecutive slot indices.
 			loadedComp, err := store.LoadCompetition(compID)
 			require.NoError(t, err)
 			tournament, err := store.LoadTournament()
@@ -372,18 +374,27 @@ func TestGeneratePools_League_G1G2(t *testing.T) {
 			perMatch := perMatchElapsedMinutes(loadedComp, tournament, false)
 			require.Positive(t, perMatch)
 
+			dayStart, openingMin, lunchMin, lunchStart := parseCeremonyParams(loadedComp, tournament)
+			timeToSlot := make(map[string]int)
+			cursor := dayStart.Add(time.Duration(openingMin) * time.Minute)
+			for k := 0; k < len(matches)*3+2; k++ { // generous bound: idle slots at most ~1 per match
+				cursor = skipCeremonyBlocks(cursor, lunchStart, lunchMin)
+				timeToSlot[cursor.Format(scheduleClockLayout)] = k
+				cursor = cursor.Add(time.Duration(perMatch) * time.Minute)
+			}
+
 			byPlayer := make(map[string][]int)
 			for _, m := range matches {
-				at := parseClockHHMM(m.ScheduledAt)
-				startMin := at.Hour()*60 + at.Minute()
-				byPlayer[m.SideA] = append(byPlayer[m.SideA], startMin)
-				byPlayer[m.SideB] = append(byPlayer[m.SideB], startMin)
+				s, ok := timeToSlot[m.ScheduledAt]
+				require.Truef(t, ok, "match time %s not found in replayed slot grid", m.ScheduledAt)
+				byPlayer[m.SideA] = append(byPlayer[m.SideA], s)
+				byPlayer[m.SideB] = append(byPlayer[m.SideB], s)
 			}
-			for player, mins := range byPlayer {
-				sort.Ints(mins)
-				for i := 1; i < len(mins); i++ {
-					assert.GreaterOrEqualf(t, mins[i]-mins[i-1], 2*perMatch,
-						"G2 violation: player %q has back-to-back matches %d minutes apart", player, mins[i]-mins[i-1])
+			for player, slotIdxs := range byPlayer {
+				sort.Ints(slotIdxs)
+				for i := 1; i < len(slotIdxs); i++ {
+					assert.Greaterf(t, slotIdxs[i]-slotIdxs[i-1], 1,
+						"G2 violation: player %q in adjacent slots %d and %d", player, slotIdxs[i-1], slotIdxs[i])
 				}
 			}
 		})

--- a/internal/engine/league_schedule_test.go
+++ b/internal/engine/league_schedule_test.go
@@ -1,0 +1,389 @@
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildLeagueMatches builds a []state.MatchResult for all n*(n-1)/2 pairs
+// using CircleMethodRounds so each match carries its Round number. Players
+// are named "P0".."P{n-1}".
+func buildLeagueMatches(n int) []state.MatchResult {
+	rounds := helper.CircleMethodRounds(n)
+	var matches []state.MatchResult
+	k := 0
+	for ri, round := range rounds {
+		for _, pair := range round {
+			matches = append(matches, state.MatchResult{
+				ID:     fmt.Sprintf("m%03d", k),
+				SideA:  fmt.Sprintf("P%d", pair.A),
+				SideB:  fmt.Sprintf("P%d", pair.B),
+				Round:  ri,
+				Status: state.MatchStatusScheduled,
+			})
+			k++
+		}
+	}
+	return matches
+}
+
+// courtLabels returns the first n uppercase letter labels starting from "A".
+func courtLabels(n int) []string {
+	labels := make([]string, n)
+	for i := range n {
+		labels[i] = string(rune('A' + i))
+	}
+	return labels
+}
+
+// verifyCompleteness checks that every (i,j) pair with i<j appears exactly
+// once in the output and that the total match count equals n*(n-1)/2.
+func verifyCompleteness(t *testing.T, ordered []state.MatchResult, n int) {
+	t.Helper()
+	expected := n * (n - 1) / 2
+	require.Len(t, ordered, expected, "total match count: want %d, got %d", expected, len(ordered))
+
+	type pair struct{ a, b string }
+	seen := make(map[pair]int, expected)
+	for _, m := range ordered {
+		a, b := m.SideA, m.SideB
+		if a > b {
+			a, b = b, a
+		}
+		seen[pair{a, b}]++
+	}
+	assert.Len(t, seen, expected, "unique pairs count mismatch")
+	for p, count := range seen {
+		assert.Equal(t, 1, count, "pair (%s,%s) appears %d times, want 1", p.a, p.b, count)
+	}
+}
+
+// verifyG1 checks that within every slot no player appears in two matches.
+func verifyG1(t *testing.T, ordered []state.MatchResult, slots []int) {
+	t.Helper()
+	// group match indices by slot
+	bySlot := make(map[int][]int)
+	for i, s := range slots {
+		bySlot[s] = append(bySlot[s], i)
+	}
+	for s, idxs := range bySlot {
+		seen := make(map[string]bool)
+		for _, idx := range idxs {
+			m := ordered[idx]
+			assert.Falsef(t, seen[m.SideA], "slot %d: player %q appears in multiple matches (G1 violation)", s, m.SideA)
+			assert.Falsef(t, seen[m.SideB], "slot %d: player %q appears in multiple matches (G1 violation)", s, m.SideB)
+			seen[m.SideA] = true
+			seen[m.SideB] = true
+		}
+	}
+}
+
+// verifyG2 checks that no player has matches in two adjacent slots.
+func verifyG2(t *testing.T, ordered []state.MatchResult, slots []int) {
+	t.Helper()
+	// lastSlot[player] -> the most recent slot index seen
+	lastSlot := make(map[string]int)
+	// Walk in slot order so we can detect adjacency.
+	// Build (slot, matchIdx) pairs sorted by slot.
+	type entry struct {
+		slot int
+		idx  int
+	}
+	entries := make([]entry, len(slots))
+	for i, s := range slots {
+		entries[i] = entry{s, i}
+	}
+	// Sort by slot asc, then by original index for determinism.
+	for i := 1; i < len(entries); i++ {
+		for j := i; j > 0 && entries[j].slot < entries[j-1].slot; j-- {
+			entries[j], entries[j-1] = entries[j-1], entries[j]
+		}
+	}
+
+	for _, e := range entries {
+		m := ordered[e.idx]
+		for _, player := range []string{m.SideA, m.SideB} {
+			if prev, ok := lastSlot[player]; ok {
+				assert.NotEqual(t, e.slot-1, prev,
+					"G2 violation: player %q is in slot %d and slot %d (adjacent)", player, prev, e.slot)
+			}
+			lastSlot[player] = e.slot
+		}
+	}
+}
+
+// --- Completeness + G1 + G2 at SuggestedMaxCourts ---
+
+func TestScheduleLeagueSlots_CompletenessG1G2(t *testing.T) {
+	t.Parallel()
+
+	sizes := []int{5, 6, 7, 8, 10, 12, 16}
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			t.Parallel()
+			numCourts := SuggestedMaxCourts(n)
+			courts := courtLabels(numCourts)
+			matches := buildLeagueMatches(n)
+
+			ordered, slots := scheduleLeagueSlots(matches, n, courts)
+
+			require.Len(t, slots, len(ordered), "slots and ordered must be same length")
+
+			verifyCompleteness(t, ordered, n)
+			verifyG1(t, ordered, slots)
+			verifyG2(t, ordered, slots)
+		})
+	}
+}
+
+// --- Warning zone: numCourts = floor(n/2) (one above SuggestedMaxCourts) ---
+// G2 is a hard invariant (idle slots are inserted when needed), so it holds
+// here too; the higher court count only means a longer schedule.
+
+func TestScheduleLeagueSlots_WarningZone_StillG2(t *testing.T) {
+	t.Parallel()
+
+	sizes := []int{6, 8, 10, 12, 16}
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d_courts=%d", n, n/2), func(t *testing.T) {
+			t.Parallel()
+			numCourts := n / 2 // warning zone: one more than SuggestedMaxCourts
+			courts := courtLabels(numCourts)
+			matches := buildLeagueMatches(n)
+
+			ordered, slots := scheduleLeagueSlots(matches, n, courts)
+
+			require.Len(t, slots, len(ordered), "slots and ordered must be same length")
+			verifyCompleteness(t, ordered, n)
+			verifyG1(t, ordered, slots)
+			verifyG2(t, ordered, slots)
+		})
+	}
+}
+
+// --- numCourts == 1 ---
+
+func TestScheduleLeagueSlots_SingleCourt(t *testing.T) {
+	t.Parallel()
+
+	// With one court each slot holds one match, so ordering alone must space
+	// every player out: G1 is trivial and G2 (no back-to-back) still holds
+	// for all n via idle-slot insertion.
+	for _, n := range []int{4, 5, 6, 8} {
+		t.Run(fmt.Sprintf("n=%d_singlecourt", n), func(t *testing.T) {
+			t.Parallel()
+			courts := []string{"A"}
+			matches := buildLeagueMatches(n)
+
+			ordered, slots := scheduleLeagueSlots(matches, n, courts)
+
+			require.Len(t, slots, len(ordered))
+			verifyCompleteness(t, ordered, n)
+			verifyG1(t, ordered, slots) // trivially holds with 1 court
+			verifyG2(t, ordered, slots)
+		})
+	}
+}
+
+// --- Empty input ---
+
+func TestScheduleLeagueSlots_Empty(t *testing.T) {
+	ordered, slots := scheduleLeagueSlots(nil, 0, []string{"A"})
+	assert.Empty(t, ordered)
+	assert.Empty(t, slots)
+}
+
+// --- assignLeagueSlotTimes ---
+
+func TestAssignLeagueSlotTimes_SameSlotSameTime(t *testing.T) {
+	comp := &state.Competition{
+		StartTime:         "09:00",
+		PoolMatchDuration: 3,
+		Courts:            []string{"A", "B"},
+	}
+	tournament := &state.Tournament{
+		ClockToElapsedMultiplier: 1.5,
+	}
+
+	// Two matches in slot 0, one in slot 1.
+	matches := []state.MatchResult{
+		{ID: "m0", SideA: "P0", SideB: "P1"},
+		{ID: "m1", SideA: "P2", SideB: "P3"},
+		{ID: "m2", SideA: "P0", SideB: "P2"},
+	}
+	slots := []int{0, 0, 1}
+
+	out, cursor := assignLeagueSlotTimes(matches, slots, comp, tournament)
+
+	require.Len(t, out, 3)
+
+	// Slot 0 matches must share the same ScheduledAt.
+	assert.Equal(t, out[0].ScheduledAt, out[1].ScheduledAt,
+		"both slot-0 matches must share the same start time")
+
+	// Slot 1 must be exactly perMatchMin later than slot 0.
+	perMatch := perMatchElapsedMinutes(comp, tournament, false)
+	gap := minutesBetween(t, out[0].ScheduledAt, out[2].ScheduledAt)
+	assert.Equal(t, perMatch, gap, "slot 1 must start exactly perMatchMin after slot 0")
+
+	// Cursor must be non-zero.
+	assert.False(t, cursor.IsZero(), "cursor must not be zero")
+}
+
+func TestAssignLeagueSlotTimes_NilComp(t *testing.T) {
+	matches := []state.MatchResult{{ID: "m0"}}
+	slots := []int{0}
+	out, cursor := assignLeagueSlotTimes(matches, slots, nil, nil)
+	require.Len(t, out, 1)
+	assert.True(t, cursor.IsZero(), "nil comp must return zero cursor")
+}
+
+func TestAssignLeagueSlotTimes_EmptyMatches(t *testing.T) {
+	comp := &state.Competition{
+		StartTime:         "09:00",
+		PoolMatchDuration: 3,
+	}
+	out, cursor := assignLeagueSlotTimes(nil, nil, comp, nil)
+	assert.Empty(t, out)
+	assert.False(t, cursor.IsZero(), "cursor for empty input should be dayStart offset")
+}
+
+func TestAssignLeagueSlotTimes_LunchSkip(t *testing.T) {
+	// Start at 11:57, 3-minute matches -> slot 0 at 11:57, slot 1 would be 12:02
+	// but lunch is 12:00-13:00, so slot 1 should be pushed to 13:00.
+	comp := &state.Competition{
+		StartTime:         "11:57",
+		PoolMatchDuration: 3,
+		Courts:            []string{"A"},
+	}
+	tournament := &state.Tournament{
+		ClockToElapsedMultiplier: 1.0, // 3 min * 1.0 = 3 min elapsed
+		LunchBlock:               "1h",
+	}
+	matches := []state.MatchResult{
+		{ID: "m0", SideA: "P0", SideB: "P1"},
+		{ID: "m1", SideA: "P0", SideB: "P2"},
+	}
+	slots := []int{0, 1}
+
+	out, _ := assignLeagueSlotTimes(matches, slots, comp, tournament)
+	require.Len(t, out, 2)
+
+	// Slot 1 must be at or after 13:00 (past the lunch block).
+	slot1Time := parseClockHHMM(out[1].ScheduledAt)
+	lunchEnd := parseClockHHMM("13:00")
+	assert.False(t, slot1Time.Before(lunchEnd),
+		"slot 1 (%s) should be at or after lunch end (13:00)", out[1].ScheduledAt)
+}
+
+// --- Integration: generatePools produces G1/G2-compliant League schedule ---
+
+func TestGeneratePools_League_G1G2(t *testing.T) {
+	t.Parallel()
+
+	// Every case must satisfy G1 and G2: G2 is a hard invariant at any court
+	// count, so a 1-court league is included alongside the SuggestedMaxCourts
+	// cases. Court count only changes schedule length, not the guarantee.
+	tests := []struct {
+		n      int
+		courts []string
+	}{
+		{n: 6, courts: courtLabels(SuggestedMaxCourts(6))},
+		{n: 8, courts: courtLabels(SuggestedMaxCourts(8))},
+		{n: 10, courts: courtLabels(SuggestedMaxCourts(10))},
+		{n: 6, courts: []string{"A"}}, // single court still gets G2 via idle slots
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d_courts=%d", tt.n, len(tt.courts)), func(t *testing.T) {
+			t.Parallel()
+
+			eng, store, _ := setupTestEngine(t)
+			compID := fmt.Sprintf("league-g1g2-%d-%d", tt.n, len(tt.courts))
+
+			comp := &state.Competition{
+				ID:           compID,
+				Name:         "League G1G2 Test",
+				Kind:         "individual",
+				Format:       state.CompFormatLeague,
+				PoolSize:     tt.n,
+				PoolSizeMode: "min",
+				PoolWinners:  1,
+				RoundRobin:   true,
+				Courts:       tt.courts,
+				StartTime:    "09:00",
+				Status:       "setup",
+			}
+			require.NoError(t, store.SaveCompetition(comp))
+
+			saveTestParticipants(t, store, compID, makeNames(tt.n))
+
+			require.NoError(t, eng.StartCompetition(compID))
+
+			matches, err := store.LoadPoolMatches(compID)
+			require.NoError(t, err)
+			require.NotEmpty(t, matches)
+
+			expectedTotal := tt.n * (tt.n - 1) / 2
+			assert.Len(t, matches, expectedTotal, "wrong total match count")
+
+			// G1: matches sharing a start time (one slot) must not share a player.
+			byTime := make(map[string][]state.MatchResult)
+			for _, m := range matches {
+				byTime[m.ScheduledAt] = append(byTime[m.ScheduledAt], m)
+			}
+			for timeStr, group := range byTime {
+				seen := make(map[string]bool)
+				for _, m := range group {
+					assert.Falsef(t, seen[m.SideA], "time %s: player %q in multiple simultaneous matches (G1)", timeStr, m.SideA)
+					assert.Falsef(t, seen[m.SideB], "time %s: player %q in multiple simultaneous matches (G1)", timeStr, m.SideB)
+					seen[m.SideA] = true
+					seen[m.SideB] = true
+				}
+			}
+
+			// G2: no player has two matches exactly one slot apart. Recompute the
+			// slot duration exactly as generatePools did (load + apply defaults),
+			// so an idle slot between two matches reads as a 2-slot gap, not a
+			// false adjacency.
+			loadedComp, err := store.LoadCompetition(compID)
+			require.NoError(t, err)
+			tournament, err := store.LoadTournament()
+			require.NoError(t, err)
+			state.ApplyTournamentDefaults(tournament)
+			state.ApplyCompetitionDefaults(loadedComp)
+			perMatch := perMatchElapsedMinutes(loadedComp, tournament, false)
+			require.Positive(t, perMatch)
+
+			byPlayer := make(map[string][]int)
+			for _, m := range matches {
+				at := parseClockHHMM(m.ScheduledAt)
+				startMin := at.Hour()*60 + at.Minute()
+				byPlayer[m.SideA] = append(byPlayer[m.SideA], startMin)
+				byPlayer[m.SideB] = append(byPlayer[m.SideB], startMin)
+			}
+			for player, mins := range byPlayer {
+				sort.Ints(mins)
+				for i := 1; i < len(mins); i++ {
+					assert.NotEqualf(t, perMatch, mins[i]-mins[i-1],
+						"G2 violation: player %q has back-to-back matches %d minutes apart", player, mins[i]-mins[i-1])
+				}
+			}
+		})
+	}
+}
+
+// makeNames returns n player names "P0".."P{n-1}".
+func makeNames(n int) []string {
+	names := make([]string, n)
+	for i := range n {
+		names[i] = fmt.Sprintf("P%d", i)
+	}
+	return names
+}

--- a/internal/engine/league_schedule_test.go
+++ b/internal/engine/league_schedule_test.go
@@ -100,11 +100,12 @@ func verifyG2(t *testing.T, ordered []state.MatchResult, slots []int) {
 		entries[i] = entry{s, i}
 	}
 	// Sort by slot asc, then by original index for determinism.
-	for i := 1; i < len(entries); i++ {
-		for j := i; j > 0 && entries[j].slot < entries[j-1].slot; j-- {
-			entries[j], entries[j-1] = entries[j-1], entries[j]
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].slot != entries[j].slot {
+			return entries[i].slot < entries[j].slot
 		}
-	}
+		return entries[i].idx < entries[j].idx
+	})
 
 	for _, e := range entries {
 		m := ordered[e.idx]
@@ -123,7 +124,7 @@ func verifyG2(t *testing.T, ordered []state.MatchResult, slots []int) {
 func TestScheduleLeagueSlots_CompletenessG1G2(t *testing.T) {
 	t.Parallel()
 
-	sizes := []int{5, 6, 7, 8, 10, 12, 16}
+	sizes := []int{2, 3, 5, 6, 7, 8, 10, 12, 16}
 	for _, n := range sizes {
 		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
 			t.Parallel()
@@ -131,7 +132,7 @@ func TestScheduleLeagueSlots_CompletenessG1G2(t *testing.T) {
 			courts := courtLabels(numCourts)
 			matches := buildLeagueMatches(n)
 
-			ordered, slots := scheduleLeagueSlots(matches, n, courts)
+			ordered, slots := scheduleLeagueSlots(matches, courts)
 
 			require.Len(t, slots, len(ordered), "slots and ordered must be same length")
 
@@ -149,7 +150,7 @@ func TestScheduleLeagueSlots_CompletenessG1G2(t *testing.T) {
 func TestScheduleLeagueSlots_WarningZone_StillG2(t *testing.T) {
 	t.Parallel()
 
-	sizes := []int{6, 8, 10, 12, 16}
+	sizes := []int{4, 6, 8, 10, 12, 16}
 	for _, n := range sizes {
 		t.Run(fmt.Sprintf("n=%d_courts=%d", n, n/2), func(t *testing.T) {
 			t.Parallel()
@@ -157,7 +158,7 @@ func TestScheduleLeagueSlots_WarningZone_StillG2(t *testing.T) {
 			courts := courtLabels(numCourts)
 			matches := buildLeagueMatches(n)
 
-			ordered, slots := scheduleLeagueSlots(matches, n, courts)
+			ordered, slots := scheduleLeagueSlots(matches, courts)
 
 			require.Len(t, slots, len(ordered), "slots and ordered must be same length")
 			verifyCompleteness(t, ordered, n)
@@ -175,13 +176,13 @@ func TestScheduleLeagueSlots_SingleCourt(t *testing.T) {
 	// With one court each slot holds one match, so ordering alone must space
 	// every player out: G1 is trivial and G2 (no back-to-back) still holds
 	// for all n via idle-slot insertion.
-	for _, n := range []int{4, 5, 6, 8} {
+	for _, n := range []int{3, 4, 5, 6, 8} {
 		t.Run(fmt.Sprintf("n=%d_singlecourt", n), func(t *testing.T) {
 			t.Parallel()
 			courts := []string{"A"}
 			matches := buildLeagueMatches(n)
 
-			ordered, slots := scheduleLeagueSlots(matches, n, courts)
+			ordered, slots := scheduleLeagueSlots(matches, courts)
 
 			require.Len(t, slots, len(ordered))
 			verifyCompleteness(t, ordered, n)
@@ -194,7 +195,7 @@ func TestScheduleLeagueSlots_SingleCourt(t *testing.T) {
 // --- Empty input ---
 
 func TestScheduleLeagueSlots_Empty(t *testing.T) {
-	ordered, slots := scheduleLeagueSlots(nil, 0, []string{"A"})
+	ordered, slots := scheduleLeagueSlots(nil, []string{"A"})
 	assert.Empty(t, ordered)
 	assert.Empty(t, slots)
 }
@@ -289,23 +290,32 @@ func TestGeneratePools_League_G1G2(t *testing.T) {
 
 	// Every case must satisfy G1 and G2: G2 is a hard invariant at any court
 	// count, so a 1-court league is included alongside the SuggestedMaxCourts
-	// cases. Court count only changes schedule length, not the guarantee.
+	// cases. Court count only changes schedule length, not the guarantee. The
+	// lunch case exercises the ceremony-block skip so a lunch break between two
+	// of a player's matches never reads as a false adjacency.
 	tests := []struct {
-		n      int
-		courts []string
+		n         int
+		courts    []string
+		startTime string
+		lunch     bool
 	}{
-		{n: 6, courts: courtLabels(SuggestedMaxCourts(6))},
-		{n: 8, courts: courtLabels(SuggestedMaxCourts(8))},
-		{n: 10, courts: courtLabels(SuggestedMaxCourts(10))},
-		{n: 6, courts: []string{"A"}}, // single court still gets G2 via idle slots
+		{n: 6, courts: courtLabels(SuggestedMaxCourts(6)), startTime: "09:00"},
+		{n: 8, courts: courtLabels(SuggestedMaxCourts(8)), startTime: "09:00"},
+		{n: 10, courts: courtLabels(SuggestedMaxCourts(10)), startTime: "09:00"},
+		{n: 6, courts: []string{"A"}, startTime: "09:00"},              // single court still gets G2 via idle slots
+		{n: 8, courts: []string{"A"}, startTime: "11:50", lunch: true}, // slots straddle the noon lunch block
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("n=%d_courts=%d", tt.n, len(tt.courts)), func(t *testing.T) {
+		t.Run(fmt.Sprintf("n=%d_courts=%d_lunch=%v", tt.n, len(tt.courts), tt.lunch), func(t *testing.T) {
 			t.Parallel()
 
 			eng, store, _ := setupTestEngine(t)
-			compID := fmt.Sprintf("league-g1g2-%d-%d", tt.n, len(tt.courts))
+			compID := fmt.Sprintf("league-g1g2-%d-%d-%v", tt.n, len(tt.courts), tt.lunch)
+
+			if tt.lunch {
+				require.NoError(t, store.SaveTournament(&state.Tournament{LunchBlock: "1h"}))
+			}
 
 			comp := &state.Competition{
 				ID:           compID,
@@ -317,12 +327,12 @@ func TestGeneratePools_League_G1G2(t *testing.T) {
 				PoolWinners:  1,
 				RoundRobin:   true,
 				Courts:       tt.courts,
-				StartTime:    "09:00",
+				StartTime:    tt.startTime,
 				Status:       "setup",
 			}
 			require.NoError(t, store.SaveCompetition(comp))
 
-			saveTestParticipants(t, store, compID, makeNames(tt.n))
+			saveTestParticipants(t, store, compID, names(tt.n))
 
 			require.NoError(t, eng.StartCompetition(compID))
 
@@ -348,10 +358,11 @@ func TestGeneratePools_League_G1G2(t *testing.T) {
 				}
 			}
 
-			// G2: no player has two matches exactly one slot apart. Recompute the
-			// slot duration exactly as generatePools did (load + apply defaults),
-			// so an idle slot between two matches reads as a 2-slot gap, not a
-			// false adjacency.
+			// G2: no player has two matches closer than two slots apart. Recompute
+			// the slot duration exactly as generatePools did (load + apply
+			// defaults). A correct schedule keeps every player's matches at least
+			// two slots (2*perMatch) apart; a lunch skip only widens the gap, so
+			// the >= check stays correct across the lunch boundary.
 			loadedComp, err := store.LoadCompetition(compID)
 			require.NoError(t, err)
 			tournament, err := store.LoadTournament()
@@ -371,19 +382,10 @@ func TestGeneratePools_League_G1G2(t *testing.T) {
 			for player, mins := range byPlayer {
 				sort.Ints(mins)
 				for i := 1; i < len(mins); i++ {
-					assert.NotEqualf(t, perMatch, mins[i]-mins[i-1],
+					assert.GreaterOrEqualf(t, mins[i]-mins[i-1], 2*perMatch,
 						"G2 violation: player %q has back-to-back matches %d minutes apart", player, mins[i]-mins[i-1])
 				}
 			}
 		})
 	}
-}
-
-// makeNames returns n player names "P0".."P{n-1}".
-func makeNames(n int) []string {
-	names := make([]string, n)
-	for i := range n {
-		names[i] = fmt.Sprintf("P%d", i)
-	}
-	return names
 }

--- a/internal/engine/pools.go
+++ b/internal/engine/pools.go
@@ -139,28 +139,6 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 		}
 	}
 
-	// For single-pool multi-court, distribute each round's matches across
-	// courts so that simultaneous matches never share a participant.
-	// When a round has more matches than courts (e.g. 6 players / 2
-	// courts → 3 matches per round), the extra match is queued on the
-	// same court and runs sequentially; the runtime simultaneity gate
-	// (checkSimultaneousMatch) prevents double-booking at match start.
-	if len(pools) == 1 && len(comp.Courts) > 1 {
-		sort.SliceStable(results, func(i, j int) bool {
-			return results[i].Round < results[j].Round
-		})
-		roundStart := 0
-		currentRound := -1
-		for i := range results {
-			if results[i].Round != currentRound {
-				currentRound = results[i].Round
-				roundStart = 0
-			}
-			results[i].Court = comp.Courts[roundStart%len(comp.Courts)]
-			roundStart++
-		}
-	}
-
 	// Per-court slot assignment (T150) + ceremony-block skipping
 	// (T151). Loads the tournament-level tuning (multiplier,
 	// opening / lunch blocks) so a missing tournament.md falls back
@@ -172,7 +150,45 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 	}
 	state.ApplyTournamentDefaults(tournament)
 	state.ApplyCompetitionDefaults(comp)
-	results, _ = assignPoolMatchSlots(results, comp, tournament)
+
+	if comp.Format == state.CompFormatLeague {
+		// League scheduling (mp-sjaz): spread every player's matches so
+		// nobody fights two slots in a row, and keep all courts in a slot
+		// strictly time-aligned. This replaces the round-position court
+		// assignment + per-court slot cursors used by the other single-pool
+		// paths. The runtime simultaneity gate (checkSimultaneousMatch)
+		// remains the defense-in-depth backstop at match start.
+		courtLabels := comp.Courts
+		if len(courtLabels) == 0 {
+			courtLabels = []string{""}
+		}
+		var slots []int
+		results, slots = scheduleLeagueSlots(results, len(players), courtLabels)
+		results, _ = assignLeagueSlotTimes(results, slots, comp, tournament)
+	} else {
+		// For single-pool multi-court, distribute each round's matches across
+		// courts so that simultaneous matches never share a participant.
+		// When a round has more matches than courts (e.g. 6 players / 2
+		// courts → 3 matches per round), the extra match is queued on the
+		// same court and runs sequentially; the runtime simultaneity gate
+		// (checkSimultaneousMatch) prevents double-booking at match start.
+		if len(pools) == 1 && len(comp.Courts) > 1 {
+			sort.SliceStable(results, func(i, j int) bool {
+				return results[i].Round < results[j].Round
+			})
+			roundStart := 0
+			currentRound := -1
+			for i := range results {
+				if results[i].Round != currentRound {
+					currentRound = results[i].Round
+					roundStart = 0
+				}
+				results[i].Court = comp.Courts[roundStart%len(comp.Courts)]
+				roundStart++
+			}
+		}
+		results, _ = assignPoolMatchSlots(results, comp, tournament)
+	}
 
 	return e.store.SavePoolMatches(comp.ID, results)
 }

--- a/internal/engine/pools.go
+++ b/internal/engine/pools.go
@@ -158,12 +158,9 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 		// assignment + per-court slot cursors used by the other single-pool
 		// paths. The runtime simultaneity gate (checkSimultaneousMatch)
 		// remains the defense-in-depth backstop at match start.
-		courtLabels := comp.Courts
-		if len(courtLabels) == 0 {
-			courtLabels = []string{""}
-		}
+		// scheduleLeagueSlots treats an empty court list as one unnamed court.
 		var slots []int
-		results, slots = scheduleLeagueSlots(results, len(players), courtLabels)
+		results, slots = scheduleLeagueSlots(results, comp.Courts)
 		results, _ = assignLeagueSlotTimes(results, slots, comp, tournament)
 	} else {
 		// For single-pool multi-court, distribute each round's matches across

--- a/internal/engine/pools.go
+++ b/internal/engine/pools.go
@@ -112,8 +112,10 @@ func (e *Engine) generatePools(comp *state.Competition, players []domain.Player,
 		if len(comp.Courts) > 0 {
 			poolCourts = []string{comp.Courts[courtAssign[pi]]}
 			// When there is only one pool (league format) and multiple
-			// courts, spread that pool's matches round-robin across all
-			// competition courts so no court sits idle.
+			// courts, seed each match with a court so none is left blank.
+			// For League this is provisional: the rest-aware scheduler
+			// below reassigns courts per slot. It matters for the
+			// non-league else branch's round-position spread.
 			if len(pools) == 1 && len(comp.Courts) > 1 {
 				poolCourts = comp.Courts
 			}

--- a/internal/engine/scheduler_slots.go
+++ b/internal/engine/scheduler_slots.go
@@ -150,6 +150,20 @@ func skipCeremonyBlocks(t, lunchStart time.Time, lunchDurationMin int) time.Time
 	return t
 }
 
+// parseCeremonyParams derives the shared scheduling anchors from a competition
+// and (optional) tournament. dayStart is always valid; openingMin/lunchMin are
+// 0 and lunchStart is the zero Time when tournament is nil. Callers must still
+// guard comp == nil themselves (they return before reaching this).
+func parseCeremonyParams(comp *state.Competition, tournament *state.Tournament) (dayStart time.Time, openingMin, lunchMin int, lunchStart time.Time) {
+	dayStart = parseClockHHMM(comp.StartTime)
+	if tournament != nil {
+		openingMin = parseDurationMinutes(tournament.OpeningBlock)
+		lunchMin = parseDurationMinutes(tournament.LunchBlock)
+		lunchStart = parseClockHHMM(defaultLunchStartClock)
+	}
+	return
+}
+
 // assignPoolMatchSlots walks the pool-match list and writes a per-
 // court time slot into each match's ScheduledAt field. Pool matches
 // are grouped by Court; matches on the same court are sequential,
@@ -181,15 +195,7 @@ func assignPoolMatchSlots(matches []state.MatchResult, comp *state.Competition, 
 	if comp == nil {
 		return matches, time.Time{}
 	}
-	dayStart := parseClockHHMM(comp.StartTime)
-	openingMin := 0
-	lunchMin := 0
-	var lunchStart time.Time
-	if tournament != nil {
-		openingMin = parseDurationMinutes(tournament.OpeningBlock)
-		lunchMin = parseDurationMinutes(tournament.LunchBlock)
-		lunchStart = parseClockHHMM(defaultLunchStartClock)
-	}
+	dayStart, openingMin, lunchMin, lunchStart := parseCeremonyParams(comp, tournament)
 	if len(matches) == 0 {
 		return matches, dayStart.Add(time.Duration(openingMin) * time.Minute)
 	}
@@ -252,15 +258,7 @@ func assignBracketMatchSlots(rounds [][]state.BracketMatch, comp *state.Competit
 	if comp == nil {
 		return time.Time{}
 	}
-	dayStart := parseClockHHMM(comp.StartTime)
-	openingMin := 0
-	lunchMin := 0
-	var lunchStart time.Time
-	if tournament != nil {
-		openingMin = parseDurationMinutes(tournament.OpeningBlock)
-		lunchMin = parseDurationMinutes(tournament.LunchBlock)
-		lunchStart = parseClockHHMM(defaultLunchStartClock)
-	}
+	dayStart, openingMin, lunchMin, lunchStart := parseCeremonyParams(comp, tournament)
 	if len(rounds) == 0 {
 		return dayStart.Add(time.Duration(openingMin) * time.Minute)
 	}


### PR DESCRIPTION
## Summary

- League-format competitions no longer schedule a player to fight two matches in a row. Previously a full round-robin League was scheduled as a single Pool with independent per-court time cursors, so a player could be sent straight from one match into the next with no rest.
- League match scheduling now runs through a dedicated rest-aware scheduler that spreads every player's matches across time slots. Guarantees: no player is ever in two matches in the same slot (no cross-court double-booking), and no player is ever in two adjacent slots (no back-to-back), for any court count.
- Court count now only affects schedule length, not correctness: fewer courts means more idle rest slots. Small pools (Mixed format) and all other formats (Swiss, Playoffs) are unchanged, back-to-back in a 3-4 player pool is expected and stays.

## Why

In kendo, a small pool forces back-to-back play by pigeonhole, but a larger League should give players rest between matches. The old single-Pool model could not express that. A first design (a runtime "play rounds in order" gate) was rejected because it only enforced order, not rest. The final design makes no-back-to-back a hard scheduling invariant: whenever every remaining match would put a just-played player straight back in, the scheduler inserts an idle slot (which is the rest period) and advances. This always terminates (after an idle slot the just-played players are two slots clear, so a match always places next) and reuses the `Round`/circle-method infrastructure from mp-dc52 rather than duplicating it. The runtime simultaneity gate (`checkSimultaneousMatch`) is untouched and remains the defense-in-depth backstop at match start.

## Files changed

| File | What |
|---|---|
| `internal/engine/league_schedule.go` | New. `scheduleLeagueSlots` (greedy rest-aware slot assignment, hard no-back-to-back via idle-slot insertion) and `assignLeagueSlotTimes` (slot-band time assignment sharing a single global cursor). |
| `internal/engine/league_schedule_test.go` | New. Completeness + no-double-booking + no-back-to-back for n=2..16 at recommended and warning-zone court counts, single-court, a lunch-boundary case, and an integration test through `generatePools`. |
| `internal/engine/pools.go` | Route `CompFormatLeague` through the new scheduler; all other single-pool / Mixed paths unchanged (tournament load moved above the branch so both share it). |
| `internal/engine/scheduler_slots.go` | Extract shared `parseCeremonyParams` helper; dedupe the ceremony-block setup across the pool, bracket, and league slot assigners (DRY). |
| `internal/engine/league_allocation_test.go` | Update the obsolete "same-round matches on distinct courts" subtest to the new per-slot invariant, since matches of one round deliberately no longer map to one parallel time slot. |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) - green; `internal/engine` at 85.9% (above the 85% gate), gosec 0 issues, govulncheck clean, vitest 2030 pass
- [x] New/updated unit tests cover the change - the two guarantees are asserted by slot index for n=2..16 across court counts, plus a `generatePools` integration test and a lunch-boundary case
- [x] Manual browser verification (for `web-mobile/` or `web/` changes): N/A, backend-only change, no UI surface touched
- [x] Screenshots added above (REQUIRED for any UI-affecting change): N/A, no UI impact
- [x] Docs updated under `docs/` for any new or changed user-facing feature, flag, command, or behavior (`make docs/build` passes): N/A, no `docs/` page describes League match ordering; no new flag or command
- [x] No new console errors or warnings: N/A, backend-only

Closes mp-sjaz
