### PR TITLE
fix(mp-9k3v, mp-94v0): round-trip engi in the settings PUT and stamp compEngi on competition-page matches

### DIFF
--- a/web-mobile/js/__tests__/admin_competition.test.jsx
+++ b/web-mobile/js/__tests__/admin_competition.test.jsx
@@ -365,6 +365,9 @@ describe('AdminSettings useEffect deps completeness (H3 regression)', () => {
     // mp-m5kf: the m:ss DurationInput binds to the canonical *Seconds fields.
     // The whole-minute siblings were retired and are no longer on the wire.
     'poolMatchDurationSeconds', 'playoffMatchDurationSeconds',
+    // mp-9k3v: engi qualifies under BOTH (a) and (b): the JSX reads
+    // `local.engi` for the Engi checkbox, and finalNext round-trips it.
+    'engi',
   ];
 
   it('useEffect deps include every field rendered via local.*', () => {
@@ -452,6 +455,11 @@ describe('AdminSettings.saveNow payload whitelist', () => {
     // Naginata support: round-trips the flag so a settings save doesn't
     // clobber a previously-set naginata: true with Go's zero-value false.
     'naginata',
+    // mp-9k3v: engi (flag-scoring kata pairs). Same zero-value-clobber
+    // hazard as naginata/mirror, with a second failure mode: past setup the
+    // backend REJECTS a mismatched engi ("engi can only be changed before the
+    // competition starts"), so omitting it broke every settings save outright.
+    'engi',
     // mp-6nq: per-competition check-in tracking flag.
     'checkInEnabled',
     // Phase 3b (mp-8rc9): league tie-breaker config. Only meaningful for
@@ -504,6 +512,62 @@ describe('AdminSettings.saveNow payload whitelist', () => {
     }
     for (const forbidden of FORBIDDEN) {
       expect(keys.includes(forbidden), `finalNext must NOT include "${forbidden}": that field is server-managed via a dedicated endpoint, not settings`).toBe(false);
+    }
+  });
+
+  // ── Cross-language drift guard (mp-9k3v) ────────────────────────────────
+  //
+  // The settings transform in handlers_competition.go merges the bound body
+  // onto disk with unconditional `current.X = comp.X` assignments. A field
+  // the PUT body omits therefore decodes to Go's ZERO VALUE and clobbers the
+  // stored value: that is one bug shape (mirror, teamMatchType, naginata all
+  // carry comments saying so). Engi added a second, worse shape: it is also
+  // guarded by `if started && comp.Engi != current.Engi { reject }`, so an
+  // omitted `engi` didn't merely clobber, it made EVERY settings save fail on
+  // a started competition with a message about a control the operator never
+  // touched.
+  //
+  // Rather than re-discovering that per field, pin the invariant directly:
+  // every field the Go transform copies unconditionally MUST appear in
+  // finalNext. This test reads both sides, so it fails the moment a new
+  // backend field is added without a matching round-trip.
+  it('every field the Go settings transform copies is round-tripped by finalNext', () => {
+    const goSrc = readFileSync(
+      resolve(__dirname, '..', '..', '..', 'internal', 'mobileapp', 'handlers_competition.go'),
+      'utf8'
+    );
+    // `current.<Field> = comp.<Field>` — the unconditional merge assignments.
+    const copied = new Set();
+    const re = /current\.([A-Za-z0-9_]+)\s*=\s*comp\.\1\b/g;
+    let m;
+    while ((m = re.exec(goSrc)) !== null) copied.add(m[1]);
+    expect(copied.size, 'parsed no `current.X = comp.X` assignments: the transform moved or was rewritten').toBeGreaterThan(10);
+
+    // Every json tag on state.Competition is lowerCamelCase(GoFieldName),
+    // verified against internal/state/models.go.
+    const jsonName = (s) => s.charAt(0).toLowerCase() + s.slice(1);
+
+    const jsSrc = readFileSync(
+      resolve(__dirname, '..', 'admin_competition_settings.jsx'),
+      'utf8'
+    );
+    const fnMatch = jsSrc.match(/const finalNext = \{([\s\S]*?)\n\s*\};/);
+    expect(fnMatch, 'expected `const finalNext = { ... };` in saveNow').not.toBeNull();
+    const keys = new Set();
+    for (const line of fnMatch[1].split('\n')) {
+      const k = line.match(/^\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/);
+      if (k) keys.add(k[1]);
+    }
+
+    for (const field of copied) {
+      const want = jsonName(field);
+      expect(
+        keys.has(want),
+        `handlers_competition.go copies current.${field} = comp.${field}, but finalNext omits "${want}". ` +
+        `An omitted field JSON-decodes to Go's zero value and clobbers the stored setting on every save ` +
+        `(and, if the field also has a started-state change guard, rejects the save outright). ` +
+        `Add "${want}" to finalNext (round-tripped from effective.${want}) and to ALLOWED above.`
+      ).toBe(true);
     }
   });
 

--- a/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
+++ b/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+
+// mp-94v0: ScoreEditorModal picks the engi flag editor purely from
+// `m.compEngi` (admin_scoring_individual.jsx: `const isEngi = !!m.compEngi`),
+// derived synchronously with NO fallback fetch of the competition config.
+// Any surface that builds its own match objects and hands them to a score
+// editor must therefore stamp compEngi, or an engi bout silently opens the
+// kendo ippon editor and the save is rejected by recordEngiMatch (0+0 flags).
+//
+// viewer_utils.jsx (the tournament/home path) stamped it; the COMPETITION-page
+// surfaces (viewer_competition.jsx, viewer_standings.jsx) did not, so the same
+// match routed correctly from the home page and incorrectly from its own
+// competition page.
+//
+// These tests drive the real click closures rather than grepping the source:
+// the reactive stub's createElement does not invoke function components, so a
+// child vnode still carries the exact onMatchClick closure the parent built.
+
+// Walk a vnode tree collecting every node matching a predicate.
+function findAll(node, pred, acc = []) {
+  if (node == null || typeof node !== 'object') return acc;
+  if (Array.isArray(node)) { node.forEach(k => findAll(k, pred, acc)); return acc; }
+  if (pred(node)) acc.push(node);
+  const kids = node.children || node.props?.children || [];
+  [].concat(kids).forEach(k => findAll(k, pred, acc));
+  return acc;
+}
+
+// The enrichment closures only. PoolsViewer forwards the RAW onMatchClick to
+// its LeagueMatrix child (pass-through), so filtering by identity against the
+// callback we supplied keeps just the `() => onMatchClick(enriched)` wrappers
+// the component built. Invoking the raw one would push undefined and mask a
+// genuine miss.
+const matchClickHandlers = (tree, raw) =>
+  findAll(tree, n => typeof n.props?.onMatchClick === 'function')
+    .map(n => n.props.onMatchClick)
+    .filter(h => h !== raw);
+
+const STUBBED = [
+  'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
+  'BracketTree', 'MatchCard', 'buildBracket', 'roundLabel', 'formatIpponsScore',
+  'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
+  'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
+  'matchStateCell', 'engiPairParts', 'bronzeUnderFinalStyle', 'API', 'LoadingSpinner',
+];
+
+function installStubs() {
+  global.window = global.window || {};
+  const saved = {};
+  STUBBED.forEach(k => {
+    saved[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+      ? { had: true, val: global.window[k] }
+      : { had: false };
+  });
+  global.window.StatusBadge = function StatusBadge() { return null; };
+  global.window.BracketTree = function BracketTree() { return null; };
+  global.window.MatchCard = function MatchCard() { return null; };
+  global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
+  global.window.formatDate = (d) => d || '';
+  global.window.formatLabel = (s) => s || '';
+  global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
+  global.window.buildBracket = () => [];
+  global.window.roundLabel = (i) => `Round ${i + 1}`;
+  global.window.formatIpponsScore = () => '';
+  global.window.teamIVScore = () => null;
+  global.window.matchScoreStr = () => '';
+  global.window.matchStateCell = () => '-';
+  global.window.ipponsFromScore = () => [];
+  global.window.isHikiwake = () => false;
+  global.window.hasBothSides = (m) => !!(m && m.sideA && m.sideB);
+  global.window.compareDmy = (a, b) => String(a).localeCompare(String(b));
+  global.window.queueLabel = () => '';
+  global.window.queueLabelCompact = () => null;
+  global.window.engiPairParts = (n) => String(n || '').split(' - ');
+  global.window.bronzeUnderFinalStyle = () => ({});
+  // LeagueStandingsViewer fetches standings on mount. The numbered match list
+  // under test is driven by the poolMatches prop, not this response, so an
+  // empty resolve is enough to get past the effect.
+  global.window.API = { leagueStandings: () => Promise.resolve([]) };
+  global.window.LoadingSpinner = function LoadingSpinner() { return null; };
+  return saved;
+}
+
+function restoreStubs(saved) {
+  STUBBED.forEach(k => {
+    if (saved[k]?.had) global.window[k] = saved[k].val;
+    else delete global.window[k];
+  });
+}
+
+// An engi pair is ONE participant whose two member names are joined by " - ".
+const engiPlayers = [
+  { id: 'p1', name: 'Aya Mori - Ken Sato', dojo: 'Dojo1' },
+  { id: 'p2', name: 'Rin Abe - Yu Ito', dojo: 'Dojo2' },
+];
+const poolMatch = {
+  id: 'Pool A-0',
+  poolName: 'Pool A',
+  sideA: { id: 'p1', name: 'Aya Mori - Ken Sato' },
+  sideB: { id: 'p2', name: 'Rin Abe - Yu Ito' },
+  status: 'scheduled',
+};
+
+describe('compEngi stamping on competition-page match objects (mp-94v0)', () => {
+  const realReact = global.React;
+  let runtime;
+  let saved;
+  let PoolsViewer, LeagueStandingsViewer, LeagueMatrix, ViewerCompetition;
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    saved = installStubs();
+    vi.resetModules();
+    ({ PoolsViewer, LeagueStandingsViewer, LeagueMatrix, ViewerCompetition } = await import('../viewer.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    restoreStubs(saved);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  // ── PoolsViewer: the Pools tab numbered match list ────────────────────────
+  describe('PoolsViewer (Pools tab)', () => {
+    const mount = (engi) => {
+      const captured = [];
+      const onMatchClick = (m) => captured.push(m);
+      const tree = runtime.mount(PoolsViewer, {
+        pools: [{ poolName: 'Pool A', players: engiPlayers }],
+        standings: {},
+        poolMatches: [poolMatch],
+        tweaks: { showDojo: false },
+        competition: { id: 'c1', name: 'Kata Open', kind: 'individual', teamSize: 0, format: 'mixed', engi },
+        onMatchClick,
+      });
+      return { tree, captured, onMatchClick };
+    };
+
+    it('stamps compEngi:true on a clicked pool match of an engi competition', () => {
+      const { tree, captured, onMatchClick } = mount(true);
+      const handlers = matchClickHandlers(tree, onMatchClick);
+      expect(handlers.length, 'expected at least one clickable pool match row').toBeGreaterThan(0);
+      handlers.forEach(h => h());
+      expect(captured.length).toBeGreaterThan(0);
+      captured.forEach(m => expect(m.compEngi, `match ${m.id} must carry compEngi`).toBe(true));
+    });
+
+    it('stamps compEngi:false for a non-engi competition (no false routing to the flag editor)', () => {
+      const { tree, captured, onMatchClick } = mount(false);
+      matchClickHandlers(tree, onMatchClick).forEach(h => h());
+      expect(captured.length).toBeGreaterThan(0);
+      captured.forEach(m => expect(m.compEngi).toBe(false));
+    });
+  });
+
+  // ── LeagueStandingsViewer: the League tab numbered match list ─────────────
+  describe('LeagueStandingsViewer (League tab)', () => {
+    it('stamps compEngi:true on a clicked league match of an engi competition', async () => {
+      const captured = [];
+      const onMatchClick = (m) => captured.push(m);
+      runtime.mount(LeagueStandingsViewer, {
+        competition: { id: 'c1', name: 'Kata Open', kind: 'individual', teamSize: 0, format: 'league', engi: true, players: engiPlayers },
+        poolMatches: [poolMatch],
+        tweaks: { showDojo: false },
+        onMatchClick,
+      });
+      // The standings fetch resolves in a microtask; until it does the
+      // component renders only the initial-load spinner.
+      await Promise.resolve();
+      await Promise.resolve();
+      const tree = runtime.currentTree();
+      const handlers = matchClickHandlers(tree, onMatchClick);
+      expect(handlers.length, 'expected at least one clickable league match row').toBeGreaterThan(0);
+      handlers.forEach(h => h());
+      expect(captured.length).toBeGreaterThan(0);
+      captured.forEach(m => expect(m.compEngi).toBe(true));
+    });
+  });
+
+  // ── LeagueMatrix: the cross-table cell click ──────────────────────────────
+  describe('LeagueMatrix (cross-table cell)', () => {
+    it('stamps compEngi on a cell-click match when isEngi is threaded in', () => {
+      const captured = [];
+      runtime.mount(LeagueMatrix, {
+        pool: { poolName: 'Pool A', players: engiPlayers },
+        matches: [poolMatch],
+        tweaks: { showDojo: false },
+        onMatchClick: (m) => captured.push(m),
+        isEngi: true,
+      });
+      // The matrix builds its enriched object in enrichMatch and fires it from
+      // handleCellClick; assert through the component's own contract rather
+      // than reaching into internals.
+      const tree = runtime.currentTree();
+      const cells = findAll(tree, n => typeof n.props?.onClick === 'function');
+      expect(cells.length, 'expected clickable matrix cells').toBeGreaterThan(0);
+      cells.forEach(c => c.props.onClick());
+      expect(captured.length, 'expected a cell click to surface a match').toBeGreaterThan(0);
+      captured.forEach(m => expect(m.compEngi).toBe(true));
+    });
+  });
+
+  // ── ViewerCompetition: the Bracket tab ────────────────────────────────────
+  describe('ViewerCompetition (Bracket tab)', () => {
+    const mkComp = (engi) => ({
+      id: 'c1',
+      name: 'Kata Open',
+      kind: 'individual',
+      teamSize: 0,
+      format: 'playoffs',
+      status: 'playoffs',
+      startTime: '09:00',
+      courts: ['A'],
+      players: engiPlayers,
+      engi,
+    });
+    const bracket = {
+      preview: false,
+      rounds: [[{ id: 'r0-m0', sideA: engiPlayers[0], sideB: engiPlayers[1], status: 'scheduled' }]],
+    };
+
+    it('stamps compEngi on a bracket match selected from the Bracket tab', () => {
+      const tree = runtime.mount(ViewerCompetition, {
+        tournament: { competitions: [mkComp(true)], mode: 'self-run' },
+        competition: mkComp(true),
+        pools: [],
+        poolMatches: [],
+        standings: [],
+        bracket,
+        onBack: () => {},
+        tweaks: {},
+        activeTab: 'bracket',
+      });
+      // BracketTree is stubbed, so its vnode still carries the click closure
+      // ViewerCompetition built.
+      const trees = findAll(tree, n => n.type === global.window.BracketTree && typeof n.props?.onMatchClick === 'function');
+      expect(trees.length, 'expected the Bracket tab to render a BracketTree with onMatchClick').toBeGreaterThan(0);
+      trees[0].props.onMatchClick(bracket.rounds[0][0], 0, 0, 1);
+      // The click sets selectedMatch, which is handed to MatchViewerModal as
+      // `match`. Find that vnode in the re-rendered tree.
+      const modals = findAll(runtime.currentTree(), n => n.props?.match?.id === 'r0-m0');
+      expect(modals.length, 'expected the selected match to reach a match modal').toBeGreaterThan(0);
+      expect(modals[0].props.match.compEngi).toBe(true);
+    });
+  });
+});

--- a/web-mobile/js/admin_competition_settings.jsx
+++ b/web-mobile/js/admin_competition_settings.jsx
@@ -131,7 +131,7 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       });
       return next;
     });
-  }, [c.id, c.name, c.date, c.startTime, c.poolSize, c.poolWinners, c.poolSizeMode, c.courts, c.roundRobin, c.withZekkenName, c.teamSize, c.numberPrefix, c.format, c.kind, c.mirror, c.status, c.poolFormat, c.poolMatchDurationSeconds, c.playoffMatchDurationSeconds, c.swissRounds, c.swissCurrentRound, c.naginata, c.checkInEnabled, c.leagueTiebreakTopN, c.leagueTwoThirdPlaces, c.teamMatchType]);
+  }, [c.id, c.name, c.date, c.startTime, c.poolSize, c.poolWinners, c.poolSizeMode, c.courts, c.roundRobin, c.withZekkenName, c.teamSize, c.numberPrefix, c.format, c.kind, c.mirror, c.status, c.poolFormat, c.poolMatchDurationSeconds, c.playoffMatchDurationSeconds, c.swissRounds, c.swissCurrentRound, c.naginata, c.engi, c.checkInEnabled, c.leagueTiebreakTopN, c.leagueTwoThirdPlaces, c.teamMatchType]);
 
   const saveNow = () => {
     // Build `effective` from the LATEST server-known state (cRef.current)
@@ -280,6 +280,16 @@ function AdminSettings({ c, tournament, onUpdate, onBack, password, showToast, o
       // value before the user types a valid replacement).
       swissRounds: safeInt(effective.swissRounds, latestC.swissRounds || 0),
       naginata: !!effective.naginata,
+      // Engi (flag-scoring kata pairs). Round-tripped for the same reason as
+      // `mirror` and `teamMatchType`: the backend transform unconditionally
+      // applies `current.Engi = comp.Engi`, so omitting the field JSON-encodes
+      // to false and either silently converts an engi competition to kendo
+      // ippon scoring (status=setup, where the change guard doesn't fire) or
+      // rejects EVERY settings save with "engi can only be changed before the
+      // competition starts" (draw-ready and later, where it does) — even
+      // though the operator never touched the control, which is disabled at
+      // those statuses.
+      engi: !!effective.engi,
       checkInEnabled: !!effective.checkInEnabled,
       // Phase 3b (mp-8rc9): league tie-breaker config. Only meaningful for
       // team-league competitions; safe to include for all formats because

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -48,7 +48,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
                 // so isTeam checks route it to the individual editor (mirrors
                 // enrichPoolMatchWithComp in admin_pools.jsx).
                 const isRepBout = isSupplementaryBout(m.id || "");
-                out.push({ ...m, phase: "pool", phaseName: p.poolName, poolName: p.poolName, compFormat: c.format, compId: c.id, compName: c.name, compKind: isRepBout ? "" : c.kind, teamSize: isRepBout ? 0 : c.teamSize, teamMatchType: isRepBout ? "" : compTMT });
+                out.push({ ...m, phase: "pool", phaseName: p.poolName, poolName: p.poolName, compFormat: c.format, compId: c.id, compName: c.name, compKind: isRepBout ? "" : c.kind, teamSize: isRepBout ? 0 : c.teamSize, compEngi: isRepBout ? false : isEngi, teamMatchType: isRepBout ? "" : compTMT });
             });
         });
     }
