### PR TITLE
fix(mp-x3p3): track simulation_data.json so mobile-app-example works on any checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ Thumbs.db
 !web-mobile/.oxlintrc.json
 !web/package.json
 !web/package-lock.json
+# Fixture data for scripts/setup_tournament.py (make mobile-app-example);
+# without this the demo target fails with FileNotFoundError on any checkout
+# other than the one that happens to have the file untracked on disk.
+!scripts/simulation_data.json
 node_modules/
 # worktree convenience symlink (web-mobile/node_modules -> main repo); the
 # bare node_modules/ rule above matches real dirs, not the symlink.

--- a/scripts/setup_tournament.py
+++ b/scripts/setup_tournament.py
@@ -6,8 +6,12 @@ import requests
 import sys
 import time
 
-BASE_URL = "http://localhost:8080"
-PASSWORD = "testpassword"
+# PORT mirrors the env var the mobile-app binary itself reads, so
+# `PORT=8081 make mobile-app-example` points the server and this script at the
+# same place. BASE_URL overrides the whole URL for a non-local server.
+PORT = os.environ.get("PORT", "8080")
+BASE_URL = os.environ.get("BASE_URL", f"http://localhost:{PORT}").rstrip("/")
+PASSWORD = os.environ.get("TOURNAMENT_PASSWORD", "testpassword")
 HEADERS = {
     "X-Tournament-Password": PASSWORD,
     "Content-Type": "application/json"

--- a/scripts/simulation_data.json
+++ b/scripts/simulation_data.json
@@ -1,0 +1,17 @@
+{
+  "individual_scores": [
+    {"winner_side": "A", "score": [2, 0], "ipponsA": ["M", "M"], "ipponsB": []},
+    {"winner_side": "B", "score": [0, 2], "ipponsA": [], "ipponsB": ["K", "D"]},
+    {"winner_side": "A", "score": [1, 0], "ipponsA": ["M"], "ipponsB": []},
+    {"winner_side": "DRAW", "score": [0, 0], "ipponsA": [], "ipponsB": [], "decision": "hikiwake"},
+    {"winner_side": "A", "score": [2, 1], "ipponsA": ["M", "K"], "ipponsB": ["D"]},
+    {"winner_side": "B", "score": [1, 2], "ipponsA": ["M"], "ipponsB": ["K", "K"]},
+    {"winner_side": "DRAW", "score": [1, 1], "ipponsA": ["M"], "ipponsB": ["K"], "decision": "hikiwake"}
+  ],
+  "team_scores": [
+    {"winner_side": "A", "winsA": 3, "winsB": 1, "draws": 1},
+    {"winner_side": "B", "winsA": 0, "winsB": 4, "draws": 1},
+    {"winner_side": "A", "winsA": 2, "winsB": 0, "draws": 3},
+    {"winner_side": "DRAW", "winsA": 2, "winsB": 2, "draws": 1}
+  ]
+}


### PR DESCRIPTION
## Summary

- `make mobile-app-example` now works on any checkout. It previously failed with `FileNotFoundError` everywhere except the one clone that happened to have an untracked `scripts/simulation_data.json` sitting on disk, and in every worktree.
- Unblocks the fixture path the `mp-yqxn` operator-UX review children need to reach a populated team competition quickly, and the natural seeding step for any future browser/end-to-end suite.
- The demo script no longer hardcodes port 8080 and the admin password, so it can drive a server on another port. Defaults are unchanged.

## Why

Root cause: the blanket `*.json` rule in `.gitignore` swallowed `scripts/simulation_data.json`. `scripts/setup_tournament.py` is tracked and loads that file at **module import time**, so the failure happens before any work starts:

```
$ git check-ignore -v scripts/simulation_data.json
.gitignore:62:*.json    scripts/simulation_data.json
```

The file is genuine fixture data (17 lines of predetermined match results) and belongs in version control. It is un-ignored with a negation rule matching the precedent already sitting directly above it for `web-mobile/package.json`, `web-mobile/.oxlintrc.json`, and `web/package.json`.

## Files changed

| File | What |
|---|---|
| `.gitignore` | Add `!scripts/simulation_data.json` negation (with a comment on why) so the blanket `*.json` rule stops swallowing the fixture |
| `scripts/simulation_data.json` | Newly tracked: the 17-line predetermined individual/team result fixture the demo script imports |
| `scripts/setup_tournament.py` | Replace hardcoded `http://localhost:8080` / `testpassword` with `PORT` / `BASE_URL` / `TOURNAMENT_PASSWORD` env lookups, same defaults |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — green, exit 0: gosec 0 issues across 153 files, govulncheck 0, 2331 JS tests in 112 files pass, all Go packages pass and every tested package is at or above the 85% coverage gate (lowest: `pdf` 85.1%, `mobileapp` 85.8%).
- [x] New/updated unit tests cover the change — **no new automated test added, deliberately**: the change adds no Go/JS code path, it corrects file tracking plus env lookups in a contributor script. Verified instead by executing the target both ways, which is the behavior at issue:
  - `PORT=8087 make mobile-app-example` runs the whole lifecycle (6 competitions incl. the 5-person team comp, rosters, seeds, start, every pool and knockout match scored, completion) through to `Tournament full simulation complete!` and exits 0. Running on 8087 rather than 8080 exercises the `PORT` override at the same time.
  - Negative check, to confirm the tracked file is what fixes it and not something incidental: moving `scripts/simulation_data.json` aside reproduces the original `FileNotFoundError` at `setup_tournament.py` import, exit 1. Restored afterwards.
- [ ] Manual browser verification (for `web-mobile/` or `web/` changes) — N/A, no front-end file is touched.
- [ ] Screenshots — N/A, no UI impact (`.gitignore` + a Python script + a JSON fixture).
- [x] Docs updated under `docs/` for any new or changed user-facing feature, flag, command, or behavior — none needed. `make mobile-app-example`, `setup_tournament.py`, and `simulation_data.json` are not referenced in `docs/`, `CONTRIBUTING.md`, or `README.md`; this is an internal dev target, and the new env vars are contributor-facing only.
- [x] No new console errors or warnings — no JS/front-end change; the demo run and the full gate produced no new warnings.

### Reviewer note

`git check-ignore -v` is misleading here: it prints the last matching pattern and exits 0 even when that pattern is a negation, so it still reports the file as matched. The reliable checks are that `git status` now lists the file and `git add` accepts it without `-f`.

<!-- Bead reference: -->
Closes mp-x3p3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
