### PR TITLE
docs: group CLI pages under Command line, add Legacy Web UI nav section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Three programs ship in the single binary. The three ways to run a tournament dec
 
     [Tournament app guide](user-guide/organisers/run-tournament.md)
 
--   **Legacy web UI**
+-   **Legacy Web UI**
 
     ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Three programs ship in the single binary. The three ways to run a tournament dec
 
     [Tournament app guide](user-guide/organisers/run-tournament.md)
 
--   **Bracket generator web UI**
+-   **Legacy web UI**
 
     ---
 
@@ -84,7 +84,7 @@ Three programs ship in the single binary. The three ways to run a tournament dec
 
     `serve`
 
-    [Web UI guide](user-guide/organisers/web-ui.md)
+    [Legacy Web UI guide](user-guide/organisers/web-ui.md)
 
 -   **CLI**
 

--- a/docs/user-guide/commands/print.md
+++ b/docs/user-guide/commands/print.md
@@ -57,7 +57,7 @@ bracket-creator print --type=tags --input=./xlsx/ -o ./tags.pdf
 
 The tournament app's in-app export needs LibreOffice **in the running server**. The CLI lets you keep the server on the lean default image (no LibreOffice) and render PDFs elsewhere:
 
-- **Offline / CLI-only events**: you built brackets with `create-pools` or the [web UI](../organisers/web-ui.md) and never ran the tournament app. Only the CLI can render those into PDFs (`--input`).
+- **Offline / CLI-only events**: you built brackets with `create-pools` or the [legacy web UI](../organisers/web-ui.md) and never ran the tournament app. Only the CLI can render those into PDFs (`--input`).
 - **Out-of-band generation**: run `print --tournament-data ...` on a LibreOffice-equipped machine instead of bundling LibreOffice into every deployment.
 - **Batch or scripted** PDF generation.
 

--- a/docs/user-guide/commands/print.md
+++ b/docs/user-guide/commands/print.md
@@ -57,7 +57,7 @@ bracket-creator print --type=tags --input=./xlsx/ -o ./tags.pdf
 
 The tournament app's in-app export needs LibreOffice **in the running server**. The CLI lets you keep the server on the lean default image (no LibreOffice) and render PDFs elsewhere:
 
-- **Offline / CLI-only events**: you built brackets with `create-pools` or the [legacy web UI](../organisers/web-ui.md) and never ran the tournament app. Only the CLI can render those into PDFs (`--input`).
+- **Offline / CLI-only events**: you built brackets with `create-pools` or the [Legacy Web UI](../organisers/web-ui.md) and never ran the tournament app. Only the CLI can render those into PDFs (`--input`).
 - **Out-of-band generation**: run `print --tournament-data ...` on a LibreOffice-equipped machine instead of bundling LibreOffice into every deployment.
 - **Batch or scripted** PDF generation.
 

--- a/docs/user-guide/commands/serve.md
+++ b/docs/user-guide/commands/serve.md
@@ -26,4 +26,4 @@ bracket-creator serve -p 8081
 bracket-creator serve -b 0.0.0.0
 ```
 
-See the [Web UI guide](../organisers/web-ui.md) for a walkthrough of the interface.
+See the [Legacy Web UI guide](../organisers/web-ui.md) for a walkthrough of the interface.

--- a/docs/user-guide/organisers/web-ui.md
+++ b/docs/user-guide/organisers/web-ui.md
@@ -1,6 +1,6 @@
 # Legacy Web UI
 
-The legacy web UI is the **organiser's** tool for the days before the event: turn a roster into a print-ready bracket, no command line required. It is a standalone one-shot bracket generator, separate from the [tournament app](run-tournament.md), which takes over on the day for scorers, competitors, and spectators.
+The Legacy Web UI is the **organiser's** tool for the days before the event: turn a roster into a print-ready bracket, no command line required. It is a standalone one-shot bracket generator, separate from the [tournament app](run-tournament.md), which takes over on the day for scorers, competitors, and spectators.
 
 Start it with the [`serve` command](../commands/serve.md):
 

--- a/docs/user-guide/organisers/web-ui.md
+++ b/docs/user-guide/organisers/web-ui.md
@@ -1,8 +1,8 @@
 # Legacy Web UI
 
-The Legacy Web UI is the **organiser's** tool for the days before the event: turn a roster into a print-ready bracket, no command line required. It is a standalone one-shot bracket generator, separate from the [tournament app](run-tournament.md), which takes over on the day for scorers, competitors, and spectators.
+The Legacy Web UI is the **organiser's** tool for the days before the event: turn a roster into a print-ready bracket from your browser, with no CSV editing. It is a standalone one-shot bracket generator, separate from the [tournament app](run-tournament.md), which takes over on the day for scorers, competitors, and spectators.
 
-Start it with the [`serve` command](../commands/serve.md):
+You run one command to start the local server, then do everything else in the browser. Start it with the [`serve` command](../commands/serve.md):
 
 ```bash
 bracket-creator serve

--- a/docs/user-guide/organisers/web-ui.md
+++ b/docs/user-guide/organisers/web-ui.md
@@ -1,8 +1,8 @@
-# Web UI
+# Legacy Web UI
 
-This is the **organiser's** tool for the days before the event: turn a roster into a print-ready bracket, no command line required. On the day, the [tournament app](run-tournament.md) takes over for scorers, competitors, and spectators.
+The legacy web UI is the **organiser's** tool for the days before the event: turn a roster into a print-ready bracket, no command line required. It is a standalone one-shot bracket generator, separate from the [tournament app](run-tournament.md), which takes over on the day for scorers, competitors, and spectators.
 
