### PR TITLE
feat: link previews, Website-link rename + migration, sponsor banner fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Init project
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Init project
@@ -175,7 +175,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install LibreOffice headless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 # Build stage
 FROM golang:${GO_VERSION} AS builder

--- a/Dockerfile.mobile
+++ b/Dockerfile.mobile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 # Build stage
 FROM golang:${GO_VERSION} AS builder

--- a/Dockerfile.mobile-pdf
+++ b/Dockerfile.mobile-pdf
@@ -11,7 +11,7 @@
 # libreoffice-nogui). The Go binary's LocateSoffice() probes $PATH first, so no
 # additional env vars are required.
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 # ---------------------------------------------------------------------------
 # Build stage, identical to Dockerfile.mobile

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -84,7 +84,7 @@ On tree and playoff brackets, the player/team on the top of the bracket is alway
 ## Building and Running
 
 ### Prerequisites
-- Go 1.26.4+
+- Go 1.26.5+
 - Make
 
 ### Key Commands

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME := bracket-creator
 GH_REPOSITORY ?= gitrgoliveira/bracket-creator
 IMAGE_NAME := ghcr.io/$(GH_REPOSITORY)
 BIN_PATH := ./bin
-GO_VERSION := 1.26.4
+GO_VERSION := 1.26.5
 GO_SOURCES := $(shell find . -name "*.go" -type f)
 EMBEDDED_ASSETS := $(shell find ./web ./web-mobile -type f 2>/dev/null)
 

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -9,7 +9,7 @@ By participating in this project, you agree to abide our
 
 Prerequisites:
 
