### PR TITLE
fix(deps): bump excelize/v2 to v2.11.0 (GHSA-h69g-9hx6-f3v4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	github.com/xuri/excelize/v2 v2.10.1
+	github.com/xuri/excelize/v2 v2.11.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/text v0.38.0
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/xuri/efp v0.0.1 h1:fws5Rv3myXyYni8uwj2qKjVaRP30PdjeYe2Y6FDsCL8=
 github.com/xuri/efp v0.0.1/go.mod h1:ybY/Jr0T0GTCnYjKqmdwxyxn2BQf2RcQIIvex5QldPI=
-github.com/xuri/excelize/v2 v2.10.1 h1:V62UlqopMqha3kOpnlHy2CcRVw1V8E63jFoWUmMzxN0=
-github.com/xuri/excelize/v2 v2.10.1/go.mod h1:iG5tARpgaEeIhTqt3/fgXCGoBRt4hNXgCp3tfXKoOIc=
+github.com/xuri/excelize/v2 v2.11.0 h1:HxaEFl6sRN2+8J5a8HaKq+0M4FsjBGMnWWtjOCPSG88=
+github.com/xuri/excelize/v2 v2.11.0/go.mod h1:jxFLbzaIwGQ5ufFNvYfUOHqXhfPaNmP14KWfmNz2Uak=
 github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 h1:+C0TIdyyYmzadGaL/HBLbf3WdLgC29pgyhTjAT/0nuE=
 github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
 go.mongodb.org/mongo-driver/v2 v2.7.0 h1:RO+zqavD2/GCL3cxOMyZhx6R9Irzr8/6gsoqx5tcY/c=


### PR DESCRIPTION
## Summary

- Bump `github.com/xuri/excelize/v2` from v2.10.1 to **v2.11.0** to remediate **GHSA-h69g-9hx6-f3v4** (high): an unbounded row-index allocation in the worksheet parser can OOM or panic the process (DoS) on a crafted workbook.
- This is the vulnerability the `validate` job's Anchore image scan flags. It fails on `main` and on every open PR (including the docs-only #341); this bump clears it repo-wide.

## Why

The grype vulnerability DB was updated to include GHSA-h69g-9hx6-f3v4, so the image scan started failing on the pre-existing v2.10.1 dependency. v2.11.0 is the first patched release (advisory range `< 2.11.0`).

## Files changed

| File | What |
|---|---|
| `go.mod` | excelize/v2 v2.10.1 -> v2.11.0 |
| `go.sum` | updated checksums |

## Test plan

- [x] `make go/test` passes (lint + gosec + govulncheck + full suite with the bumped dependency)
- [x] New/updated unit tests cover the change - N/A, dependency patch bump; existing suite exercises the excelize codepaths (Excel generation, PDF pipeline)
- [ ] Manual browser verification - N/A, no UI change
- [ ] Screenshots added above - N/A, no UI change
- [x] Docs updated under `docs/` - N/A, no user-facing behavior change
- [x] No new console errors or warnings

Closes mp-cx0d
