### PR TITLE
docs(mp-owsy): redirect pre-restructure user-guide URLs to their new homes

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,10 @@
 mkdocs==1.6.1
 mkdocs-material==9.7.6
+# Held at 1.2.2 deliberately: 1.2.3 was published from the ProperDocs fork
+# ecosystem and pulls in `properdocs` (an MkDocs fork) alongside mkdocs.
+# Do not bump without re-verifying the release comes from
+# https://github.com/mkdocs/mkdocs-redirects
+mkdocs-redirects==1.2.2
 mkdocs-material-extensions==1.3.1
 pymdown-extensions==10.21.3
 Markdown==3.10.2

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -37,6 +37,21 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
 
+plugins:
+  # Defining a plugins block suppresses the implicit default, so `search`
+  # must be listed explicitly to keep the search box working.
+  - search
+  # Forward the pre-restructure user-guide URLs (published for a long time,
+  # so linked externally and indexed by search engines) to their new homes.
+  - redirects:
+      redirect_maps:
+        'user-guide/getting-started.md': 'user-guide/install/install.md'
+        'user-guide/hosting.md': 'user-guide/install/hosting.md'
+        'user-guide/input-format.md': 'user-guide/organisers/input-format.md'
+        'user-guide/mobile-app.md': 'user-guide/organisers/run-tournament.md'
+        'user-guide/naginata.md': 'user-guide/organisers/naginata.md'
+        'user-guide/web-ui.md': 'user-guide/organisers/web-ui.md'
+
 theme:
   name: material
   custom_dir: overrides


### PR DESCRIPTION
## Summary

- Old (pre-restructure) user-guide URLs now forward to their new locations instead of returning 404. PR #341 moved six long-published pages, so external links and search-engine results were breaking.
- Adds the `mkdocs-redirects` plugin (pinned) and a redirect map covering exactly the six pages the PR #341 merge removed, verified by diffing the docs tree before and after that merge (`getting-started`, `hosting`, `input-format`, `mobile-app`, `naginata`, `web-ui`). No other published page moved; `run-live.md` never existed on main.
- The generated stubs include a canonical link, a meta-refresh, and an anchor-preserving JS redirect, so browsers, external links, and search engines all get forwarded.

## Why

The `overrides/404.html` fallback is branded but static: it has no `Location` header or per-page destination, so it cannot forward the renamed URLs. A redirect map does.

**Version pin rationale (supply chain):** `mkdocs-redirects` is pinned to **1.2.2**, not the latest 1.2.3. The 1.2.3 release on PyPI (2026-03-28) was not published from the canonical `mkdocs/mkdocs-redirects` repo (whose latest release is v1.2.2, Nov 2024): it came from the ProperDocs fork org created two weeks earlier during the MkDocs governance schism, caps `mkdocs<=1.6.1`, and adds a dependency on `properdocs` (an MkDocs fork). Installing it would pull an unreviewed MkDocs fork alongside our pinned `mkdocs==1.6.1`. 1.2.2 depends only on `mkdocs>=1.1.1`. A comment in `docs/requirements.txt` warns against a blind bump. Background: https://fpgmaas.com/blog/collapse-of-mkdocs/

The `plugins:` block lists `search` explicitly because defining `plugins:` at all suppresses MkDocs' implicit default; search was browser-verified to still work.

## Files changed

| File | What |
|---|---|
| `docs/requirements.txt` | Add `mkdocs-redirects==1.2.2` with a comment explaining the deliberate hold at 1.2.2 |
| `mkdocs.yaml` | Add `plugins:` block: explicit `search` + `redirects` map for the six moved user-guide pages |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change: N/A, config-only docs-site change (no Go/JS code); covered by `make docs/build --strict` and `make docs/linkcheck` (35 pages, 1885 internal links resolve)
- [x] Manual browser verification: loaded `/user-guide/web-ui/`, `/user-guide/mobile-app/#some-anchor`, and `/user-guide/getting-started/` on the served site; each forwarded to its new page (anchor preserved) and rendered correctly. Search overlay returns results ("seeding" finds 8 documents), confirming the explicit `search` plugin entry works
- [x] Screenshots: N/A, no `web-mobile/` or `web/` UI change; the redirect stubs are transient non-visual pages and the destinations are unchanged existing docs pages
- [x] Docs updated under `docs/`: this PR is the docs-site change; `make docs/build` (strict) passes
- [x] No new console errors or warnings (checked via browser console on a redirected page: zero messages)

Closes mp-owsy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
