### PR TITLE
fix(mobileapp): quiet two benign console errors (logo + tournament bootstrap)

### DIFF
--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -34,8 +34,11 @@ func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 	// calls onMissing, which differs by method (GET redirects to the default,
 	// HEAD 404s for the existence probe).
 	serveLogo := func(c *gin.Context, onMissing func(*gin.Context)) {
-		// Prevent browsers/proxies from caching the miss/redirect: a newly
-		// uploaded logo would otherwise stay "missing" until a hard refresh.
+		// /branding/logo is a stable URL whose bytes change when the operator
+		// uploads, replaces, or removes a logo, so mark EVERY response (the
+		// served logo, and the missing-logo redirect/404 alike) no-cache: a
+		// browser/proxy must revalidate rather than keep serving a stale logo
+		// or a stale "missing" redirect after the logo changes.
 		c.Header("Cache-Control", "no-cache")
 		t, err := store.LoadTournament()
 		if err != nil {

--- a/internal/mobileapp/handlers_branding.go
+++ b/internal/mobileapp/handlers_branding.go
@@ -24,13 +24,18 @@ var validBrandingContentTypes = map[string]string{
 }
 
 // RegisterPublicBrandingHandlers wires the unauthenticated GET and HEAD routes
-// that serve the tournament logo bytes. Returns 404 when no logo is configured.
-// HEAD is registered explicitly because Gin does not auto-route HEAD to GET.
-// The BrandingManager component uses HEAD to probe logo existence on mount.
+// that serve the tournament logo bytes. When no custom logo is configured, GET
+// redirects to the bundled default (/logo.jpeg) so image consumers never see a
+// 404, while HEAD returns 404 so BrandingManager can probe whether a custom
+// logo is set. HEAD is registered explicitly because Gin does not auto-route
+// HEAD to GET.
 func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
-	brandingLogoHandler := func(c *gin.Context) {
-		// Prevent browsers/proxies from caching 404s, a newly uploaded logo
-		// would otherwise stay "missing" until a hard refresh.
+	// serveLogo serves the custom logo when one is configured; otherwise it
+	// calls onMissing, which differs by method (GET redirects to the default,
+	// HEAD 404s for the existence probe).
+	serveLogo := func(c *gin.Context, onMissing func(*gin.Context)) {
+		// Prevent browsers/proxies from caching the miss/redirect: a newly
+		// uploaded logo would otherwise stay "missing" until a hard refresh.
 		c.Header("Cache-Control", "no-cache")
 		t, err := store.LoadTournament()
 		if err != nil {
@@ -38,19 +43,19 @@ func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 			return
 		}
 		if t == nil || t.Theme == nil || t.Theme.LogoPath == "" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"})
+			onMissing(c)
 			return
 		}
 		name := t.Theme.LogoPath
 		// Only allow the two known filenames, never serve arbitrary paths.
 		if name != "logo.png" && name != "logo.jpg" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"})
+			onMissing(c)
 			return
 		}
 		path := filepath.Join(store.GetFolder(), brandingDirName, name)
 		info, err := os.Lstat(path)
 		if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-			c.JSON(http.StatusNotFound, gin.H{"error": "logo file not found"})
+			onMissing(c)
 			return
 		}
 		ext := strings.ToLower(filepath.Ext(name))
@@ -60,18 +65,20 @@ func RegisterPublicBrandingHandlers(r *gin.RouterGroup, store *state.Store) {
 		case ".jpg":
 			c.Header("Content-Type", "image/jpeg")
 		}
-		// Logo filename changes on each upload (png vs jpg could flip), so
-		// use no-cache to ensure browsers don't serve a stale type. The
-		// admin upload flow is infrequent, so this is acceptable.
-		c.Header("Cache-Control", "no-cache")
 		c.File(path)
 	}
-	r.GET("/branding/logo", brandingLogoHandler)
-	// HEAD is used by BrandingManager to probe logo existence without
-	// fetching the full image payload. Gin does not auto-route HEAD to GET,
-	// so we register it explicitly with the same handler (c.File/ServeContent
-	// strips the body for HEAD requests automatically).
-	r.HEAD("/branding/logo", brandingLogoHandler)
+	// GET: fall back to the bundled default logo so the topbar/auth <img>
+	// never logs a console 404 (it would otherwise swap to /logo.jpeg via its
+	// onError handler anyway). Redirecting keeps that outcome without the noise.
+	r.GET("/branding/logo", func(c *gin.Context) {
+		serveLogo(c, func(c *gin.Context) { c.Redirect(http.StatusFound, "/logo.jpeg") })
+	})
+	// HEAD is used by BrandingManager to probe custom-logo existence without
+	// fetching the payload, so it must keep returning 404 when none is set.
+	// Gin does not auto-route HEAD to GET, so register it explicitly.
+	r.HEAD("/branding/logo", func(c *gin.Context) {
+		serveLogo(c, func(c *gin.Context) { c.JSON(http.StatusNotFound, gin.H{"error": "no logo configured"}) })
+	})
 }
 
 // RegisterBrandingHandlers wires admin-gated mutation endpoints. The caller

