### PR TITLE
docs(readme): fix pre-compiled binary install example (404s + extract dir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,15 +417,14 @@ This builds the full binary, including the `serve` and `mobile-app` subcommands.
 <details>
   <summary><h3>from the GitHub releases</h3></summary>
 
-Download the pre-compiled binaries from the [release page](https://github.com/gitrgoliveira/bracket-creator/releases) page and copy them to the desired location.
+Download the pre-compiled binaries from the [release page](https://github.com/gitrgoliveira/bracket-creator/releases) and copy them to the desired location.
 
 ```bash
-$ VERSION=v1.0.0
-$ OS=Linux
+$ OS=linux
 $ ARCH=x86_64
 $ TAR_FILE=bracket-creator_${OS}_${ARCH}.tar.gz
-$ wget https://github.com/gitrgoliveira/bracket-creator/releases/download/${VERSION}/${TAR_FILE}
-$ sudo tar xvf ${TAR_FILE} bracket-creator -C /usr/local/bin
+$ wget https://github.com/gitrgoliveira/bracket-creator/releases/latest/download/${TAR_FILE}
+$ sudo tar xvf ${TAR_FILE} -C /usr/local/bin bracket-creator
 $ rm -f ${TAR_FILE}
 ```
 

--- a/README.md
+++ b/README.md
@@ -420,12 +420,12 @@ This builds the full binary, including the `serve` and `mobile-app` subcommands.
 Download the pre-compiled binaries from the [release page](https://github.com/gitrgoliveira/bracket-creator/releases) and copy them to the desired location.
 
 ```bash
-$ OS=linux
-$ ARCH=x86_64
-$ TAR_FILE=bracket-creator_${OS}_${ARCH}.tar.gz
-$ wget https://github.com/gitrgoliveira/bracket-creator/releases/latest/download/${TAR_FILE}
-$ sudo tar xvf ${TAR_FILE} -C /usr/local/bin bracket-creator
-$ rm -f ${TAR_FILE}
+OS=linux
+ARCH=x86_64
+TAR_FILE=bracket-creator_${OS}_${ARCH}.tar.gz
+wget https://github.com/gitrgoliveira/bracket-creator/releases/latest/download/${TAR_FILE}
+sudo tar xvf ${TAR_FILE} -C /usr/local/bin bracket-creator
+rm -f ${TAR_FILE}
 ```
 
 </details>
@@ -434,10 +434,10 @@ $ rm -f ${TAR_FILE}
   <summary><h3>manually</h3></summary>
 
 ```bash
-$ git clone github.com/gitrgoliveira/bracket-creator
-$ cd bracket-creator
-$ go generate ./...
-$ go install
+git clone github.com/gitrgoliveira/bracket-creator
+cd bracket-creator
+go generate ./...
+go install
 ```
 
 </details>


### PR DESCRIPTION
## Summary

- Fix the pre-compiled binary install example in `README.md`. It had copy-paste-breaking bugs already corrected in `docs/user-guide/install/install.md` (PR #341) but never mirrored to the README.
- `VERSION=v1.0.0` was not a real tag (latest is `v0.17.0`), so the `wget` URL 404'd. Switched to GitHub's `/releases/latest/download/` alias, which always resolves to the current release and never goes stale (the `VERSION` variable is gone).
- `OS=Linux` (uppercase) produced `bracket-creator_Linux_x86_64.tar.gz`, which does not exist (404). The asset OS token is lowercase `linux`.
- `tar -C` came after the member operand, so extraction landed in the current directory instead of `/usr/local/bin`; `-C` now precedes the file list.
- Removed a doubled "page" in the sentence above the block.
- Removed the `$ ` shell-prompt markers from the pre-compiled and build-from-source blocks (the only two of the README's 24 bash blocks that carried them). They break naive copy-paste (`$ OS=linux` runs the command `$`); both blocks are now directly runnable and consistent with the other 22. Mirrors the same cleanup in `install.md` (PR #341).

## Why

The README install snippet had drifted from reality: it pinned a nonexistent release tag, used the wrong-case OS token, and ordered `tar` flags so extraction went to the wrong directory. Anyone copy-pasting it hit a 404 or a binary in the current directory. The docs site page (`docs/user-guide/install/install.md`) was already fixed in PR #341; this mirrors that fix to the README so both stay consistent.

## Files changed

| File | What |
|---|---|
| `README.md` | Fix the "from the GitHub releases" install example: drop the nonexistent `VERSION=v1.0.0` in favour of the `latest/download` alias, lowercase `OS=linux`, move `tar -C` before the member operand, and remove a doubled "page". Also strip `$ ` prompt markers from the pre-compiled and build-from-source blocks so they are directly runnable. |

## Test plan

- [x] `make go/test` — N/A: README prose only, no Go/JS code affected.
- [x] New/updated unit tests — N/A: documentation prose, no test surface.
- [x] Manual browser verification — N/A: no `web-mobile/` or `web/` change.
- [x] Screenshots — N/A: no UI change (section removed).
- [x] Docs: the analogous MkDocs page (`docs/user-guide/install/install.md`) already carries this fix (PR #341, `make docs/build` green). The README is not part of the MkDocs site, so there is no separate site build for it.
- [x] No new console errors or warnings — N/A: no runtime surface.

**Validation performed (commands, not assumptions):**
- `curl -sI https://github.com/gitrgoliveira/bracket-creator/releases/latest/download/bracket-creator_linux_x86_64.tar.gz` → `HTTP/2 302` redirecting to the current release asset (`.../download/v0.17.0/...`).
- `curl -sI https://github.com/gitrgoliveira/bracket-creator/releases/download/v1.0.0/bracket-creator_linux_x86_64.tar.gz` → `HTTP/2 404` (confirms the old pin was broken).
- Asset name confirmed via `gh release view --repo gitrgoliveira/bracket-creator --json assets` → `bracket-creator_linux_x86_64.tar.gz` (lowercase `linux`).

Closes mp-orfs
