### PR TITLE
docs(mp-yhkr): Linux packages wording to present tense (v1.1.0 ships them)

### DIFF
--- a/docs/user-guide/install/install.md
+++ b/docs/user-guide/install/install.md
@@ -63,7 +63,7 @@ The single binary bundles every subcommand, including `bracket-creator serve` (w
 
 ## Linux packages (deb, rpm, apk)
 
-From the next release onwards, `.deb`, `.rpm`, and `.apk` packages for amd64/x86_64 and arm64/aarch64 are attached to the [release page](https://github.com/gitrgoliveira/bracket-creator/releases). Download the package for your distribution and architecture, then install it with the native tool (which resolves dependencies for local files):
+Each release attaches `.deb`, `.rpm`, and `.apk` packages for amd64/x86_64 and arm64/aarch64 to the [release page](https://github.com/gitrgoliveira/bracket-creator/releases). Download the package for your distribution and architecture, then install it with the native tool (which resolves dependencies for local files):
 
 === "Debian/Ubuntu"
 


### PR DESCRIPTION
## Summary

- One-sentence docs fix: the install guide's Linux packages section said "From the next release onwards" as deliberate interim wording while PR #359 was merged but untagged. v1.1.0 is now released and carries the `.deb`/`.rpm`/`.apk` assets, so the sentence switches to present tense ("Each release attaches ...").

## Files changed

| File | What |
|---|---|
| `docs/user-guide/install/install.md` | "From the next release onwards" to "Each release attaches" in the Linux packages section |

## Test plan

- [x] `make go/test` N/A judgement: docs-only one-line wording change, no code touched; `make docs/build` (strict) passes
- [x] New/updated unit tests: N/A (prose only)
- [x] Manual browser verification: N/A (docs site content, validated by strict build)
- [x] Screenshots: N/A (no UI change)
- [x] Docs updated under `docs/` (`make docs/build` passes)
- [x] No new console errors or warnings (no runtime surface)

Verified against reality: the [v1.1.0 release](https://github.com/gitrgoliveira/bracket-creator/releases/tag/v1.1.0) carries all six package assets and the release workflow's smoke-test job installed each amd64 package from the published release successfully.

Closes mp-yhkr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