-The web UI lets you generate brackets without using the command line. Start it with:
+Start it with the [`serve` command](../commands/serve.md):
 
 ```bash
 bracket-creator serve

--- a/docs/user-guide/start-here/first-tournament.md
+++ b/docs/user-guide/start-here/first-tournament.md
@@ -41,4 +41,4 @@ Go to the **Scores** tab, open a match, and record the result. See [Scoring a ma
 
 ## Next steps
 
-For the complete organiser workflow, including pools, seeding, and competition settings, see [Run a tournament](../organisers/run-tournament.md). To generate print-ready brackets without the tournament app, see [Web UI](../organisers/web-ui.md) and the [create-pools command](../commands/create-pools.md).
+For the complete organiser workflow, including pools, seeding, and competition settings, see [Run a tournament](../organisers/run-tournament.md). To generate print-ready brackets without the tournament app, see [Legacy Web UI](../organisers/web-ui.md) and the [create-pools command](../commands/create-pools.md).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -101,7 +101,6 @@ nav:
           - Install: user-guide/install/install.md
           - Host the tournament app: user-guide/install/hosting.md
       - For organisers:
-          - Web UI: user-guide/organisers/web-ui.md
           - Input format: user-guide/organisers/input-format.md
           - Run a tournament on the day: user-guide/organisers/run-tournament.md
           - Operating modes and access control: user-guide/organisers/operating-modes.md
@@ -118,11 +117,13 @@ nav:
       - Commands:
           - create-pools: user-guide/commands/create-pools.md
           - create-playoffs: user-guide/commands/create-playoffs.md
-          - serve: user-guide/commands/serve.md
           - mobile-app: user-guide/commands/mobile-app.md
           - print: user-guide/commands/print.md
           - hash-password: user-guide/commands/hash-password.md
           - version: user-guide/commands/version.md
+      - Legacy Web UI:
+          - Overview: user-guide/organisers/web-ui.md
+          - serve command: user-guide/commands/serve.md
   - Developer guide:
       - Code of conduct: dev-guide/code_of_conduct.md
       - Contributing: dev-guide/contributing.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -114,7 +114,7 @@ nav:
           - Self-run tournaments: user-guide/competitors/self-run.md
       - For spectators:
           - Follow the tournament: user-guide/spectators/following.md
-      - Commands:
+      - Command line:
           - create-pools: user-guide/commands/create-pools.md
           - create-playoffs: user-guide/commands/create-playoffs.md
           - mobile-app: user-guide/commands/mobile-app.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -123,7 +123,7 @@ nav:
           - version: user-guide/commands/version.md
       - Legacy Web UI:
           - Overview: user-guide/organisers/web-ui.md
-          - serve command: user-guide/commands/serve.md
+          - serve: user-guide/commands/serve.md
   - Developer guide:
       - Code of conduct: dev-guide/code_of_conduct.md
       - Contributing: dev-guide/contributing.md


### PR DESCRIPTION
## Summary

- Reorganise the MkDocs **User guide** nav so every CLI command reference sits under one section, renamed from **Commands** to **Command line**: `create-pools`, `create-playoffs`, `mobile-app`, `print`, `hash-password`, `version`.
- Add a dedicated **Legacy Web UI** nav section holding the web UI walkthrough (*Overview*) plus the *serve command* that launches it. Removed the old **Web UI** entry buried under *For organisers*.
- Reframe the web-ui page as the **Legacy Web UI**: it is a standalone one-shot bracket generator, separate from the tournament app. Updated cross-references (index card, `serve`, `print`, `first-tournament`) to match.

## Why

The `serve` web UI is the older, pre-tournament-app way to generate brackets. Grouping it under a clearly labelled *Legacy Web UI* section (and consolidating the remaining CLI references under *Command line*) makes the docs nav reflect that split, so readers land on the tournament app for live events and only reach the legacy generator when they specifically want offline print-ready brackets.

Files stay in their current on-disk locations (`organisers/web-ui.md`, `commands/serve.md`); only the nav grouping changed, so the already-published page URLs and the existing `redirect_maps` entry remain valid.

## Files changed

| File | What |
|---|---|
| `mkdocs.yaml` | Renamed the *Commands* nav group to *Command line*, moved `serve` out of it into a new *Legacy Web UI* group (with the web-ui walkthrough), and removed *Web UI* from *For organisers* |
| `docs/user-guide/organisers/web-ui.md` | H1 is now *Legacy Web UI*; intro reframed as a standalone one-shot generator that points at the `serve` command |
| `docs/user-guide/commands/serve.md` | Cross-reference relabelled to *Legacy Web UI guide* |
| `docs/index.md` | Tools card retitled *Legacy web UI*; guide link relabelled |
| `docs/user-guide/start-here/first-tournament.md` | Link text updated to *Legacy Web UI* |
| `docs/user-guide/commands/print.md` | Prose reference updated to *legacy web UI* |

## Screenshots

Rendered docs nav (built site, `--strict`), showing the renamed **Command line** section and the new **Legacy Web UI** section (Overview + serve command):

![Docs nav: Command line and Legacy Web UI sections](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/357/docs-nav.png)

## Test plan

- [ ] `make go/test` passes (lint + security scan + tests) — N/A: docs-only change, no Go/JS source touched
- [ ] New/updated unit tests cover the change — N/A: docs-only
- [ ] Manual browser verification (for `web-mobile/` or `web/` changes): describe what you exercised — N/A: no `web-mobile/` or `web/` changes
- [x] Screenshots added above (rendered docs nav)
- [x] Docs updated under `docs/` (`make docs/build --strict` passes with no broken links)
- [x] No new console errors or warnings (verified in the docs preview)

Closes mp-ft79
