### PR TITLE
docs(mp-hebi): remove deprecated Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@
   <a href="https://github.com/gitrgoliveira/bracket-creator/actions/workflows/codeql.yaml" rel="nofollow">
     <img src="https://github.com/gitrgoliveira/bracket-creator/actions/workflows/codeql.yaml/badge.svg" alt="codeql" style="max-width:100%;">
   </a>
-
-  <a href="https://goreportcard.com/report/github.com/gitrgoliveira/bracket-creator" rel="nofollow">
-    <img src="https://goreportcard.com/badge/github.com/gitrgoliveira/bracket-creator" alt="Go report card" style="max-width:100%;">
-  </a>
 </p>
 <br/>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,6 @@ template: home.html
   <a href="https://pkg.go.dev/github.com/gitrgoliveira/bracket-creator">
     <img src="https://pkg.go.dev/badge/github.com/gitrgoliveira/bracket-creator.svg" alt="Go reference">
   </a>
-  <a href="https://goreportcard.com/report/github.com/gitrgoliveira/bracket-creator">
-    <img src="https://goreportcard.com/badge/github.com/gitrgoliveira/bracket-creator" alt="Go report card">
-  </a>
 </p>
 
 **bracket-creator** lets any club or organisation run kendo tournaments at whatever level of digitization fits the venue. Give it a CSV of participants and it produces fully formatted, print-ready Excel brackets (pool draws, match schedules, and elimination trees), and it can run pools and scores on the day. Choose how digital you go.


### PR DESCRIPTION
## Summary

- Removed the Go Report Card badge from the README and the docs site homepage: goreportcard.com has been deprecated, so the badge no longer renders meaningful data.
- No other references to goreportcard exist in the repo (verified with a full-tree grep).

## Files changed

| File | What |
|---|---|
| `README.md` | Removed the Go Report Card badge link/image from the badge block |
| `docs/index.md` | Removed the Go Report Card badge link/image from the docs homepage badge block |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (N/A: badge removal in Markdown only, no code touched)
- [x] Manual browser verification (for `web-mobile/` or `web/` changes): N/A, no `web-mobile/` or `web/` changes
- [x] Screenshots added above (N/A: no UI impact, README/docs Markdown only)
- [x] Docs updated under `docs/` for any new or changed user-facing feature, flag, command, or behavior (`make docs/build` passes)
- [x] No new console errors or warnings (N/A: no runtime surface)

Closes mp-hebi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