-- [Go 1.26.4+](https://golang.org/doc/install)
+- [Go 1.26.5+](https://golang.org/doc/install)
 
 Other things you might need to run the tests:
 

--- a/docs/user-guide/commands/version.md
+++ b/docs/user-guide/commands/version.md
@@ -6,6 +6,6 @@ bracket-creator - v1.0.0
 
 Git Commit: ee8538fa83f36ccf9910fe6fc0c42e56afaf07ca
 Build date: 2022-12-17 17:55:45 +0100
-Go version: go1.26.4
+Go version: go1.26.5
 OS / Arch : darwin arm64
 ```

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -45,7 +45,7 @@ The single binary bundles every subcommand, including `bracket-creator serve` (w
 If you prefer to compile from source, `bracket-creator` is written in [Go](https://golang.org/).
 
 Prerequisites:
-- [Go 1.26.4+](https://golang.org/doc/install)
+- [Go 1.26.5+](https://golang.org/doc/install)
 - [Node.js](https://nodejs.org/) (`make go/build` runs `npx esbuild` to compile the web assets)
 - `curl` (used to fetch the vendored frontend runtime)
 

--- a/docs/user-guide/mobile-app.md
+++ b/docs/user-guide/mobile-app.md
@@ -206,11 +206,11 @@ The dashboard lists all competitions. Each card shows the competition type, numb
 
 ### Tournament details and the public info page
 
-Edit the tournament details from **Admin** to set the public-facing information attendees see: the venue address and a map link, opening and closing times, a link to the rules, an awards note, free-form info notes, and contact people. Setting the **public URL** here also enables the [QR codes on tags](#export-print) and shareable links. These fields populate a public **info page** in the viewer, so spectators have one place for the practical details of the day.
+Edit the tournament details from **Admin** to set the public-facing information attendees see: the venue address and a map link, opening and closing times, a link to the tournament website, an awards note, free-form info notes, and contact people. Setting the **public URL** here also enables the [QR codes on tags](#export-print) and shareable links. These fields populate a public **info page** in the viewer, so spectators have one place for the practical details of the day.
 
 ### Branding and sponsors
 
-The same details screen lets you brand the tournament: upload a **logo** and set the **primary and accent colours**, and the public viewer and displays adopt them. You can also add an ordered list of **sponsor logos** that appear on the public tournament page. All of these are optional; with nothing set, the app uses its default kendo theme.
+The same details screen lets you brand the tournament: upload a **logo** and set the **primary and accent colours**, and the public viewer and displays adopt them. You can also add **sponsor banners** that appear as full-width images on the public viewer page (they are not shown on the TV and lobby display boards, which stay focused on match information). All of these are optional; with nothing set, the app uses its default kendo theme.
 
 ### Announcements
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gitrgoliveira/bracket-creator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/internal/mobileapp/coverage_gap_test.go
+++ b/internal/mobileapp/coverage_gap_test.go
@@ -266,13 +266,13 @@ func TestValidateTournamentLengths_ErrorCases(t *testing.T) {
 		ClosingTime: strings.Repeat("x", MaxLenDisplayTime+1),
 	}))
 
-	// RulesURL invalid scheme.
+	// WebsiteURL invalid scheme.
 	require.Error(t, validateTournamentLengths(&state.Tournament{
-		Name:     base.Name,
-		Venue:    base.Venue,
-		Date:     base.Date,
-		Password: base.Password,
-		RulesURL: "ftp://example.com",
+		Name:       base.Name,
+		Venue:      base.Venue,
+		Date:       base.Date,
+		Password:   base.Password,
+		WebsiteURL: "ftp://example.com",
 	}))
 
 	// VenueMapURL too long.
@@ -284,13 +284,13 @@ func TestValidateTournamentLengths_ErrorCases(t *testing.T) {
 		VenueMapURL: strings.Repeat("x", MaxLenVenueMapURL+1),
 	}))
 
-	// RulesURL too long.
+	// WebsiteURL too long.
 	require.Error(t, validateTournamentLengths(&state.Tournament{
-		Name:     base.Name,
-		Venue:    base.Venue,
-		Date:     base.Date,
-		Password: base.Password,
-		RulesURL: strings.Repeat("x", MaxLenRulesURL+1),
+		Name:       base.Name,
+		Venue:      base.Venue,
+		Date:       base.Date,
+		Password:   base.Password,
+		WebsiteURL: strings.Repeat("x", MaxLenWebsiteURL+1),
 	}))
 
 	// AwardsNote too long.

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -76,12 +76,16 @@ func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 
 // RegisterBrandingHandlers wires admin-gated mutation endpoints. The caller
 // must use a group whose body cap is at least BrandingMaxBodyBytes (2 MB).
-func RegisterBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
-	r.POST("/branding/logo", handleBrandingLogoUpload(store))
-	r.DELETE("/branding/logo", handleBrandingLogoDelete(store))
+//
+// hub broadcasts EventTournamentUpdated after a successful logo upload/delete
+// so open viewer and display surfaces re-fetch and re-apply branding live,
+// matching PUT /tournament (same live-update gap as sponsors, mp-scf).
+func RegisterBrandingHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
+	r.POST("/branding/logo", handleBrandingLogoUpload(store, hub))
+	r.DELETE("/branding/logo", handleBrandingLogoDelete(store, hub))
 }
 
-func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
+func handleBrandingLogoUpload(store *state.Store, hub *Hub) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		fh, err := c.FormFile("file")
 		if err != nil {
@@ -193,11 +197,14 @@ func handleBrandingLogoUpload(store *state.Store) gin.HandlerFunc {
 		}
 		_ = os.Remove(filepath.Join(brandingDir, other))
 
+		if hub != nil {
+			hub.Broadcast(EventTournamentUpdated, nil)
+		}
 		c.JSON(http.StatusOK, gin.H{"logoPath": fileName})
 	}
 }
 
-func handleBrandingLogoDelete(store *state.Store) gin.HandlerFunc {
+func handleBrandingLogoDelete(store *state.Store, hub *Hub) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var removed string
 		_, err := store.UpdateTournamentChanged(&state.Tournament{}, func(current, desired *state.Tournament) error {
@@ -222,6 +229,9 @@ func handleBrandingLogoDelete(store *state.Store) gin.HandlerFunc {
 		}
 		if removed == "logo.png" || removed == "logo.jpg" {
 			_ = os.Remove(filepath.Join(store.GetFolder(), brandingDirName, removed))
+		}
+		if hub != nil {
+			hub.Broadcast(EventTournamentUpdated, nil)
 		}
 		c.JSON(http.StatusOK, gin.H{"removed": removed})
 	}

--- a/internal/mobileapp/handlers_sponsors.go
+++ b/internal/mobileapp/handlers_sponsors.go
@@ -86,12 +86,19 @@ func RegisterPublicSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
 // middleware). The caller must use a group whose body cap is at least
 // SponsorMaxBodyBytes (2 MB), the in-handler file size check at
 // SponsorMaxFileBytes still applies separately.
-func RegisterSponsorHandlers(r *gin.RouterGroup, store *state.Store) {
-	r.POST("/sponsors", handleSponsorUpload(store))
-	r.DELETE("/sponsors/:index", handleSponsorDelete(store))
+//
+// hub is used to broadcast EventTournamentUpdated after a successful
+// upload/delete so that already-open viewer and display (TV/lobby) surfaces
+// re-fetch the tournament and show the sponsor change live, matching the
+// behaviour of PUT /tournament. Without this, a sponsor uploaded on the admin
+// device stays invisible on a display wall until a manual page reload (mp-c38
+// gap surfaced during UAT).
+func RegisterSponsorHandlers(r *gin.RouterGroup, store *state.Store, hub *Hub) {
+	r.POST("/sponsors", handleSponsorUpload(store, hub))
+	r.DELETE("/sponsors/:index", handleSponsorDelete(store, hub))
 }
 
-func handleSponsorUpload(store *state.Store) gin.HandlerFunc {
+func handleSponsorUpload(store *state.Store, hub *Hub) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		candidate := state.Sponsor{
 			Name: strings.TrimSpace(c.PostForm("name")),
@@ -217,11 +224,16 @@ func handleSponsorUpload(store *state.Store) gin.HandlerFunc {
 			}
 			return
 		}
+		// Notify open viewer/display surfaces to re-fetch (see
+		// RegisterSponsorHandlers doc). Broadcast is a no-op if hub is nil.
+		if hub != nil {
+			hub.Broadcast(EventTournamentUpdated, nil)
+		}
 		c.JSON(http.StatusCreated, candidate)
 	}
 }
 
-func handleSponsorDelete(store *state.Store) gin.HandlerFunc {
+func handleSponsorDelete(store *state.Store, hub *Hub) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		idx, err := strconv.Atoi(c.Param("index"))
 		if err != nil || idx < 0 {
@@ -262,6 +274,9 @@ func handleSponsorDelete(store *state.Store) gin.HandlerFunc {
 		// already removed.
 		if sponsorFilePattern.MatchString(removed.File) {
 			_ = os.Remove(filepath.Join(store.GetFolder(), sponsorsDirName, removed.File))
+		}
+		if hub != nil {
+			hub.Broadcast(EventTournamentUpdated, nil)
 		}
 		c.JSON(http.StatusOK, gin.H{"removed": removed})
 	}

--- a/internal/mobileapp/handlers_sponsors_test.go
+++ b/internal/mobileapp/handlers_sponsors_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gitrgoliveira/bracket-creator/internal/engine"
@@ -110,6 +111,54 @@ func TestPostSponsor_HappyPath_PNG(t *testing.T) {
 	on, err := os.ReadFile(filepath.Join(tempDir, "sponsors", got.File))
 	require.NoError(t, err)
 	assert.Equal(t, tinyPNG, on)
+}
+
+// TestSponsor_MutationsBroadcastTournamentUpdated locks in the live-update
+// fix: uploading or deleting a sponsor must broadcast EventTournamentUpdated
+// so already-open viewer surfaces refetch and show the change without a manual
+// reload. Before this, a sponsor uploaded on the admin device stayed invisible
+// on an open viewer/display until refresh (the reported UAT bug).
+func TestSponsor_MutationsBroadcastTournamentUpdated(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "sponsor-sse-*")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	store, err := state.NewStore(tempDir)
+	require.NoError(t, err)
+	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "SSE Cup", Password: "secret"}))
+	eng := engine.New(store)
+	res := resources.NewResources(nil, fstest.MapFS{"web-mobile/index.html": {Data: []byte("<html/>")}})
+	router, hub, limiter := NewRouter(store, eng, res, NewFileVerifier(store))
+	defer limiter.Close()
+
+	ch := hub.Subscribe()
+	defer hub.Unsubscribe(ch)
+
+	expectEvent := func(action string) {
+		t.Helper()
+		select {
+		case msg := <-ch:
+			var env SSEEvent
+			require.NoError(t, json.Unmarshal([]byte(msg), &env))
+			assert.Equalf(t, EventTournamentUpdated, env.Type,
+				"%s must broadcast tournament_updated so open viewers refetch", action)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for tournament_updated broadcast after %s", action)
+		}
+	}
+
+	// Upload.
+	body, ct := buildSponsorUpload(t, "Acme", "", "acme.png", tinyPNG)
+	w := postSponsor(t, router, body, ct, "secret")
+	require.Equalf(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	expectEvent("sponsor upload")
+
+	// Delete index 0.
+	dw := httptest.NewRecorder()
+	dreq, _ := http.NewRequest(http.MethodDelete, "/api/sponsors/0", nil)
+	dreq.Header.Set("X-Tournament-Password", "secret")
+	router.ServeHTTP(dw, dreq)
+	require.Equalf(t, http.StatusOK, dw.Code, "body: %s", dw.Body.String())
+	expectEvent("sponsor delete")
 }
 
 func TestPostSponsor_HappyPath_JPEG(t *testing.T) {

--- a/internal/mobileapp/handlers_tournament.go
+++ b/internal/mobileapp/handlers_tournament.go
@@ -186,7 +186,7 @@ func trimPublicInfoFields(t *state.Tournament) {
 	t.VenueMapURL = strings.TrimSpace(t.VenueMapURL)
 	t.OpeningTime = strings.TrimSpace(t.OpeningTime)
 	t.ClosingTime = strings.TrimSpace(t.ClosingTime)
-	t.RulesURL = strings.TrimSpace(t.RulesURL)
+	t.WebsiteURL = strings.TrimSpace(t.WebsiteURL)
 	t.AwardsNote = strings.TrimSpace(t.AwardsNote)
 	t.InfoNotes = strings.TrimSpace(t.InfoNotes)
 	if len(t.Contacts) > 0 {
@@ -259,10 +259,10 @@ func validateTournamentLengths(t *state.Tournament) error {
 	if err := validateMaxLen("closingTime", t.ClosingTime, MaxLenDisplayTime); err != nil {
 		return err
 	}
-	if err := validateMaxLen("rulesURL", t.RulesURL, MaxLenRulesURL); err != nil {
+	if err := validateMaxLen("websiteURL", t.WebsiteURL, MaxLenWebsiteURL); err != nil {
 		return err
 	}
-	if err := validateHTTPURL("rulesURL", t.RulesURL); err != nil {
+	if err := validateHTTPURL("websiteURL", t.WebsiteURL); err != nil {
 		return err
 	}
 	if err := validateMaxLen("awardsNote", t.AwardsNote, MaxLenAwardsNote); err != nil {

--- a/internal/mobileapp/index_meta.go
+++ b/internal/mobileapp/index_meta.go
@@ -28,7 +28,10 @@ const defaultAppTitle = "Bracket Creator Mobile"
 // keep surfacing a stale preview.
 func serveIndexHTML(c *gin.Context, indexHTML []byte, store *state.Store) {
 	page := injectPreviewMeta(string(indexHTML), store, requestBaseURL(c))
-	c.Header("Cache-Control", "no-cache")
+	// no-store (not no-cache): the injected tags depend on mutable tournament
+	// state, so no intermediary should store this response at all, not merely
+	// revalidate it, or a crawler could be served a stale preview from a proxy.
+	c.Header("Cache-Control", "no-store")
 	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(page))
 }
 

--- a/internal/mobileapp/index_meta.go
+++ b/internal/mobileapp/index_meta.go
@@ -1,0 +1,147 @@
+package mobileapp
+
+import (
+	"html"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// defaultAppTitle is the fallback <title> / og:site_name used when no
+// tournament name is configured. It mirrors the static title baked into
+// web-mobile/index.html.
+const defaultAppTitle = "Bracket Creator Mobile"
+
+// serveIndexHTML writes web-mobile/index.html with server-rendered Open Graph
+// and Twitter Card meta tags injected into <head>, populated from the live
+// tournament state.
+//
+// Link-preview crawlers (Slack, WhatsApp, iMessage, Discord, Facebook, ...) do
+// NOT execute JavaScript, so the SPA's client-side title/logo never reaches
+// them; without these static tags a shared link resolves to the generic app
+// name and bundled icon instead of the tournament's name and logo (mp-p9o8).
+//
+// index.html is intentionally served uncached here: the injected tags depend on
+// mutable tournament state (name, venue, logo), so a renamed tournament must not
+// keep surfacing a stale preview.
+func serveIndexHTML(c *gin.Context, indexHTML []byte, store *state.Store) {
+	page := injectPreviewMeta(string(indexHTML), store, requestBaseURL(c))
+	c.Header("Cache-Control", "no-cache")
+	c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(page))
+}
+
+// injectPreviewMeta rewrites the <title> and inserts link-preview meta tags into
+// the given index.html markup. base is the absolute scheme://host prefix used to
+// build absolute image/url values (crawlers require absolute URLs). A nil store
+// or an absent tournament yields the default title with no description and the
+// bundled favicon as the preview image.
+func injectPreviewMeta(pageHTML string, store *state.Store, base string) string {
+	title := defaultAppTitle
+	description := ""
+
+	var t *state.Tournament
+	if store != nil {
+		// A load error is non-fatal: fall back to defaults so the page always
+		// serves. The preview is cosmetic; a broken tournament read must not
+		// take down the SPA shell.
+		t, _ = store.LoadTournament()
+	}
+	if t != nil {
+		switch {
+		case t.Name != "":
+			title = t.Name
+		case t.Theme != nil && t.Theme.WindowTitle != "":
+			title = t.Theme.WindowTitle
+		}
+		parts := make([]string, 0, 2)
+		if t.Venue != "" {
+			parts = append(parts, t.Venue)
+		}
+		if t.Date != "" {
+			parts = append(parts, t.Date)
+		}
+		description = strings.Join(parts, ", ")
+	}
+
+	// Prefer the uploaded tournament logo (served unauthenticated at
+	// /api/branding/logo); fall back to the bundled app icon. Guard on the two
+	// known filenames so a stale LogoPath never points the preview at a missing
+	// image (mirrors RegisterPublicBrandingHandlers).
+	imageURL := base + "/favicon.jpeg"
+	if t != nil && t.Theme != nil && (t.Theme.LogoPath == "logo.png" || t.Theme.LogoPath == "logo.jpg") {
+		imageURL = base + "/api/branding/logo"
+	}
+
+	var b strings.Builder
+	b.WriteString("\n    <!-- Server-rendered link-preview metadata (mp-p9o8). -->\n")
+	writeMeta := func(attrName, attrVal, content string) {
+		b.WriteString(`    <meta ` + attrName + `="` + attrVal + `" content="` + html.EscapeString(content) + `">` + "\n")
+	}
+	writeMeta("property", "og:type", "website")
+	writeMeta("property", "og:site_name", defaultAppTitle)
+	writeMeta("property", "og:title", title)
+	writeMeta("property", "og:url", base+"/")
+	writeMeta("property", "og:image", imageURL)
+	writeMeta("name", "twitter:card", "summary")
+	writeMeta("name", "twitter:title", title)
+	writeMeta("name", "twitter:image", imageURL)
+	if description != "" {
+		writeMeta("property", "og:description", description)
+		writeMeta("name", "twitter:description", description)
+		writeMeta("name", "description", description)
+	}
+
+	pageHTML = replaceTitleContent(pageHTML, title)
+	if idx := strings.Index(pageHTML, "</head>"); idx != -1 {
+		pageHTML = pageHTML[:idx] + b.String() + pageHTML[idx:]
+	}
+	return pageHTML
+}
+
+// replaceTitleContent swaps the text between the first <title> and </title> for
+// the (HTML-escaped) newTitle. If either tag is missing the markup is returned
+// unchanged.
+func replaceTitleContent(pageHTML, newTitle string) string {
+	const openTag = "<title>"
+	const closeTag = "</title>"
+	start := strings.Index(pageHTML, openTag)
+	if start == -1 {
+		return pageHTML
+	}
+	rel := strings.Index(pageHTML[start:], closeTag)
+	if rel == -1 {
+		return pageHTML
+	}
+	end := start + rel
+	return pageHTML[:start+len(openTag)] + html.EscapeString(newTitle) + pageHTML[end:]
+}
+
+// requestBaseURL derives the absolute scheme://host prefix for the current
+// request. It honors X-Forwarded-Proto / X-Forwarded-Host so absolute preview
+// URLs come out as https://<public-host> when the app runs behind a TLS proxy
+// (the production deployment), rather than the plaintext internal origin.
+func requestBaseURL(c *gin.Context) string {
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	if proto := firstCSV(c.GetHeader("X-Forwarded-Proto")); proto != "" {
+		scheme = proto
+	}
+	host := c.Request.Host
+	if fwd := firstCSV(c.GetHeader("X-Forwarded-Host")); fwd != "" {
+		host = fwd
+	}
+	return scheme + "://" + host
+}
+
+// firstCSV returns the first comma-separated token, trimmed. Forwarded headers
+// may carry a proxy chain (e.g. "https, http"); the client-facing value is first.
+func firstCSV(v string) string {
+	if i := strings.IndexByte(v, ','); i != -1 {
+		v = v[:i]
+	}
+	return strings.TrimSpace(v)
+}

--- a/internal/mobileapp/index_meta_test.go
+++ b/internal/mobileapp/index_meta_test.go
@@ -1,0 +1,199 @@
+package mobileapp
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleIndexHTML mirrors the relevant structure of web-mobile/index.html: a
+// <head> with the static default <title> and a </head> insertion point.
+const sampleIndexHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Bracket Creator Mobile</title>
+</head>
+<body><div id="root"></div></body>
+</html>`
+
+func TestInjectPreviewMeta_WithTournament(t *testing.T) {
+	store := newTempStore(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:  "Spring Kendo Cup",
+		Date:  "01-06-2026",
+		Venue: "Central Dojo",
+		Mode:  state.TournamentModeOfficiated,
+	}))
+
+	out := injectPreviewMeta(sampleIndexHTML, store, "https://tora.example.org")
+
+	// Title rewritten to the tournament name.
+	assert.Contains(t, out, "<title>Spring Kendo Cup</title>")
+	// Open Graph + Twitter tags present with the name.
+	assert.Contains(t, out, `<meta property="og:title" content="Spring Kendo Cup">`)
+	assert.Contains(t, out, `<meta name="twitter:card" content="summary">`)
+	assert.Contains(t, out, `<meta name="twitter:title" content="Spring Kendo Cup">`)
+	// Description built from venue + date.
+	assert.Contains(t, out, `<meta property="og:description" content="Central Dojo, 01-06-2026">`)
+	assert.Contains(t, out, `<meta name="description" content="Central Dojo, 01-06-2026">`)
+	// No logo configured → favicon fallback, absolute URL.
+	assert.Contains(t, out, `<meta property="og:image" content="https://tora.example.org/favicon.jpeg">`)
+	assert.Contains(t, out, `<meta property="og:url" content="https://tora.example.org/">`)
+	// Injected before </head>.
+	assert.Less(t, strings.Index(out, "og:title"), strings.Index(out, "</head>"))
+}
+
+func TestInjectPreviewMeta_WithLogo(t *testing.T) {
+	store := newTempStore(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:  "Logo Cup",
+		Date:  "01-06-2026",
+		Venue: "Dojo",
+		Theme: &state.Theme{LogoPath: "logo.png"},
+		Mode:  state.TournamentModeOfficiated,
+	}))
+
+	out := injectPreviewMeta(sampleIndexHTML, store, "https://tora.example.org")
+
+	assert.Contains(t, out, `<meta property="og:image" content="https://tora.example.org/api/branding/logo">`)
+	assert.Contains(t, out, `<meta name="twitter:image" content="https://tora.example.org/api/branding/logo">`)
+	assert.NotContains(t, out, "/favicon.jpeg")
+}
+
+func TestInjectPreviewMeta_UnknownLogoPathFallsBackToFavicon(t *testing.T) {
+	store := newTempStore(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:  "Stale Logo Cup",
+		Date:  "01-06-2026",
+		Venue: "Dojo",
+		Theme: &state.Theme{LogoPath: "logo.gif"}, // not one of the two allowed names
+		Mode:  state.TournamentModeOfficiated,
+	}))
+
+	out := injectPreviewMeta(sampleIndexHTML, store, "https://tora.example.org")
+
+	assert.Contains(t, out, `content="https://tora.example.org/favicon.jpeg"`)
+	assert.NotContains(t, out, "/api/branding/logo")
+}
+
+func TestInjectPreviewMeta_NoTournament(t *testing.T) {
+	store := newTempStore(t) // no tournament saved → LoadTournament returns nil
+
+	out := injectPreviewMeta(sampleIndexHTML, store, "https://tora.example.org")
+
+	assert.Contains(t, out, "<title>Bracket Creator Mobile</title>")
+	assert.Contains(t, out, `<meta property="og:title" content="Bracket Creator Mobile">`)
+	assert.Contains(t, out, `content="https://tora.example.org/favicon.jpeg"`)
+	// No description tags when nothing to describe.
+	assert.NotContains(t, out, "og:description")
+	assert.NotContains(t, out, `<meta name="description"`)
+}
+
+func TestInjectPreviewMeta_WindowTitleFallback(t *testing.T) {
+	store := newTempStore(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:  "", // empty name
+		Date:  "01-06-2026",
+		Venue: "Dojo",
+		Theme: &state.Theme{WindowTitle: "My Custom Title"},
+		Mode:  state.TournamentModeOfficiated,
+	}))
+
+	out := injectPreviewMeta(sampleIndexHTML, store, "https://tora.example.org")
+
+	assert.Contains(t, out, "<title>My Custom Title</title>")
+	assert.Contains(t, out, `<meta property="og:title" content="My Custom Title">`)
+}
+
+func TestInjectPreviewMeta_EscapesTournamentName(t *testing.T) {
+	store := newTempStore(t)
+	require.NoError(t, store.SaveTournament(&state.Tournament{
+		Name:  `Cup "2026" <script>`,
+		Date:  "01-06-2026",
+		Venue: "Dojo",
+		Mode:  state.TournamentModeOfficiated,
+	}))
+
+	out := injectPreviewMeta(sampleIndexHTML, store, "https://tora.example.org")
+
+	// Raw injection must not survive: no unescaped script tag, no attribute breakout.
+	assert.NotContains(t, out, "<script>")
+	assert.Contains(t, out, "&lt;script&gt;")
+	assert.Contains(t, out, "&#34;2026&#34;")
+}
+
+func TestInjectPreviewMeta_NilStore(t *testing.T) {
+	out := injectPreviewMeta(sampleIndexHTML, nil, "https://tora.example.org")
+	assert.Contains(t, out, "<title>Bracket Creator Mobile</title>")
+	assert.Contains(t, out, `<meta property="og:title" content="Bracket Creator Mobile">`)
+}
+
+func TestReplaceTitleContent(t *testing.T) {
+	assert.Equal(t,
+		"<head><title>New</title></head>",
+		replaceTitleContent("<head><title>Old</title></head>", "New"))
+	// Escapes the replacement.
+	assert.Equal(t,
+		"<title>a&amp;b</title>",
+		replaceTitleContent("<title>x</title>", "a&b"))
+	// Missing tags → unchanged.
+	assert.Equal(t, "<head></head>", replaceTitleContent("<head></head>", "New"))
+	assert.Equal(t, "<title>x", replaceTitleContent("<title>x", "New"))
+}
+
+func TestRequestBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		tls     bool
+		headers map[string]string
+		want    string
+	}{
+		{
+			name: "plain http from host",
+			host: "localhost:8080",
+			want: "http://localhost:8080",
+		},
+		{
+			name: "tls sets https",
+			host: "localhost:8443",
+			tls:  true,
+			want: "https://localhost:8443",
+		},
+		{
+			name:    "forwarded proto and host win (TLS proxy)",
+			host:    "127.0.0.1:8080",
+			headers: map[string]string{"X-Forwarded-Proto": "https", "X-Forwarded-Host": "tora.icaro.familyds.org"},
+			want:    "https://tora.icaro.familyds.org",
+		},
+		{
+			name:    "forwarded header proxy chain takes first token",
+			host:    "127.0.0.1:8080",
+			headers: map[string]string{"X-Forwarded-Proto": "https, http", "X-Forwarded-Host": "public.example.org, internal"},
+			want:    "https://public.example.org",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = tc.host
+			if tc.tls {
+				req.TLS = &tls.ConnectionState{}
+			}
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			c.Request = req
+			assert.Equal(t, tc.want, requestBaseURL(c))
+		})
+	}
+}

