### PR TITLE
fix: bug squash session (mp-pglr, mp-q8c6, mp-qq8d)

### DIFF
--- a/internal/mobileapp/broadcast_coalescer.go
+++ b/internal/mobileapp/broadcast_coalescer.go
@@ -34,6 +34,11 @@ type matchBroadcastCoalescer struct {
 
 const matchCoalesceWindow = 250 * time.Millisecond
 
+// coalescerNow is a test seam: TestScoreHandler_C3Coalescer pins it to a
+// fixed instant so the 250ms window cannot lapse between two writes on a
+// contended CI runner. Production code never reassigns it.
+var coalescerNow = time.Now
+
 func newMatchBroadcastCoalescer() *matchBroadcastCoalescer {
 	return &matchBroadcastCoalescer{last: make(map[string]time.Time)}
 }
@@ -56,7 +61,7 @@ func (c *matchBroadcastCoalescer) Allow(matchKey string, isRunning bool) bool {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	now := time.Now()
+	now := coalescerNow()
 	if t, ok := c.last[matchKey]; ok && now.Sub(t) < matchCoalesceWindow {
 		return false
 	}

--- a/internal/mobileapp/broadcast_coalescer_test.go
+++ b/internal/mobileapp/broadcast_coalescer_test.go
@@ -168,6 +168,16 @@ func TestScoreHandler_C3Coalescer(t *testing.T) {
 	r, store, _, hub, tempDir := setupTestRouter(t)
 	defer os.RemoveAll(tempDir)
 
+	// Pin the coalescer clock to a fixed instant so both running writes land
+	// at the same coalescer-time and the second is ALWAYS inside the 250ms
+	// window. Without this, >250ms of wall time between the two ServeHTTP
+	// calls on a contended CI runner lets the window lapse, the second write
+	// legitimately broadcasts, and the count==1 assertion can never pass
+	// (observed twice on CI; second flake on PR #349 run 29166974332).
+	frozen := time.Now()
+	coalescerNow = func() time.Time { return frozen }
+	defer func() { coalescerNow = time.Now }()
+
 	require.NoError(t, store.SaveTournament(&state.Tournament{Name: "T", Password: "", Courts: []string{"A"}}))
 	require.NoError(t, store.SaveCompetition(&state.Competition{ID: "c3", Courts: []string{"A"}}))
 	require.NoError(t, store.SavePoolMatches("c3", []state.MatchResult{

--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { makeReactive } from './helpers/reactive_react.js';
 import { parsePath, pathFromState } from '../app.jsx';
-import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, isTeamMatch, groupQueueMatches, shiaijoStandingsKind, makeReconnectRefetcher, pendingFeederSlots, propagateBracketWinnerLocal, applyBronzeLoserLocal } from '../admin_shiaijo.jsx';
+import { sortShiaijoMatches, partitionShiaijoMatches, shiaijoScoreCell, isTeamMatch, groupQueueMatches, shiaijoStandingsKind, swissRoundLabel, makeReconnectRefetcher, pendingFeederSlots, propagateBracketWinnerLocal, applyBronzeLoserLocal } from '../admin_shiaijo.jsx';
 
 // A team encounter's score must never be shown as a bare number; it always
 // carries an IV (Individual Victories) label, since a raw figure could read as
@@ -56,9 +56,16 @@ describe('shiaijoScoreCell; team and engi numbers are never context-free', () =>
 // court-side standings must render through the rank-ordered viewer, exactly
 // like the public viewer and admin Pools tab, never the draw-order pool
 // viewer. This pins the routing decision so it cannot silently regress.
-describe('shiaijoStandingsKind; standings viewer routing follows format (mp-ahu6)', () => {
+describe('shiaijoStandingsKind; standings viewer routing follows format (mp-ahu6/mp-pglr)', () => {
   it('routes a league match to the rank-ordered viewer', () => {
     expect(shiaijoStandingsKind({ compFormat: 'league' })).toBe('league');
+  });
+
+  it('routes a swiss match to the swiss standings viewer (mp-pglr)', () => {
+    // Swiss matches piggyback on the pool pipeline with a synthetic pool
+    // name but never write pools.csv; the pool path would spin on
+    // "Loading standings…" forever.
+    expect(shiaijoStandingsKind({ compFormat: 'swiss' })).toBe('swiss');
   });
 
   it('routes mixed and playoffs matches to the draw-order viewer', () => {
@@ -69,6 +76,27 @@ describe('shiaijoStandingsKind; standings viewer routing follows format (mp-ahu6
   it('defaults to the draw-order viewer for a missing/unknown format', () => {
     expect(shiaijoStandingsKind({})).toBe('pool');
     expect(shiaijoStandingsKind(null)).toBe('pool');
+  });
+});
+
+describe('swissRoundLabel; synthetic engine pool name → operator-facing label', () => {
+  it('converts the canonical Swiss-RN shape to "Round N"', () => {
+    expect(swissRoundLabel('Swiss-R1')).toBe('Round 1');
+    expect(swissRoundLabel('Swiss-R12')).toBe('Round 12');
+  });
+
+  it('passes through non-canonical values unchanged', () => {
+    expect(swissRoundLabel('Pool A')).toBe('Pool A');
+    expect(swissRoundLabel('')).toBe('');
+    expect(swissRoundLabel(null)).toBe('');
+  });
+
+  it('groupQueueMatches labels a swiss round group "Round N", not the synthetic pool name', () => {
+    const groups = groupQueueMatches([
+      { phase: 'pool', poolName: 'Swiss-R2', compFormat: 'swiss' },
+      { phase: 'pool', poolName: 'Pool A', compFormat: 'mixed' },
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Round 2', 'Pool A']);
   });
 });
 

--- a/web-mobile/js/__tests__/sync_queue.test.jsx
+++ b/web-mobile/js/__tests__/sync_queue.test.jsx
@@ -277,6 +277,104 @@ describe('_flushQueue: non-retryable 4xx discards, 5xx/429/network retries', () 
     });
 });
 
+// 3a. mp-q8c6: a DETERMINISTIC 5xx (server bug answering 500 to a write it
+//     will never accept) must not poison the queue forever. After
+//     MAX_QUEUE_SERVER_REJECTIONS the entry is dropped and surfaced through
+//     the write-failed channel. Network failures never count toward the cap.
+
+describe('_flushQueue: server-rejection cap (mp-q8c6)', () => {
+    it('drops a persistently-500ing write after the rejection cap and surfaces it', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const failures = [];
+        const unsub = mod.subscribeTerminalWriteFailed((info) => failures.push(info));
+
+        let attempt = 0;
+        global.fetch = vi.fn().mockImplementation(() => {
+            attempt++;
+            // Deterministic rejection: the observed mp-n19y poison was an engi
+            // flag validation error surfaced as HTTP 500 on every retry.
+            return Promise.resolve({
+                ok: false,
+                status: 500,
+                json: () => Promise.resolve({ error: 'flag total 0+0=0 is invalid' }),
+            });
+        });
+
+        enqueueRunningWrite('c1', 'm1', { status: 'running', rev: 1 }, 'pw');
+        await flushMicrotasks(); // immediate flush: rejection 1
+
+        // Ride out every backoff step (500+1000+2000+4000+8000×6 ≈ 55s for
+        // 10 rejections); the cap must fire well within this window.
+        await tick(120000);
+
+        // 10 rejections total, then the entry is gone: no further fetches.
+        expect(attempt).toBe(10);
+        const callsAtCap = global.fetch.mock.calls.length;
+        await tick(60000);
+        expect(global.fetch).toHaveBeenCalledTimes(callsAtCap);
+
+        // Surfaced to the operator through the write-failed channel.
+        expect(failures.length).toBe(1);
+        expect(failures[0]).toMatchObject({ compID: 'c1', matchID: 'm1', kind: 'score', status: 500 });
+        expect(failures[0].reason).toBe('flag total 0+0=0 is invalid');
+
+        unsub();
+        warnSpy.mockRestore();
+    });
+
+    it('does NOT count network failures toward the cap (offline periods keep writes queued)', async () => {
+        const failures = [];
+        const unsub = mod.subscribeTerminalWriteFailed((info) => failures.push(info));
+
+        let attempt = 0;
+        global.fetch = vi.fn().mockImplementation(() => {
+            attempt++;
+            // Far more network failures than the rejection cap, then recovery.
+            if (attempt <= 15) return Promise.reject(new TypeError('network error'));
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        });
+
+        enqueueRunningWrite('c1', 'm1', { status: 'running', rev: 1 }, 'pw');
+        await flushMicrotasks();
+
+        // Enough time for all 15 failed attempts plus the successful one.
+        await tick(200000);
+
+        // The write survived every network failure and eventually landed.
+        expect(attempt).toBeGreaterThanOrEqual(16);
+        expect(failures.length).toBe(0);
+
+        unsub();
+    });
+
+    it('a superseding write resets the rejection count (fresh descriptor)', async () => {
+        let attempt = 0;
+        const sentRevs = [];
+        global.fetch = vi.fn().mockImplementation((_url, opts) => {
+            attempt++;
+            // First 9 attempts: one shy of the cap.
+            if (attempt <= 9) {
+                return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) });
+            }
+            sentRevs.push(JSON.parse(opts.body).rev);
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        });
+
+        enqueueRunningWrite('c1', 'm1', { status: 'running', rev: 1 }, 'pw');
+        await flushMicrotasks();
+        // 9 rejections: entry still queued (cap is 10).
+        await tick(40000);
+        expect(attempt).toBe(9);
+
+        // A newer operator write replaces the descriptor: count starts fresh,
+        // and the write goes through on the recovered server.
+        enqueueRunningWrite('c1', 'm1', { status: 'running', rev: 2 }, 'pw');
+        await flushMicrotasks();
+        await tick(1000);
+        expect(sentRevs).toEqual([2]);
+    });
+});
+
 // 3b. Single-in-flight serialization: overlapping triggers must not start a
 //     second concurrent flush loop or duplicate PUTs.
 

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -1699,6 +1699,14 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
         ? detail.pools.find((p) => p.poolName === match.poolName)
         : null;
 
+    // Shared loading placeholder for the self-fetching standings viewers
+    // (swiss + league branches below).
+    const standingsLoader = (
+        <p style={{ fontSize: 12, color: "var(--ink-3)", margin: 0 }}>
+            Loading standings…
+        </p>
+    );
+
     return (
         <div className="shiaijo-context">
             <button type="button" className="section-title shiaijo-context__toggle" aria-expanded={open} onClick={onToggle}>
@@ -1727,11 +1735,7 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
                                         tweaks={tweaks || { showDojo: true }}
                                     />
                                 </div>
-                            ) : (
-                                <p style={{ fontSize: 12, color: "var(--ink-3)", margin: 0 }}>
-                                    Loading standings…
-                                </p>
-                            )
+                            ) : standingsLoader
                         ) : isLeagueComp ? (
                             // Leagues are always RANK-ordered (mp-ahu6): never fall
                             // through to the draw-order PoolsViewer here. Renders off
@@ -1747,11 +1751,7 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
                                         highlightPlayers={[]}
                                     />
                                 </div>
-                            ) : (
-                                <p style={{ fontSize: 12, color: "var(--ink-3)", margin: 0 }}>
-                                    Loading standings…
-                                </p>
-                            )
+                            ) : standingsLoader
                         ) : (
                             <>
                                 <div className="shiaijo-context__next">

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -1436,7 +1436,11 @@ export function groupQueueMatches(matches) {
             label = m.round || "Playoffs";
         } else if (m.phase === "pool") {
             key = "pool:" + (m.poolName || "");
-            label = m.poolName || "Pool";
+            // Swiss rounds piggyback on the pool pipeline with a synthetic
+            // "Swiss-RN" pool name (mp-pglr); show the operator "Round N".
+            label = m.compFormat === "swiss"
+                ? swissRoundLabel(m.poolName)
+                : (m.poolName || "Pool");
         } else {
             key = "other";
             label = null;
@@ -1614,13 +1618,28 @@ function MatchSides({ m, large }) {
 }
 
 // Standings ordering is decided by competition FORMAT, not by surface
-// (mp-ahu6): leagues are always rank-ordered (window.LeagueStandingsViewer),
-// pools are always draw-ordered with rank as a badge (window.PoolsViewer) -
-// same split as the public viewer and admin Pools tab. Exported so the
-// format->viewer decision is independently testable and this invariant
-// cannot silently regress again.
+// (mp-ahu6/mp-pglr): swiss renders cumulative standings from the dedicated
+// /swiss/standings endpoint (window.SwissStandingsViewer), leagues are always
+// rank-ordered (window.LeagueStandingsViewer), pools are always draw-ordered
+// with rank as a badge (window.PoolsViewer) - the same three-way split as the
+// public viewer (viewer_competition.jsx) and admin Pools tab. Swiss must NOT
+// fall through to the pool path: Swiss piggybacks on pool-matches.csv with a
+// synthetic pool name ("Swiss-R1") but never writes pools.csv, so the pool
+// path's detail.pools lookup finds nothing and the panel sticks on "Loading
+// standings…" forever. Exported so the format->viewer decision is
+// independently testable and this invariant cannot silently regress again.
 export function shiaijoStandingsKind(match) {
-    return match && match.compFormat === "league" ? "league" : "pool";
+    if (!match) return "pool";
+    if (match.compFormat === "swiss") return "swiss";
+    return match.compFormat === "league" ? "league" : "pool";
+}
+
+// "Swiss-R3" (the synthetic engine pool name, see engine/swiss.go
+// swissPoolName) → "Round 3" for the panel header; any other shape is
+// returned unchanged.
+export function swissRoundLabel(poolName) {
+    const m = /^Swiss-R(\d+)$/.exec(poolName || "");
+    return m ? `Round ${m[1]}` : (poolName || "");
 }
 
 // Collapsible context for the match being scored:
@@ -1632,12 +1651,17 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
     const comp = (competitions || []).find((c) => c.id === match.compId);
     const bracket = comp && (comp.bracket || (Array.isArray(comp.rounds) ? { rounds: comp.rounds } : null));
     const isPool = match.phase === "pool";
-    const isLeagueComp = shiaijoStandingsKind(match) === "league";
+    const standingsKind = shiaijoStandingsKind(match);
+    const isLeagueComp = standingsKind === "league";
+    const isSwissComp = standingsKind === "swiss";
     const phaseLabel = isPool
-        ? window.leagueAwareLabel(match.compFormat, match.poolName, "Pool")
+        ? (isSwissComp
+            ? swissRoundLabel(match.poolName)
+            : window.leagueAwareLabel(match.compFormat, match.poolName, "Pool"))
         : (match.round || "Elimination");
     const PoolsViewer = window.PoolsViewer;
     const LeagueStandingsViewer = window.LeagueStandingsViewer;
+    const SwissStandingsViewer = window.SwissStandingsViewer;
 
     // Pools/standings aren't on the console's competition list payload: fetch
     // the competition detail on demand. Refetch whenever this comp's pool
@@ -1656,7 +1680,10 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
     const [detail, setDetail] = useStateSh(null);
     const [detailErr, setDetailErr] = useStateSh(false);
     useEffectSh(() => {
-        if (!isPool || isLeagueComp || !match.compId || !window.API || typeof window.API.fetchCompetitionDetails !== "function") {
+        // Swiss and league both render self-fetching viewers off `comp` alone
+        // (dedicated standings endpoints), so the competition-detail fetch is
+        // only needed for the pool path.
+        if (!isPool || isLeagueComp || isSwissComp || !match.compId || !window.API || typeof window.API.fetchCompetitionDetails !== "function") {
             setDetail(null);
             return;
         }
@@ -1666,7 +1693,7 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
             .then((d) => { if (!cancelled) setDetail(d); })
             .catch(() => { if (!cancelled) { setDetail(null); setDetailErr(true); } });
         return () => { cancelled = true; };
-    }, [match.compId, isPool, isLeagueComp, poolSig]);
+    }, [match.compId, isPool, isLeagueComp, isSwissComp, poolSig]);
 
     const currentPool = detail && Array.isArray(detail.pools)
         ? detail.pools.find((p) => p.poolName === match.poolName)
@@ -1680,7 +1707,32 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
             {open && (
                 <div className="shiaijo-context__body">
                     {isPool ? (
-                        isLeagueComp ? (
+                        isSwissComp ? (
+                            // Swiss standings come from the dedicated
+                            // /swiss/standings endpoint; SwissStandingsViewer
+                            // fetches its own data (like LeagueStandingsViewer)
+                            // and needs only `comp` from the court feed. The
+                            // poolSig key remounts it after any scored bout so
+                            // the cumulative table stays current mid-round
+                            // (its own refetch deps only cover round changes).
+                            // No "next pool" banner: Swiss rounds are not
+                            // pools, the next round doesn't exist until the
+                            // operator generates it.
+                            SwissStandingsViewer && comp ? (
+                                <div className="shiaijo-context__pools">
+                                    <SwissStandingsViewer
+                                        key={poolSig}
+                                        competition={comp}
+                                        poolMatches={comp.poolMatches}
+                                        tweaks={tweaks || { showDojo: true }}
+                                    />
+                                </div>
+                            ) : (
+                                <p style={{ fontSize: 12, color: "var(--ink-3)", margin: 0 }}>
+                                    Loading standings…
+                                </p>
+                            )
+                        ) : isLeagueComp ? (
                             // Leagues are always RANK-ordered (mp-ahu6): never fall
                             // through to the draw-order PoolsViewer here. Renders off
                             // `comp` alone (see the poolSig effect above for why) -

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -174,6 +174,9 @@ const _revSession = (typeof crypto !== 'undefined' && crypto.randomUUID)
  *   method          : HTTP method string ('PUT' | 'POST')
  *   url             : same-origin request path, e.g. /api/competitions/… (for replay in _flushQueue)
  *   enqueuedAt      : Date.now() at enqueue time (for TTL eviction on reload)
+ *   attempts        : count of server 5xx/429 rejections on flush retries (mp-q8c6
+ *                     retry cap); absent until the first rejection. Network
+ *                     failures never increment it.
  *
  * Running score descriptors set terminal=false and do not use method/url
  * (they are always PUT to the score endpoint: _flushQueue hard-codes that
@@ -189,6 +192,7 @@ const _revSession = (typeof crypto !== 'undefined' && crypto.randomUUID)
  *   method?: string,
  *   url?: string,
  *   enqueuedAt: number,
+ *   attempts?: number,
  * }} WriteDescriptor
  * `method`/`url` are present only on terminal entries; running entries omit them.
  */
@@ -266,8 +270,9 @@ function _setSyncStatus(s) {
 
 // Terminal-write FAILURE channel. When a queued terminal write (completed score /
 // decision / lineup) is permanently discarded: a non-retryable 4xx on retry
-// (409 conflict, 400 validation, 401/403 auth) or a corrupt entry: the write
-// never landed. Sync status alone returns to 'synced', which would let the editor
+// (409 conflict, 400 validation, 401/403 auth), a corrupt entry, or the mp-q8c6
+// server-rejection cap (also applied to running writes): the write never landed.
+// Sync status alone returns to 'synced', which would let the editor
 // clear its pending banner and look "saved". This channel lets surfaces show an
 // explicit "not saved" state instead. Payload: {compID, matchID, kind, status, reason}.
 const _terminalFailListeners = new Set();
@@ -324,6 +329,19 @@ function subscribeSyncStatus(fn) {
 let _flushTimer = null;
 const FLUSH_BACKOFF_MS = [500, 1000, 2000, 4000, 8000];
 let _flushAttempt = 0;
+// mp-q8c6: per-entry cap on SERVER rejections (5xx/429). A deterministic 5xx
+// (e.g. a validation bug surfaced as HTTP 500, observed with an engi flag
+// check during mp-n19y UAT) would otherwise retry forever: the entry poisons
+// the queue for the rest of the session, the pill wedges on "Syncing…", and
+// the operator gets no signal short of clearing localStorage. After this many
+// consecutive server rejections the entry is dropped and surfaced through the
+// write-failed channel instead. Network failures (fetch rejected: connection
+// down / timeout) deliberately do NOT count: a real offline period must keep
+// writes queued for the full QUEUE_TTL_MS, not silently shed them. At the 8s
+// max backoff, 10 rejections ≈ 1 minute of a persistently-erroring server:
+// long enough to ride out a restart behind the TLS proxy (transient 502/503),
+// short enough that a poisoned write can't wedge the queue for hours.
+const MAX_QUEUE_SERVER_REJECTIONS = 10;
 // Single-in-flight guard. _flushQueue's body awaits network I/O, so without a
 // lock a second trigger (a rapid enqueue, an `online` event, or a backoff timer
 // firing mid-flush) would start an OVERLAPPING loop iterating the same snapshot:
@@ -421,7 +439,23 @@ async function _flushQueue() {
                     } else if (res.status >= 500 || res.status === 429) {
                         // Transient server error: server is up but erroring; keep in
                         // queue and retry with backoff, but this is NOT "offline".
-                        anyFailed = true;
+                        // Bounded (mp-q8c6): a DETERMINISTIC rejection (a server bug
+                        // answering 500 to a write it will never accept) must not
+                        // retry forever. Count server rejections on the descriptor
+                        // (persisted with it) and drop + surface once the cap is hit.
+                        // The identity checks above compare object references, so
+                        // mutating the live descriptor is safe: a superseding write
+                        // installs a fresh object and naturally resets the count.
+                        const rejections = (Number(descriptor.attempts) || 0) + 1;
+                        if (rejections >= MAX_QUEUE_SERVER_REJECTIONS) {
+                            const body = await res.json().catch(() => ({}));
+                            console.warn(`[sync] dropping queued ${kind || 'running'} write after ${rejections} server rejections (${res.status}):`, body);
+                            _notifyTerminalWriteFailed({ compID, matchID, kind, status: res.status, reason: body.reasonHuman || body.error || `HTTP ${res.status} (gave up after ${rejections} attempts)` });
+                            if (_writeQueue.get(key) === descriptor) _writeQueue.delete(key);
+                        } else {
+                            descriptor.attempts = rejections;
+                            anyFailed = true;
+                        }
                     } else if (terminal && kind === 'decision' && res.status === 409) {
                         // F5: decision-locked-as-success for queued terminal decision entries.
                         //

--- a/web-mobile/js/viewer.jsx
+++ b/web-mobile/js/viewer.jsx
@@ -15,7 +15,7 @@ import { matchParticipantIds, isFollowedPlayer, isPlayerWatched, WATCHLIST_MAX, 
 import { computeSecondaryAlert, MyMatchAlertBanner } from './viewer_alerts.jsx';
 import { AnnouncementCard, AnnouncementBanner } from './viewer_notifications.jsx';
 import { mymatchQueueLabel, MatchDetailCard, VSchedItem, MatchViewerModal } from './viewer_match.jsx';
-import { isSwissFinalStandings, swissStandingsHeading, LeagueMatrix, PoolNumberedMatchRow, PoolsViewer, LeagueStandingsViewer } from './viewer_standings.jsx';
+import { isSwissFinalStandings, swissStandingsHeading, LeagueMatrix, PoolNumberedMatchRow, PoolsViewer, LeagueStandingsViewer, SwissStandingsViewer } from './viewer_standings.jsx';
 import { deriveAwards, bracketHasDecidedFinal, resolveCompetitionAwards, AwardsView, FightingSpiritSection } from './viewer_awards.jsx';
 import { PlayerMultiFilter, applyFilters, matchHighlightedBy, buildPlayerMatchHighlight, buildWatchlistUpcoming } from './viewer_schedule.jsx';
 import { ViewerCompetition, ViewerOverview } from './viewer_competition.jsx';
@@ -53,6 +53,9 @@ if (typeof window !== 'undefined') {
     // Reused read-only on the shiaijo operator console (pool standings + results).
     window.PoolsViewer = PoolsViewer;
     window.LeagueStandingsViewer = LeagueStandingsViewer;
+    // mp-pglr: the shiaijo console's Swiss standings panel reads this off
+    // window, same pattern as the two viewers above.
+    window.SwissStandingsViewer = SwissStandingsViewer;
 
     // Helpers consumed by viewer_watchlist.jsx (WatchlistPanel/BellIcon) at
     // render time. poolLabel is already exposed by viewer_utils.jsx.


### PR DESCRIPTION
## Summary

Bug squash session covering all three open `bug` beads:

- **mp-pglr**: the shiaijo operator console's Standings panel no longer hangs on "Loading standings..." for Swiss competitions; it now renders the real Swiss standings table (self-fetching `SwissStandingsViewer`, same three-way swiss/league/pool routing as the public viewer), refreshes after every scored bout, labels the panel and queue group "Round N" instead of the synthetic "Swiss-RN", and drops the meaningless "next pool" banner for Swiss.
- **mp-q8c6**: the offline write queue no longer retries a permanently-rejected write forever. Server 5xx/429 rejections are counted per entry; after 10 consecutive rejections the write is dropped and surfaced to the operator through the existing write-failed channel ("not saved" state) instead of silently wedging the sync pill on "Syncing...". Network failures never count toward the cap, so genuine offline periods still hold writes for the full 6h TTL.
- **mp-qq8d**: `TestScoreHandler_C3Coalescer` is de-flaked with a pinned clock seam (`coalescerNow`), so the 250ms coalesce window can no longer lapse between the two test writes on a contended CI runner. No production behavior change.

## Why

- **mp-pglr root cause**: Swiss matches piggyback on `pool-matches.csv` with a synthetic pool name ("Swiss-R1") but never write `pools.csv`. `shiaijoStandingsKind` routed swiss down the pool path, whose `detail.pools` lookup found nothing, leaving the panel in its loading state forever.
- **mp-q8c6 root cause**: the flush loop treated every 5xx as transient and retried with backoff indefinitely. A deterministic 500 (observed: an engi flag validation error surfaced as HTTP 500 during mp-n19y UAT) poisoned the queue for the rest of the session.
- **mp-qq8d root cause**: the test asserted the second running write lands inside the real 250ms window; over 250ms of scheduler delay between the two writes makes the assertion unsatisfiable (flaked twice on CI, latest on PR #349 run 29166974332).

## Files changed

| File | What |
|---|---|
| `internal/mobileapp/broadcast_coalescer.go` | `coalescerNow` test seam (production always `time.Now`) |
| `internal/mobileapp/broadcast_coalescer_test.go` | pin the coalescer clock in `TestScoreHandler_C3Coalescer` |
| `web-mobile/js/admin_shiaijo.jsx` | three-way standings routing (swiss/league/pool), `swissRoundLabel`, Swiss branch renders `SwissStandingsViewer` keyed off `poolSig`, queue group label |
| `web-mobile/js/viewer.jsx` | expose `window.SwissStandingsViewer` for the console (same pattern as the other two viewers) |
| `web-mobile/js/__tests__/admin_shiaijo.test.jsx` | swiss routing + `swissRoundLabel` + queue-group label tests |
| `web-mobile/js/api_client.jsx` | per-entry server-rejection cap (`MAX_QUEUE_SERVER_REJECTIONS = 10`), drop + surface on cap |
| `web-mobile/js/__tests__/sync_queue.test.jsx` | cap tests: drop after 10 rejections + surfaced, network failures never count, superseding write resets the count |

## Screenshots

Shiaijo operator console for a Swiss competition after the first scored match: the Standings panel (previously stuck on "Loading standings...") renders the live Swiss standings, the queue group and panel header read "Round 1", and there is no bogus "next pool" banner.

![Shiaijo console showing Swiss standings](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/352/shiaijo-swiss-standings.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (3 new sync-queue tests, 4 new shiaijo routing/label tests; full vitest suite 2219 green, `TestScoreHandler_C3Coalescer` green at `-count=3`)
- [x] Manual browser verification: created a Swiss competition (8 players, 4 rounds, 2 courts) through the admin UI, started it, opened the Shiaijo A console, confirmed the Standings panel renders the Swiss standings table (previously stuck on "Loading standings..."), scored and finished match 1 through the score editor, confirmed the standings refreshed mid-round (winner to rank 1 with W=1/PW=2), confirmed chained Finish + Start Next stayed on the same shiaijo, and confirmed the queue group and panel header read "Round 1"
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] Docs: N/A, verified by grep. No page under `docs/` describes the shiaijo context panel, and the offline-sync doc only covers network-loss behavior, which is unchanged (network failures never count toward the new rejection cap)
- [x] No new console errors or warnings (checked via browser console after exercising the console flows)

Closes mp-pglr
Closes mp-q8c6
Closes mp-qq8d
