### PR TITLE
fix(deps): bump brace-expansion to patched versions (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/web-mobile/package-lock.json
+++ b/web-mobile/package-lock.json
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2081,9 +2081,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web-mobile/package-lock.json
+++ b/web-mobile/package-lock.json
@@ -3537,9 +3537,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3866,7 +3866,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- Bumps two dev-scope transitive packages to patched versions in `web-mobile/package-lock.json`, clearing both high-severity advisories that `npm audit --audit-level=high` flags: `brace-expansion` (Dependabot alert 18, `GHSA-3jxr-9vmj-r5cp` / `CVE-2026-13149`) and `postcss` (`GHSA-r28c-9q8g-f849`). `npm audit` now reports **0 vulnerabilities** (was 2 high).
- **No user-visible behavior change and no runtime impact.** All vulnerable copies are dev-scope transitive dependencies of the eslint / vite toolchains. `web-mobile/package.json` lists only `preact-router` under `dependencies`, so no vulnerable code is bundled into the embedded frontend or the Go binary.

_Updated: the `postcss` bump (`mp-e80n`) was bundled into this PR by operator decision, since the same local audit gate flags it alongside `brace-expansion`._

## Why

`brace-expansion`'s `expand()` is O(2ⁿ) in the number of consecutive non-expanding `{}` groups: `post` is computed unconditionally before the early-return branches that discard it, so each level spawns two recursive expansions over the same tail. A ~90-byte all-ASCII input blocks the calling thread for minutes.

Exposure here is **development tooling only** (lint/test), where the only inputs to `expand()` are the repo's own glob patterns, not attacker-controlled data. Low practical risk, trivial fix.

Three vulnerable copies, all `dev: true`:

| Path | Pulled by | Before | After |
|---|---|---|---|
| `node_modules/brace-expansion` | `minimatch@3.1.5` | 1.1.14 | 1.1.16 |
| `eslint/node_modules/brace-expansion` | eslint | 5.0.6 | 5.0.7 |
| `@eslint/config-array/node_modules/brace-expansion` | eslint | 5.0.6 | 5.0.7 |

### `postcss` — `GHSA-r28c-9q8g-f849` (mp-e80n)

Path traversal in postcss's previous-source-map auto-loading (`sourceMappingURL`) leads to arbitrary `.map` file disclosure. Transitive under the vite toolchain, `dev: true`:

| Path | Pulled by | Before | After |
|---|---|---|---|
| `node_modules/postcss` | `@vitejs/plugin-react` → `vite` | 8.5.15 | 8.5.23 |
| `node_modules/nanoid` | `postcss` (its own dep) | 3.3.12 | 3.3.16 |

Semver-compatible bump within the pinned vite range (no `npm audit fix --force`, no breaking major bump).

**Note on tooling:** the `brace-expansion` bumps were applied with `npx npm@11` (not the locally installed npm 9.2.0). npm 9 does not understand the lockfile's `libc` field and silently strips it from 10 platform-specific optional binaries (`@rolldown/binding-linux-*`, `lightningcss-linux-*`), plus `license` from several entries — unrelated metadata deletions that would degrade optional-dependency resolution on musl/Alpine. The `postcss`/`nanoid` bumps were applied as surgical single-block edits for the same reason, keeping the diff to exactly the five security-relevant packages.

## Files changed

| File | What |
|---|---|
| `web-mobile/package-lock.json` | Bump `brace-expansion` 1.1.14→1.1.16 and 5.0.6→5.0.7 (×2), `postcss` 8.5.15→8.5.23, `nanoid` 3.3.12→3.3.16 |

## Test plan

- [x] `npm audit --audit-level=high` reports 0 vulnerabilities (was 2 high: brace-expansion + postcss)
- [x] `npm ci` (fresh install, 306 packages) resolves all new integrity hashes against the registry
- [x] `govulncheck ./...` — no vulnerabilities affecting the code
- [x] `npm run lint` (`eslint . --max-warnings 0`) passes clean
- [x] `npm test` — 2317 tests across 111 files pass
- [x] `npm run test:render` — 72 tests across 10 files pass
- [x] `go test . ./cmd/... ./internal/... ./tests/...` passes (exit 0)
- [x] No new console errors or warnings
- [ ] ~~New/updated unit tests cover the change~~ — N/A: lockfile-only change with no source delta to test
- [ ] ~~Manual browser verification~~ — N/A: dev-dependency metadata only; no runtime, UI, or bundled-output change
- [ ] ~~Screenshots~~ — N/A: no UI impact
- [ ] ~~Docs updated~~ — N/A: no user-facing feature, flag, command, or behavior change

### `make go/test` — not fully green locally, for two pre-existing reasons

Reported honestly rather than checked off. Neither is caused by this change, and both reproduce on the base commit `8140a167`:

1. **`go/sec` fails on a pre-existing gosec finding.** `G706` (log injection) at `cmd/mobile_app.go:181`. The code already carries a comment (lines 177-180) documenting that `slog` escapes attribute values through its encoder, so a malicious `SSE_MAX_CLIENTS` lands as a quoted value rather than a second log line. The finding is a false positive that a developer already analyzed, so per CLAUDE.md's rule on intentional defensive code I did not rewrite it. CI is green because `.github/workflows/validate.yaml` runs gosec with `-no-fail` (findings go to SARIF); the Makefile's `go/sec` target has no such flag, so the documented local gate fails where CI passes.
2. **`go/lint` fails on a fresh worktree** until `go generate ./...` has run, because `internal/cmd/version/build_date.txt` is a gitignored generated file consumed by `//go:embed`. After `go generate`, lint passes clean.

Two adjacent issues found while verifying, deliberately **not** fixed here to keep this a one-file security PR (happy to file or fix on request):

- `Makefile:43` installs golangci-lint from `github.com/golangci/golangci-lint/cmd/golangci-lint@v2.12.2`, which fails with `invalid version: unknown revision`. v2 moved to the `/v2/` module path; the working command is `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2`.
- The `make go/sec` / CI `-no-fail` divergence above means `make go/test` cannot pass locally on a clean checkout.

<!-- Bead reference: -->
Closes mp-0qso
Closes mp-e80n