--- a/internal/mobileapp/server.go
+++ b/internal/mobileapp/server.go
@@ -211,11 +211,11 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 	// its own 2 MB group separate from the 1 MB JSON tier. DELETE rides
 	// on the same group (DELETE skips the cap by method anyway).
 	adminSponsorBody := adminGroup(r, SponsorMaxBodyBytes, verifier, store)
-	RegisterSponsorHandlers(adminSponsorBody, store)
+	RegisterSponsorHandlers(adminSponsorBody, store, hub)
 
 	// Tournament branding logo (mp-scf), same 2 MB envelope as sponsors.
 	adminBrandingBody := adminGroup(r, BrandingMaxBodyBytes, verifier, store)
-	RegisterBrandingHandlers(adminBrandingBody, store)
+	RegisterBrandingHandlers(adminBrandingBody, store, hub)
 
 	// Static files & SPA Fallback
 	mobileFS := res.GetMobileWebFS()
@@ -237,6 +237,16 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 			filePath := strings.TrimPrefix(path, "/")
 			if filePath == "" {
 				filePath = "index.html"
+			}
+
+			// index.html gets server-rendered link-preview meta tags injected
+			// from live tournament state (mp-p9o8). Handle it before the generic
+			// file server so the static bytes are never served bare.
+			if filePath == "index.html" {
+				if data, rerr := fs.ReadFile(subFS, "index.html"); rerr == nil {
+					serveIndexHTML(c, data, store)
+					return
+				}
 			}
 
 			// Check if file exists in FS