@@ -60,12 +60,14 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     // renders `bracket`/`derivedBracket` directly and is NOT affected.
     if (bracket && bracket.rounds && !bracket.preview) {
         bracket.rounds.forEach((round, ri) => {
-            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length), roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, teamMatchType: compTMT }));
+            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length), roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, compEngi: isEngi, teamMatchType: compTMT }));
         });
     }
     return out;
+    // isEngi (not c.engi) because that is the binding the memo closes over; it
+    // is a derived primitive, so it changes exactly when c.engi does.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [pools, poolMatches, bracket, c.id, c.name, c.kind, c.teamSize, c.format, c.teamMatchType, c.config?.teamMatchType]);
+  }, [pools, poolMatches, bracket, c.id, c.name, c.kind, c.teamSize, c.format, isEngi, c.teamMatchType, c.config?.teamMatchType]);
 
   // mp-xhaa: the schedule filter and bracket/pool highlight are driven by the
   // unified watchlist (resolved to flat players, so dojo entries expand to
@@ -344,7 +346,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
                       // (legacy mode where ri equals the backend index). Prefer it
                       // over the display-column index so lineup fetches use the right
                       // round when phantom leading rounds shift the display column.
-                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, roundIndex: m.roundIndex ?? ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, teamMatchType: teamMatchTypeFor(c) });
+                      setSelectedMatch({ ...m, phase: "bracket", round: label, phaseName: label, roundIndex: m.roundIndex ?? ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, compEngi: isEngi, teamMatchType: teamMatchTypeFor(c) });
                     }}
                   />
                   {derivedBracket.thirdPlaceMatch && (() => {
@@ -364,7 +366,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
                           showDojo={tweaks.showDojo ?? true}
                           highlighted={currentMatch?.id === bm.id}
                           highlightPlayers={highlightPlayers}
-                          onClick={() => setSelectedMatch({ ...bm, phase: "bracket", round: "3rd Place", phaseName: "3rd Place", roundIndex: derivedBracket.rounds.length, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, teamMatchType: teamMatchTypeFor(c) })}
+                          onClick={() => setSelectedMatch({ ...bm, phase: "bracket", round: "3rd Place", phaseName: "3rd Place", roundIndex: derivedBracket.rounds.length, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, compEngi: isEngi, teamMatchType: teamMatchTypeFor(c) })}
                         />
                       </div>
                     );

--- a/web-mobile/js/viewer_standings.jsx
+++ b/web-mobile/js/viewer_standings.jsx
@@ -324,7 +324,7 @@ export function LeagueStandingsViewer({ competition, poolMatches, tweaks, onMatc
               {(poolMatches || []).map((m, idx) => {
                 if (isTeam) {
                   const isRepBout = isSupplementaryBout(m.id || "");
-                  const enriched = { ...m, phase: "pool", poolName: m.poolName || "", phaseName: m.poolName || "", compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isRepBout ? "" : competition.kind, teamSize: isRepBout ? 0 : competition.teamSize, teamMatchType: isRepBout ? "" : compTMT };
+                  const enriched = { ...m, phase: "pool", poolName: m.poolName || "", phaseName: m.poolName || "", compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isRepBout ? "" : competition.kind, teamSize: isRepBout ? 0 : competition.teamSize, compEngi: isRepBout ? false : isEngi, teamMatchType: isRepBout ? "" : compTMT };
                   return (
                     <PoolNumberedMatchRow
                       key={m.id}
@@ -334,7 +334,7 @@ export function LeagueStandingsViewer({ competition, poolMatches, tweaks, onMatc
                     />
                   );
                 } else {
-                  const enriched = { ...m, phase: "pool", poolName: m.poolName || "", phaseName: m.poolName || "", compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0 };
+                  const enriched = { ...m, phase: "pool", poolName: m.poolName || "", phaseName: m.poolName || "", compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0, compEngi: isEngi };
                   return (
                     <PoolNumberedMatchRow
                       key={m.id}
@@ -391,7 +391,11 @@ PoolMatchRow.displayName = "PoolMatchRow";
 
 // Round-robin matrix for a single pool/league. Each off-diagonal cell shows the
 // row player's result (W/L/X) against the column player; diagonal cells are self.
-export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayers }) {
+// isEngi is threaded in as a prop (rather than read off a `competition` object,
+// which this component does not take) so a cell click can stamp compEngi on the
+// enriched match: ScoreEditorModal dispatches to the flag editor purely on
+// m.compEngi, with no fallback fetch of the competition config.
+export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPlayers, isEngi = false }) {
   const players = pool.players || [];
   if (players.length < 2) return null;
 
@@ -437,7 +441,7 @@ export function LeagueMatrix({ pool, matches, tweaks, onMatchClick, highlightPla
     return parts.length > 1 ? parts[0][0] + ". " + parts.slice(1).join(" ") : n;
   };
 
-  const enrichMatch = (m) => ({ ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: m.compFormat, compName: m.compName, compKind: "", teamSize: 0 });
+  const enrichMatch = (m) => ({ ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: m.compFormat, compName: m.compName, compKind: "", teamSize: 0, compEngi: isEngi });
 
   const handleCellClick = (m) => { if (onMatchClick) onMatchClick(enrichMatch(m)); };
 
@@ -817,7 +821,7 @@ export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition
                       // bout even in a team comp, so force compKind/teamSize to route
                       // it to the individual editor (matches enrichPoolMatchWithComp).
                       const isRepBout = isSupplementaryBout(m.id || "");
-                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isRepBout ? "" : competition.kind, teamSize: isRepBout ? 0 : competition.teamSize, teamMatchType: isRepBout ? "" : compTMT };
+                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isRepBout ? "" : competition.kind, teamSize: isRepBout ? 0 : competition.teamSize, compEngi: isRepBout ? false : isEngi, teamMatchType: isRepBout ? "" : compTMT };
                       return (
                         <PoolNumberedMatchRow
                           key={m.id}
@@ -828,7 +832,7 @@ export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition
                       );
                     } else {
                       // Individual or engi: delegates name/pair rendering to PoolNumberedMatchRow (isEngi passed through for name stacking)
-                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0 };
+                      const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0, compEngi: isEngi };
                       return (
                         <PoolNumberedMatchRow
                           key={m.id}
@@ -847,7 +851,7 @@ export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition
             {/* Round-robin matrix: optional grid below the match list (individual only) */}
             {matches.length > 0 && !isTeam && (
               <div style={{ marginTop: 4 }}>
-                <LeagueMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayers={highlightPlayers} />
+                <LeagueMatrix pool={pool} matches={matches} tweaks={tweaks} onMatchClick={onMatchClick} highlightPlayers={highlightPlayers} isEngi={isEngi} />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Two P1 engi defects with one shared root cause: `engi` was missed from the plumbing every sibling competition flag already goes through.

- **The Settings tab no longer destroys an engi competition.** The tab renders an "Engi (kata competition)" checkbox, but `engi` was absent from `saveNow`'s `finalNext` allowlist, so it never reached the PUT body. The backend merges unconditionally (`current.Engi = comp.Engi`), so the omitted field decoded to Go's zero value and split the damage in two:
  - **status=setup** — the change guard doesn't fire, so the flag was **silently cleared**. Saving an unrelated field (a name, a start time) converted an engi competition to kendo ippon scoring and mis-scored the entire division.
  - **draw-ready and later** — `started && comp.Engi != current.Engi` *did* fire, so **every** settings save was rejected with `engi can only be changed before the competition starts`, naming a control the operator never touched and which the UI disables at that status. The tab was unusable for the competition's whole life.
- **Matches opened from the competition page now open the flag editor.** `ScoreEditorModal` picks the engi editor purely from `m.compEngi`, derived synchronously with no fallback fetch. `viewer_utils.jsx` (the home/tournament path) stamped it; the competition-page surfaces built their own match objects and did not. The *same match* therefore routed correctly from the home page and to the kendo ippon editor from its own competition page, where the save then failed closed on a 0+0 flag total.
- `c.engi` was also missing from the settings sync-to-local `useEffect` deps, so an SSE-pushed engi change never reached the checkbox.

## Why

Both bugs are the same omission in two places. The codebase already treats this as a known hazard class: `mirror` and `teamMatchType` carry comments explaining that omitting them clobbers the stored value on every save, and `naginata` avoids the bug only because it is in the allowlist. Engi was missed from both the allowlist and the compEngi stamping convention.

**Allowlist audit** (requested explicitly on mp-9k3v): all **24** fields the Go settings transform copies unconditionally are now round-tripped. **`engi` was the only omission.** Rather than leave that as a one-time manual check, a new test parses `handlers_competition.go` and `finalNext` and pins the invariant across the language boundary, so the next backend field added without a round-trip fails the suite instead of silently clobbering on save.

**Recorded decision** (mp-94v0 flagged this as "related but separate, do not fix blind"): `admin_scoring_individual.jsx:515` forwarding neither `password` nor `selfReport` to `EngiScoreEditorModal` is **not** a second omission. That component's signature accepts neither prop. They gate the *team* editor's decision controls (kiken/fusenpai/daihyosen); the engi editor has none, so forwarding them would add dead props.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/admin_competition_settings.jsx` | Add `engi` to the `finalNext` PUT allowlist (round-tripped like `mirror`/`teamMatchType`); add `c.engi` to the sync-effect deps |
| `web-mobile/js/viewer_competition.jsx` | Stamp `compEngi` on pool + bracket enrichment, the bracket click and the bronze click; add `isEngi` to the `allMatches` memo deps |
| `web-mobile/js/viewer_standings.jsx` | Stamp `compEngi` in `LeagueStandingsViewer` and `PoolsViewer`; thread `isEngi` into `LeagueMatrix` so its cross-table cell click can stamp it |
| `web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx` | New: 5 behavioural render tests driving the real click closures on all four surfaces |
| `web-mobile/js/__tests__/admin_competition.test.jsx` | Add `engi` to `ALLOWED` + `EXPECTED_DEPS`; new cross-language test pinning Go transform ⊆ `finalNext` |

## Screenshots

**mp-94v0 — the flag editor now opens from the competition page.** Pools tab (left) and Bracket tab (right); both previously opened the kendo ippon editor.

![Flag editor from the Pools tab](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/engi-mp9k3v/engi-flag-editor-pools-tab.png)

![Flag editor from the Bracket tab](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/engi-mp9k3v/engi-flag-editor-bracket-tab.png)

A result saved end-to-end from the public self-run surface (1–2, Aka wins) — flag counts render as numbers, confirming engi scoring:

![Engi result saved](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/engi-mp9k3v/engi-result-saved.png)

**mp-9k3v Mode A** — competition renamed in Settings at status=setup; the Engi checkbox is still ticked afterwards (previously it silently cleared):

![Engi survives an unrelated settings save](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/engi-mp9k3v/modeA-engi-survives-save.png)

**mp-9k3v Mode B** — same edit at **draw-ready** (where the Engi control is disabled, "Locked after draw"). The save is accepted and the rename lands; previously it was rejected outright:

![Settings save accepted at draw-ready](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/engi-mp9k3v/modeB-save-succeeded.png)

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — all packages ≥85% coverage
- [x] `make js/test` (2337 passed) and `make js/lint` (oxlint `--deny-warnings`) pass
- [x] New/updated unit tests cover the change — **all 7 new-or-changed tests confirmed to fail with the production fix reverted** (`compEngi` undefined; `engi` missing from `finalNext`), so they genuinely pin both bugs rather than passing vacuously
- [x] Manual browser verification — see below
- [x] Screenshots added above
- [x] Docs updated under `docs/` — n/a, no user-facing feature/flag/command/behaviour change (both are bug fixes restoring documented behaviour)
- [x] No new console errors or warnings

### Manual browser verification

Self-run tournament, individual **engi** competitions, exercised through the UI (public surface for scoring, not the admin console):

- **Pools tab** (`LeagueMatrix` cross-table cell) → Report result → **flag editor** ("Enter flags (total must be 1, 3, or 5)", `A`/`S` add-flag keys, engi pair names stacked)
- **Overview "Up next" card** (the `allMatches` memo, a distinct code path) → **flag editor**
- **Bracket tab** on a knockout-only engi competition, real participants → **flag editor**
- Saved a result end-to-end: 2 Aka + 1 Shiro → "Total: 3, Aka wins" → persisted as `1–2 Final`
- **Mode A**: renamed the competition at status=setup → Engi checkbox still ticked. Independently corroborated: a later roster paste was rejected by the engi pair-name validator, which only runs when engi is still set
- **Mode B**: renamed at draw-ready with Engi disabled/locked → save accepted, no engi rejection. (The save *succeeding* is itself proof the PUT carried `engi: true` — had it sent `false`, the backend guard would have rejected it)

Closes mp-9k3v
Closes mp-94v0