--- a/internal/mobileapp/handlers_branding_test.go
+++ b/internal/mobileapp/handlers_branding_test.go
@@ -50,10 +50,24 @@ func buildBrandingUpload(t *testing.T, filename string, content []byte) (*bytes.
 	return body, mw.FormDataContentType()
 }
 
-func TestGetBrandingLogo_NotFound(t *testing.T) {
+func TestGetBrandingLogo_NoLogo_RedirectsToDefault(t *testing.T) {
+	// With no custom logo, GET redirects to the bundled default so image
+	// consumers never see a 404 (see RegisterPublicBrandingHandlers).
 	h, _, cleanup := brandingTestSetup(t)
 	defer cleanup()
 	req := httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/logo.jpeg", w.Header().Get("Location"))
+}
+
+func TestHeadBrandingLogo_NoLogo_NotFound(t *testing.T) {
+	// HEAD keeps 404 as the existence probe used by BrandingManager, even
+	// though GET now redirects to the default.
+	h, _, cleanup := brandingTestSetup(t)
+	defer cleanup()
+	req := httptest.NewRequest(http.MethodHead, "/api/branding/logo", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -176,11 +190,12 @@ func TestDeleteBrandingLogo_RemovesFile(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.NoFileExists(t, filepath.Join(dir, brandingDirName, "logo.png"))
 
-	// GET should now return 404.
+	// GET should now redirect to the bundled default logo.
 	req = httptest.NewRequest(http.MethodGet, "/api/branding/logo", nil)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "/logo.jpeg", w.Header().Get("Location"))
 }
 
 // TestDeleteBrandingLogo_PreservesWindowTitle verifies that deleting the logo

--- a/internal/mobileapp/handlers_test.go
+++ b/internal/mobileapp/handlers_test.go
@@ -2145,12 +2145,14 @@ func TestViewerHandlers(t *testing.T) {
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	// GET /api/viewer/tournament (not found)
+	// GET /api/viewer/tournament (no tournament: 200 with a null body, not a
+	// 404, so the SPA bootstrap doesn't log a console error)
 	os.Remove(filepath.Join(tempDir, "tournament.md"))
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/api/viewer/tournament", nil)
 	r.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null", w.Body.String())
 	// Restore
 	store.SaveTournament(&state.Tournament{Name: "Test"})
 

--- a/internal/mobileapp/handlers_viewer.go
+++ b/internal/mobileapp/handlers_viewer.go
@@ -192,7 +192,12 @@ func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.
 			publicT.Password = ""
 			c.JSON(http.StatusOK, publicT)
 		} else {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			// No tournament configured yet is a normal bootstrap state, not an
+			// error: return 200 with a null body so the SPA opens the create-
+			// tournament gate without the browser logging a console 404.
+			// fetchTournament (api_client.jsx) treats a null payload as "no
+			// tournament" exactly like it did the old 404.
+			c.JSON(http.StatusOK, nil)
 		}
 	})
 

--- a/internal/mobileapp/handlers_viewer_test.go
+++ b/internal/mobileapp/handlers_viewer_test.go
@@ -131,11 +131,14 @@ func TestViewerHandlers_Standalone(t *testing.T) {
 	r, store, _, _, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
-	// 1. GET /api/viewer/tournament - No tournament case
+	// 1. GET /api/viewer/tournament - No tournament case: 200 with a null
+	// body (a normal bootstrap state, not a 404, so the SPA doesn't log a
+	// console error).
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/api/viewer/tournament", nil)
 	r.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "null", w.Body.String())
 
 	// 2. GET /api/viewer/tournament - With tournament
 	tourney := state.Tournament{Name: "Test Tourney", Password: "secret"}

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -88,8 +88,12 @@ def wait_for_server():
 
 def setup_tournament():
     resp = requests.get(f"{BASE_URL}/api/viewer/tournament")
