### PR TITLE
fix(mp-5psv): make the pre-PR gate self-provisioning on a fresh checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,10 @@ Thumbs.db
 !web/package.json
 !web/package-lock.json
 node_modules/
-# worktree convenience symlink (web-mobile/node_modules -> main repo); the
-# bare node_modules/ rule above matches real dirs, not the symlink.
+# Each worktree installs its own node_modules (see js/deps in the Makefile), so
+# the bare rule above covers it. This extra no-trailing-slash rule stays only to
+# catch a legacy worktree symlink into the main checkout, which the directory
+# rule above would not match.
 web-mobile/node_modules
 specs/*
 specs/*/*

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ else
 endif
 
 # Define phony targets
-.PHONY: default help clean local/deps hooks/install go/fmt go/test go/build go/lint go/sec go/vuln go/security js/lint js/sec js/outdated js/security js/check-imports js/validate examples docker/build docker/run pre-commit docs/deps docs/serve docs/open docs/build docs/linkcheck docs/clean run run-mobile esbuild-jsx goreleaser/test release version
+.PHONY: default help clean local/deps hooks/install go/fmt go/generate go/test go/build go/lint go/sec go/vuln go/security js/deps js/lint js/sec js/outdated js/security js/check-imports js/validate examples docker/build docker/run pre-commit docs/deps docs/serve docs/open docs/build docs/linkcheck docs/clean run run-mobile esbuild-jsx goreleaser/test release version
 
 default: help ## Show help information (default)
 
@@ -35,7 +35,7 @@ clean: ## Clean build artifacts
 	rm -rf dist/
 	@echo "Done!"
 
-local/deps: hooks/install ## Install project dependencies
+local/deps: hooks/install js/deps ## Install project dependencies
 	@echo "Installing dependencies..."
 	go mod tidy
 	go install github.com/spf13/cobra-cli@v1.3.0
@@ -44,8 +44,6 @@ local/deps: hooks/install ## Install project dependencies
 	go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	python3 -m pip install -r docs/requirements.txt
