### PR TITLE
fix: pure-playoffs export bracket + tied-standings determinism + npm audit gate (mp-ndfu, mp-xemw, mp-jlph)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,11 @@ js/lint: ## Run Javascript linters
 	@echo "Running Javascript linters..."
 	@cd web-mobile && npm run lint
 
-js/sec: ## Run Javascript security scans (npm audit)
+js/sec: ## Run Javascript security scans (audit-ci + npm audit)
 	@echo "Running Javascript security scans..."
-	@cd web-mobile && npm audit --audit-level=high
+	@# web-mobile uses audit-ci so one proven-unfixable dev-only advisory can be
+	@# allowlisted (web-mobile/audit-ci.jsonc) without disabling the whole scan.
+	@cd web-mobile && npm run --silent audit
 	@cd web && npm audit --audit-level=high
 
 js/outdated: ## Check for outdated npm packages

--- a/internal/engine/export.go
+++ b/internal/engine/export.go
@@ -62,11 +62,6 @@ func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
 	//    silently dropping those entrants' half of the draw. It was not a
 	//    large-draw edge case: TreePageLayout raises the page count to
 	//    NextPow2(numCourts), so every competition on 2 or more courts hit it.
-	// The stored bracket is authoritative about whether this competition has a
-	// bronze (3rd-place) bout to hand-score. Load it ONLY for naginata: it is
-	// used for nothing else on this path, and an unconditional load would let a
-	// corrupted bracket.json abort the export of formats (league, swiss, ...)
-	// that have zero functional dependency on that file.
 	// Load the stored bracket ONLY for the paths that actually consume it:
 	// naginata (its bronze gate) and a pure playoffs competition (its elimination
 	// leaves — mp-ndfu). Still skipped for league/swiss/mixed, whose export has
@@ -84,29 +79,12 @@ func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
 		hasBronze = bracket != nil && bracket.ThirdPlaceMatch != nil
 	}
 