@@ -272,7 +282,7 @@ func NewRouterWithHub(store *state.Store, eng *engine.Engine, res *resources.Res
 			if ext == "" || ext == ".html" {
 				data, err := fs.ReadFile(subFS, "index.html")
 				if err == nil {
-					c.Data(http.StatusOK, "text/html; charset=utf-8", data)
+					serveIndexHTML(c, data, store)
 					return
 				}
 			}

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -44,7 +44,7 @@ const (
 	MaxLenVenueAddress    = 300
 	MaxLenVenueMapURL     = 500
 	MaxLenDisplayTime     = 8 // "HH:MM" or "HH:MM:SS"
-	MaxLenRulesURL        = 500
+	MaxLenWebsiteURL      = 500
 	MaxLenAwardsNote      = 500
 	MaxLenInfoNotes       = 2000
 	MaxLenContactLabel    = 50

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -100,10 +100,10 @@ type Tournament struct {
 	// Tournament.UnmarshalYAML that would have to enumerate every field.
 	RulesURLLegacy string `yaml:"rules_url,omitempty" json:"-"`
 
-	// Sponsors is the ordered list of sponsor logos to display on the
-	// public viewer home and the /display TV/lobby surfaces (mp-c38).
-	// Stored as omitempty so legacy tournament.md files without sponsors
-	// round-trip cleanly (no `sponsors: []` key emitted).
+	// Sponsors is the ordered list of sponsor banners shown on the public
+	// viewer home page only (the /display TV/lobby surfaces intentionally
+	// omit them; mp-c38/mp-vb3u). Stored as omitempty so legacy tournament.md
+	// files without sponsors round-trip cleanly (no `sponsors: []` key emitted).
 	Sponsors []Sponsor `yaml:"sponsors,omitempty" json:"sponsors,omitempty"`
 
 	// Theme holds optional branding overrides: custom accent colors and a

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -86,10 +86,19 @@ type Tournament struct {
 	VenueMapURL  string              `yaml:"venue_map_url,omitempty" json:"venueMapURL,omitempty"`
 	OpeningTime  string              `yaml:"opening_time,omitempty" json:"openingTime,omitempty"`
 	ClosingTime  string              `yaml:"closing_time,omitempty" json:"closingTime,omitempty"`
-	RulesURL     string              `yaml:"rules_url,omitempty" json:"rulesURL,omitempty"`
+	WebsiteURL   string              `yaml:"website_url,omitempty" json:"websiteURL,omitempty"`
 	AwardsNote   string              `yaml:"awards_note,omitempty" json:"awardsNote,omitempty"`
 	InfoNotes    string              `yaml:"info_notes,omitempty" json:"infoNotes,omitempty"`
 	Contacts     []TournamentContact `yaml:"contacts,omitempty" json:"contacts,omitempty"`
+
+	// RulesURLLegacy captures the pre-rename `rules_url` YAML key from
+	// tournament.md files written before the field was renamed to
+	// website_url. It is migrated into WebsiteURL by ApplyTournamentDefaults
+	// and is never emitted on the wire (json:"-") nor re-persisted (the
+	// migration clears it, so omitempty drops the old key on the next save).
+	// Field-based capture + migrate keeps the change additive: no custom
+	// Tournament.UnmarshalYAML that would have to enumerate every field.
+	RulesURLLegacy string `yaml:"rules_url,omitempty" json:"-"`
 
 	// Sponsors is the ordered list of sponsor logos to display on the
 	// public viewer home and the /display TV/lobby surfaces (mp-c38).
@@ -246,6 +255,14 @@ func ApplyTournamentDefaults(t *Tournament) {
 		// Default to at least one court ("A") for legacy or malformed configs
 		t.Courts = []string{"A"}
 	}
+	// Migrate the pre-rename rules_url key into website_url. Only fill when
+	// website_url is absent so a file carrying both keys prefers the new one.
+	// Clearing the legacy field means the next save writes only website_url,
+	// completing the migration on disk. Idempotent: a no-op once migrated.
+	if t.WebsiteURL == "" && t.RulesURLLegacy != "" {
+		t.WebsiteURL = t.RulesURLLegacy
+	}
+	t.RulesURLLegacy = ""
 }
 
 // Days returns the ordered list of DD-MM-YYYY calendar day strings

--- a/internal/state/models_test.go
+++ b/internal/state/models_test.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,6 +11,49 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+// TestApplyTournamentDefaults_MigratesLegacyRulesURL covers the field-rename
+// migration: a tournament.md written before the rename carries the old
+// `rules_url` key, which deserialises into RulesURLLegacy and must land in
+// WebsiteURL (and never be re-persisted).
+func TestApplyTournamentDefaults_MigratesLegacyRulesURL(t *testing.T) {
+	legacyOnly := &Tournament{RulesURLLegacy: "https://old.example/rules.pdf"}
+	ApplyTournamentDefaults(legacyOnly)
+	assert.Equal(t, "https://old.example/rules.pdf", legacyOnly.WebsiteURL)
+	assert.Empty(t, legacyOnly.RulesURLLegacy, "legacy field cleared so save drops the old key")
+
+	// A file carrying BOTH keys prefers the new website_url.
+	both := &Tournament{WebsiteURL: "https://new.example", RulesURLLegacy: "https://old.example"}
+	ApplyTournamentDefaults(both)
+	assert.Equal(t, "https://new.example", both.WebsiteURL)
+	assert.Empty(t, both.RulesURLLegacy)
+}
+
+// TestLoadTournament_MigratesRulesURLToWebsiteURL is the end-to-end migration:
+// a legacy tournament.md on disk loads with WebsiteURL populated, and the next
+// save rewrites the file with website_url and no rules_url.
+func TestLoadTournament_MigratesRulesURLToWebsiteURL(t *testing.T) {
+	dir := t.TempDir()
+	legacy := "---\nname: Legacy Cup\ndate: 01-06-2026\nvenue: Dojo\nrules_url: https://old.example/rules.pdf\n---\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tournament.md"), []byte(legacy), 0o600))
+
+	store, err := NewStore(dir)
+	require.NoError(t, err)
+
+	got, err := store.LoadTournament()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "https://old.example/rules.pdf", got.WebsiteURL, "legacy rules_url migrated on load")
+	assert.Empty(t, got.RulesURLLegacy)
+
+	// Persisting the migrated record drops the legacy key on disk.
+	require.NoError(t, store.SaveTournament(got))
+	raw, err := os.ReadFile(filepath.Join(dir, "tournament.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "website_url:")
+	assert.Contains(t, string(raw), "old.example/rules.pdf")
+	assert.NotContains(t, string(raw), "rules_url", "old key must not be re-persisted")
+}
 
 func TestApplyTournamentDefaults_ZeroValues(t *testing.T) {
 	tour := &Tournament{}

--- a/internal/state/tournament.go
+++ b/internal/state/tournament.go
@@ -215,6 +215,13 @@ func (s *Store) UpdateTournamentChanged(desired *Tournament, transform func(curr
 				// deserialises to the zero value (0), treat as 1.
 				t.DurationDays = 1
 			}
+			// Migrate the pre-rename rules_url key into website_url (mirrors
+			// ApplyTournamentDefaults) so an edit through this path never
+			// re-persists the legacy key or drops the value.
+			if t.WebsiteURL == "" && t.RulesURLLegacy != "" {
+				t.WebsiteURL = t.RulesURLLegacy
+			}
+			t.RulesURLLegacy = ""
 			current = &t
 		} else {
 			// Parse failure: fall back to the same default record

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7641,75 +7641,85 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
    Used on viewer home, LobbyDisplay, and TvDisplay. Three variants
    share the base styles; per-variant overrides handle the different
    backdrops and logo heights of each surface. */
+/* Sponsors render as full-width banners stacked vertically: each uploaded
+   image fills the viewer column up to a responsive cap (a landscape banner,
+   not a small centred logo). Multiple sponsors stack with a gap. */
 .sponsor-strip {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 20px;
-  padding: 16px 12px;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 0;
   margin-top: 16px;
 }
+/* Footprint is bounded on BOTH axes so an arbitrary user upload (portrait,
+   square, or many stacked banners) can never dominate the viewer page.
+   Mobile-first caps; widened per device below. object-fit:contain + centring
+   letterbox a non-landscape image inside the capped box instead of blowing up
+   the page. */
 .sponsor-strip__logo {
-  height: 40px;
-  width: auto;
-  max-width: 160px;
-  object-fit: contain;
   display: block;
+  width: 100%;
+  height: auto;
+  max-height: 96px;
+  object-fit: contain;
+  object-position: center;
+  border-radius: var(--r);
 }
+@media (min-width: 768px) {
+  .sponsor-strip__logo { max-height: 120px; }
+}
+@media (min-width: 1024px) {
+  .sponsor-strip__logo { max-height: 140px; }
+}
+/* Banners span the full viewer column; only the height is capped (above), so
+   a landscape banner fills the width edge-to-edge while a tall/square upload
+   is bounded by max-height + object-fit:contain. The full-width wrapper also
+   keeps the linked banner's ↗ badge on the banner's own (== column) corner. */
 .sponsor-strip__link,
 .sponsor-strip__item {
-  display: inline-flex;
-  align-items: center;
+  display: block;
+  width: 100%;
   text-decoration: none;
 }
+/* Linked banners carry a persistent "opens externally" cue: without it a
+   linked and non-linked banner are pixel-identical and the tap target is
+   undiscoverable on touch (hover doesn't exist on mobile). */
+.sponsor-strip__link {
+  position: relative;
+}
+.sponsor-strip__link::after {
+  content: "\2197"; /* ↗ */
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--accent-fg);
+  background: var(--accent);
+  border-radius: 999px;
+  pointer-events: none;
+}
 .sponsor-strip__link:hover .sponsor-strip__logo {
-  filter: brightness(1.05);
+  box-shadow: var(--shadow);
+}
+/* Keyboard focus: banners are links, so they must show a visible focus ring
+   (WCAG 2.4.7). Matches the button outline convention, not the input ring. */
+.sponsor-strip__link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--r);
 }
 
