### PR TITLE
test(mp-kd8t): stub window.engiPairParts in engi pool-viewer tests

### DIFF
--- a/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer_pools_viewer.test.jsx
@@ -455,7 +455,7 @@ describe('PoolNumberedMatchRow engi stacked pair names (mp-gy6g)', () => {
   let runtime;
   let PoolNumberedMatchRow;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact', 'engiPairParts'];
 
   beforeEach(async () => {
     runtime = makeReactive();
@@ -479,6 +479,14 @@ describe('PoolNumberedMatchRow engi stacked pair names (mp-gy6g)', () => {
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;
+    // Stub the engi pair-name splitter (real impl lives in ui.jsx, not imported
+    // here). Without it PoolNumberedMatchRow falls back to unsplit names, so the
+    // stacked-member assertions would be order-dependent on ui.jsx loading first.
+    global.window.engiPairParts = (name) => {
+      const s = String(name || '');
+      const i = s.indexOf(' - ');
+      return i < 0 ? [s.trim(), ''] : [s.slice(0, i).trim(), s.slice(i + 3).trim()];
+    };
     vi.resetModules();
     ({ PoolNumberedMatchRow } = await import('../viewer.jsx'));
   });
@@ -552,7 +560,7 @@ describe('PoolsViewer engi stacked pair names in standings (mp-gy6g)', () => {
   let runtime;
   let PoolsViewer;
   const savedGlobals = {};
-  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact'];
+  const STUBBED = ['Term', 'isHikiwake', 'formatIpponsScore', 'teamIVScore', 'matchScoreStr', 'matchStateCell', 'ipponsFromScore', 'queueLabel', 'queueLabelCompact', 'engiPairParts'];
 
   const tweaks = { showDojo: false };
   const engiComp = { format: 'league', kind: 'individual', teamSize: 0, engi: true, poolWinners: 2 };
@@ -595,6 +603,14 @@ describe('PoolsViewer engi stacked pair names in standings (mp-gy6g)', () => {
     global.window.ipponsFromScore = () => [];
     global.window.queueLabel = () => '';
     global.window.queueLabelCompact = () => null;
+    // Stub the engi pair-name splitter (real impl lives in ui.jsx, not imported
+    // here). Without it PoolsViewer falls back to unsplit names, so the stacked-
+    // member assertions would be order-dependent on ui.jsx loading first.
+    global.window.engiPairParts = (name) => {
+      const s = String(name || '');
+      const i = s.indexOf(' - ');
+      return i < 0 ? [s.trim(), ''] : [s.slice(0, i).trim(), s.slice(i + 3).trim()];
+    };
     vi.resetModules();
     ({ PoolsViewer } = await import('../viewer.jsx'));
   });


### PR DESCRIPTION
## Summary

- Follow-up to merged PR #351 (mp-wvba): resolves the two outstanding Copilot review threads on `web-mobile/js/__tests__/viewer_pools_viewer.test.jsx` (lines 506 and 625).
- The two engi stacked-pair-name suites assert that a combined pair name (`"Name1 - Name2"`) splits into stacked members, but they never stubbed `window.engiPairParts`. The real implementation lives in `ui.jsx`, which this test file does not import.
- Because `PoolNumberedMatchRow` / `PoolsViewer` intentionally fall back to unsplit names when the helper is absent, the split assertions passed only if another test had already loaded `ui.jsx` earlier in the run. The tests were order-dependent (flaky under isolation / reordering).

## Why

Root cause: a missing test-local stub. The production component guards on `window.engiPairParts` and degrades gracefully when it is undefined, so the tests silently relied on global load order rather than on their own setup. The fix makes each engi suite self-contained: `engiPairParts` is added to the block's `STUBBED` array (so the existing save/restore `afterEach` handles cleanup) and defined in `beforeEach` with the real `ui.jsx` splitter.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/__tests__/viewer_pools_viewer.test.jsx` | Add `engiPairParts` to the `STUBBED` array and define it in `beforeEach` for both engi blocks (`PoolNumberedMatchRow engi stacked pair names`, `PoolsViewer engi stacked pair names in standings`), matching the real `ui.jsx` implementation |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests): all packages green, coverage >= 85%
- [x] New/updated unit tests cover the change: the affected file runs green in isolation (`npx vitest run js/__tests__/viewer_pools_viewer.test.jsx` -> 29 passed), which is exactly the ordering case Copilot flagged; full JS suite 2252 passed; `npm run lint` clean
- [x] Manual browser verification (for `web-mobile/` or `web/` changes): N/A, test-only change with no runtime/UI impact
- [x] Screenshots added above (REQUIRED for any UI-affecting change): N/A, no UI change (test file only)
- [x] Docs updated under `docs/` for any new or changed user-facing feature, flag, command, or behavior: N/A, no user-facing behavior change
- [x] No new console errors or warnings

Closes mp-kd8t