-	@cd web-mobile && npm install
-	@cd web && npm install
 
 hooks/install: ## Wire scripts/hooks/ as the git hooks dir for this clone
 	@chmod +x scripts/hooks/*
@@ -56,11 +54,22 @@ go/fmt: ## Format Go code
 	@echo "Formatting Go code..."
 	go fmt ./...
 
-go/lint: go/fmt ## Run linters
+go/generate: ## Generate embedded build metadata and glossary data
+	@echo "Running go generate..."
+	@# internal/cmd/version //go:embed's commit.txt / version.txt / build_date.txt,
+	@# which are gitignored, so without this gosec cannot parse the package on a
+	@# fresh checkout and exits 1 reporting zero findings. The single definition
+	@# of "how to generate": the binary build depends on this target too.
+	go generate ./...
+
+# The Go tool binaries (golangci-lint, gosec, govulncheck) stay on local/deps by
+# design: they install into GOPATH/bin, which is machine-global and survives a
+# fresh worktree, unlike node_modules and the generated embeds below.
+go/lint: go/fmt go/generate ## Run linters
 	@echo "Running linters..."
 	golangci-lint run ./cmd/... ./internal/... ./tests/... .
 
-go/sec: ## Run security scans (gosec)
+go/sec: go/generate ## Run security scans (gosec)
 	@echo "Running security scans..."
 	gosec ./cmd/... ./internal/... ./tests/... .
 
@@ -70,11 +79,35 @@ go/vuln: ## Run vulnerability check (govulncheck)
 
 go/security: go/sec go/vuln ## Run all security checks
 
-js/lint: ## Run Javascript linters
+# Each worktree installs its own node_modules. Worktrees are short-lived and
+# removed after their PR merges, so the disk cost is transient, and a private
+# tree always matches that branch's package.json. Sharing one install across
+# branches is what made js/lint die with "oxlint: not found": the shared tree
+# predated the branch that added oxlint.
+#
+# npm maintains node_modules/.package-lock.json to describe the installed tree,
+# so it is a reliable staleness stamp. Keying the rule on it means npm runs only
+# when the lockfile is newer, and costs nothing on an up-to-date tree.
+web-mobile/node_modules/.package-lock.json: web-mobile/package-lock.json
+	@echo "Installing web-mobile Javascript dependencies..."
+	@# Remove a legacy shared symlink first, the LINK ONLY, never its target:
+	@# npm ci deletes node_modules by recursing into the symlink target, which
+	@# would wipe the main checkout's install and every other worktree's.
+	@if [ -L web-mobile/node_modules ]; then rm web-mobile/node_modules; fi
+	@cd web-mobile && npm ci --no-audit --no-fund
+
+js/deps: web-mobile/node_modules/.package-lock.json ## Install this worktree's JS dependencies
+	@# web/ declares no dependencies, so npm ci is a ~0.1s no-op there and
+	@# creates no node_modules, leaving no stamp file to key a rule on. Run it
+	@# unconditionally so this still works the day web/ gains a dependency.
+	@if [ -L web/node_modules ]; then rm web/node_modules; fi
+	@cd web && npm ci --no-audit --no-fund
+
+js/lint: js/deps ## Run Javascript linters
 	@echo "Running Javascript linters..."
 	@cd web-mobile && npm run lint
 
-js/sec: ## Run Javascript security scans (audit-ci + npm audit)
+js/sec: js/deps ## Run Javascript security scans (audit-ci + npm audit)
 	@echo "Running Javascript security scans..."
 	@# web-mobile uses audit-ci so one proven-unfixable dev-only advisory can be
 	@# allowlisted (web-mobile/audit-ci.jsonc) without disabling the whole scan.
@@ -88,7 +121,7 @@ js/outdated: ## Check for outdated npm packages
 
 js/security: js/sec ## Run all Javascript security checks
 
-js/test: ## Run JavaScript unit tests
+js/test: js/deps ## Run JavaScript unit tests
 	@echo "Running JavaScript tests..."
 	@cd web-mobile && NODE_NO_WARNINGS=1 npm test
 	@cd web && NODE_NO_WARNINGS=1 npm test
@@ -124,10 +157,11 @@ esbuild-jsx: ## Pre-compile JSX files to web-mobile/dist/
 		--outdir=web-mobile/dist --loader:.jsx=jsx \
 		--jsx-factory=React.createElement --jsx-fragment=React.Fragment
 
-$(BIN_PATH)/$(BIN_NAME): vendor-frontend esbuild-jsx $(GO_SOURCES) $(EMBEDDED_ASSETS)
+# go/generate is listed after esbuild-jsx so generation still runs once the
+# dist/ directory exists, matching the order when it was inline in this recipe.
+$(BIN_PATH)/$(BIN_NAME): vendor-frontend esbuild-jsx go/generate $(GO_SOURCES) $(EMBEDDED_ASSETS)
 	@echo "Building $(BIN_NAME) version $(VERSION)..."
 	@mkdir -p $(BIN_PATH)
-	go generate ./...
 	@# -buildvcs=false: version/commit/build-date are already embedded via `go generate`
 	@# (internal/cmd/version/get_build_info.sh writes commit.txt/version.txt/build_date.txt
 	@# consumed by //go:embed), so Go's auto VCS stamp is redundant. Go 1.26's default


### PR DESCRIPTION
## Summary

- `make go/test` now works on a fresh clone or a brand-new worktree. It previously failed twice over, because nothing in the Makefile depended on `local/deps`, so the pre-PR gate assumed an already-provisioned tree.
- Each worktree now installs its **own** `node_modules` instead of symlinking the main checkout's. Worktrees are short-lived and removed after their PR merges, so the disk cost is transient, while a private tree always matches its branch's `package.json`.
- CI was never affected (`validate.yaml` runs `npm ci` itself); this was a local-dev-only gap.

## Why

Two independent failures on an unprovisioned checkout:

```
sh: 1: oxlint: not found
make: *** [Makefile:75: js/lint] Error 127
```

```
Golang errors in file: [internal/cmd/version/version.go]:
  > [line 22 : column 13] - pattern build_date.txt: no matching files found
make: *** [Makefile:63: go/sec] Error 1
```

The second is easy to miss: gosec reports `Issues: 0` and still exits 1, because it cannot parse the version package. `internal/cmd/version` embeds `commit.txt` / `version.txt` / `build_date.txt`, which `get_build_info.sh` writes via `go generate` and which are gitignored. The build recipe ran `go generate` inline, so only the static analysers were left short.

The oxlint failure was not simply a missing install. `oxlint` was declared in `package.json` and present in `package-lock.json`, but absent from `node_modules/.bin`, because the **shared** install predated the branch that added oxlint (`f912b0bc` / `3646c7c1`). Sharing one `node_modules` across worktrees is only sound while every branch agrees on dependencies, which is exactly what failed here. Per-worktree installs remove that whole class of problem.

### `npm ci` and the legacy symlink

`npm ci` is the right tool once installs are private, since it installs the lockfile exactly. It is still dangerous through a **legacy symlink**: it deletes `node_modules` by recursing into the symlink target. Verified with a canary file in the shared install:

| | shared install | symlink | cost |
|---|---|---|---|
| `npm ci` through a symlink | **destroyed** | replaced | full reinstall |
| `npm ci` after dropping the link (this PR) | untouched | replaced by a real dir | 4s once per worktree |

So the web-mobile rule removes such a symlink, **the link only, never its target**, before installing. Migration is automatic and non-destructive.

### Cost

The rule is keyed on npm's own `node_modules/.package-lock.json`, so npm runs only when the lockfile is newer:

| Situation | Cost |
|---|---|
| Fresh worktree | 4s (162 packages) |
| Up to date | 0.7s (web-mobile skipped entirely) |
| `go/generate` | 0.37s |

Make dedupes both prerequisites to one run per invocation, confirmed with `make -n go/test`.

## Files changed

| File | What |
|---|---|
| `Makefile` | Add `js/deps` (per-worktree `npm ci`, keyed on npm's `.package-lock.json` stamp, dropping any legacy symlink first) and `go/generate` (build-metadata embeds); make `js/lint` / `js/sec` / `js/test` depend on the former and `go/lint` / `go/sec` on the latter; drop the two duplicated `npm install` lines from `local/deps`, which now just depends on `js/deps`; register both new targets as `.PHONY` |
| `.gitignore` | Update the comment that documented the retired worktree-symlink convention; the rule itself stays to catch a legacy symlink |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — verified in a worktree with **neither** `node_modules` **nor** the generated embeds, which is the exact broken condition. Exit 0: gosec 0 issues, govulncheck 0, 2331 JS tests pass, all Go packages pass and every tested package stays at or above the 85% coverage gate.
- [x] New/updated unit tests cover the change — **no automated test added, deliberately**: this is build tooling with no Go/JS code path, and the behavior under test is "the gate runs at all". Verified by reproducing each failure against the pre-change Makefile and then re-running with the fix:
  - `make -f <pre-change Makefile> js/lint` reproduces `oxlint: not found`, exit 127. With the fix: installs 162 packages, oxlint runs clean, exit 0.
  - `make -f <pre-change Makefile> go/sec` reproduces `pattern build_date.txt: no matching files found`, exit 1 despite `Issues: 0`. With the fix: exit 0.
- [x] All three provisioning paths exercised end to end:
  - **Fresh** (no `node_modules`) installs and yields a working `oxlint`.
  - **Up to date** skips web-mobile entirely (no npm invocation).
  - **Legacy symlink** is replaced by a real per-worktree directory, with a canary file confirming the main checkout's shared install survives intact.
- [x] No regression in tree cleanliness — `go generate` now runs during the gate, so this was checked explicitly: the `.txt` embeds are gitignored and the tracked `web-mobile/js/glossary_data.js` regenerates byte-identically, leaving `git status` showing only the two changed files.
- [ ] Manual browser verification (for `web-mobile/` or `web/` changes) — N/A, no front-end file is touched.
- [ ] Screenshots — N/A, no UI impact (Makefile and .gitignore only).
- [x] Docs updated under `docs/` — none needed. These are contributor-facing build targets; `docs/` documents the shipped CLI and mobile app, not the Makefile.
- [x] No new console errors or warnings — no JS/front-end change; the full gate produced no new warnings.

<!-- Bead reference: -->
Closes mp-5psv

🤖 Generated with [Claude Code](https://claude.com/claude-code)