-/* Viewer variant, sits in the white viewer body, neutral framing. */
+/* Viewer variant, sits in the white viewer body, neutral framing. The
+   sponsor strip renders ONLY on the viewer page; the TV/lobby display
+   surfaces intentionally omit it, so there are no lobby/tv variants. */
 .sponsor-strip--viewer {
   border-top: 1px solid var(--line);
   background: var(--surface);
-}
-
-/* Lobby variant, dark lobby board; logos need a touch more breathing
-   room and a subtle backdrop so they remain legible against the dark
-   gradient behind them. */
-.sponsor-strip--lobby {
-  background: rgba(255, 255, 255, 0.04);
-  padding: 14px 24px;
-  margin-top: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-.sponsor-strip--lobby .sponsor-strip__logo {
-  height: 48px;
-  filter: brightness(1.1);
-}
-
-/* TV variant, fullscreen per-court board; smaller strip so it stays
-   subordinate to match info. */
-.sponsor-strip--tv {
-  /* Normal flow, not absolute. position: absolute would take the strip
-     out of flow and overlay the upcoming-matches list below it (the tvd
-     container only has 4vh bottom padding, but the strip is ~6vh tall).
-     Keeping it in flow lets the flex column stack sponsor strip under the
-     queue cards without overlap. */
-  padding: 1vh 2vw;
-  margin-top: auto; /* push to bottom of the flex column when there's space */
-  background: rgba(0, 0, 0, 0.35);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  gap: 2vw;
-}
-.sponsor-strip--tv .sponsor-strip__logo {
-  height: 5vh;
-  max-width: 12vw;
-  filter: brightness(1.05);
-}
-
-@media (max-width: 480px) {
-  .sponsor-strip__logo { height: 32px; max-width: 120px; }
-  .sponsor-strip { gap: 12px; padding: 12px 8px; }
 }
 
 /* mp-dm5e: tied standings row, amber caution highlight. Background-only,

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -7638,12 +7638,11 @@ abbr.msb-lab { text-decoration: none; cursor: help; }
 .tvd-upnext-note { font: 700 2.2vh/1 var(--font-strong); letter-spacing: 0.16em; text-transform: uppercase; color: rgba(255,209,102,0.85); }
 
 /* ---------- Sponsor strip (mp-c38) ----------
-   Used on viewer home, LobbyDisplay, and TvDisplay. Three variants
-   share the base styles; per-variant overrides handle the different
-   backdrops and logo heights of each surface. */
-/* Sponsors render as full-width banners stacked vertically: each uploaded
-   image fills the viewer column up to a responsive cap (a landscape banner,
-   not a small centred logo). Multiple sponsors stack with a gap. */
+   Viewer home ONLY (the TV/lobby display surfaces intentionally omit
+   sponsors), so there is a single viewer variant, no per-surface overrides.
+   Sponsors render as full-width banners stacked vertically: each uploaded
+   image fills the viewer column up to a responsive height cap (a landscape
+   banner, not a small centred logo). Multiple sponsors stack with a gap. */
 .sponsor-strip {
   display: flex;
   flex-direction: column;

--- a/web-mobile/js/__tests__/sponsor_strip.test.jsx
+++ b/web-mobile/js/__tests__/sponsor_strip.test.jsx
@@ -118,6 +118,20 @@ describe('SponsorStrip', () => {
     expect(() => img.props.onError({ currentTarget: {} })).not.toThrow();
   });
 
+  it('keys the root on the sponsor file list so a mutation forces a remount', () => {
+    // handleError hides the strip imperatively; preact will not clear that
+    // inline display on a plain re-render. Keying by the file list makes any
+    // upload/delete change the key, forcing a remount that drops the stale
+    // hidden state so valid new banners show.
+    const a = SponsorStrip({ sponsors: [{ name: 'A', file: 'aa.png' }] });
+    const b = SponsorStrip({ sponsors: [{ name: 'B', file: 'bb.png' }] });
+    const ab = SponsorStrip({ sponsors: [{ name: 'A', file: 'aa.png' }, { name: 'B', file: 'bb.png' }] });
+    expect(a.props.key).toBe('aa.png');
+    expect(a.props.key).not.toBe(b.props.key);       // delete/replace changes the key
+    expect(ab.props.key).toBe('aa.png|bb.png');       // add changes the key
+    expect(ab.props.key).not.toBe(a.props.key);
+  });
+
   it('root div has role=complementary and aria-label=Sponsors', () => {
     const tree = SponsorStrip({ sponsors: sponsorsWithLink });
     expect(tree.props.role).toBe('complementary');

--- a/web-mobile/js/__tests__/sponsor_strip.test.jsx
+++ b/web-mobile/js/__tests__/sponsor_strip.test.jsx
@@ -88,6 +88,36 @@ describe('SponsorStrip', () => {
     });
   });
 
+  it('onError collapses the whole strip when the LAST visible banner fails', () => {
+    // When every wrapper is hidden, the .sponsor-strip container's border-top
+    // + padding would otherwise render as a mysterious empty band. The handler
+    // must hide the strip once no visible children remain.
+    const img = findAll(SponsorStrip({ sponsors: sponsorsWithLink }), (n) => n.type === 'img')[0];
+    const wrapper = { style: {} };
+    const strip = { style: {}, children: [wrapper] }; // only this one banner
+    wrapper.parentElement = strip;
+    img.props.onError({ currentTarget: { parentElement: wrapper } });
+    expect(wrapper.style.display).toBe('none');
+    expect(strip.style.display).toBe('none'); // last one failed -> collapse
+  });
+
+  it('onError does NOT collapse the strip while another banner is still visible', () => {
+    const img = findAll(SponsorStrip({ sponsors: sponsorsWithLink }), (n) => n.type === 'img')[0];
+    const wrapper = { style: {} };
+    const stillVisible = { style: { display: '' } }; // sibling not hidden
+    const strip = { style: {}, children: [wrapper, stillVisible] };
+    wrapper.parentElement = strip;
+    img.props.onError({ currentTarget: { parentElement: wrapper } });
+    expect(wrapper.style.display).toBe('none');
+    expect(strip.style.display).toBeUndefined(); // strip stays visible
+  });
+
+  it('onError is a no-op when the wrapper has no parent (defensive guard)', () => {
+    const img = findAll(SponsorStrip({ sponsors: sponsorsWithLink }), (n) => n.type === 'img')[0];
+    // currentTarget with no parentElement must not throw.
+    expect(() => img.props.onError({ currentTarget: {} })).not.toThrow();
+  });
+
   it('root div has role=complementary and aria-label=Sponsors', () => {
     const tree = SponsorStrip({ sponsors: sponsorsWithLink });
     expect(tree.props.role).toBe('complementary');

--- a/web-mobile/js/__tests__/sponsor_strip.test.jsx
+++ b/web-mobile/js/__tests__/sponsor_strip.test.jsx
@@ -26,15 +26,15 @@ describe('SponsorStrip', () => {
   ];
 
   it('returns null when sponsors is empty', () => {
-    expect(SponsorStrip({ sponsors: [], variant: 'viewer' })).toBeNull();
+    expect(SponsorStrip({ sponsors: [] })).toBeNull();
   });
 
   it('returns null when sponsors is undefined', () => {
-    expect(SponsorStrip({ sponsors: undefined, variant: 'viewer' })).toBeNull();
+    expect(SponsorStrip({ sponsors: undefined })).toBeNull();
   });
 
-  it('viewer variant wraps linked sponsors in <a target="_blank" rel="noopener noreferrer">', () => {
-    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'viewer' });
+  it('wraps linked sponsors in <a target="_blank" rel="noopener noreferrer">', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink });
     const anchors = findAll(tree, (n) => n.type === 'a');
     expect(anchors).toHaveLength(1);
     expect(anchors[0].props.target).toBe('_blank');
@@ -42,20 +42,8 @@ describe('SponsorStrip', () => {
     expect(anchors[0].props.href).toBe('https://acme.example');
   });
 
-  it('viewer variant: sponsor without link renders bare <img> (no anchor)', () => {
-    const tree = SponsorStrip({ sponsors: sponsorsNoLink, variant: 'viewer' });
-    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(0);
-    expect(findAll(tree, (n) => n.type === 'img')).toHaveLength(1);
-  });
-
-  it('lobby variant never renders <a> even when link is set', () => {
-    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'lobby' });
-    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(0);
-    expect(findAll(tree, (n) => n.type === 'img')).toHaveLength(1);
-  });
-
-  it('tv variant never renders <a> even when link is set', () => {
-    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'tv' });
+  it('sponsor without link renders bare <img> (no anchor)', () => {
+    const tree = SponsorStrip({ sponsors: sponsorsNoLink });
     expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(0);
     expect(findAll(tree, (n) => n.type === 'img')).toHaveLength(1);
   });
@@ -66,7 +54,7 @@ describe('SponsorStrip', () => {
       { name: 'B', file: '2.jpg', link: 'https://b.example' },
       { name: 'C', file: '3.png' },
     ];
-    const tree = SponsorStrip({ sponsors, variant: 'viewer' });
+    const tree = SponsorStrip({ sponsors });
     const imgs = findAll(tree, (n) => n.type === 'img');
     expect(imgs).toHaveLength(3);
     expect(imgs.map((i) => i.props.src)).toEqual([
@@ -76,19 +64,9 @@ describe('SponsorStrip', () => {
     ]);
   });
 
-  it('applies the variant suffix to the root className', () => {
-    expect(SponsorStrip({ sponsors: sponsorsWithLink, variant: 'viewer' }).props.className)
+  it('always uses the viewer-only root className (sponsors render on the viewer page only)', () => {
+    expect(SponsorStrip({ sponsors: sponsorsWithLink }).props.className)
       .toContain('sponsor-strip--viewer');
-    expect(SponsorStrip({ sponsors: sponsorsWithLink, variant: 'lobby' }).props.className)
-      .toContain('sponsor-strip--lobby');
-    expect(SponsorStrip({ sponsors: sponsorsWithLink, variant: 'tv' }).props.className)
-      .toContain('sponsor-strip--tv');
-  });
-
-  it('defaults variant to viewer when omitted', () => {
-    const tree = SponsorStrip({ sponsors: sponsorsWithLink });
-    expect(tree.props.className).toContain('sponsor-strip--viewer');
-    expect(findAll(tree, (n) => n.type === 'a')).toHaveLength(1);
   });
 
   it('every <img> onError hides the wrapper element, not just the img', () => {
@@ -97,23 +75,21 @@ describe('SponsorStrip', () => {
     // The onError handler must climb to parentElement and hide the wrapper.
     // We verify this by simulating the DOM event: stub parentElement with a
     // spy, call the handler, and confirm style.display was set on the parent.
-    for (const variant of ['viewer', 'lobby', 'tv']) {
-      const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant });
-      const imgs = findAll(tree, (n) => n.type === 'img');
-      expect(imgs.length).toBeGreaterThan(0);
-      imgs.forEach((img) => {
-        expect(typeof img.props.onError).toBe('function');
-        // Simulate the browser onError event with a fake currentTarget.
-        const parentStyle = {};
-        const fakeEvent = { currentTarget: { parentElement: { style: parentStyle } } };
-        img.props.onError(fakeEvent);
-        expect(parentStyle.display).toBe('none');
-      });
-    }
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink });
+    const imgs = findAll(tree, (n) => n.type === 'img');
+    expect(imgs.length).toBeGreaterThan(0);
+    imgs.forEach((img) => {
+      expect(typeof img.props.onError).toBe('function');
+      // Simulate the browser onError event with a fake currentTarget.
+      const parentStyle = {};
+      const fakeEvent = { currentTarget: { parentElement: { style: parentStyle } } };
+      img.props.onError(fakeEvent);
+      expect(parentStyle.display).toBe('none');
+    });
   });
 
   it('root div has role=complementary and aria-label=Sponsors', () => {
-    const tree = SponsorStrip({ sponsors: sponsorsWithLink, variant: 'viewer' });
+    const tree = SponsorStrip({ sponsors: sponsorsWithLink });
     expect(tree.props.role).toBe('complementary');
     expect(tree.props['aria-label']).toBe('Sponsors');
   });

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -629,17 +629,17 @@ describe('TournamentInfo', () => {
     expect(text).toContain('Bring your shinai');
   });
 
-  it('creates an anchor for http(s) rulesURL but renders plain text for non-http', () => {
+  it('creates an anchor for http(s) websiteURL but renders plain text for non-http', () => {
     // http URL → anchor element
     const treeHttp = runtime.mount(TournamentInfo, {
-      tournament: { rulesURL: 'https://example.com/rules.pdf' },
+      tournament: { websiteURL: 'https://example.com/rules.pdf' },
     });
     const anchor = findInTree(treeHttp, n => n.type === 'a');
     expect(anchor).not.toBeNull();
 
     // Non-http value → plain text, no anchor
     const treePlain = runtime.mount(TournamentInfo, {
-      tournament: { rulesURL: 'See the notice board' },
+      tournament: { websiteURL: 'See the notice board' },
     });
     const anchorPlain = findInTree(treePlain, n => n.type === 'a');
     expect(anchorPlain).toBeNull();

--- a/web-mobile/js/admin_setup.jsx
+++ b/web-mobile/js/admin_setup.jsx
@@ -139,7 +139,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   const [venueMapURL, setVenueMapURL] = useStateA(tournament.venueMapURL || "");
   const [openingTime, setOpeningTime] = useStateA(tournament.openingTime || "");
   const [closingTime, setClosingTime] = useStateA(tournament.closingTime || "");
-  const [rulesURL, setRulesURL] = useStateA(tournament.rulesURL || "");
+  const [websiteURL, setWebsiteURL] = useStateA(tournament.websiteURL || "");
   const [awardsNote, setAwardsNote] = useStateA(tournament.awardsNote || "");
   const [infoNotes, setInfoNotes] = useStateA(tournament.infoNotes || "");
   const [contacts, setContacts] = useStateA((tournament.contacts || []).map((ct, i) => ({ ...ct, _key: i })));
@@ -186,7 +186,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   // Open by default only when the tournament already has public data, so
   // existing values are never hidden behind a collapsed section.
   const hasPublicInfo = !!(publicURL || venueAddress || venueMapURL || openingTime ||
-    closingTime || rulesURL || awardsNote || infoNotes || (contacts && contacts.length));
+    closingTime || websiteURL || awardsNote || infoNotes || (contacts && contacts.length));
   const [publicOpen, setPublicOpen] = useStateA(hasPublicInfo);
 
   // mp-sspn: dirty tracking for the unsaved-changes cue + cancel guard.
@@ -202,7 +202,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
   useEffectA(() => {
     const snap = JSON.stringify({
       name, venue, date, durationDays, courts, openingBlock, lunchBlock, closingBlock,
-      publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
+      publicURL, venueAddress, venueMapURL, openingTime, closingTime, websiteURL,
       awardsNote, infoNotes, pass,
       contacts: contacts.map(c => ({ label: c.label || "", value: c.value || "" })),
       theme: normalizeTheme(theme),
@@ -210,7 +210,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
     if (initialSnapRef.current === null) { initialSnapRef.current = snap; return; }
     setDirty(snap !== initialSnapRef.current);
   }, [name, venue, date, durationDays, courts, openingBlock, lunchBlock, closingBlock,
-    publicURL, venueAddress, venueMapURL, openingTime, closingTime, rulesURL,
+    publicURL, venueAddress, venueMapURL, openingTime, closingTime, websiteURL,
     awardsNote, infoNotes, pass, contacts, theme]);
 
   // Elevated (destructive-ops) password: spec 004 / mp-e21. File mode only;
@@ -297,7 +297,7 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
         venueMapURL: venueMapURL.trim() || undefined,
         openingTime: openingTime.trim() || undefined,
         closingTime: closingTime.trim() || undefined,
-        rulesURL: rulesURL.trim() || undefined,
+        websiteURL: websiteURL.trim() || undefined,
         awardsNote: awardsNote.trim() || undefined,
         infoNotes: infoNotes.trim() || undefined,
         contacts: contacts.filter(c => (c.value || "").trim()).map(c => ({ label: (c.label || "").trim(), value: (c.value || "").trim() })),
@@ -530,9 +530,9 @@ function AdminEditTournament({ tournament, onCancel, onSave, onLogout, onViewerM
               </div>
             </div>
             <div className="field">
-              <label className="field__label">Rules link</label>
-              <input className="input" value={rulesURL} onChange={(e) => setRulesURL(e.target.value)} placeholder="https://..." />
-              <div className="field__hint">Link to tournament rules document or PDF.</div>
+              <label className="field__label">Website link</label>
+              <input className="input" value={websiteURL} onChange={(e) => setWebsiteURL(e.target.value)} placeholder="https://..." />
+              <div className="field__hint">Link to the tournament website.</div>
             </div>
             <div className="field">
               <label className="field__label">Awards</label>

--- a/web-mobile/js/display_lobby.jsx
+++ b/web-mobile/js/display_lobby.jsx
@@ -411,10 +411,6 @@ function LobbyDisplay({ tournament, competitions, connected = true }) {
                 }
             </div>
 
-            {/* mp-c38: sponsor strip: non-interactive on lobby (no input
-                hardware to click; touchscreen lobbies should not focus-trap). */}
-            {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="lobby" />}
-
             {/* Keyframe for the cycle progress bar animation. Injected via a
                 <style> tag because inline styles cannot express @keyframes.
                 Re-rendered with the component but content is static/idempotent. */}

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -152,9 +152,7 @@ function TvWhiteBoard({ tournament, court, linkState = 'connected', promoted, is
                         <span style={{ color: "#b91c1c", fontWeight: 600 }}>{sideLabel(next.sideA, next._comp?.withZekkenName)}</span>
                     </span>
                 </div>
-            )}
-            {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="tv" />}
-        </div>
+            )}        </div>
     );
 }
 
@@ -471,9 +469,7 @@ function TvIndividualBoard({ tournament, court, linkState = 'connected', promote
                         <span style={{ color: "#b91c1c", fontWeight: 600 }}>{sideLabel(next.sideA, next._comp?.withZekkenName ?? zekken)}</span>
                     </span>
                 </div>
-            )}
-            {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="tv" />}
-        </div>
+            )}        </div>
     );
 }
 
@@ -739,8 +735,6 @@ function TvDisplay({ court, tournament, competitions, withZekkenName, linkState 
                     </div>
                 )}
             </div>
-
-            {window.SponsorStrip && <window.SponsorStrip sponsors={tournament && tournament.sponsors} variant="tv" />}
         </div>
     );
 }

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -152,7 +152,8 @@ function TvWhiteBoard({ tournament, court, linkState = 'connected', promoted, is
                         <span style={{ color: "#b91c1c", fontWeight: 600 }}>{sideLabel(next.sideA, next._comp?.withZekkenName)}</span>
                     </span>
                 </div>
-            )}        </div>
+            )}
+        </div>
     );
 }
 
