### PR TITLE
feat(mp-ce66): match competitor number/tag in schedule free-text filter

### DIFF
--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -74,7 +74,7 @@ The public surfaces (viewer, displays) need no password; the operator and manage
 The default view needs no password: it is the one screen **competitors, coaches, and spectators** share. It shows:
 
 - A personal **Watchlist**: track yourself, specific competitors, or a whole dojo, and get an on-deck nudge as a watched match approaches, so players know when to warm up and coaches know when to be matside.
-- The full match schedule across all shiai-jo, filterable by player or team.
+- The full match schedule across all shiai-jo, filterable by player or team. The free-text filter also matches a competitor's assigned number or tag (for example "A1"), so you can jump straight to a competitor's bouts by their tag.
 - Pool standings updated in real time as scores are entered.
 - The elimination bracket as it fills in.
 

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -89,6 +89,16 @@ describe('Viewer Utils', () => {
       expect(filtered.length).toBe(2);
     });
 
+    it('matches the free-text filter against a side competitor number/tag (mp-ce66)', () => {
+      const tagged = [
+        { id: 'm1', compId: 'c1', sideA: { id: 'p1', name: 'Alice', dojo: 'Dojo A', number: 'A1' }, sideB: { id: 'p2', name: 'Bob', dojo: 'Dojo B', number: 'A2' } },
+        { id: 'm2', compId: 'c2', sideA: { id: 'p3', name: 'Charlie', dojo: 'Dojo A', number: 'B1' }, sideB: { id: 'p4', name: 'David', dojo: 'Dojo C', number: 'B2' } },
+      ];
+      const filtered = applyFilters(tagged, [], 'A1', 'all');
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].id).toBe('m1');
+    });
+
     it('matches by name when picked id differs from match side id (UUID vs name)', () => {
       const uuidMatches = [
         { id: 'm1', compId: 'c1', sideA: { id: 'Alice', name: 'Alice' }, sideB: { id: 'Bob', name: 'Bob' } },
@@ -116,6 +126,12 @@ describe('Viewer Utils', () => {
     it('should return true if dojo matches', () => {
       expect(matchHighlightedBy(match, [], 'Dojo B')).toBe(true);
       expect(matchHighlightedBy(match, [], 'Dojo C')).toBe(false);
+    });
+
+    it('highlights when the free-text filter matches a competitor number/tag (mp-ce66)', () => {
+      const tagged = { sideA: { id: 'p1', name: 'Alice', dojo: 'Dojo A', number: 'A1' }, sideB: { id: 'p2', name: 'Bob', dojo: 'Dojo B', number: 'A2' } };
+      expect(matchHighlightedBy(tagged, [], 'A2')).toBe(true);
+      expect(matchHighlightedBy(tagged, [], 'A9')).toBe(false);
     });
 
     it('highlights by name when picked id differs from match side id', () => {

--- a/web-mobile/js/viewer_schedule.jsx
+++ b/web-mobile/js/viewer_schedule.jsx
@@ -123,7 +123,7 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
 
   const q = query.trim().toLowerCase();
   const matches = q ? roster.filter((p) =>
-    p.name.toLowerCase().includes(q) || (p.dojo || "").toLowerCase().includes(q)
+    p.name.toLowerCase().includes(q) || (p.dojo || "").toLowerCase().includes(q) || (p.number || "").toLowerCase().includes(q)
   ).slice(0, 30) : roster.slice(0, 30);
 
   window.useClickOutside(ref, () => setOpen(false), open);
@@ -136,8 +136,8 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
   return (
     <div className="pmf" ref={ref}>
       <div className="pmf__bar" onClick={() => setOpen(true)}>
-        {picked.length === 0 && !dojoText ? (
-          <span className="pmf__placeholder">Filter by player, team, or dojo…</span>
+        {picked.length === 0 && !dojoText && !query ? (
+          <span className="pmf__placeholder">Filter by player, tag, team, or dojo…</span>
         ) : null}
         {picked.map((p) => (
           <span key={p.id} className="pmf__chip">
@@ -177,7 +177,7 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
           </div>
           {q && (
             <button type="button" className="pmf__option pmf__option--text" onClick={() => { setDojoText(query.trim()); setQuery(""); }}>
-              <span>Match text "<b>{query}</b>" in any name/dojo</span>
+              <span>Match "<b>{query}</b>" in any name, tag, or dojo</span>
             </button>
           )}
           {matches.map((p) => {

--- a/web-mobile/js/viewer_schedule.jsx
+++ b/web-mobile/js/viewer_schedule.jsx
@@ -210,7 +210,7 @@ export function applyFilters(matches, picked, dojoText, compFilter) {
       if (!hit) return false;
     }
     if (dt) {
-      const hit = [m.sideA?.name, m.sideB?.name, m.sideA?.dojo, m.sideB?.dojo].some((s) => (s || "").toLowerCase().includes(dt));
+      const hit = [m.sideA?.name, m.sideB?.name, m.sideA?.dojo, m.sideB?.dojo, m.sideA?.number, m.sideB?.number].some((s) => (s || "").toLowerCase().includes(dt));
       if (!hit) return false;
     }
     return true;
@@ -222,7 +222,7 @@ export function matchHighlightedBy(m, picked, dojoText) {
   const names = new Set(picked.map((p) => p.name).filter(Boolean));
   if (ids.size > 0 && ((m.sideA && (ids.has(m.sideA.id) || names.has(m.sideA.name))) || (m.sideB && (ids.has(m.sideB.id) || names.has(m.sideB.name))))) return true;
   const dt = (dojoText || "").trim().toLowerCase();
-  if (dt && [m.sideA?.name, m.sideB?.name, m.sideA?.dojo, m.sideB?.dojo].some((s) => (s || "").toLowerCase().includes(dt))) return true;
+  if (dt && [m.sideA?.name, m.sideB?.name, m.sideA?.dojo, m.sideB?.dojo, m.sideA?.number, m.sideB?.number].some((s) => (s || "").toLowerCase().includes(dt))) return true;
   return false;
 }
 

--- a/web-mobile/js/viewer_schedule.jsx
+++ b/web-mobile/js/viewer_schedule.jsx
@@ -171,7 +171,7 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
       {open && (
         <div className="pmf__dropdown">
           <div className="pmf__dropdown-head">
-            {q ? (filtered.length > 30 ? "30+ matches" : pluralize(filtered.length, "match", "matches")) : `${pluralize(roster.length, "participant")}: type to search`}
+            {q ? (filtered.length > 30 ? "30+ participants" : pluralize(filtered.length, "participant")) : `${pluralize(roster.length, "participant")}: type to search`}
             {(picked.length > 0 || dojoText) && (
               <button type="button" className="btn btn--ghost btn--sm" onClick={() => { setPicked([]); setDojoText(""); setQuery(""); }}>Clear all</button>
             )}

--- a/web-mobile/js/viewer_schedule.jsx
+++ b/web-mobile/js/viewer_schedule.jsx
@@ -122,9 +122,10 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
   }, [tournament]);
 
   const q = query.trim().toLowerCase();
-  const matches = q ? roster.filter((p) =>
+  const filtered = q ? roster.filter((p) =>
     p.name.toLowerCase().includes(q) || (p.dojo || "").toLowerCase().includes(q) || (p.number || "").toLowerCase().includes(q)
-  ).slice(0, 30) : roster.slice(0, 30);
+  ) : roster;
+  const matches = filtered.slice(0, 30);
 
   window.useClickOutside(ref, () => setOpen(false), open);
 
@@ -170,7 +171,7 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
       {open && (
         <div className="pmf__dropdown">
           <div className="pmf__dropdown-head">
-            {q ? pluralize(matches.length, "match", "matches") : `${pluralize(roster.length, "participant")}: type to search`}
+            {q ? (filtered.length > 30 ? "30+ matches" : pluralize(filtered.length, "match", "matches")) : `${pluralize(roster.length, "participant")}: type to search`}
             {(picked.length > 0 || dojoText) && (
               <button type="button" className="btn btn--ghost btn--sm" onClick={() => { setPicked([]); setDojoText(""); setQuery(""); }}>Clear all</button>
             )}
@@ -186,7 +187,7 @@ export function PlayerMultiFilter({ tournament, picked, setPicked, dojoText, set
               <button type="button" key={p.id} className={`pmf__option ${isPicked ? "is-picked" : ""}`} onClick={() => toggle(p)}>
                 <span className="pmf__check">{isPicked ? "✓" : ""}</span>
                 <span className="pmf__opt-body">
-                  <span className="pmf__opt-name">{p.name}</span>
+                  <span className="pmf__opt-name">{p.number ? `${p.number} · ` : ""}{p.name}</span>
                   <span className="pmf__opt-dojo">{p.dojo}{p.comps?.length ? ` · ${p.comps.join(", ")}` : ""}</span>
                 </span>
               </button>


### PR DESCRIPTION
## Summary

- The public schedule page's free-text filter now matches a competitor's assigned **number/tag** (for example "A1"), not just name and dojo. Typing a tag surfaces that competitor's bouts and highlights their match rows.
- The filter's **typeahead now suggests competitors by tag** too, and the placeholder/hint copy advertise it — so typing a tag shows the competitor instead of the old, contradictory "0 matches".
- Previously the filter checked only `name` and `dojo`, so a tag query returned nothing even though the number was already carried on each match side.

## Why

`buildPlayerMap`/`resolveSide` already propagate `number` onto `m.sideA`/`m.sideB`, but `applyFilters` and `matchHighlightedBy` never looked at it. Root cause was a two-field substring check. Source/provenance (`manual`/`registered`/`transfer`) is intentionally **excluded**: it is admin-only and must not leak on the public viewer.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer_schedule.jsx` | Add `sideA/sideB.number` to the free-text check in `applyFilters` and `matchHighlightedBy`; add `p.number` to the typeahead suggestion predicate; update placeholder + hint copy to mention tag; clear the placeholder span while a query is being typed; echo the tag in suggestion rows (`A3 · Watanabe Aoi`) and show `30+ matches` when the suggestion list is capped |
| `web-mobile/js/__tests__/viewer.test.jsx` | New cases: filter and highlight match on a competitor number/tag (and a non-match) |
| `docs/user-guide/mobile-app.md` | Note that the schedule filter also matches a competitor's number/tag |

## Screenshots

Public viewer, all-shiaijo schedule. Typing a competitor tag (`A3`) into the free-text filter narrows 51 → 2 matches, surfacing only that competitor's bouts (Watanabe Aoi, red Aka badge). Captured headless (Chrome, 390×844) against the seeded `tournament-data` fixture; no console errors.

| Unfiltered (51 matches) | Filtered by tag `A3` (2 matches) |
|---|---|
| ![schedule unfiltered](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/331/schedule_all.png) | ![schedule filtered by tag A3](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/331/schedule_filtered_tag.png) |

Typeahead now suggests the competitor by tag (`A3` → Watanabe Aoi) with accurate hint copy, instead of the old "0 matches":

![typeahead suggesting competitor by tag](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/331/filter_typeahead_tag.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages `ok`, coverage ≥85%
- [x] New/updated unit tests cover the change — 2 vitest cases (`applyFilters`, `matchHighlightedBy`); full JS suite 2162 passed
- [x] Manual browser verification (public viewer): typed tag `A3` into the schedule filter → narrowed 51 → 2 matches, both Watanabe Aoi's bouts; no console errors
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] Docs updated under `docs/` (`make docs/build` passes)
- [x] No new console errors or warnings

Closes mp-ce66