-    # "No tournament configured yet" bootstrap state: newer servers return 200
-    # with a null JSON body; older servers return 404. Treat both as "create it".
+    # Expected: 200 (a tournament, or a null body on newer-server bootstrap) or
+    # 404 (older-server bootstrap). Surface anything else (5xx, auth) instead of
+    # masking it as "no tournament" and creating against an unhealthy server.
+    if resp.status_code not in (200, 404):
+        resp.raise_for_status()  # 4xx/5xx -> HTTPError
+        raise RuntimeError(f"unexpected status {resp.status_code} from /api/viewer/tournament")
     existing = None
     if resp.status_code == 200 and resp.text.strip():
         existing = resp.json()  # None when the body is JSON null

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -88,7 +88,12 @@ def wait_for_server():
 
 def setup_tournament():
     resp = requests.get(f"{BASE_URL}/api/viewer/tournament")
-    if resp.status_code == 404:
+    # "No tournament configured yet" bootstrap state: newer servers return 200
+    # with a null JSON body; older servers return 404. Treat both as "create it".
+    existing = None
+    if resp.status_code == 200 and resp.text.strip():
+        existing = resp.json()  # None when the body is JSON null
+    if resp.status_code == 404 or existing is None:
         print("Creating tournament...")
         payload = {
             "name": "London Cup Demo",

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -2491,16 +2491,19 @@ paths:
     get:
       tags: [viewer]
       summary: Get public tournament info
-      description: Returns tournament details with password field redacted.
+      description: |
+        Returns tournament details with the password field redacted, or `null`
+        when no tournament is configured yet (a normal bootstrap state, so the
+        response is `200` with a null body rather than a `404`).
       responses:
         '200':
-          description: Public tournament info.
+          description: Public tournament info, or null when no tournament is configured yet.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tournament'
-        '404':
-          $ref: '#/components/responses/NotFound'
+                oneOf:
+                  - $ref: '#/components/schemas/Tournament'
+                  - type: 'null'
 
   /api/viewer/competitions:
     get:

--- a/web-mobile/js/__tests__/api.test.jsx
+++ b/web-mobile/js/__tests__/api.test.jsx
@@ -480,6 +480,24 @@ describe('API Utils', () => {
       expect(data.name).toBe('London Cup');
     });
 
+    it('fetchTournament should return null on 404 (older-server bootstrap state)', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'not found' })
+      });
+      expect(await API.fetchTournament()).toBeNull();
+    });
+
+    it('fetchTournament should return null on a 200 null body (newer-server bootstrap state)', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => null
+      });
+      expect(await API.fetchTournament()).toBeNull();
+    });
+
     it('startCompetition should normalize result', async () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,

--- a/web-mobile/js/admin_shell.jsx
+++ b/web-mobile/js/admin_shell.jsx
@@ -357,7 +357,11 @@ function AdminDashboard({ tournament, password, onOpenCompetition, onCreateCompe
           window.API.fetchTournament(),
           window.API.fetchCompetitions()
         ]).then(([tourney, competitions]) => {
-          onUpdate({ ...tourney, competitions });
+          // fetchTournament returns null when no tournament is configured
+          // (e.g. it was reset while the dashboard is open). Fall back to the
+          // current tournament (as admin.jsx's refresh does) rather than
+          // spreading null into a malformed { competitions } object.
+          onUpdate({ ...(tourney || t), competitions });
         }).catch(err => console.error("Dashboard refresh failed", err))
           .finally(() => {
             fetching = false;

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -787,10 +787,12 @@ function adminHdr(adminPassword) {
 const API = {
     async fetchTournament() {
         const res = await fetch('/api/viewer/tournament');
-        // 404 is the expected "no tournament configured yet" bootstrap state,
-        // not an error: return null so callers open the create-tournament gate
-        // quietly instead of logging a console error. Genuine failures (5xx,
-        // network) still throw below.
+        // "No tournament configured yet" is a normal bootstrap state, not an
+        // error: return null so callers open the create-tournament gate quietly
+        // instead of logging a console error. Newer servers signal it with a 200
+        // and a null JSON body (handled by the res.json() return below); older
+        // servers used a 404 (handled here). Genuine failures (5xx, network)
+        // still throw below.
         if (res.status === 404) {
             return null;
         }

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -787,6 +787,13 @@ function adminHdr(adminPassword) {
 const API = {
     async fetchTournament() {
         const res = await fetch('/api/viewer/tournament');
+        // 404 is the expected "no tournament configured yet" bootstrap state,
+        // not an error: return null so callers open the create-tournament gate
+        // quietly instead of logging a console error. Genuine failures (5xx,
+        // network) still throw below.
+        if (res.status === 404) {
+            return null;
+        }
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
             throw new Error(err.error || `Failed to fetch tournament (Status ${res.status})`);

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -577,8 +577,9 @@ function App() {
     try {
       const t = await window.API.fetchTournament();
       if (!t || t.error) {
-        // null = no tournament configured yet (fetchTournament returns null on
-        // 404); open the create-tournament gate without logging an error.
+        // null = no tournament configured yet: fetchTournament returns null for
+        // the bootstrap state (a 200 with a null body on newer servers, or a 404
+        // on older ones). Open the create-tournament gate without logging an error.
         setTournament(null);
       } else {
         const comps = await window.API.fetchCompetitions();

--- a/web-mobile/js/app.jsx
+++ b/web-mobile/js/app.jsx
@@ -576,7 +576,9 @@ function App() {
   const load = async () => {
     try {
       const t = await window.API.fetchTournament();
-      if (t && t.error) {
+      if (!t || t.error) {
+        // null = no tournament configured yet (fetchTournament returns null on
+        // 404); open the create-tournament gate without logging an error.
         setTournament(null);
       } else {
         const comps = await window.API.fetchCompetitions();


### PR DESCRIPTION
## Summary

- Silence two benign console-noise items observed while driving the running app to capture docs screenshots (PR #341). Both had working fallbacks and no user-visible effect, but logged red errors in devtools on normal use.
- `GET /api/branding/logo` now redirects (302) to the bundled default `/logo.jpeg` when no custom logo is configured, instead of returning 404. `HEAD` keeps its 404 so `BrandingManager`'s existence probe still works.
- `GET /api/viewer/tournament` now returns 200 with a null body when no tournament is configured yet (a normal bootstrap state), instead of 404. `fetchTournament` returns null and the SPA opens the create-tournament gate without logging an error.

## Why

Root cause: two endpoints returned 404 for states that are actually normal (no custom logo set; no tournament created yet), and the browser logs every 404 response as a console error regardless of how the JavaScript handles it.

1. `GET /api/branding/logo` 404'd on every page that renders the logo. The topbar/auth `<img>` fell back to `/logo.jpeg` via its `onError` handler, so nothing broke, but a red 404 was logged each time.
2. During bootstrap, before any tournament exists, `app.jsx` logged `console.error("Failed to load tournament")`, and the browser logged the underlying `/api/viewer/tournament` 404.

Both are cosmetic (working fallbacks already existed), so this is a chore-level cleanup, not a functional bug fix.

## Files changed

| File | What |
|---|---|
| `internal/mobileapp/handlers_branding.go` | GET `/branding/logo` redirects to the bundled default `/logo.jpeg` when no custom logo; HEAD keeps its 404 existence probe |
| `internal/mobileapp/handlers_viewer.go` | GET `/viewer/tournament` returns 200 with a null body (not 404) when no tournament is configured |
| `web-mobile/js/api_client.jsx` | `fetchTournament` returns null on 404 (defensive fallback for older servers) instead of throwing |
| `web-mobile/js/app.jsx` | `load()` treats a null/absent tournament as the create-gate state, without `console.error`; genuine failures still throw and log |
| `internal/mobileapp/handlers_branding_test.go` | Assert GET redirect to `/logo.jpeg` + HEAD-probe 404 |
| `internal/mobileapp/handlers_viewer_test.go`, `handlers_test.go` | Assert the 200 null-body no-tournament response |

## Screenshots

No visual change: the logo renders identically (the bundled default, now served via a 302 rather than an `onError` fallback), and the console fix is invisible to users. Screenshot confirms the dashboard renders correctly after the change:

![Dashboard renders correctly after the fix; logo served via the new redirect path](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/346/console-fix-dashboard.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) - green, mobileapp coverage 85.8%
- [x] New/updated unit tests cover the change - GET redirect + HEAD 404 (branding); 200 null-body no-tournament (viewer)
- [x] Manual browser verification - drove a fresh instance with a headless browser: the boot console is now completely clean (0 errors, was 2); network shows `GET /api/branding/logo -> 302 -> /logo.jpeg 200` and no `/api/viewer/tournament` 404
- [x] Screenshots added above - dashboard renders correctly (no visual regression)

Closes mp-mq6j