@@ -469,7 +470,8 @@ function TvIndividualBoard({ tournament, court, linkState = 'connected', promote
                         <span style={{ color: "#b91c1c", fontWeight: 600 }}>{sideLabel(next.sideA, next._comp?.withZekkenName ?? zekken)}</span>
                     </span>
                 </div>
-            )}        </div>
+            )}
+        </div>
     );
 }
 

--- a/web-mobile/js/sponsor_strip.jsx
+++ b/web-mobile/js/sponsor_strip.jsx
@@ -16,8 +16,16 @@
 function SponsorStrip({ sponsors }) {
   if (!sponsors || sponsors.length === 0) return null;
 
+  // Key the root on the sponsor file list. handleError below hides the strip
+  // imperatively (strip.style.display = "none") when the last image fails, but
+  // preact never owns that inline style, so a plain re-render would NOT clear
+  // it: after an upload/delete the list changes yet the strip could stay
+  // permanently hidden even with valid new images. Keying by the file list
+  // forces a full remount on any sponsor mutation, discarding the stale inline
+  // display and re-attempting every image from a clean element.
   return (
     <div
+      key={sponsors.map((s) => s.file).join("|")}
       className="sponsor-strip sponsor-strip--viewer"
       role="complementary"
       aria-label="Sponsors"

--- a/web-mobile/js/sponsor_strip.jsx
+++ b/web-mobile/js/sponsor_strip.jsx
@@ -1,25 +1,24 @@
-// SponsorStrip: renders a horizontal row of sponsor logos. Used on the
-// viewer home and on the /display TV / lobby surfaces. See mp-c38.
+// SponsorStrip: renders a vertical stack of full-width sponsor banners on the
+// viewer home page ONLY. See mp-c38. The /display TV and lobby surfaces
+// intentionally do NOT show sponsors (organiser decision: keep the wall
+// boards focused on match info), so there is no variant prop. Banner footprint
+// (max width + max height) is capped responsively in CSS so an arbitrary
+// user-uploaded image can never dominate the viewer page.
 //
 // Props:
 //   sponsors  Array<{name, file, link?}> from tournament.sponsors
-//   variant   "viewer" | "lobby" | "tv"
 //
-// The viewer variant wraps logos with a link in <a target="_blank"
-// rel="noopener noreferrer">. The lobby and tv variants are passive
-// (TVs have no mouse; lobby touch installs shouldn't focus-trap on a
-// sponsor logo): they always render a bare <img>.
+// A sponsor with a link is wrapped in <a target="_blank"
+// rel="noopener noreferrer">; without one it renders a bare <img>.
 //
 // Hidden when sponsors is empty or undefined.
 
-function SponsorStrip({ sponsors, variant }) {
+function SponsorStrip({ sponsors }) {
   if (!sponsors || sponsors.length === 0) return null;
-  const v = variant || "viewer";
-  const interactive = v === "viewer";
 
   return (
     <div
-      className={"sponsor-strip sponsor-strip--" + v}
+      className="sponsor-strip sponsor-strip--viewer"
       role="complementary"
       aria-label="Sponsors"
     >
@@ -33,19 +32,28 @@ function SponsorStrip({ sponsors, variant }) {
         // img. Hiding only the img leaves the wrapper as an empty flex
         // item that still occupies a gap in the row layout. Climbing to
         // the parentElement removes both the gap and the broken image.
+        // If that was the LAST visible banner, collapse the whole strip too,
+        // otherwise the container's border-top + padding render as a
+        // mysterious empty band when every sponsor image fails to load.
         const handleError = (e) => {
           const wrapper = e.currentTarget.parentElement;
-          if (wrapper) wrapper.style.display = "none";
+          if (!wrapper) return;
+          wrapper.style.display = "none";
+          const strip = wrapper.parentElement;
+          if (strip && ![...strip.children].some((c) => c.style.display !== "none")) {
+            strip.style.display = "none";
+          }
         };
         const img = (
           <img
             src={"/api/sponsors/" + s.file}
             alt={s.name || "Sponsor"}
             className="sponsor-strip__logo"
+            loading="lazy"
             onError={handleError}
           />
         );
-        if (interactive && s.link) {
+        if (s.link) {
           return (
             <a
               key={s.file}

--- a/web-mobile/js/viewer_home.jsx
+++ b/web-mobile/js/viewer_home.jsx
@@ -417,8 +417,8 @@ export function ViewerHome({ tournament, onSelectCompetition, onAdminClick, onOp
             </>
           )}
 
-          {/* mp-c38: sponsor logos. Hidden when none configured. */}
-          {window.SponsorStrip && <window.SponsorStrip sponsors={t && t.sponsors} variant="viewer" />}
+          {/* mp-c38: sponsor logos, viewer page only. Hidden when none configured. */}
+          {window.SponsorStrip && <window.SponsorStrip sponsors={t && t.sponsors} />}
 
           {/* U1: link to the kendo glossary so volunteers (and
               spectators new to kendo) can browse the term register

--- a/web-mobile/js/viewer_utils.jsx
+++ b/web-mobile/js/viewer_utils.jsx
@@ -226,7 +226,7 @@ export const isNonPublicOrigin = (origin) => {
 // are set so the card is invisible for tournaments that haven't filled them in.
 export function TournamentInfo({ tournament }) {
   const t = tournament;
-  if (!t.venueAddress && !t.venueMapURL && !t.openingTime && !t.closingTime && !t.awardsNote && !t.rulesURL && !t.infoNotes && !(t.contacts && t.contacts.length > 0)) return null;
+  if (!t.venueAddress && !t.venueMapURL && !t.openingTime && !t.closingTime && !t.awardsNote && !t.websiteURL && !t.infoNotes && !(t.contacts && t.contacts.length > 0)) return null;
 
   const contactLink = (value) => {
     if (!value) return value;
@@ -264,9 +264,9 @@ export function TournamentInfo({ tournament }) {
           <dt className="tournament-info__label">Awards</dt>
           <dd className="tournament-info__value">{t.awardsNote}</dd>
         </>}
-        {t.rulesURL && <>
-          <dt className="tournament-info__label">Rules</dt>
-          <dd className="tournament-info__value">{isHttpURL(t.rulesURL) ? <a href={t.rulesURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{t.rulesURL.replace(/^https?:\/\//i, "")}</a>: t.rulesURL}</dd>
+        {t.websiteURL && <>
+          <dt className="tournament-info__label">Website</dt>
+          <dd className="tournament-info__value">{isHttpURL(t.websiteURL) ? <a href={t.websiteURL} className="tournament-info__link" target="_blank" rel="noopener noreferrer">{t.websiteURL.replace(/^https?:\/\//i, "")}</a>: t.websiteURL}</dd>
         </>}
         {t.infoNotes && <>
           <dt className="tournament-info__label">Notes</dt>


### PR DESCRIPTION
## Summary

Three related tournament-customisation improvements to the mobile app:

- **Link previews resolve to the tournament** (mp-p9o8). Sharing the app URL in Slack / WhatsApp / iMessage now shows the tournament name and logo instead of the generic app title and icon. `index.html` is served through a server-side injector that adds Open Graph + Twitter Card tags from live tournament state.
- **"Rules link" is now "Website link"** (mp-3fr3), a full-stack rename of the underlying `rules_url` field to `website_url` with a backward-compatible YAML migration, so existing `tournament.md` files keep working.
- **Sponsor banners work correctly** (mp-vb3u): they now render as full-width banners on the public viewer page only, update live on upload/delete (the "I uploaded a banner and it didn't show up" report), and have a bounded height so an oversized upload can't dominate the page.

## Why

- Link previews: crawlers do not run JavaScript, so the SPA's client-set title/logo never reached them; the static `index.html` had no OG tags at all.
- Sponsor "didn't show up": the sponsor and branding upload/delete endpoints never broadcast over the SSE hub, so an already-open viewer/display stayed stale until a manual reload (unlike `PUT /tournament`, which broadcasts).
- Go toolchain bump (1.26.4 -> 1.26.5) is bundled because `GO-2026-5856` (crypto/tls) fails the `make go/test` vuln gate repo-wide.

## Files changed

| File | What |
|---|---|
| `internal/mobileapp/index_meta.go` | New: injects OG/Twitter meta into index.html from tournament state; absolute URLs honour X-Forwarded-Proto/Host |
| `internal/mobileapp/index_meta_test.go` | New: unit tests for meta injection, title rewrite, escaping, base-URL derivation |
| `internal/mobileapp/server.go` | Serve index.html via the injector (root + SPA fallback); pass hub to sponsor/branding handlers |
| `go.mod` | Go 1.26.4 -> 1.26.5 (clears GO-2026-5856) |
| `internal/mobileapp/handlers_sponsors.go` | Broadcast EventTournamentUpdated on sponsor upload/delete |
| `internal/mobileapp/handlers_branding.go` | Broadcast EventTournamentUpdated on logo upload/delete |
| `internal/mobileapp/handlers_sponsors_test.go` | Test: mutations broadcast tournament_updated |
| `internal/state/models.go` | RulesURL -> WebsiteURL; RulesURLLegacy capture field + migration in ApplyTournamentDefaults |
| `internal/state/tournament.go` | Inline rules_url -> website_url migration in UpdateTournamentChanged |
| `internal/state/models_test.go` | Migration tests (unit + load/save round-trip) |
| `internal/mobileapp/validation.go` | MaxLenRulesURL -> MaxLenWebsiteURL |
| `internal/mobileapp/handlers_tournament.go` | Validate/trim WebsiteURL |
| `internal/mobileapp/coverage_gap_test.go` | Updated field name in validation tests |
| `web-mobile/js/sponsor_strip.jsx` | Viewer-only; full-width height-capped banner; onError collapses strip when last image fails; lazy-load |
| `web-mobile/css/styles.css` | Full-width banner, responsive max-height, external-link badge + focus ring on linked banners |
| `web-mobile/js/display_scoreboard.jsx`, `display_lobby.jsx` | Remove SponsorStrip from TV/lobby surfaces |
| `web-mobile/js/viewer_home.jsx` | Drop the now-unused variant prop |
| `web-mobile/js/admin_setup.jsx` | "Website link" field label/hint + websiteURL state/payload |
| `web-mobile/js/viewer_utils.jsx` | Info label "Rules" -> "Website"; read t.websiteURL |
| `web-mobile/js/__tests__/sponsor_strip.test.jsx`, `viewer.test.jsx` | Updated for viewer-only variant + websiteURL |
| `docs/user-guide/mobile-app.md` | Sponsors as full-width viewer banners; website-link wording |

## Screenshots

**Viewer info: "Website link" (renamed from "Rules link"), reading the migrated `website_url`** (mobile viewer)

![Viewer tournament info showing WEBSITE label](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/340/viewer-website.png)

**Sponsor banner: full-width on the public viewer page, with the external-link badge** (mobile viewer)

![Full-width sponsor banner on the viewer page](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/340/viewer-sponsor.png)

**Admin: the renamed "Website link" field**

![Admin Website link field](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/340/admin-website-field.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + vuln + tests); mobileapp 85.7%, state 89.6%
- [x] New/updated unit tests cover the change (meta injection, sponsor broadcast, rules->website migration load/save)
- [x] Manual browser verification: link preview `<head>` served with OG tags (incl. X-Forwarded-Proto/Host); sponsor upload live-updates an open viewer (two-tab test); sponsor shows on viewer only (not TV/lobby); full-width banner + square bounded + no horizontal overflow at 375px; legacy `rules_url` tournament.md loads as Website and re-saves as `website_url`
- [x] Screenshots added above (viewer Website label, full-width sponsor banner, admin Website field)
- [x] Docs updated under `docs/` (`make docs/build` passes)
- [x] No new console errors or warnings

Closes mp-p9o8
Closes mp-3fr3
Closes mp-vb3u
