### PR TITLE
docs(mp-8hwk): declutter left nav and reorder Tools cards

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -441,6 +441,14 @@ html, body { overflow-x: clip; }
 .md-tabs__link { font-weight: 600; opacity: 1; }
 .md-tabs__item--active .md-tabs__link { font-weight: 800; }
 
+/* ===== Primary sidebar: section titles read as headings ===== */
+/* Groups are collapsible rows (navigation.sections is off, see mkdocs.yaml).
+ * Bold the group labels so a section title is identifiable at a glance next
+ * to plain page links; Material adds the expander caret on top of this. */
+.md-nav--primary .md-nav__item--nested > .md-nav__link {
+	font-weight: 700;
+}
+
 /* ===== Footer: slim navy strip ===== */
 .md-footer-meta { background: var(--bc-navy-deep); }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,15 +66,15 @@ Three programs ship in the single binary. The three ways to run a tournament dec
 
 <div class="grid cards" markdown>
 
--   **CLI**
+-   **Tournament app**
 
     ---
 
-    Generate print-ready Excel brackets from the command line.
+    Run pools and scores on the day, in real time on any device.
 
-    `create-pools` (pools + knockout) · `create-playoffs` (straight knockout)
+    `mobile-app`
 
-    [Command reference](user-guide/commands/create-pools.md)
+    [Tournament app guide](user-guide/organisers/run-tournament.md)
 
 -   **Bracket generator web UI**
 
@@ -86,15 +86,15 @@ Three programs ship in the single binary. The three ways to run a tournament dec
 
     [Web UI guide](user-guide/organisers/web-ui.md)
 
--   **Tournament app**
+-   **CLI**
 
     ---
 
-    Run pools and scores on the day, in real time on any device.
+    Generate print-ready Excel brackets from the command line.
 
-    `mobile-app`
+    `create-pools` (pools + knockout) · `create-playoffs` (straight knockout)
 
-    [Tournament app guide](user-guide/organisers/run-tournament.md)
+    [Command reference](user-guide/commands/create-pools.md)
 
 </div>
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -57,7 +57,9 @@ theme:
   custom_dir: overrides
   features:
     - navigation.indexes
-    - navigation.sections
+    # navigation.sections is intentionally OFF: with it, every group renders
+    # permanently expanded (~30 sidebar rows, overflowing the viewport).
+    # Without it, groups are collapsible and only the active path expands.
     - navigation.instant
     - navigation.tabs
     - navigation.tabs.sticky


### PR DESCRIPTION
## Summary

- Decluttered the docs-site left navigation: sidebar groups now collapse, with only the active section expanded. Previously every group rendered permanently expanded (about 30 rows on the User guide tab), overflowing the viewport so the last sections ("For competitors", "For spectators", "Commands") were hidden below the fold.
- Section titles in the sidebar are now visually identifiable: group labels render bold with Material's expander caret, so a section reads differently from a plain page link.
- Reordered the landing-page Tools cards to put the primary tool first: Tournament app, then Bracket generator web UI, then CLI (was CLI first).

## Why

User feedback on the published site: the left menu "looks too busy" and lacked "visual identification of what's a section title". Root cause of the busyness was the `navigation.sections` Material feature, which flattens every nav group permanently open. Removing it restores collapsible groups. The Tools reorder matches how the tools rank for the typical reader (the tournament app is the flagship surface).

## Files changed

| File | What |
|---|---|
| `mkdocs.yaml` | Remove `navigation.sections` (with a comment explaining why it stays off) so sidebar groups collapse |
| `docs/assets/stylesheets/extra.css` | Bold primary-sidebar group labels so section titles are identifiable at a glance |
| `docs/index.md` | Reorder Tools grid cards: Tournament app, Bracket generator web UI, CLI |

## Screenshots

Left nav after (collapsed groups, bold section titles, everything above the fold; before, all ~30 rows rendered expanded and overflowed the viewport):

![Collapsed left nav on Choosing your setup](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/354/nav-collapsed.png)

A section expanded ("For organisers"), showing the section-title vs page-link distinction:

![Left nav with For organisers expanded](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/354/nav-expanded.png)

Landing-page Tools cards reordered (Tournament app, Bracket generator web UI, CLI):

![Reordered Tools cards on the landing page](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/354/tools-order.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [ ] New/updated unit tests cover the change (N/A: docs-site config, CSS, and card order only; no Go/JS logic touched)
- [x] Manual browser verification: served with `make docs/serve`, verified on the Choosing your setup page that the sidebar shows collapsed bold group rows with carets, only "Start here" expanded for the active page, expanding "For organisers" reveals its pages; verified the landing-page Tools grid renders Tournament app, Bracket generator web UI, CLI in that order
- [x] Screenshots added above (REQUIRED for any UI-affecting change)
- [x] Docs updated under `docs/` (`make docs/build` strict passes)
- [x] No new console errors or warnings

Closes mp-8hwk