-	// GenerateFinals returns placeholder "Pool A-1st" labels for ANY pooled
-	// format, including ones with no knockout phase, so gate on the format the
-	// way the results workbook does (builder.go, TestBuildResultsWorkbook_
-	// LeagueNoPhantomBracket); otherwise a league template grows a phantom
-	// bracket implying a knockout that will never be played.
-	// EffectivePoolWinners, not the raw field: an unset (<=0) PoolWinners runs
-	// a 2-winner knockout everywhere else (draw validation, bracket build,
-	// seeding, schedule), and the results workbook already exports it that
-	// way, so the raw 0 here rendered a blank-template printout with no
-	// knockout for the tournament actually being run (mp-0yd8).
-	finals := helper.GenerateFinals(pools, comp.EffectivePoolWinners())
-	// A pure playoffs competition has no pools, so GenerateFinals returns nothing.
-	// Derive the elimination leaves the same way the results workbook does
-	// (PlayoffLeavesFromBracket, then a participant-seeding fallback) so this
-	// blank template renders the bracket instead of an empty Elimination sheet
-	// (mp-ndfu), and its leaf order matches the results export of the same draw.
-	if len(finals) == 0 && len(pools) == 0 && comp.Format == state.CompFormatPlayoffs {
-		if leaves := PlayoffLeavesFromBracket(bracket); len(leaves) > 0 {
-			finals = leaves
-		} else {
-			finals = PlayoffFinalsFromParticipants(e.store, comp)
-		}
-	}
+	// Elimination leaves for the knockout phase, shared with the results workbook
+	// (EliminationLeaves) so both exports of one competition render the identical
+	// bracket: pool winners for pooled formats, or the stored bracket's leaves for
+	// a pure playoffs competition (mp-ndfu, mp-0yd8). The IsPlayoffEnabled gate
+	// below then drops the phantom bracket a league's placeholder finals imply.
+	finals := EliminationLeaves(e.store, comp, pools, bracket)
 	if len(finals) > 0 && comp.IsPlayoffEnabled() {
 		// 4b. Tree pages plus the Elimination Matches sheet, in the one mandatory
 		//     order RenderKnockoutPages enforces. This path used to skip the

--- a/internal/engine/export.go
+++ b/internal/engine/export.go
@@ -71,7 +71,7 @@ func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
 	// two exports of one competition agree.
 	hasBronze := false
 	var bracket *state.Bracket
-	if comp.Naginata || (len(pools) == 0 && comp.Format == state.CompFormatPlayoffs) {
+	if comp.Naginata || isPurePlayoffs(comp, pools) {
 		bracket, err = e.store.LoadBracket(id)
 		if err != nil {
 			return nil, err

--- a/internal/engine/export.go
+++ b/internal/engine/export.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gitrgoliveira/bracket-creator/internal/excel"
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
 func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
@@ -66,9 +67,17 @@ func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
 	// used for nothing else on this path, and an unconditional load would let a
 	// corrupted bracket.json abort the export of formats (league, swiss, ...)
 	// that have zero functional dependency on that file.
+	// Load the stored bracket ONLY for the paths that actually consume it:
+	// naginata (its bronze gate) and a pure playoffs competition (its elimination
+	// leaves — mp-ndfu). Still skipped for league/swiss/mixed, whose export has
+	// zero dependency on bracket.json, so a corrupted file can never abort an
+	// export that never needed it. Bronze gates on the stored bracket's
+	// ThirdPlaceMatch exactly as the results workbook does (builder.go), so the
+	// two exports of one competition agree.
 	hasBronze := false
-	if comp.Naginata {
-		bracket, err := e.store.LoadBracket(id)
+	var bracket *state.Bracket
+	if comp.Naginata || (len(pools) == 0 && comp.Format == state.CompFormatPlayoffs) {
+		bracket, err = e.store.LoadBracket(id)
 		if err != nil {
 			return nil, err
 		}
@@ -86,6 +95,18 @@ func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
 	// way, so the raw 0 here rendered a blank-template printout with no
 	// knockout for the tournament actually being run (mp-0yd8).
 	finals := helper.GenerateFinals(pools, comp.EffectivePoolWinners())
+	// A pure playoffs competition has no pools, so GenerateFinals returns nothing.
+	// Derive the elimination leaves the same way the results workbook does
+	// (PlayoffLeavesFromBracket, then a participant-seeding fallback) so this
+	// blank template renders the bracket instead of an empty Elimination sheet
+	// (mp-ndfu), and its leaf order matches the results export of the same draw.
+	if len(finals) == 0 && len(pools) == 0 && comp.Format == state.CompFormatPlayoffs {
+		if leaves := PlayoffLeavesFromBracket(bracket); len(leaves) > 0 {
+			finals = leaves
+		} else {
+			finals = PlayoffFinalsFromParticipants(e.store, comp)
+		}
+	}
 	if len(finals) > 0 && comp.IsPlayoffEnabled() {
 		// 4b. Tree pages plus the Elimination Matches sheet, in the one mandatory
 		//     order RenderKnockoutPages enforces. This path used to skip the
@@ -101,9 +122,12 @@ func (e *Engine) ExportCompetitionXlsx(id string) ([]byte, error) {
 		}
 		helper.PrintEliminationWithBronze(f, matchWinners, eliminationMatchRounds, comp.TeamSize, numCourts, comp.Mirror, comp.Engi, hasBronze)
 	} else if hasBronze {
-		// A pure playoffs competition has no pools, so GenerateFinals returns
-		// nothing and the block above is skipped: this path renders no bracket at
-		// all for it (mp-ndfu). The bronze block is then the only content on the
+		// Narrow fallback: a competition whose bracket has a third-place bout but
+		// yields no elimination leaves at all (no pools, no first-round entrants
+		// and no participants to seed — e.g. a bracket saved with an empty first
+		// round). The bracket-leaf/participant fallback above already covers the
+		// normal pure-playoffs case (mp-ndfu), so this only fires for that
+		// degenerate shape. The bronze block is then the only content on the
 		// sheet, rendered at court band 1, so numCourts=1 covers it exactly.
 		// nil rounds derive zero semi numbers, leaving both entrant slots
 		// hand-fillable.

--- a/internal/engine/export_tree_test.go
+++ b/internal/engine/export_tree_test.go
@@ -349,6 +349,60 @@ func TestExportCompetitionXlsx_LeagueHasNoTreeSheet(t *testing.T) {
 	assert.Empty(t, treeSheets(f), "a league has no knockout, so it must export no bracket page")
 }
 
+// TestExportCompetitionXlsx_PurePlayoffsRendersBracket pins mp-ndfu: a pure
+// playoffs competition has NO pools, so helper.GenerateFinals returns nothing and
+// the blank-template export used to skip the entire knockout block -- shipping a
+// workbook (and PDF booklet) with no tree pages and an empty Elimination Matches
+// sheet. The fix derives the elimination leaves from the stored bracket
+// (PlayoffLeavesFromBracket), exactly as the results workbook does, so the two
+// exports of the same draw agree.
+func TestExportCompetitionXlsx_PurePlayoffsRendersBracket(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "pure-playoffs-bracket"
+	createTestCompetition(t, store, compID, "playoffs", 0, func(c *state.Competition) {
+		c.Courts = []string{"A"}
+	})
+	names := make([]string, 8)
+	for i := range names {
+		names[i] = fmt.Sprintf("Player%02d", i+1)
+	}
+	saveTestParticipants(t, store, compID, names)
+	require.NoError(t, eng.StartCompetition(compID))
+
+	f := openExportedWorkbook(t, eng, compID)
+
+	// (1) The bracket page(s) must be rendered, not skipped, and carry content --
+	// not left as a blank sheet.
+	pages := treeSheets(f)
+	require.NotEmpty(t, pages, "a pure playoffs competition must render its bracket page(s)")
+	nonEmpty := 0
+	rows, err := f.GetRows(pages[0])
+	require.NoError(t, err)
+	for _, row := range rows {
+		for _, c := range row {
+			if strings.TrimSpace(c) != "" {
+				nonEmpty++
+			}
+		}
+	}
+	assert.Positive(t, nonEmpty, "the bracket page must render content, not be blank")
+
+	// (2) The Elimination Matches sheet must carry the operator's score blocks.
+	// A knockout of 8 entrants is always 8-1 = 7 matches (every internal bracket
+	// node is one match, each eliminating exactly one entrant).
+	elim, err := f.GetRows(helper.SheetEliminationMatches)
+	require.NoError(t, err)
+	headers := 0
+	for _, row := range elim {
+		for _, cell := range row {
+			if strings.HasPrefix(cell, "Round ") && strings.Contains(cell, " - Match ") {
+				headers++
+			}
+		}
+	}
+	assert.Equal(t, 7, headers, "an 8-entrant playoffs knockout must render 7 elimination match blocks")
+}
+
 // TestExportTournamentWorkbooks_MultiPageTree covers the PDF pipeline's input:
 // the workbooks written for pdf.Generator come from ExportCompetitionXlsx, so
 // the printed "Pool Draw + Trees" booklet inherited the blank-page bug. The

--- a/internal/engine/export_tree_test.go
+++ b/internal/engine/export_tree_test.go
@@ -84,6 +84,22 @@ func leafLabelsOnSheet(t *testing.T, f *excelize.File, sheet string) []string {
 	return labels
 }
 
+// countEliminationMatchBlocks counts the "Round N - Match N" block headers on
+// the Elimination Matches sheet -- one per real knockout match. Takes the
+// already-fetched rows so callers that reuse them (e.g. for per-court bucketing)
+// need not read the sheet twice.
+func countEliminationMatchBlocks(rows [][]string) int {
+	headers := 0
+	for _, row := range rows {
+		for _, cell := range row {
+			if strings.HasPrefix(cell, "Round ") && strings.Contains(cell, " - Match ") {
+				headers++
+			}
+		}
+	}
+	return headers
+}
+
 // openExportedWorkbook exports compID as the blank template and opens it.
 func openExportedWorkbook(t *testing.T, eng *Engine, compID string) *excelize.File {
 	t.Helper()
@@ -237,15 +253,7 @@ func TestExportCompetitionXlsx_EliminationMatchesPopulated(t *testing.T) {
 			// one entrant.
 			elim, err := f.GetRows(helper.SheetEliminationMatches)
 			require.NoError(t, err)
-			headers := 0
-			for _, row := range elim {
-				for _, cell := range row {
-					if strings.HasPrefix(cell, "Round ") && strings.Contains(cell, " - Match ") {
-						headers++
-					}
-				}
-			}
-			assert.Equal(t, sc.finalists-1, headers,
+			assert.Equal(t, sc.finalists-1, countEliminationMatchBlocks(elim),
 				"a knockout of %d entrants must render %d match blocks", sc.finalists, sc.finalists-1)
 
 			// Elimination block numbers per court band (8 columns per court).
@@ -372,7 +380,9 @@ func TestExportCompetitionXlsx_PurePlayoffsRendersBracket(t *testing.T) {
 	f := openExportedWorkbook(t, eng, compID)
 
 	// (1) The bracket page(s) must be rendered, not skipped, and carry content --
-	// not left as a blank sheet.
+	// not left as a blank sheet. (leafLabelsOnSheet is not usable here: its regex
+	// matches the pool CONCATENATE("Pool A-1st ", ...) placeholder form, but a
+	// pure-playoffs leaf renders a participant name via a different formula.)
 	pages := treeSheets(f)
 	require.NotEmpty(t, pages, "a pure playoffs competition must render its bracket page(s)")
 	nonEmpty := 0
@@ -392,15 +402,8 @@ func TestExportCompetitionXlsx_PurePlayoffsRendersBracket(t *testing.T) {
 	// node is one match, each eliminating exactly one entrant).
 	elim, err := f.GetRows(helper.SheetEliminationMatches)
 	require.NoError(t, err)
-	headers := 0
-	for _, row := range elim {
-		for _, cell := range row {
-			if strings.HasPrefix(cell, "Round ") && strings.Contains(cell, " - Match ") {
-				headers++
-			}
-		}
-	}
-	assert.Equal(t, 7, headers, "an 8-entrant playoffs knockout must render 7 elimination match blocks")
+	assert.Equal(t, 7, countEliminationMatchBlocks(elim),
+		"an 8-entrant playoffs knockout must render 7 elimination match blocks")
 }
 
 // TestExportTournamentWorkbooks_MultiPageTree covers the PDF pipeline's input:

--- a/internal/engine/mp_xemw_tie_order_test.go
+++ b/internal/engine/mp_xemw_tie_order_test.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/domain"
+	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPoolStandings_TiedPlayersDeterministicOrder is the mp-xemw regression
+// guard. computeStandingsFrom builds a map[string]*PlayerStanding and ranges it
+// into a slice, then sorts by a single packed Points score. Two players who tie
+// on every ranking criterion (equal Points, no supplementary bout) compare equal
+// in that sort, so their relative order used to be left to Go's randomized map
+// iteration -- different on every call. For a live tournament that means two tied
+// qualifiers seed into the knockout in a run-dependent order. The fix adds a
+// total-order (ID, then Name) tiebreaker.
+//
+// The pool players are inserted [Zeta, Alpha] but the deterministic order is
+// [Alpha, Zeta] (by Name, since these players carry no ID), so a passing run
+// proves the tiebreaker actually reordered rather than merely preserving
+// insertion order. computeStandings is the UNCACHED core: CalculatePoolStandings
+// would cache the first result and hide the nondeterminism.
+func TestPoolStandings_TiedPlayersDeterministicOrder(t *testing.T) {
+	eng, store, _ := setupTestEngine(t)
+	compID := "xemw-tie"
+
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: compID, Name: compID, Kind: "individual",
+		Format: state.CompFormatMixed, Status: state.CompStatusPools,
+		Courts: []string{"A"}, StartTime: "09:00", PoolWinners: 2,
+	}))
+	require.NoError(t, store.SavePools(compID, []helper.Pool{
+		{PoolName: "Pool A", Players: []helper.Player{{Name: "Zeta"}, {Name: "Alpha"}}},
+	}))
+	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+		{Name: "Zeta"}, {Name: "Alpha"},
+	}))
+	// A draw with no ippons: both finish W:0 L:0 D:1, P:0-0, so they tie on every
+	// criterion and no bout separates them.
+	require.NoError(t, store.SavePoolMatches(compID, []state.MatchResult{
+		{ID: "Pool A-0", SideA: "Zeta", SideB: "Alpha", Status: state.MatchStatusCompleted,
+			Winner: "", Decision: string(domain.DecisionHikiwake)},
+	}))
+
+	// Map iteration is re-randomized on every computeStandings call, so pre-fix
+	// roughly half of these runs flip the pair; 50 runs makes an all-identical
+	// result astronomically unlikely without a total order.
+	const runs = 50
+	var firstOrder []string
+	for i := 0; i < runs; i++ {
+		standings, err := eng.computeStandings(compID)
+		require.NoError(t, err)
+		poolA := standings["Pool A"]
+		require.Len(t, poolA, 2)
+		order := []string{poolA[0].Player.Name, poolA[1].Player.Name}
+		if i == 0 {
+			firstOrder = order
+			continue
+		}
+		require.Equalf(t, firstOrder, order,
+			"tied players must rank identically on every computeStandings call (run %d)", i)
+	}
+	assert.Equal(t, []string{"Alpha", "Zeta"}, firstOrder,
+		"with no IDs, a genuine tie must resolve deterministically by Name")
+}

--- a/internal/engine/playoff_skeleton.go
+++ b/internal/engine/playoff_skeleton.go
@@ -16,6 +16,35 @@ import (
 // bracket generation, because internal/export already imports engine (the reverse
 // import would be a cycle).
 
+// EliminationLeaves returns the elimination-tree leaf order for a competition's
+// knockout phase. It is the single owner of the leaf derivation so the blank-
+// template export (Engine.ExportCompetitionXlsx) and the results export
+// (internal/export) of one competition always render the identical bracket
+// (mp-ndfu) -- the invariant that prose-synchronized copies in the two callers
+// used to risk drifting.
+//
+// Pooled formats (Mixed), and the League case the IsPlayoffEnabled gate later
+// drops, come straight from helper.GenerateFinals on the pool winners.
+// EffectivePoolWinners (not the raw field) is used so an unset (<=0) PoolWinners
+// still yields the 2-winner knockout the tournament actually runs (mp-0yd8). A
+// pure playoffs competition has no pools, so GenerateFinals is empty; its leaves
+// come from the frozen bracket's own first-round order
+// (PlayoffLeavesFromBracket, which cannot desync from the stored bracket the
+// score overlay fills in), falling back to participant seeding only pre-start,
+// when no bracket exists yet. bracket may be nil for any non-pure-playoffs
+// caller: it is consulted only on the pure-playoffs branch, where both callers
+// load it.
+func EliminationLeaves(store *state.Store, comp *state.Competition, pools []helper.Pool, bracket *state.Bracket) []string {
+	finals := helper.GenerateFinals(pools, comp.EffectivePoolWinners())
+	if len(finals) == 0 && len(pools) == 0 && comp.Format == state.CompFormatPlayoffs {
+		if leaves := PlayoffLeavesFromBracket(bracket); len(leaves) > 0 {
+			return leaves
+		}
+		return PlayoffFinalsFromParticipants(store, comp)
+	}
+	return finals
+}
+
 // PlayoffLeavesFromBracket reconstructs the pow2 leaf ordering the engine used to
 // build a pure-playoffs bracket, read straight from the frozen bracket's first
 // round: each round-1 match contributes SideA then SideB, in order, with "" for a

--- a/internal/engine/playoff_skeleton.go
+++ b/internal/engine/playoff_skeleton.go
@@ -16,6 +16,15 @@ import (
 // bracket generation, because internal/export already imports engine (the reverse
 // import would be a cycle).
 
+// isPurePlayoffs reports whether comp runs a standalone elimination bracket with
+// no pool phase -- the case where helper.GenerateFinals yields nothing and the
+// leaves must come from the stored bracket / participant seeding instead. Both
+// the bracket-load guard (export.go) and EliminationLeaves gate on this exact
+// condition, so it lives in one predicate rather than two hand-copied literals.
+func isPurePlayoffs(comp *state.Competition, pools []helper.Pool) bool {
+	return len(pools) == 0 && comp.Format == state.CompFormatPlayoffs
+}
+
 // EliminationLeaves returns the elimination-tree leaf order for a competition's
 // knockout phase. It is the single owner of the leaf derivation so the blank-
 // template export (Engine.ExportCompetitionXlsx) and the results export
@@ -36,7 +45,7 @@ import (
 // load it.
 func EliminationLeaves(store *state.Store, comp *state.Competition, pools []helper.Pool, bracket *state.Bracket) []string {
 	finals := helper.GenerateFinals(pools, comp.EffectivePoolWinners())
-	if len(finals) == 0 && len(pools) == 0 && comp.Format == state.CompFormatPlayoffs {
+	if len(finals) == 0 && isPurePlayoffs(comp, pools) {
 		if leaves := PlayoffLeavesFromBracket(bracket); len(leaves) > 0 {
 			return leaves
 		}

--- a/internal/engine/playoff_skeleton.go
+++ b/internal/engine/playoff_skeleton.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/helper"
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// Playoff elimination-skeleton leaf derivation, shared by both workbook builders
+// so a pure-playoffs competition (no pools, so helper.GenerateFinals returns
+// nothing) still renders a bracket. The results export (internal/export) overlays
+// scores onto these leaves; the blank-template export (Engine.ExportCompetitionXlsx)
+// prints them empty. Both MUST derive leaves the same way or the two exports of one
+// competition would disagree (mp-ndfu). This lives in engine, the layer that owns
+// bracket generation, because internal/export already imports engine (the reverse
+// import would be a cycle).
+
+// PlayoffLeavesFromBracket reconstructs the pow2 leaf ordering the engine used to
+// build a pure-playoffs bracket, read straight from the frozen bracket's first
+// round: each round-1 match contributes SideA then SideB, in order, with "" for a
+// bye. Feeding THIS order to the export skeleton guarantees its printed
+// "Round N - Match N" numbering matches the stored bracket's MatchNumber (the two
+// numbering walks are equal-by-contract, assignBracketMatchNumbers vs
+// helper.AssignMatchNumbers), so overlayBracketScores writes each score into the
+// right block even when seeds.csv has drifted. Returns nil for a nil/empty bracket
+// (e.g. a playoffs competition not yet started).
+func PlayoffLeavesFromBracket(bracket *state.Bracket) []string {
+	if bracket == nil || len(bracket.Rounds) == 0 {
+		return nil
+	}
+	first := bracket.Rounds[0]
+	leaves := make([]string, 0, len(first)*2)
+	for _, m := range first {
+		leaves = append(leaves, m.SideA, m.SideB)
+	}
+	return leaves
+}
+
+// PlayoffFinalsFromParticipants seeds the competition's participants exactly as
+// generatePlayoffs does (ApplySeeds → optional numbering → StandardSeeding),
+// returning the seeded names to feed the elimination-tree skeleton. This is the
+// PRE-START fallback only: once a bracket exists, PlayoffLeavesFromBracket is used
+// instead because it cannot desync from the frozen bracket. Since there is no
+// bracket to overlay when this runs, a best-effort (possibly unseeded) order is
+// acceptable. Returns nil when participants can't be loaded, in which case no
+// elimination sheet is rendered.
+func PlayoffFinalsFromParticipants(store *state.Store, comp *state.Competition) []string {
+	players, err := store.LoadParticipants(comp.ID, comp.EffectiveWithZekkenName())
+	if err != nil || len(players) == 0 {
+		return nil
+	}
+	if seeds, serr := store.LoadSeeds(comp.ID); serr == nil && len(seeds) > 0 {
+		if aerr := helper.ApplySeeds(players, seeds); aerr != nil {
+			// An unmatched seed name is non-fatal for a read-only export; the
+			// bracket still renders, just unseeded. Mirror the file's warn pattern.
+			fmt.Printf("export: warning: apply seeds for playoffs skeleton: %v\n", aerr)
+		}
+	}
+	if comp.NumberPrefix != "" {
+		helper.AssignPlayerNumbers(players, comp.NumberPrefix, 1)
+	}
+	seeded := helper.StandardSeeding(players)
+	names := make([]string, len(seeded))
+	for i, p := range seeded {
+		names[i] = p.Name
+	}
+	return names
+}

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -702,7 +702,22 @@ func (e *Engine) computeStandingsFrom(loader poolStandingsLoader, compId string)
 		}
 
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Points > sorted[j].Points
+			if sorted[i].Points != sorted[j].Points {
+				return sorted[i].Points > sorted[j].Points
+			}
+			// Total-order tiebreaker. A genuine Points tie (equal on every ranking
+			// criterion, no supplementary bout) must resolve deterministically
+			// rather than by the iteration order of playerStandings (ranged just
+			// above), or two tied qualifiers would seed into knockout slots in a
+			// run-dependent order (mp-xemw). ID first (stable UUID); Name is the
+			// human-unique fallback for players persisted without an ID. This only
+			// reorders players already equal on Points, so applyTiebreakSort (which
+			// reorders a tied group only when a decided TB/DH bout exists) and
+			// markTiedStandings (which flags on Points equality) are unaffected.
+			if sorted[i].Player.ID != sorted[j].Player.ID {
+				return sorted[i].Player.ID < sorted[j].Player.ID
+			}
+			return sorted[i].Player.Name < sorted[j].Player.Name
 		})
 
 		// Apply supplementary-bout results as a secondary sort within each tied

--- a/internal/export/builder.go
+++ b/internal/export/builder.go
@@ -133,16 +133,16 @@ func BuildResultsWorkbook(store *state.Store, eng *engine.Engine, compID string)
 	// overlayBracketScores fills in.
 	finals := helper.GenerateFinals(pools, comp.EffectivePoolWinners())
 	if len(finals) == 0 && len(pools) == 0 && comp.Format == state.CompFormatPlayoffs {
-		// Prefer the frozen bracket's own leaf order (see playoffLeavesFromBracket).
+		// Prefer the frozen bracket's own leaf order (see engine.PlayoffLeavesFromBracket).
 		// Recomputing from participants+seeds at export time can desync the skeleton
 		// numbering from the stored bracket if seeds.csv drifted since generation
 		// (e.g. a seeded participant was replaced), which would silently write scores
 		// into the wrong match blocks. Fall back to participant seeding only when no
 		// bracket exists yet (pre-start; there is nothing to overlay anyway).
-		if leaves := playoffLeavesFromBracket(bracket); len(leaves) > 0 {
+		if leaves := engine.PlayoffLeavesFromBracket(bracket); len(leaves) > 0 {
 			finals = leaves
 		} else {
-			finals = playoffFinalsFromParticipants(store, comp)
+			finals = engine.PlayoffFinalsFromParticipants(store, comp)
 		}
 	}
 	if len(finals) > 0 && comp.IsPlayoffEnabled() {
@@ -294,58 +294,6 @@ func attachPoolMatches(pools []helper.Pool, matchResults []state.MatchResult) ma
 		poolOrdinals[p.PoolName] = ords
 	}
 	return poolOrdinals
-}
-
-// playoffLeavesFromBracket reconstructs the pow2 leaf ordering the engine used to
-// build a pure-playoffs bracket, read straight from the frozen bracket's first
-// round: each round-1 match contributes SideA then SideB, in order, with "" for a
-// bye. Feeding THIS order to the export skeleton guarantees its printed
-// "Round N - Match N" numbering matches the stored bracket's MatchNumber (the two
-// numbering walks are equal-by-contract, engine.assignBracketMatchNumbers vs
-// helper.AssignMatchNumbers), so overlayBracketScores writes each score into the
-// right block even when seeds.csv has drifted. Returns nil for a nil/empty bracket
-// (e.g. a playoffs competition not yet started).
-func playoffLeavesFromBracket(bracket *state.Bracket) []string {
-	if bracket == nil || len(bracket.Rounds) == 0 {
-		return nil
-	}
-	first := bracket.Rounds[0]
-	leaves := make([]string, 0, len(first)*2)
-	for _, m := range first {
-		leaves = append(leaves, m.SideA, m.SideB)
-	}
-	return leaves
-}
-
-// playoffFinalsFromParticipants seeds the competition's participants exactly as
-// engine.generatePlayoffs does (ApplySeeds → optional numbering → StandardSeeding),
-// returning the seeded names to feed the elimination-tree skeleton. This is the
-// PRE-START fallback only: once a bracket exists, playoffLeavesFromBracket is used
-// instead because it cannot desync from the frozen bracket. Since there is no
-// bracket to overlay when this runs, a best-effort (possibly unseeded) order is
-// acceptable. Returns nil when participants can't be loaded, in which case no
-// elimination sheet is rendered.
-func playoffFinalsFromParticipants(store *state.Store, comp *state.Competition) []string {
-	players, err := store.LoadParticipants(comp.ID, comp.EffectiveWithZekkenName())
-	if err != nil || len(players) == 0 {
-		return nil
-	}
-	if seeds, serr := store.LoadSeeds(comp.ID); serr == nil && len(seeds) > 0 {
-		if aerr := helper.ApplySeeds(players, seeds); aerr != nil {
-			// An unmatched seed name is non-fatal for a read-only export; the
-			// bracket still renders, just unseeded. Mirror the file's warn pattern.
-			fmt.Printf("export: warning: apply seeds for playoffs skeleton: %v\n", aerr)
-		}
-	}
-	if comp.NumberPrefix != "" {
-		helper.AssignPlayerNumbers(players, comp.NumberPrefix, 1)
-	}
-	seeded := helper.StandardSeeding(players)
-	names := make([]string, len(seeded))
-	for i, p := range seeded {
-		names[i] = p.Name
-	}
-	return names
 }
 
 // ---------- pool score overlay ----------

--- a/internal/export/builder.go
+++ b/internal/export/builder.go
@@ -122,29 +122,15 @@ func BuildResultsWorkbook(store *state.Store, eng *engine.Engine, compID string)
 		return nil, fmt.Errorf("export: overlay standings: %w", err)
 	}
 
-	// 4. Elimination Matches + Tree sheets.
-	//    Only for formats that actually have a knockout phase (Playoffs, Mixed).
-	// A League is a single round-robin with no bracket, yet GenerateFinals still
-	// returns placeholder "Pool A-1st" finalist labels for it; without the format
-	// gate that would emit a phantom Elimination/Tree bracket with no real scores.
-	// Elimination skeleton leaves: pool winners for pools-based formats, or seeded
-	// participants for a pure playoffs bracket (no pools). The latter mirrors
-	// engine.generatePlayoffs so the rendered tree matches the stored bracket that
-	// overlayBracketScores fills in.
-	finals := helper.GenerateFinals(pools, comp.EffectivePoolWinners())
-	if len(finals) == 0 && len(pools) == 0 && comp.Format == state.CompFormatPlayoffs {
-		// Prefer the frozen bracket's own leaf order (see engine.PlayoffLeavesFromBracket).
-		// Recomputing from participants+seeds at export time can desync the skeleton
-		// numbering from the stored bracket if seeds.csv drifted since generation
-		// (e.g. a seeded participant was replaced), which would silently write scores
-		// into the wrong match blocks. Fall back to participant seeding only when no
-		// bracket exists yet (pre-start; there is nothing to overlay anyway).
-		if leaves := engine.PlayoffLeavesFromBracket(bracket); len(leaves) > 0 {
-			finals = leaves
-		} else {
-			finals = engine.PlayoffFinalsFromParticipants(store, comp)
-		}
-	}
+	// 4. Elimination Matches + Tree sheets. Only for formats with a knockout
+	//    phase: the IsPlayoffEnabled gate below drops the phantom bracket a
+	//    league's placeholder finals would otherwise imply. EliminationLeaves owns
+	//    the leaf order -- pool winners, or the frozen bracket's own leaves for a
+	//    pure playoffs competition -- and is shared with the blank-template export
+	//    so the two exports of one competition render the identical bracket, with
+	//    numbering that matches the stored bracket overlayBracketScores fills in
+	//    (mp-ndfu).
+	finals := engine.EliminationLeaves(store, comp, pools, bracket)
 	if len(finals) > 0 && comp.IsPlayoffEnabled() {
 		tree := helper.CreateBalancedTree(finals)
 

--- a/internal/export/builder_test.go
+++ b/internal/export/builder_test.go
@@ -1224,8 +1224,8 @@ func TestBuildResultsWorkbook_EndToEndEngineScored(t *testing.T) {
 // round-1 match contributes SideA then SideB in order, byes included as "".
 func TestPlayoffLeavesFromBracket(t *testing.T) {
 	t.Parallel()
-	assert.Nil(t, playoffLeavesFromBracket(nil))
-	assert.Nil(t, playoffLeavesFromBracket(&state.Bracket{}))
+	assert.Nil(t, engine.PlayoffLeavesFromBracket(nil))
+	assert.Nil(t, engine.PlayoffLeavesFromBracket(&state.Bracket{}))
 
 	br := &state.Bracket{Rounds: [][]state.BracketMatch{
 		{
@@ -1234,7 +1234,7 @@ func TestPlayoffLeavesFromBracket(t *testing.T) {
 		},
 		{{SideA: "Winner of r1-m0", SideB: "Winner of r1-m1"}},
 	}}
-	assert.Equal(t, []string{"Alice", "Dave", "Carol", ""}, playoffLeavesFromBracket(br))
+	assert.Equal(t, []string{"Alice", "Dave", "Carol", ""}, engine.PlayoffLeavesFromBracket(br))
 }
 
 // TestBuildResultsWorkbook_PlayoffsNonPow2TopologyMatchesBracket is the regression
@@ -1355,7 +1355,7 @@ func TestBuildResultsWorkbook_PlayoffsBracket(t *testing.T) {
 // mp-uagg: internal/helper.printSingleEliminationMatch used to decide leaf- vs
 // match-feeder nodes by asking whether Node.LeafVal parsed as an Excel cell
 // reference (excelize.SplitCellName). A no-pools playoffs bracket renders raw
-// participant names as leaves (playoffFinalsFromParticipants), so a competitor
+// participant names as leaves (engine.PlayoffFinalsFromParticipants), so a competitor
 // named like a cell coordinate ("P1" = column P row 1, "M3", "A4") was
 // misclassified as a match-feeder, producing a broken CONCATENATE(...,”!)
 // formula. The fix checks the structural Node.LeafNode flag instead.

--- a/web-mobile/audit-ci.jsonc
+++ b/web-mobile/audit-ci.jsonc
@@ -1,0 +1,44 @@
+{
+  // Security gate for web-mobile's npm dependency tree, run from `make js/sec`.
+  // Replaces a bare `npm audit --audit-level=high` so that individual,
+  // known-unfixable advisories can be suppressed WITHOUT disabling the whole
+  // scan (the `--omit=dev` alternative would have silently stopped gating the
+  // entire eslint/vite/vitest toolchain).
+
+  // Fail on HIGH or CRITICAL advisories (matches the previous gate level).
+  "high": true,
+
+  // Keep the gate output terse: a one-line pass/fail plus any offending paths,
+  // instead of dumping the full npm-audit JSON metadata on every run.
+  "report-type": "summary",
+
+  // Dev dependencies stay in scope: every other high/critical advisory in the
+  // toolchain must still fail the gate. Do NOT set "skip-dev": that would
+  // defeat the reason this file exists.
+  "skip-dev": false,
+
+  // Allowlist: suppress ONLY advisories we have proven cannot be fixed by a
+  // version bump. Each entry MUST carry a reason and a removal condition.
+  "allowlist": [
+    // GHSA-mh99-v99m-4gvg -- brace-expansion DoS (unbounded expansion OOM).
+    // DEV-ONLY, never shipped: the exposure is a lint tool expanding globs
+    // from the developer's own eslint config, not untrusted input.
+    //
+    // It reaches the tree solely via:
+    //   eslint-plugin-react -> minimatch@3 -> brace-expansion@1
+    // and cannot be cleared by any override:
+    //   * The advisory is fixed only in brace-expansion 5.0.8, whose CommonJS
+    //     export is the non-callable { expand } -- forcing it onto minimatch@3
+    //     (which calls require('brace-expansion')(pattern)) throws at runtime.
+    //   * The only clean path, minimatch@10, has a non-callable { minimatch }
+    //     export that breaks eslint-plugin-react's callable minimatch() sites.
+    //   * npm's only auto-fix is a breaking eslint-plugin-react downgrade,
+    //     which also drops eslint-10 flat-config support.
+    // eslint-plugin-react is dormant (latest 7.37.5, April 2025) and closed
+    // the minimatch-v9 upgrade as "not planned" (jsx-eslint/eslint-plugin-react#4021).
+    //
+    // REMOVE this entry when eslint-plugin-react ships a release off minimatch@3,
+    // or when the plugin is replaced -- tracked in bead mp-vdkw.
+    "GHSA-mh99-v99m-4gvg"
+  ]
+}

--- a/web-mobile/package-lock.json
+++ b/web-mobile/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^6.0.1",
+        "audit-ci": "^7.1.0",
         "eslint": "^10.3.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^17.6.0",
@@ -1391,6 +1392,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/audit-ci/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1494,6 +1532,41 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1736,6 +1809,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -1931,6 +2018,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2183,6 +2280,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2299,6 +2412,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2363,6 +2483,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2605,6 +2735,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -2779,6 +2916,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -3041,6 +3188,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3109,6 +3263,33 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/jsqr": {
       "version": "1.4.0",
@@ -3489,6 +3670,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3815,6 +4003,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3982,6 +4183,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4038,6 +4264,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -4127,6 +4363,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -4361,6 +4618,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4387,6 +4657,42 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -4487,6 +4793,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4519,6 +4838,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4615,8 +4951,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4747,6 +5082,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -5096,6 +5438,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -5112,6 +5488,45 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web-mobile/package.json
+++ b/web-mobile/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "test": "vitest run",
     "test:render": "vitest run --config vitest.config.render.js",
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint . --max-warnings 0",
+    "audit": "audit-ci --config audit-ci.jsonc"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "audit-ci": "^7.1.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Summary

Closes three unrelated P2 beads that were each blocking or degrading a distinct surface. Bundled at the maintainer's explicit request; each is an independent, self-contained commit.

- **mp-ndfu (Excel):** A pure-playoffs competition (no pools) exported a blank-template workbook — and PDF booklet — with **no bracket at all**: `helper.GenerateFinals` returns nothing without pools, so the entire knockout block was skipped. It now derives the elimination leaves from the stored bracket (falling back to participant seeding pre-start), exactly as the results workbook already does, so both exports of one competition render the identical bracket.
- **mp-xemw (engine determinism):** The `TestResolveQualifiedPools_*` flake **as filed was already fixed on main** by the standings-cache write-counter commits. Investigating it surfaced a *distinct*, still-live nondeterminism: pool standings sort tied competitors by map-iteration order, so two players tied on every criterion seed into the knockout in a run-dependent order. Added a total-order `(ID, Name)` tiebreaker.
- **mp-jlph (build gate):** `npm audit` reddened the `js/sec` gate on every branch (brace-expansion GHSA-mh99-v99m-4gvg). The advisory is **unfixable by any version pin** (proven below), so `js/sec` now runs through `audit-ci` with a documented allowlist of exactly that one dev-only advisory; every other high/critical still fails the gate.

## Why

- **mp-ndfu root cause:** `Engine.ExportCompetitionXlsx` sourced knockout entrants solely from pool finals. To share the fix with the results path without an import cycle (`internal/export` already imports `internal/engine`), the leaf-derivation helpers moved down into `engine` as exported `PlayoffLeavesFromBracket` / `PlayoffFinalsFromParticipants`.
- **mp-jlph root cause:** brace-expansion is fixed only in 5.0.8, whose CommonJS export is the non-callable `{ expand }`. It enters the tree solely via `eslint-plugin-react → minimatch@3 → brace-expansion@1`, and minimatch@3 calls `require('brace-expansion')(pattern)`, which throws on 5.0.8. The only clean path (minimatch@10) has a non-callable `{ minimatch }` export that breaks eslint-plugin-react's callable `minimatch()` sites. npm's sole auto-fix is a breaking eslint-plugin-react downgrade. The plugin is dormant (latest 7.37.5, April 2025) and closed the minimatch-v9 upgrade as "not planned" upstream. The root-cause fix (replacing eslint-plugin-react) is tracked in the new follow-up **mp-vdkw**.

## Files changed

| File | What |
|---|---|
| `internal/engine/playoff_skeleton.go` | New. Exported `PlayoffLeavesFromBracket` / `PlayoffFinalsFromParticipants`, moved from `internal/export` so both workbook builders share one leaf derivation (mp-ndfu) |
| `internal/engine/export.go` | Blank-template path loads the bracket for pure playoffs and derives leaves via the shared helpers; stale mp-ndfu comment updated (mp-ndfu) |
| `internal/export/builder.go` | Calls the relocated helpers via `engine.` (mp-ndfu) |
| `internal/export/builder_test.go` | Test call sites updated to `engine.PlayoffLeavesFromBracket` (mp-ndfu) |
| `internal/engine/export_tree_test.go` | New `TestExportCompetitionXlsx_PurePlayoffsRendersBracket` regression test (mp-ndfu) |
| `internal/engine/scoring.go` | Total-order `(ID, Name)` tiebreaker for Points-tied standings (mp-xemw) |
| `internal/engine/mp_xemw_tie_order_test.go` | New determinism regression test (mp-xemw) |
| `Makefile` | `js/sec` routes web-mobile through `audit-ci` (mp-jlph) |
| `web-mobile/audit-ci.jsonc` | New. `high` gate + single documented allowlist entry (mp-jlph) |
| `web-mobile/package.json` | `audit-ci` devDep + `audit` script (mp-jlph) |
| `web-mobile/package-lock.json` | Lockfile for audit-ci (regenerated with npm 11) (mp-jlph) |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — note: run after `go generate ./...` / a build, which stamps the version-info files the `cmd/version` tests read (CI runs generate first; a bare `make go/test` on a fresh worktree fails only those version tests)
- [x] New/updated unit tests cover each change, and each was verified to FAIL with its fix reverted (no-tree-pages for mp-ndfu; order-flips for mp-xemw; `audit-ci` fails naming the exact `eslint-plugin-react>minimatch>brace-expansion` path for mp-jlph)
- [x] `js/sec` gate is green: `audit-ci` passes with the allowlist and fails without it; audit-ci's own dependency tree audits clean
- [ ] Manual browser verification — N/A (no `web-mobile/` or `web/` runtime code changed; the only web-mobile edits are the audit-ci build-tooling config)
- [x] No new console errors or warnings
- [x] Docs — N/A (no user-facing feature, flag, command, or behavior change; mp-jlph is internal build tooling)

Closes mp-ndfu
Closes mp-xemw
Closes mp-jlph
