### PR TITLE
refactor(mp-ey84): remove the Men/Women/Mixed competition category setting

### DIFF
--- a/web-mobile/js/__tests__/admin_setup.test.jsx
+++ b/web-mobile/js/__tests__/admin_setup.test.jsx
@@ -53,7 +53,7 @@ describe('pickStackPredecessor', () => {
 
 describe('deriveCompetitionName', () => {
   // Copilot round-8 finding: AdminCreateCompetition.create used
-  //   const finalName = name || <kind/gender default>
+  //   const finalName = name || <kind default>
   // where `name` was the raw input. A whitespace-only string ("   ") is
   // truthy, so it would slip past the default-fallback and be sent to the
   // backend, which trims `comp.Name` on save; landing a competition with
@@ -62,75 +62,56 @@ describe('deriveCompetitionName', () => {
   // competitions with the same effective name could be created.
   //
   // Fix: trim early; fall through to the default when the trimmed value
-  // is empty. Tested below for every (kind, gender) tuple plus the
-  // whitespace edge cases.
+  // is empty. Tested below for each kind plus the whitespace edge cases.
+  // (mp-ey84 removed the Men/Women/Mixed "gender" input, so the default
+  // is now kind-only: "Teams" / "Individual".)
 
   describe('trimmed user input wins when non-empty', () => {
     it('uses the user-provided name when present', () => {
-      expect(deriveCompetitionName('Cup A', 'individual', 'M')).toBe('Cup A');
+      expect(deriveCompetitionName('Cup A', 'individual')).toBe('Cup A');
     });
 
     it('strips surrounding whitespace', () => {
-      expect(deriveCompetitionName('  Cup A  ', 'individual', 'M')).toBe('Cup A');
+      expect(deriveCompetitionName('  Cup A  ', 'individual')).toBe('Cup A');
     });
 
     it('keeps internal whitespace', () => {
-      expect(deriveCompetitionName('  Men Open  ', 'individual', 'M')).toBe('Men Open');
+      expect(deriveCompetitionName('  Men Open  ', 'individual')).toBe('Men Open');
     });
   });
 
   describe('whitespace-only input falls through to the default', () => {
     it('"" falls through', () => {
-      expect(deriveCompetitionName('', 'individual', 'M')).toBe("Men's Individual");
+      expect(deriveCompetitionName('', 'individual')).toBe('Individual');
     });
 
     it('"   " falls through (the Copilot finding)', () => {
-      expect(deriveCompetitionName('   ', 'individual', 'M')).toBe("Men's Individual");
+      expect(deriveCompetitionName('   ', 'individual')).toBe('Individual');
     });
 
     it('"\\t\\n" falls through (tabs + newlines)', () => {
-      expect(deriveCompetitionName('\t\n', 'individual', 'M')).toBe("Men's Individual");
+      expect(deriveCompetitionName('\t\n', 'individual')).toBe('Individual');
     });
 
     it('null/undefined falls through to default', () => {
-      expect(deriveCompetitionName(null, 'individual', 'M')).toBe("Men's Individual");
-      expect(deriveCompetitionName(undefined, 'individual', 'M')).toBe("Men's Individual");
+      expect(deriveCompetitionName(null, 'individual')).toBe('Individual');
+      expect(deriveCompetitionName(undefined, 'individual')).toBe('Individual');
     });
   });
 
   describe('default name picks (when input is empty)', () => {
-    it("team / F → Women's Teams", () => {
-      expect(deriveCompetitionName('', 'team', 'F')).toBe("Women's Teams");
+    it('team → "Teams"', () => {
+      expect(deriveCompetitionName('', 'team')).toBe('Teams');
     });
 
-    it("team / M → Men's Teams", () => {
-      expect(deriveCompetitionName('', 'team', 'M')).toBe("Men's Teams");
+    it('individual → "Individual"', () => {
+      expect(deriveCompetitionName('', 'individual')).toBe('Individual');
     });
 
-    it("team / unspecified gender → Men's Teams (current default)", () => {
-      // The original code falls through to the "Men's Teams" branch when
-      // gender is neither "F" nor "M". Pinned here so anyone changing the
-      // default has to update the test deliberately.
-      expect(deriveCompetitionName('', 'team', null)).toBe("Men's Teams");
-    });
-
-    it("individual / F → Women's Individual", () => {
-      expect(deriveCompetitionName('', 'individual', 'F')).toBe("Women's Individual");
-    });
-
-    it("individual / M → Men's Individual", () => {
-      expect(deriveCompetitionName('', 'individual', 'M')).toBe("Men's Individual");
-    });
-
-    it('individual / unspecified → "Individual"', () => {
-      expect(deriveCompetitionName('', 'individual', null)).toBe('Individual');
-      expect(deriveCompetitionName('', 'individual', undefined)).toBe('Individual');
-    });
-
-    it('unknown kind / unspecified gender → "Individual"', () => {
+    it('unknown kind → "Individual"', () => {
       // Defensive: if kind is some future value, fall through to the
       // most-generic individual default.
-      expect(deriveCompetitionName('', 'unknown', null)).toBe('Individual');
+      expect(deriveCompetitionName('', 'unknown')).toBe('Individual');
     });
   });
 });

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -58,8 +58,7 @@ describe('Viewer Utils', () => {
 
   describe('competitionKindLabel', () => {
     it('should return correct label for individual', () => {
-      expect(competitionKindLabel({ kind: 'individual', gender: 'M' })).toBe('Individual · Men');
-      expect(competitionKindLabel({ kind: 'individual', gender: 'F' })).toBe('Individual · Women');
+      expect(competitionKindLabel({ kind: 'individual' })).toBe('Individual');
     });
     it('should return correct label for teams', () => {
       expect(competitionKindLabel({ kind: 'team' })).toBe('Teams');

--- a/web-mobile/js/admin_participants.jsx
+++ b/web-mobile/js/admin_participants.jsx
@@ -289,7 +289,7 @@ function AdminParticipants({ c, tournament: _tournament, onUpdate, password, sho
   // "Apply changes": it reuses the whole parse/validate/save path. The
   // generated ids are placeholders; apply() assigns `${compId}-pN` ids.
   const fillSample = (count) => {
-    const sample = window.makeCompetitors(count, c.kind, c.id, 0, c.gender || "M");
+    const sample = window.makeCompetitors(count, c.kind, c.id, 0);
     setText(generateText(sample));
   };
 

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -23,7 +23,7 @@ const isNonPublicOrigin = window.isNonPublicOrigin || (() => false);
 
 // Returns the final competition name, trimming the raw user input before
 // the empty-check so a whitespace-only string ("   ") falls through to the
-// kind/gender-based default instead of being treated as a valid name.
+// kind-based default instead of being treated as a valid name.
 //
 // The bug shape without this trim: `name || default` where name=" " is
 // truthy → creates a comp with name=" " → backend trims `comp.Name` on
@@ -34,12 +34,10 @@ const isNonPublicOrigin = window.isNonPublicOrigin || (() => false);
 //
 // Defaults match the labels users see in the dashboard's "team event" and
 // "individual event" pickers.
-function deriveCompetitionName(rawName, kind, gender) {
+function deriveCompetitionName(rawName, kind) {
   const trimmed = (rawName || "").trim();
   if (trimmed) return trimmed;
-  if (kind === "team") return gender === "F" ? "Women's Teams" : "Men's Teams";
-  if (gender === "F") return "Women's Individual";
-  if (gender === "M") return "Men's Individual";
+  if (kind === "team") return "Teams";
   return "Individual";
 }
 
@@ -661,7 +659,6 @@ const MIN_STACK_BLOCK_MIN = 30;
 function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onViewerMode, password }) {
   const [name, setName] = useStateA("");
   const [kind, setKind] = useStateA("individual");
-  const [gender, setGender] = useStateA("M"); // for individual: M/F/X
   const [format, setFormat] = useStateA("playoffs");
   // FR-050 / T044: per-phase round-robin shape selector. Only meaningful
   // when the format runs pool play ("mixed", "league"); default
@@ -734,7 +731,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     // never bypasses the default-fallback (truthy strings of spaces would
     // create a backend-trimmed empty name). See the helper at the top of
     // this file for the full rationale + tests.
-    const finalName = deriveCompetitionName(name, kind, gender);
+    const finalName = deriveCompetitionName(name, kind);
 
     const exists = (tournament.competitions || []).some(cc => cc.name.toLowerCase() === finalName.toLowerCase());
     if (exists) {
@@ -811,7 +808,7 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
     const c = window.buildCompetition({
       id,
       name: finalName,
-      kind, gender,
+      kind,
       format,
       // New competitions start with an empty roster: participants (or a
       // sample roster) are added in the Participants view, not here.
@@ -878,16 +875,6 @@ function AdminCreateCompetition({ tournament, onCancel, onCreate, onLogout, onVi
               <button className={`radio-pill ${kind === "individual" ? "is-active" : ""}`} type="button" onClick={() => setKind("individual")}>Individual</button>
               <button className={`radio-pill ${kind === "team" ? "is-active" : ""}`} type="button" onClick={() => setKind("team")}>Team</button>
             </div>
-          </div>
-
-          <div className="field">
-            <label className="field__label">Category (optional)</label>
-            <div className="radio-group">
-              <button className={`radio-pill ${gender === "M" ? "is-active" : ""}`} type="button" onClick={() => setGender("M")}>Men</button>
-              <button className={`radio-pill ${gender === "F" ? "is-active" : ""}`} type="button" onClick={() => setGender("F")}>Women</button>
-              <button className={`radio-pill ${gender === "X" ? "is-active" : ""}`} type="button" onClick={() => setGender("X")}>Mixed / Other</button>
-            </div>
-            <div className="field__hint">Used for the display label and in name suggestions. You can change later.</div>
           </div>
 
           <div className="row">

--- a/web-mobile/js/data.jsx
+++ b/web-mobile/js/data.jsx
@@ -20,7 +20,8 @@
 //   - holds many Competitions.
 //
 // Competition: one event within a tournament (e.g., "Men's Individual", "Women's Teams").
-//   - kind: "individual" | "team"  (only two kinds: gender/age tags are metadata)
+//   - kind: "individual" | "team"  (the only two kinds; any division, e.g.
+//     Men's / Women's / Youth, is expressed in the competition name)
 //   - format: "playoffs" (knockout only) | "mixed" (pools + knockout) | "league" | "swiss"
 //     Note: the sample generator (applyFormat) only simulates "mixed" fully;
 //     "league" and "swiss" fall back to bracket-only display in demo data.
@@ -32,8 +33,7 @@
 // status, score. Score can be edited at any time by an admin.
 
 const DOJOS = ['Team Alpha', 'Team Beta', 'Team Chi', 'Team Delta', 'Team Epsilon', 'Team Eta', 'Team Gamma', 'Team Iota', 'Team Kappa', 'Team Lambda', 'Team Mu', 'Team Nu', 'Team Omega', 'Team Omicron', 'Team Phi', 'Team Pi', 'Team Psi', 'Team Rho', 'Team Sigma', 'Team Tau', 'Team Theta', 'Team Upsilon', 'Team Xi', 'Team Zeta'];
-const FIRST_M = ['Aaron', 'Albus', 'Arthur', 'Benjamin', 'Bilbo', 'Bram', 'Caleb', 'Charles', 'Daniel', 'Dylan', 'Eddard', 'Elijah', 'Finn', 'Frodo', 'Fyodor', 'Gabriel', 'Gandalf', 'George', 'Herman', 'Hudson', 'Inigo', 'Isaac', 'Jackson', 'Jon', 'Kaden', 'Kevin', 'Kurt', 'Legolas', 'Lewis', 'Liam', 'Luke', 'Mason', 'Michael', 'Moby', 'Nathan', 'Nathaniel', 'Neville', 'Nolan', 'Oliver', 'Oscar', 'Othello', 'Owen', 'Parker', 'Paul', 'Petyr', 'Philip', 'Quentin', 'Quinn', 'Quirinus', 'Ray', 'Robert', 'Ron', 'Ryan', 'Samwise', 'Sebastian', 'Steven', 'Thomas', 'Tristan', 'Tyrion', 'Ulysses', 'Uriel', 'Victor', 'Vincent', 'Voldemort', 'William', 'Willy', 'Xaro', 'Xavier', 'Yann', 'Yosef', 'Zachary'];
-const FIRST_F = ['Cersei', 'Daenerys', 'Emily', 'Hermione', 'Jane', 'Katniss', 'Mary', 'Sylvia', 'Ursula', 'Virginia', 'Ygritte'];
+const FIRST = ['Aaron', 'Albus', 'Arthur', 'Benjamin', 'Bilbo', 'Bram', 'Caleb', 'Cersei', 'Charles', 'Daenerys', 'Daniel', 'Dylan', 'Eddard', 'Elijah', 'Emily', 'Finn', 'Frodo', 'Fyodor', 'Gabriel', 'Gandalf', 'George', 'Herman', 'Hermione', 'Hudson', 'Inigo', 'Isaac', 'Jackson', 'Jane', 'Jon', 'Kaden', 'Katniss', 'Kevin', 'Kurt', 'Legolas', 'Lewis', 'Liam', 'Luke', 'Mary', 'Mason', 'Michael', 'Moby', 'Nathan', 'Nathaniel', 'Neville', 'Nolan', 'Oliver', 'Oscar', 'Othello', 'Owen', 'Parker', 'Paul', 'Petyr', 'Philip', 'Quentin', 'Quinn', 'Quirinus', 'Ray', 'Robert', 'Ron', 'Ryan', 'Samwise', 'Sebastian', 'Steven', 'Sylvia', 'Thomas', 'Tristan', 'Tyrion', 'Ulysses', 'Uriel', 'Ursula', 'Victor', 'Vincent', 'Virginia', 'Voldemort', 'William', 'Willy', 'Xaro', 'Xavier', 'Yann', 'Ygritte', 'Yosef', 'Zachary'];
 const LAST = ['Adams', 'Allen', 'Anderson', 'Asimov', 'Austen', 'Baelish', 'Baggins', 'Blake', 'Bradbury', 'Bronte', 'Carroll', 'Clark', 'Conan', 'Defoe', 'Dick', 'Dickens', 'Dostoevsky', 'Dumbledore', 'Evans', 'Everdeen', 'Gamgee', 'Granger', 'Green', 'Greenleaf', 'Hall', 'Hardy', 'Harris', 'Hawthorne', 'Herbert', 'Hernandez', 'Hill', 'Jackson', 'K Dick', 'K Le Guin', 'King', 'Lannister', 'Lee', 'Lewis', 'Longbottom', 'Lopez', 'Martel', 'Martin', 'Martinez', 'Melville', 'Montoya', 'Moore', 'Orwell', 'Plath', 'Quirrell', 'Rodriguez', 'Scott', 'Shakespeare', 'Shelley', 'Snow', 'Stark', 'Stoker', 'Targaryen', 'Taylor', 'Thomas', 'Thompson', 'Vonnegut', 'Walker', 'Weasley', 'White', 'Wilde', 'Wilson', 'Wonka', 'Woolf', 'Wright', 'Xhoan Daxos', 'Young', 'the Grey'];
 
 
@@ -48,23 +48,22 @@ function mergeMatchPatch(existing, patch) {
   return merged;
 }
 
-function makePlayer(i, gender, prefix, seed) {
-  const first = (gender === "F" ? FIRST_F : FIRST_M);
-  const fn = first[i % first.length];
-  const ln = LAST[(i * 7 + (gender === "F" ? 3 : 0)) % LAST.length];
+function makePlayer(i, prefix, seed) {
+  const fn = FIRST[i % FIRST.length];
+  const ln = LAST[(i * 7) % LAST.length];
   return { id: `${prefix}-p${i + 1}`, name: `${fn} ${ln}`, dojo: DOJOS[(i * 3) % DOJOS.length], seed: seed || null };
 }
 function makeTeam(i, prefix, seed) {
   const dojo = DOJOS[i % DOJOS.length];
   return { id: `${prefix}-t${i + 1}`, name: `${dojo} ${["A","B","C","Red","Blue"][i % 5]}`, dojo, seed: seed || null };
 }
-// kind: "individual" | "team". gender hint: "M" | "F" | "X" (for naming variety only).
-function makeCompetitors(count, kind, prefix, seedCount = 0, gender = "M") {
+// kind: "individual" | "team".
+function makeCompetitors(count, kind, prefix, seedCount = 0) {
   const out = [];
   for (let i = 0; i < count; i++) {
     const seed = i < seedCount ? i + 1 : null;
     if (kind === "team") out.push(makeTeam(i, prefix, seed));
-    else out.push(makePlayer(i, gender, prefix, seed));
+    else out.push(makePlayer(i, prefix, seed));
   }
   return out;
 }
@@ -208,11 +207,11 @@ function poolWinners(pools) {
 // format: "playoffs" | "mixed" | "league" | "swiss"
 function buildEmptyCompetition(args) {
   if (!args) { console.error("buildEmptyCompetition: args is undefined!"); return null; }
-  const { id, name, kind, gender = "X", format, sampleRoster = "medium", courts, seedCount, status, startTime, date, teamSize, poolMode, poolSize, winnersPerPool, withZekkenName, numberPrefix, checkInEnabled } = args;
+  const { id, name, kind, format, sampleRoster = "medium", courts, seedCount, status, startTime, date, teamSize, poolMode, poolSize, winnersPerPool, withZekkenName, numberPrefix, checkInEnabled } = args;
   const count = sampleRoster ? ({ small: 8, medium: 16, large: 32 }[sampleRoster] || 16) : 0;
-  const players = count > 0 ? makeCompetitors(count, kind, id, seedCount, gender) : [];
+  const players = count > 0 ? makeCompetitors(count, kind, id, seedCount) : [];
   return {
-    id, name, kind, gender, format, status,
+    id, name, kind, format, status,
     teamSize: teamSize || (kind === "team" ? 5 : 0),
     poolSize: poolSize || 3,
     poolSizeMode: poolMode || "max",
@@ -281,8 +280,8 @@ const SAMPLE_TOURNAMENTS = [
   (() => {
     const courts = ["A", "B", "C"];
     const comps = [
-      buildCompetition({ id: "lc26-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "playoffs", sampleRoster: "medium", seedCount: 4, status: "playoffs", startTime: "09:00", courts: ["A","B"] }),
-      buildCompetition({ id: "lc26-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "playoffs", sampleRoster: "small", seedCount: 2, status: "playoffs", startTime: "09:00", courts: ["C"] }),
+      buildCompetition({ id: "lc26-mi", name: "Men's Individual", kind: "individual", format: "playoffs", sampleRoster: "medium", seedCount: 4, status: "playoffs", startTime: "09:00", courts: ["A","B"] }),
+      buildCompetition({ id: "lc26-wi", name: "Women's Individual", kind: "individual", format: "playoffs", sampleRoster: "small", seedCount: 2, status: "playoffs", startTime: "09:00", courts: ["C"] }),
       buildCompetition({ id: "lc26-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "setup", startTime: "14:00", teamSize: 5, courts: ["A","B"] }),
     ];
     return buildTournament({ id: "lc2026", name: "London Cup 2026", date: "2026-05-12", venue: "Crystal Palace Sports Centre", courts, status: competitionStatus(comps), competitions: comps });
@@ -290,8 +289,8 @@ const SAMPLE_TOURNAMENTS = [
   (() => {
     const courts = ["A", "B", "C", "D"];
     const comps = [
-      buildCompetition({ id: "ko-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "mixed", sampleRoster: "large", seedCount: 4, status: "pools", startTime: "09:00", courts: ["A","B"] }),
-      buildCompetition({ id: "ko-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "pools", startTime: "09:00", courts: ["C","D"] }),
+      buildCompetition({ id: "ko-mi", name: "Men's Individual", kind: "individual", format: "mixed", sampleRoster: "large", seedCount: 4, status: "pools", startTime: "09:00", courts: ["A","B"] }),
+      buildCompetition({ id: "ko-wi", name: "Women's Individual", kind: "individual", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "pools", startTime: "09:00", courts: ["C","D"] }),
       buildCompetition({ id: "ko-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "medium", seedCount: 0, status: "setup", startTime: "14:00", teamSize: 5, courts: ["A","B","C","D"] }),
       buildCompetition({ id: "ko-wt", name: "Women's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "setup", startTime: "16:00", teamSize: 5, courts: ["A","B"] }),
     ];
@@ -300,16 +299,16 @@ const SAMPLE_TOURNAMENTS = [
   (() => {
     const courts = ["A"];
     const comps = [
-      buildCompetition({ id: "wk-yi", name: "Youth Individual", kind: "individual", gender: "M", format: "playoffs", sampleRoster: "small", seedCount: 0, status: "setup", courts: ["A"] }),
-      buildCompetition({ id: "wk-bi", name: "Beginners Individual", kind: "individual", gender: "M", format: "playoffs", sampleRoster: "small", seedCount: 0, status: "setup", courts: ["A"] }),
+      buildCompetition({ id: "wk-yi", name: "Youth Individual", kind: "individual", format: "playoffs", sampleRoster: "small", seedCount: 0, status: "setup", courts: ["A"] }),
+      buildCompetition({ id: "wk-bi", name: "Beginners Individual", kind: "individual", format: "playoffs", sampleRoster: "small", seedCount: 0, status: "setup", courts: ["A"] }),
     ];
     return buildTournament({ id: "wakaba-cup", name: "Wakaba Cup: Beginners", date: "2026-06-04", venue: "Sanshukai Dojo", courts, status: "setup", competitions: comps });
   })(),
   (() => {
     const courts = ["A", "B", "C"];
     const comps = [
-      buildCompetition({ id: "ako25-mi", name: "Men's Individual", kind: "individual", gender: "M", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
-      buildCompetition({ id: "ako25-wi", name: "Women's Individual", kind: "individual", gender: "F", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
+      buildCompetition({ id: "ako25-mi", name: "Men's Individual", kind: "individual", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
+      buildCompetition({ id: "ako25-wi", name: "Women's Individual", kind: "individual", format: "mixed", sampleRoster: "medium", seedCount: 4, status: "completed", courts: ["A","B"] }),
       buildCompetition({ id: "ako25-mt", name: "Men's Teams", kind: "team", format: "mixed", sampleRoster: "small", seedCount: 0, status: "completed", teamSize: 5, courts: ["A","B","C"] }),
     ];
     return buildTournament({ id: "autumn-open-2025", name: "Autumn Kendo Open 2025", date: "2025-11-08", venue: "City Arena", courts, status: "completed", competitions: comps });

--- a/web-mobile/js/viewer_utils.jsx
+++ b/web-mobile/js/viewer_utils.jsx
@@ -23,10 +23,7 @@ export function TermV(props) {
 }
 
 export function competitionKindLabel(c) {
-  const base = c.kind === "team" ? "Teams" : "Individual";
-  if (c.gender === "M") return `${base} · Men`;
-  if (c.gender === "F") return `${base} · Women`;
-  return base;
+  return c.kind === "team" ? "Teams" : "Individual";
 }
 
 // leagueAwareLabel: the single source of truth for the pool-vs-league heading.


### PR DESCRIPTION
## Summary

- Removes the "Category (Men / Women / Mixed)" selector from the create-competition form. It was a half-wired setting with no competitive effect.
- The frontend collected a `gender` value and sent it, but the Go backend (`CompetitionConfig`) has no such field, so it was silently dropped and never persisted. Its only surviving effect was seeding a default competition name when the name was left blank; the viewer division label reading `c.gender` was dead for real competitions (the value never round-trips from the server).
- Division (Men's / Women's / Youth, etc.) is already expressed in the competition name, so nothing user-facing is lost.

## Why

A competition's gender/category was never stored on the server and touched none of seeding, pools, brackets, scoring, eligibility, or scheduling. The setting only added UI clutter and a misleading (dead) viewer label. Removing it deletes the ambiguity.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_setup.jsx` | Delete the Category radio-pill field and `gender` state; simplify `deriveCompetitionName(rawName, kind)` to kind-only defaults ("Teams" / "Individual"); drop `gender` from the create payload |
| `web-mobile/js/viewer_utils.jsx` | `competitionKindLabel` no longer reads `c.gender` (the dead "· Men" / "· Women" branch) |
| `web-mobile/js/data.jsx` | Remove `gender` from `makePlayer` / `makeCompetitors` / `buildCompetition` and the stored competition object; merge `FIRST_M` + `FIRST_F` into one `FIRST` sample-name pool; strip `gender` from `SAMPLE_TOURNAMENTS` |
| `web-mobile/js/admin_participants.jsx` | Drop the `c.gender` argument to `makeCompetitors` |
| `web-mobile/js/__tests__/admin_setup.test.jsx` | Rewrite the `deriveCompetitionName` cases for the kind-only default |
| `web-mobile/js/__tests__/viewer.test.jsx` | Update `competitionKindLabel` expectations |

No Go changes: the field never existed in the backend.

## Screenshots

The "Add competition" form after removal, with no Category selector (Competition type, Display name, Start time, Day, Player number prefix, Format, Assigned shiaijo, then the option checkboxes):

![Add competition form without the Category selector](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/337/add-competition-no-category.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages ≥85% coverage
- [x] New/updated unit tests cover the change (`vitest run`: 2173 passed; `eslint --max-warnings 0` clean)
- [x] Manual browser verification: created an Individual competition with a blank name via the live mobile-app; the Category field is absent and the name correctly defaults to "Individual" (kind-only), with the header label reading plain "Individual" (no "· Men")
- [x] Screenshots added above
- [x] Docs updated under `docs/` for any new or changed user-facing feature — N/A: grepped `docs/`, no mention of the Men/Women/Mixed category setting
- [x] No new console errors or warnings

Closes mp-ey84
