### PR TITLE
test(mp-yqxn.1): pin score-editor dispatch + cross-surface invariants as render tests

### DIFF
--- a/web-mobile/js/__tests__/render/admin_scoring_engi.render.test.jsx
+++ b/web-mobile/js/__tests__/render/admin_scoring_engi.render.test.jsx
@@ -246,3 +246,22 @@ describe('EngiScoreEditorModal correction footer (impeccable critique P1)', () =
     expect(screen.queryByTestId('engi-submit')).not.toBeNull();
   });
 });
+
+// mp-yqxn.1: naginata's Sune button belongs to the ippon editors ONLY. The
+// engi editor scores by flag counts and has NO ippon buttons at all, so there
+// is nothing for naginata to extend: pinned so a future shared-scoring-board
+// refactor cannot accidentally grow ippon affordances here. Engi never reads
+// the competition config (no fetch), so no naginata flag can reach it either.
+describe('mp-yqxn.1: engi editor has no ippon buttons and no Sune', () => {
+  it('renders flag counters but zero ippon buttons and no Sune affordance', () => {
+    const { container } = render(
+      <EngiScoreEditorModal match={makeMatch()} onClose={() => {}} onSubmit={() => {}} />
+    );
+    expect(container.querySelectorAll('.ipt-btn').length).toBe(0);
+    expect(screen.queryByText('Sune')).toBeNull();
+    expect(container.textContent).not.toContain('Sune');
+    // The flag counters ARE the scoring surface.
+    expect(screen.getByTestId('engi-shiro-inc')).toBeTruthy();
+    expect(screen.getByTestId('engi-aka-inc')).toBeTruthy();
+  });
+});

--- a/web-mobile/js/__tests__/render/admin_scoring_engi.render.test.jsx
+++ b/web-mobile/js/__tests__/render/admin_scoring_engi.render.test.jsx
@@ -258,7 +258,6 @@ describe('mp-yqxn.1: engi editor has no ippon buttons and no Sune', () => {
       <EngiScoreEditorModal match={makeMatch()} onClose={() => {}} onSubmit={() => {}} />
     );
     expect(container.querySelectorAll('.ipt-btn').length).toBe(0);
-    expect(screen.queryByText('Sune')).toBeNull();
     expect(container.textContent).not.toContain('Sune');
     // The flag counters ARE the scoring surface.
     expect(screen.getByTestId('engi-shiro-inc')).toBeTruthy();

--- a/web-mobile/js/__tests__/render/admin_shiaijo.render.test.jsx
+++ b/web-mobile/js/__tests__/render/admin_shiaijo.render.test.jsx
@@ -20,7 +20,6 @@ const STUBBED_GLOBALS = {
   // LAZY: only called in event handlers or guarded effects
   filterMatchesByCourt: (matches, _court) => matches,
   tournamentMatches: () => [],
-  filterMatchesByPhase: (matches) => matches,
   API: {
     fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
     sendAnnouncement: vi.fn(),

--- a/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
@@ -14,7 +14,11 @@
 import React from 'react';
 import { render, act, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
+import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
+
+// Expected button-letter sets, built once (compared per cell with Set toEqual).
+const KENDO_SET = new Set(KENDO_LETTERS);
+const NAGINATA_SET = new Set(NAGINATA_LETTERS);
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -121,9 +125,7 @@ describe('individual ScoreEditorModal config matrix (running match, admin surfac
     const letters = new Set(
       [...container.querySelectorAll('.ipt-btn')].map(b => b.textContent)
     );
-    expect([...letters].sort()).toEqual(
-      [...(cell.naginata ? NAGINATA_LETTERS : KENDO_LETTERS)].sort()
-    );
+    expect(letters).toEqual(cell.naginata ? NAGINATA_SET : KENDO_SET);
 
     // Hikiwake: the draw button is DISABLED for knockout matches (no draws in
     // elimination — decide by hantei after encho) and enabled for pool-shaped
@@ -148,22 +150,20 @@ describe('individual ScoreEditorModal config matrix (running match, admin surfac
 });
 
 describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
-  it('playoffs × phase "pool": product-impossible; the editor trusts the stamp and ALLOWS a draw', async () => {
-    // Playoffs generates no pool matches. Pinned: the individual editor's
-    // knockout check is phase-only, so a playoffs match mis-stamped "pool"
-    // could be recorded as a hikiwake — which knockout advancement cannot
-    // consume. Ruled on by mp-yqxn.2.
-    await renderCell({ format: 'playoffs', phase: 'pool', naginata: false, maxEncho: 0 });
-    expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(false);
-  });
-
-  it.each([['league'], ['swiss']])(
-    '%s × phase "bracket": product-impossible; the phase stamp alone blocks the draw',
-    async (format) => {
-      // League/swiss produce no bracket matches; pinned for symmetry with the
-      // team-editor matrix. Ruled on by mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
-      await renderCell({ format, phase: 'bracket', naginata: false, maxEncho: 0 });
-      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(true);
+  // IMPOSSIBLE_FORMAT_PHASES is the derived complement of FORMAT_PHASES, so a
+  // format added to the axes module automatically extends this block. Pinned:
+  // the individual editor's knockout check is phase-only.
+  //   playoffs × pool      → draw ALLOWED: a mis-stamped playoffs match could
+  //                          record a hikiwake, which knockout advancement
+  //                          cannot consume. Ruled on by mp-yqxn.2.
+  //   league|swiss × bracket → draw blocked by the phase stamp alone; pinned
+  //                          for symmetry with the team matrix. Ruled on by
+  //                          mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
+  it.each(IMPOSSIBLE_FORMAT_PHASES.map(fp => [`${fp.format} × phase "${fp.phase}"`, fp]))(
+    '%s: product-impossible; the phase stamp alone decides the draw gate',
+    async (_name, fp) => {
+      await renderCell({ ...fp, naginata: false, maxEncho: 0 });
+      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(fp.phase === 'bracket');
     }
   );
 });

--- a/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
@@ -14,6 +14,7 @@
 import React from 'react';
 import { render, act, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -56,16 +57,8 @@ afterAll(() => {
   }
 });
 
-const FORMAT_PHASES = [
-  { format: 'playoffs', phase: 'bracket' },
-  { format: 'mixed', phase: 'pool' },
-  { format: 'mixed', phase: 'bracket' },
-  { format: 'league', phase: 'pool' },
-  { format: 'swiss', phase: 'pool' },
-];
-const NAGINATA = [false, true];
-const MAX_ENCHO = [0, 2];
-
+// Shared axes + letter tables live in score_editor_matrix_axes.js (kept in
+// lockstep with the team-editor matrix).
 const CELLS = FORMAT_PHASES.flatMap(fp =>
   NAGINATA.flatMap(naginata =>
     MAX_ENCHO.map(maxEncho => ({ ...fp, naginata, maxEncho }))
@@ -117,9 +110,6 @@ async function renderCell(cell, matchOverrides = {}, props = {}) {
   });
   return utils;
 }
-
-const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
-const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];
 
 describe('individual ScoreEditorModal config matrix (running match, admin surface)', () => {
   it.each(CELLS.map(c => [cellName(c), c]))('%s', async (_name, cell) => {

--- a/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
@@ -1,0 +1,198 @@
+// mp-yqxn.1: individual (kendo) ScoreEditorModal config matrix — the same
+// matrix applied to the team editor, minus the axes that don't exist for
+// individuals (teamSize, teamMatchType):
+//   {format(+phase)} × {naginata: on, off} × {maxEnchoPeriods: 0, 2}
+//
+// Config reaches the individual editor ONLY via the async competition fetch
+// (window.API.fetchCompetitionDetails → naginata + maxEnchoPeriods); the
+// format/phase axes ride on the match stamps.
+//
+// REGRESSION-PIN ONLY (epic mp-yqxn constraint): DOM assertions prove nothing
+// about rendering, friction, or legibility under time pressure. Judgement
+// calls belong to the browser-review children named in the comments.
+
+import React from 'react';
+import { render, act, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+const STUBBED_GLOBALS = {
+  isHikiwake: (_type) => false,
+  arraysEqual: (a, b) => a.length === b.length && a.every((v, i) => v === b[i]),
+  isKikenDecision: (_kind) => false,
+  isTextEntry: () => false,
+  isInteractiveTarget: () => false,
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  resolveRoundIndex: () => 0,
+  API: {
+    fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
+    recordScore: vi.fn().mockResolvedValue(undefined),
+    recordDaihyosen: vi.fn(),
+    removeDaihyosen: vi.fn(),
+    putMatchLineup: vi.fn(),
+    recordDecision: vi.fn(),
+  },
+  AdminLineupHelpers: { rosterFor: vi.fn().mockReturnValue([]) },
+  compMatches: () => [],
+  Term: ({ children }) => <span>{children}</span>,
+  GlossaryHint: ({ name }) => <span title={name} />,
+};
+
+const originals = {};
+let ScoreEditorModal;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  await import('../../admin_scoring_modal.jsx');
+  ScoreEditorModal = window.ScoreEditorModal;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+const FORMAT_PHASES = [
+  { format: 'playoffs', phase: 'bracket' },
+  { format: 'mixed', phase: 'pool' },
+  { format: 'mixed', phase: 'bracket' },
+  { format: 'league', phase: 'pool' },
+  { format: 'swiss', phase: 'pool' },
+];
+const NAGINATA = [false, true];
+const MAX_ENCHO = [0, 2];
+
+const CELLS = FORMAT_PHASES.flatMap(fp =>
+  NAGINATA.flatMap(naginata =>
+    MAX_ENCHO.map(maxEncho => ({ ...fp, naginata, maxEncho }))
+  )
+);
+
+function cellName(c) {
+  return `${c.format}/${c.phase} naginata=${c.naginata} maxEncho=${c.maxEncho}`;
+}
+
+function makeMatch(cell, overrides = {}) {
+  return {
+    id: 'm1',
+    compId: 'comp1',
+    status: 'running',
+    phase: cell.phase,
+    court: 'A',
+    compFormat: cell.format,
+    ...(cell.phase === 'pool'
+      ? { poolName: 'Pool 1' }
+      : { round: 'Semi-final', matchNumber: 1 }),
+    sideA: { id: 'p1', name: 'Yamada' },
+    sideB: { id: 'p2', name: 'Tanaka' },
+    ...overrides,
+  };
+}
+
+async function renderCell(cell, matchOverrides = {}, props = {}) {
+  window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({
+    id: 'comp1',
+    config: {
+      format: cell.format,
+      naginata: cell.naginata,
+      maxEnchoPeriods: cell.maxEncho,
+      players: [],
+    },
+  });
+  let utils;
+  await act(async () => {
+    utils = render(
+      <ScoreEditorModal
+        match={makeMatch(cell, matchOverrides)}
+        onClose={vi.fn()}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        password=""
+        {...props}
+      />
+    );
+  });
+  return utils;
+}
+
+const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
+const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];
+
+describe('individual ScoreEditorModal config matrix (running match, admin surface)', () => {
+  it.each(CELLS.map(c => [cellName(c), c]))('%s', async (_name, cell) => {
+    const { container } = await renderCell(cell);
+
+    // Sune: the ippon buttons gain "S" ONLY for naginata competitions
+    // (config fetch → getIpponButtons(isNaginata)). Two button strips render
+    // (one per side), so compare the SET of letters.
+    const letters = new Set(
+      [...container.querySelectorAll('.ipt-btn')].map(b => b.textContent)
+    );
+    expect([...letters].sort()).toEqual(
+      [...(cell.naginata ? NAGINATA_LETTERS : KENDO_LETTERS)].sort()
+    );
+
+    // Hikiwake: the draw button is DISABLED for knockout matches (no draws in
+    // elimination — decide by hantei after encho) and enabled for pool-shaped
+    // matches. The individual editor derives knockout from m.phase ALONE
+    // (isKnockoutPhase = phase === "bracket"): unlike the team editor there is
+    // no compFormat fallback clause. Pinned; ruled on by mp-yqxn.2.
+    const drawBtn = screen.getByTestId('scoring-modal-mark-draw');
+    expect(drawBtn.disabled).toBe(cell.phase === 'bracket');
+
+    // Encho affordance: collapsed pill, always present on a running match.
+    expect(screen.queryByTestId('scoring-modal-encho-pill')).not.toBeNull();
+
+    // Hantei row: surfaces whenever the scoreline is TIED (a fresh 0–0 is
+    // tied), in every phase — hantei is not knockout-gated here.
+    expect(screen.queryByTestId('scoring-modal-hantei-row')).not.toBeNull();
+
+    // Admin decision controls (kiken/fusenpai).
+    expect(screen.queryByTestId('scoring-modal-kiken-voluntary-button')).not.toBeNull();
+    expect(screen.queryByTestId('scoring-modal-kiken-injury-button')).not.toBeNull();
+    expect(screen.queryByTestId('scoring-modal-fusenpai-button')).not.toBeNull();
+  });
+});
+
+describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
+  it('playoffs × phase "pool": product-impossible; the editor trusts the stamp and ALLOWS a draw', async () => {
+    // Playoffs generates no pool matches. Pinned: the individual editor's
+    // knockout check is phase-only, so a playoffs match mis-stamped "pool"
+    // could be recorded as a hikiwake — which knockout advancement cannot
+    // consume. Ruled on by mp-yqxn.2.
+    await renderCell({ format: 'playoffs', phase: 'pool', naginata: false, maxEncho: 0 });
+    expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(false);
+  });
+
+  it.each([['league'], ['swiss']])(
+    '%s × phase "bracket": product-impossible; the phase stamp alone blocks the draw',
+    async (format) => {
+      // League/swiss produce no bracket matches; pinned for symmetry with the
+      // team-editor matrix. Ruled on by mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
+      await renderCell({ format, phase: 'bracket', naginata: false, maxEncho: 0 });
+      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(true);
+    }
+  );
+});
+
+describe('individual editor selfReport (public self-run surface)', () => {
+  it('selfReport hides the kiken/fusenpai controls but KEEPS the hantei row on a tied scoreline', async () => {
+    // Pinned CURRENT behaviour: the hantei affordance has its own
+    // tied-scoreline condition and deliberately still surfaces in self-report
+    // mode, while the admin-only withdrawal controls hide. Whether the public
+    // self-run surface should be able to record a judges' decision is ruled
+    // on by mp-yqxn.5.
+    await renderCell(
+      { format: 'mixed', phase: 'pool', naginata: false, maxEncho: 0 },
+      {},
+      { selfReport: true }
+    );
+    expect(screen.queryByTestId('scoring-modal-kiken-voluntary-button')).toBeNull();
+    expect(screen.queryByTestId('scoring-modal-kiken-injury-button')).toBeNull();
+    expect(screen.queryByTestId('scoring-modal-fusenpai-button')).toBeNull();
+    expect(screen.queryByTestId('scoring-modal-hantei-row')).not.toBeNull();
+  });
+});

--- a/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { render, act, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_SET, NAGINATA_SET } from './score_editor_matrix_axes.js';
+import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, cellKey, NAGINATA, MAX_ENCHO, KENDO_SET, NAGINATA_SET } from './score_editor_matrix_axes.js';
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -165,7 +165,7 @@ describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
   // this 1:1 check by name.
   it('expectation map stays 1:1 with the derived impossible-cell list', () => {
     expect(Object.keys(IMPOSSIBLE_EXPECT_DRAW_DISABLED).sort()).toEqual(
-      IMPOSSIBLE_FORMAT_PHASES.map(fp => `${fp.format}/${fp.phase}`).sort()
+      IMPOSSIBLE_FORMAT_PHASES.map(cellKey).sort()
     );
   });
 
@@ -173,7 +173,7 @@ describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
     '%s: product-impossible; the phase stamp alone decides the draw gate',
     async (_name, fp) => {
       await renderCell({ ...fp, naginata: false, maxEncho: 0 });
-      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(IMPOSSIBLE_EXPECT_DRAW_DISABLED[`${fp.format}/${fp.phase}`]);
+      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(IMPOSSIBLE_EXPECT_DRAW_DISABLED[cellKey(fp)]);
     }
   );
 });

--- a/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
@@ -146,11 +146,9 @@ describe('individual ScoreEditorModal config matrix (running match, admin surfac
 });
 
 describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
-  // The cell LIST is derived (axes module complement); the EXPECTATIONS are
-  // explicit and independent, mirroring the team suite's map (its knockout
-  // gate has a format clause this editor lacks, so a shared derived
-  // expectation cannot exist). A newly-derived cell with no map entry fails
-  // loudly here until its expectation is pinned deliberately. Pinned:
+  // Expectations are pinned explicitly, mirroring the team suite's map (its
+  // knockout gate has a format clause this editor lacks, so a shared derived
+  // expectation cannot exist). Pinned:
   //   playoffs × pool      → draw ALLOWED: a mis-stamped playoffs match could
   //                          record a hikiwake, which knockout advancement
   //                          cannot consume. Ruled on by mp-yqxn.2.
@@ -161,13 +159,21 @@ describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
     'league/bracket': true,
     'swiss/bracket': true,
   };
+
+  // Both directions at once: a newly-derived cell with no pinned expectation
+  // AND a stale expectation for a cell that became product-possible each fail
+  // this 1:1 check by name.
+  it('expectation map stays 1:1 with the derived impossible-cell list', () => {
+    expect(Object.keys(IMPOSSIBLE_EXPECT_DRAW_DISABLED).sort()).toEqual(
+      IMPOSSIBLE_FORMAT_PHASES.map(fp => `${fp.format}/${fp.phase}`).sort()
+    );
+  });
+
   it.each(IMPOSSIBLE_FORMAT_PHASES.map(fp => [`${fp.format} × phase "${fp.phase}"`, fp]))(
     '%s: product-impossible; the phase stamp alone decides the draw gate',
     async (_name, fp) => {
-      const key = `${fp.format}/${fp.phase}`;
-      expect(IMPOSSIBLE_EXPECT_DRAW_DISABLED, `no pinned expectation for new impossible cell ${key}`).toHaveProperty(key);
       await renderCell({ ...fp, naginata: false, maxEncho: 0 });
-      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(IMPOSSIBLE_EXPECT_DRAW_DISABLED[key]);
+      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(IMPOSSIBLE_EXPECT_DRAW_DISABLED[`${fp.format}/${fp.phase}`]);
     }
   );
 });

--- a/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx
@@ -14,11 +14,7 @@
 import React from 'react';
 import { render, act, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
-
-// Expected button-letter sets, built once (compared per cell with Set toEqual).
-const KENDO_SET = new Set(KENDO_LETTERS);
-const NAGINATA_SET = new Set(NAGINATA_LETTERS);
+import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_SET, NAGINATA_SET } from './score_editor_matrix_axes.js';
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -150,20 +146,28 @@ describe('individual ScoreEditorModal config matrix (running match, admin surfac
 });
 
 describe('individual editor IMPOSSIBLE CELLS (asserted, not skipped)', () => {
-  // IMPOSSIBLE_FORMAT_PHASES is the derived complement of FORMAT_PHASES, so a
-  // format added to the axes module automatically extends this block. Pinned:
-  // the individual editor's knockout check is phase-only.
+  // The cell LIST is derived (axes module complement); the EXPECTATIONS are
+  // explicit and independent, mirroring the team suite's map (its knockout
+  // gate has a format clause this editor lacks, so a shared derived
+  // expectation cannot exist). A newly-derived cell with no map entry fails
+  // loudly here until its expectation is pinned deliberately. Pinned:
   //   playoffs × pool      → draw ALLOWED: a mis-stamped playoffs match could
   //                          record a hikiwake, which knockout advancement
   //                          cannot consume. Ruled on by mp-yqxn.2.
-  //   league|swiss × bracket → draw blocked by the phase stamp alone; pinned
-  //                          for symmetry with the team matrix. Ruled on by
-  //                          mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
+  //   league|swiss × bracket → draw blocked by the phase stamp alone. Ruled on
+  //                          by mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
+  const IMPOSSIBLE_EXPECT_DRAW_DISABLED = {
+    'playoffs/pool': false,
+    'league/bracket': true,
+    'swiss/bracket': true,
+  };
   it.each(IMPOSSIBLE_FORMAT_PHASES.map(fp => [`${fp.format} × phase "${fp.phase}"`, fp]))(
     '%s: product-impossible; the phase stamp alone decides the draw gate',
     async (_name, fp) => {
+      const key = `${fp.format}/${fp.phase}`;
+      expect(IMPOSSIBLE_EXPECT_DRAW_DISABLED, `no pinned expectation for new impossible cell ${key}`).toHaveProperty(key);
       await renderCell({ ...fp, naginata: false, maxEncho: 0 });
-      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(fp.phase === 'bracket');
+      expect(screen.getByTestId('scoring-modal-mark-draw').disabled).toBe(IMPOSSIBLE_EXPECT_DRAW_DISABLED[key]);
     }
   );
 });

--- a/web-mobile/js/__tests__/render/score_editor_dispatch.render.test.jsx
+++ b/web-mobile/js/__tests__/render/score_editor_dispatch.render.test.jsx
@@ -208,22 +208,22 @@ describe('ScoreEditorModal dispatch: which branch renders', () => {
 });
 
 describe('ScoreEditorModal dispatch: forwarded props per branch', () => {
+  // Props BOTH non-default branches must forward identically. The three
+  // admin/self-run props (password, selfReport, onAfterDecision) are asserted
+  // per branch below because the branches deliberately DIFFER on them.
+  const FORWARDED_TO_BOTH = [
+    'onClose', 'onSubmit', 'onSubmitAndNext', 'prevMatch', 'nextMatch',
+    'onPrev', 'onNext', 'variant', 'canClose',
+  ];
+
   it('team branch forwards the FULL bag including password, selfReport and onAfterDecision', () => {
     const bag = fullPropBag();
     render(<ScoreEditorModal match={makeMatch({ compKind: 'team', teamSize: 5 })} {...bag} />);
     const p = probes.team.props;
-    expect(p.onClose).toBe(bag.onClose);
-    expect(p.onSubmit).toBe(bag.onSubmit);
-    expect(p.onSubmitAndNext).toBe(bag.onSubmitAndNext);
-    expect(p.onAfterDecision).toBe(bag.onAfterDecision);
-    expect(p.prevMatch).toBe(bag.prevMatch);
-    expect(p.nextMatch).toBe(bag.nextMatch);
-    expect(p.onPrev).toBe(bag.onPrev);
-    expect(p.onNext).toBe(bag.onNext);
+    for (const k of FORWARDED_TO_BOTH) expect(p[k], k).toBe(bag[k]);
     expect(p.password).toBe('pw');
     expect(p.selfReport).toBe(true);
-    expect(p.variant).toBe('inline');
-    expect(p.canClose).toBe(false);
+    expect(p.onAfterDecision).toBe(bag.onAfterDecision);
   });
 
   it('engi branch forwards navigation but DROPS password, selfReport and onAfterDecision', () => {
@@ -238,15 +238,7 @@ describe('ScoreEditorModal dispatch: forwarded props per branch', () => {
     const bag = fullPropBag();
     render(<ScoreEditorModal match={makeMatch({ compEngi: true })} {...bag} />);
     const p = probes.engi.props;
-    expect(p.onClose).toBe(bag.onClose);
-    expect(p.onSubmit).toBe(bag.onSubmit);
-    expect(p.onSubmitAndNext).toBe(bag.onSubmitAndNext);
-    expect(p.prevMatch).toBe(bag.prevMatch);
-    expect(p.nextMatch).toBe(bag.nextMatch);
-    expect(p.onPrev).toBe(bag.onPrev);
-    expect(p.onNext).toBe(bag.onNext);
-    expect(p.variant).toBe('inline');
-    expect(p.canClose).toBe(false);
+    for (const k of FORWARDED_TO_BOTH) expect(p[k], k).toBe(bag[k]);
     // The three dropped props:
     expect(p.password).toBeUndefined();
     expect(p.selfReport).toBeUndefined();

--- a/web-mobile/js/__tests__/render/score_editor_dispatch.render.test.jsx
+++ b/web-mobile/js/__tests__/render/score_editor_dispatch.render.test.jsx
@@ -1,0 +1,255 @@
+// mp-yqxn.1: pin the ScoreEditorModal DISPATCH (admin_scoring_individual.jsx).
+//
+// window.ScoreEditorModal is a dispatcher with THREE terminal branches:
+//   m.compEngi truthy                      → EngiScoreEditorModal
+//   m.compKind === "team" || m.teamSize>0  → TeamScoreEditorModal
+//   else                                   → the individual kendo editor
+//
+// These tests pin, for a given match shape, WHICH branch renders and WHICH
+// props the dispatcher forwards to it. This is the cheapest guard against the
+// class of bug already found twice here: a missing compEngi stamp routing an
+// engi match to the ippon editor (mp-9k3v and its predecessor).
+//
+// REGRESSION-PIN ONLY (epic mp-yqxn constraint): these DOM assertions prove
+// nothing about rendering, friction, or legibility. Every judgement call is
+// owned by a browser-review child of mp-yqxn; where a pinned behaviour is
+// probably wrong, the comment names the child that rules on it.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+
+// Prop-recording probes for the two non-default branches. vi.mock factories
+// are hoisted, so the recorders live in vi.hoisted state. The factory spreads
+// importOriginal(): admin_scoring_modal.jsx also re-exports the team module's
+// named helpers (teamResultLabel, isKoTieBlocked, ...) and those must keep
+// resolving to the real implementations.
+const probes = vi.hoisted(() => ({
+  team: { props: null },
+  engi: { props: null },
+}));
+
+vi.mock('../../admin_scoring_team.jsx', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    TeamScoreEditorModal: (props) => {
+      probes.team.props = props;
+      return React.createElement('div', { 'data-testid': 'probe-team-editor' });
+    },
+  };
+});
+
+vi.mock('../../admin_scoring_engi.jsx', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    EngiScoreEditorModal: (props) => {
+      probes.engi.props = props;
+      return React.createElement('div', { 'data-testid': 'probe-engi-editor' });
+    },
+  };
+});
+
+// Window globals required by admin_scoring_modal.jsx and its transitive
+// imports (same set as admin_scoring_modal.render.test.jsx).
+const STUBBED_GLOBALS = {
+  isHikiwake: (_type) => false,
+  arraysEqual: (a, b) => a.length === b.length && a.every((v, i) => v === b[i]),
+  isKikenDecision: (_kind) => false,
+  isTextEntry: () => false,
+  isInteractiveTarget: () => false,
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  resolveRoundIndex: () => 0,
+  API: {
+    fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
+    recordScore: vi.fn(),
+    recordDaihyosen: vi.fn(),
+    removeDaihyosen: vi.fn(),
+    putMatchLineup: vi.fn(),
+    recordDecision: vi.fn(),
+  },
+  AdminLineupHelpers: { rosterFor: vi.fn().mockReturnValue([]) },
+  compMatches: () => [],
+  Term: ({ children }) => <span>{children}</span>,
+  GlossaryHint: ({ name }) => <span title={name} />,
+};
+
+const originals = {};
+let ScoreEditorModal;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  await import('../../admin_scoring_modal.jsx');
+  ScoreEditorModal = window.ScoreEditorModal;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+beforeEach(() => {
+  probes.team.props = null;
+  probes.engi.props = null;
+});
+
+// Base match: no compId so the config-fetch effect returns early.
+function makeMatch(overrides = {}) {
+  return {
+    id: 'm1',
+    status: 'running',
+    phase: 'pool',
+    poolName: 'Pool 1',
+    court: 'A',
+    sideA: { id: 'p1', name: 'Yamada' },
+    sideB: { id: 'p2', name: 'Tanaka' },
+    ...overrides,
+  };
+}
+
+// The full prop bag a mount site could wire. Forwarding gaps show up as
+// undefined on the receiving probe.
+function fullPropBag() {
+  return {
+    onClose: vi.fn(),
+    onSubmit: vi.fn(),
+    onSubmitAndNext: vi.fn(),
+    onAfterDecision: vi.fn(),
+    prevMatch: { id: 'pm' },
+    nextMatch: { id: 'nm' },
+    onPrev: vi.fn(),
+    onNext: vi.fn(),
+    password: 'pw',
+    selfReport: true,
+    variant: 'inline',
+    canClose: false,
+  };
+}
+
+function renderDispatch(match, props = {}) {
+  return render(<ScoreEditorModal match={match} onClose={vi.fn()} onSubmit={vi.fn()} password="" {...props} />);
+}
+
+describe('ScoreEditorModal dispatch: which branch renders', () => {
+  it('compEngi: true routes to the engi editor', () => {
+    renderDispatch(makeMatch({ compEngi: true }));
+    expect(screen.getByTestId('probe-engi-editor')).toBeTruthy();
+    expect(probes.team.props).toBeNull();
+  });
+
+  it('compEngi UNDEFINED (missing stamp — the real-world failure shape) routes an engi pair to the INDIVIDUAL ippon editor', () => {
+    // This is the bug class found twice (mp-9k3v): a surface that forgets to
+    // stamp compEngi sends a flag-scored engi pair to the ippon editor. The
+    // dispatcher cannot recover a missing stamp; this pins that reality so
+    // any new enrichment path that forgets the stamp fails visibly here
+    // once someone strengthens the dispatch. Ruled on by mp-yqxn.6.
+    const pairMatch = makeMatch({
+      sideA: { id: 'p1', name: 'Aka One - Aka Two' },
+      sideB: { id: 'p2', name: 'Shiro One - Shiro Two' },
+    });
+    expect('compEngi' in pairMatch).toBe(false);
+    renderDispatch(pairMatch);
+    expect(screen.queryByTestId('probe-engi-editor')).toBeNull();
+    expect(screen.queryByTestId('probe-team-editor')).toBeNull();
+    // Individual editor landmark: the modal root plus ippon buttons.
+    expect(screen.getByTestId('scoring-modal-root')).toBeTruthy();
+  });
+
+  it('compEngi: false routes to the individual editor', () => {
+    renderDispatch(makeMatch({ compEngi: false }));
+    expect(screen.queryByTestId('probe-engi-editor')).toBeNull();
+    expect(screen.getByTestId('scoring-modal-root')).toBeTruthy();
+  });
+
+  it('compKind: "team" routes to the team editor', () => {
+    renderDispatch(makeMatch({ compKind: 'team', teamSize: 5, sideA: { id: 't1', name: 'Team A' }, sideB: { id: 't2', name: 'Team B' } }));
+    expect(screen.getByTestId('probe-team-editor')).toBeTruthy();
+    expect(probes.engi.props).toBeNull();
+  });
+
+  it('teamSize > 0 alone (compKind empty) still routes to the team editor', () => {
+    // A team competition created with only teamSize set must not fall through
+    // to the individual editor (dispatch comment, admin_scoring_individual.jsx).
+    renderDispatch(makeMatch({ teamSize: 3, sideA: { id: 't1', name: 'Team A' }, sideB: { id: 't2', name: 'Team B' } }));
+    expect(screen.getByTestId('probe-team-editor')).toBeTruthy();
+  });
+
+  it('compKind: "team" with teamSize 0 routes to the team editor (defaults to 5 positions)', () => {
+    renderDispatch(makeMatch({ compKind: 'team', teamSize: 0, sideA: { id: 't1', name: 'Team A' }, sideB: { id: 't2', name: 'Team B' } }));
+    expect(screen.getByTestId('probe-team-editor')).toBeTruthy();
+    expect(probes.team.props.teamSize).toBe(5);
+  });
+
+  it('IMPOSSIBLE CELL — compEngi + team markers: engi wins (engi is checked first)', () => {
+    // engi+team is rejected at creation and settings-PUT time
+    // (handlers_competition.go: "engi is only valid for individual
+    // competitions, not team"), so this state cannot be produced by the
+    // product. Asserted rather than skipped: if it ever leaks in via legacy
+    // data or a missed validation, the dispatch routes to the ENGI editor,
+    // matching the server's "engi is never a team" rule.
+    renderDispatch(makeMatch({ compEngi: true, compKind: 'team', teamSize: 5 }));
+    expect(screen.getByTestId('probe-engi-editor')).toBeTruthy();
+    expect(probes.team.props).toBeNull();
+  });
+
+  it('pool-daihyosen rep rows (compKind "", teamSize 0) route to the individual editor', () => {
+    // viewer_utils.compMatches forces compKind="" AND teamSize=0 on rep bouts
+    // so a team competition's tiebreaker bout is scored as ONE individual bout.
+    renderDispatch(makeMatch({ compKind: '', teamSize: 0 }));
+    expect(screen.queryByTestId('probe-team-editor')).toBeNull();
+    expect(screen.getByTestId('scoring-modal-root')).toBeTruthy();
+  });
+});
+
+describe('ScoreEditorModal dispatch: forwarded props per branch', () => {
+  it('team branch forwards the FULL bag including password, selfReport and onAfterDecision', () => {
+    const bag = fullPropBag();
+    render(<ScoreEditorModal match={makeMatch({ compKind: 'team', teamSize: 5 })} {...bag} />);
+    const p = probes.team.props;
+    expect(p.onClose).toBe(bag.onClose);
+    expect(p.onSubmit).toBe(bag.onSubmit);
+    expect(p.onSubmitAndNext).toBe(bag.onSubmitAndNext);
+    expect(p.onAfterDecision).toBe(bag.onAfterDecision);
+    expect(p.prevMatch).toBe(bag.prevMatch);
+    expect(p.nextMatch).toBe(bag.nextMatch);
+    expect(p.onPrev).toBe(bag.onPrev);
+    expect(p.onNext).toBe(bag.onNext);
+    expect(p.password).toBe('pw');
+    expect(p.selfReport).toBe(true);
+    expect(p.variant).toBe('inline');
+    expect(p.canClose).toBe(false);
+  });
+
+  it('engi branch forwards navigation but DROPS password, selfReport and onAfterDecision', () => {
+    // CURRENT behaviour, pinned: the engi branch forwards neither password
+    // nor selfReport nor onAfterDecision (admin_scoring_individual.jsx).
+    // Consequences: the engi editor cannot distinguish the public self-run
+    // surface from the admin console, and a decision recorded from an engi
+    // match cannot trigger the mount site's after-decision advance.
+    // Whether that is correct is ruled on by mp-yqxn.6 (engi operator path)
+    // and mp-yqxn.5 (public self-run surface). If a fix lands, flip these
+    // expectations deliberately.
+    const bag = fullPropBag();
+    render(<ScoreEditorModal match={makeMatch({ compEngi: true })} {...bag} />);
+    const p = probes.engi.props;
+    expect(p.onClose).toBe(bag.onClose);
+    expect(p.onSubmit).toBe(bag.onSubmit);
+    expect(p.onSubmitAndNext).toBe(bag.onSubmitAndNext);
+    expect(p.prevMatch).toBe(bag.prevMatch);
+    expect(p.nextMatch).toBe(bag.nextMatch);
+    expect(p.onPrev).toBe(bag.onPrev);
+    expect(p.onNext).toBe(bag.onNext);
+    expect(p.variant).toBe('inline');
+    expect(p.canClose).toBe(false);
+    // The three dropped props:
+    expect(p.password).toBeUndefined();
+    expect(p.selfReport).toBeUndefined();
+    expect(p.onAfterDecision).toBeUndefined();
+  });
+});

--- a/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
+++ b/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
@@ -7,12 +7,9 @@
 // Not a test file: the render project only collects *.render.test.jsx.
 
 // Product-possible format+phase pairs: playoffs has ONLY bracket matches;
-// league and swiss have ONLY pool-shaped matches; mixed has both. Cells
-// outside this mapping are product-impossible and asserted as such in each
-// suite's IMPOSSIBLE CELLS block, not silently skipped.
-export const FORMATS = ['playoffs', 'mixed', 'league', 'swiss'];
-export const PHASES = ['pool', 'bracket'];
-
+// league and swiss have ONLY pool-shaped matches; mixed has both. This list is
+// the single source of truth for the whole axis space: the format/phase value
+// sets below and the impossible complement are both derived from it.
 export const FORMAT_PHASES = [
   { format: 'playoffs', phase: 'bracket' },
   { format: 'mixed', phase: 'pool' },
@@ -21,10 +18,16 @@ export const FORMAT_PHASES = [
   { format: 'swiss', phase: 'pool' },
 ];
 
+const FORMATS = [...new Set(FORMAT_PHASES.map(fp => fp.format))];
+const PHASES = [...new Set(FORMAT_PHASES.map(fp => fp.phase))];
+
 // The complement of FORMAT_PHASES within FORMATS × PHASES: shapes the product
-// cannot produce, which each suite's IMPOSSIBLE CELLS block pins (the editor
-// trusts a mis-stamped phase outright). Derived, so a format added to
-// FORMAT_PHASES automatically extends the impossible blocks too.
+// cannot produce, which each suite's IMPOSSIBLE CELLS block pins (the editors
+// trust a mis-stamped phase). Each suite pairs this DERIVED list with an
+// EXPLICIT per-cell expectation map — the editors' knockout gates differ (the
+// team editor has a format fallback clause the individual editor lacks), so a
+// derived expectation cannot be shared; a newly-derived cell instead fails
+// loudly until someone pins its expectation deliberately.
 export const IMPOSSIBLE_FORMAT_PHASES = FORMATS
   .flatMap(format => PHASES.map(phase => ({ format, phase })))
   .filter(fp => !FORMAT_PHASES.some(p => p.format === fp.format && p.phase === fp.phase));
@@ -34,6 +37,9 @@ export const MAX_ENCHO = [0, 2];
 
 // Independent hardcoded expectations for getIpponButtons(isNaginata) — NOT
 // computed from the component, so a letter-set change in
-// admin_scoring_shared.jsx fails these suites.
-export const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
-export const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];
+// admin_scoring_shared.jsx fails these suites. Exported as Sets, the form the
+// suites compare against the rendered buttons.
+const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
+const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];
+export const KENDO_SET = new Set(KENDO_LETTERS);
+export const NAGINATA_SET = new Set(NAGINATA_LETTERS);

--- a/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
+++ b/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
@@ -32,6 +32,11 @@ export const IMPOSSIBLE_FORMAT_PHASES = FORMATS
   .flatMap(format => PHASES.map(phase => ({ format, phase })))
   .filter(fp => !FORMAT_PHASES.some(p => p.format === fp.format && p.phase === fp.phase));
 
+// Canonical "format/phase" key for a cell: the suites' expectation maps are
+// keyed by this shape, and their 1:1 completeness checks compare against
+// IMPOSSIBLE_FORMAT_PHASES.map(cellKey).
+export const cellKey = (fp) => `${fp.format}/${fp.phase}`;
+
 export const NAGINATA = [false, true];
 export const MAX_ENCHO = [0, 2];
 

--- a/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
+++ b/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
@@ -1,0 +1,28 @@
+// mp-yqxn.1: shared axes + expected ippon-letter tables for the two
+// score-editor config-matrix suites (team_editor_config_matrix and
+// individual_editor_config_matrix), extracted so the matrices cannot silently
+// diverge on their SHARED dimensions (e.g. a format added to one file only).
+// Team-only axes (TEAM_SIZES, MATCH_TYPES) stay local to the team suite.
+//
+// Not a test file: the render project only collects *.render.test.jsx.
+
+// Product-possible format+phase pairs: playoffs has ONLY bracket matches;
+// league and swiss have ONLY pool-shaped matches; mixed has both. Cells
+// outside this mapping are product-impossible and asserted as such in each
+// suite's IMPOSSIBLE CELLS block, not silently skipped.
+export const FORMAT_PHASES = [
+  { format: 'playoffs', phase: 'bracket' },
+  { format: 'mixed', phase: 'pool' },
+  { format: 'mixed', phase: 'bracket' },
+  { format: 'league', phase: 'pool' },
+  { format: 'swiss', phase: 'pool' },
+];
+
+export const NAGINATA = [false, true];
+export const MAX_ENCHO = [0, 2];
+
+// Independent hardcoded expectations for getIpponButtons(isNaginata) — NOT
+// computed from the component, so a letter-set change in
+// admin_scoring_shared.jsx fails these suites.
+export const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
+export const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];

--- a/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
+++ b/web-mobile/js/__tests__/render/score_editor_matrix_axes.js
@@ -10,6 +10,9 @@
 // league and swiss have ONLY pool-shaped matches; mixed has both. Cells
 // outside this mapping are product-impossible and asserted as such in each
 // suite's IMPOSSIBLE CELLS block, not silently skipped.
+export const FORMATS = ['playoffs', 'mixed', 'league', 'swiss'];
+export const PHASES = ['pool', 'bracket'];
+
 export const FORMAT_PHASES = [
   { format: 'playoffs', phase: 'bracket' },
   { format: 'mixed', phase: 'pool' },
@@ -17,6 +20,14 @@ export const FORMAT_PHASES = [
   { format: 'league', phase: 'pool' },
   { format: 'swiss', phase: 'pool' },
 ];
+
+// The complement of FORMAT_PHASES within FORMATS × PHASES: shapes the product
+// cannot produce, which each suite's IMPOSSIBLE CELLS block pins (the editor
+// trusts a mis-stamped phase outright). Derived, so a format added to
+// FORMAT_PHASES automatically extends the impossible blocks too.
+export const IMPOSSIBLE_FORMAT_PHASES = FORMATS
+  .flatMap(format => PHASES.map(phase => ({ format, phase })))
+  .filter(fp => !FORMAT_PHASES.some(p => p.format === fp.format && p.phase === fp.phase));
 
 export const NAGINATA = [false, true];
 export const MAX_ENCHO = [0, 2];

--- a/web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx
+++ b/web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx
@@ -1,0 +1,369 @@
+// mp-yqxn.1: cross-surface invariants — the five ScoreEditorModal mount sites.
+//
+// Five surfaces mount the score editor and they DISAGREE on affordances:
+//   1. admin_shiaijo.jsx        inline; Finish + Start Next; cannot close
+//   2. admin_pools.jsx          modal; no chaining (onSubmitAndNext null)
+//   3. admin_competition_bracket.jsx  inline; no chaining; close only when complete
+//   4. admin_schedule_score_editor.jsx  modal; Prev/Next + Finish-and-next
+//   5. viewer_match.jsx         public self-run; bare submit only
+//
+// Whether that divergence is a DEFECT is for the mp-yqxn review children to
+// decide (mp-yqxn.2–.5). This file only makes the divergence VISIBLE and
+// regression-proof: each surface's wiring is pinned as an exact prop-kind
+// table, so any future change to what a surface wires fails the build here
+// and forces a deliberate update.
+//
+// Mechanism: window.ScoreEditorModal is replaced by a prop-recording probe
+// BEFORE the surface modules load (three of the five capture it at module-eval
+// time), each surface is driven until its editor mounts, and the recorded prop
+// bag is normalized to {absent|null|fn|value} kinds and compared exactly.
+
+import React from 'react';
+import { render, act, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+
+// ── the probe ────────────────────────────────────────────────────────────────
+
+const probe = { props: null };
+function ProbeScoreEditor(props) {
+  probe.props = props;
+  return React.createElement('div', { 'data-testid': 'probe-score-editor' });
+}
+
+// Normalize a prop to a stable kind so tables diff cleanly.
+const kind = (v) =>
+  v === undefined ? 'absent'
+  : v === null ? 'null'
+  : typeof v === 'function' ? 'fn'
+  : typeof v === 'object' ? 'object'
+  : v;
+
+// The invariant surface under test: every wiring-relevant prop of the editor.
+function wiringOf(p) {
+  return {
+    onSubmit: kind(p.onSubmit),
+    onSubmitAndNext: kind(p.onSubmitAndNext),
+    onAfterDecision: kind(p.onAfterDecision),
+    onPrev: kind(p.onPrev),
+    onNext: kind(p.onNext),
+    prevMatch: kind(p.prevMatch),
+    nextMatch: kind(p.nextMatch),
+    onClose: kind(p.onClose),
+    canClose: kind(p.canClose),
+    variant: kind(p.variant),
+    password: kind(p.password) === 'absent' ? 'absent' : p.password,
+    selfReport: kind(p.selfReport),
+  };
+}
+
+// ── window stubs (superset of the per-surface render tests) ──────────────────
+// hasBothSides / hasPoolOriginPlaceholder / pluralize / Icon / EmptyState /
+// useEscapeToClose / poolLabel are the REAL implementations published by
+// vitest.setup.render.js (admin_helpers.jsx, ui.jsx, viewer_utils.jsx).
+
+const STUBBED_GLOBALS = {
+  // MODULE-EVAL captures: must exist before the imports in beforeAll
+  ScoreEditorModal: ProbeScoreEditor,
+  AdminTopbar: ({ children }) => <div data-testid="topbar">{children}</div>,
+  Breadcrumbs: () => null,
+  CourtPicker: () => null,
+  BracketTree: () => null, // per-test override drives bracket selection
+  getScoreBtnClass: () => 'test-score-open',
+  ipponsFromScore: () => [],
+  matchScoreStr: () => '',
+  // LAZY / render-time
+  filterMatchesByCourt: (matches) => matches,
+  filterMatchesByPhase: (matches) => matches,
+  tournamentMatches: () => [],
+  compMatches: () => [],
+  startPatch: () => ({ status: 'running', winner: null }),
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  resolveRoundIndex: () => 0,
+  PoolsViewer: () => null, // per-test override drives pools open
+  LeagueStandingsViewer: () => null,
+  API: {
+    fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
+    fetchCourtMatches: vi.fn().mockResolvedValue([]),
+    subscribeToEvents: () => () => {},
+    recordScore: vi.fn().mockResolvedValue(undefined),
+    sendAnnouncement: vi.fn(),
+    updateMatchTime: vi.fn(),
+    startMatch: vi.fn(),
+  },
+  Term: ({ children }) => <span>{children}</span>,
+  GlossaryHint: ({ name }) => <span title={name} />,
+};
+
+const originals = {};
+let AdminShiaijoPage, AdminPools, AdminBracket, AdminScoreEditor, MatchViewerModal;
+
+beforeAll(async () => {
+  // jsdom doesn't implement scrollTo; the schedule surface calls it on open.
+  window.scrollTo = vi.fn();
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  await import('../../admin_shiaijo.jsx');
+  await import('../../admin_pools.jsx');
+  await import('../../admin_competition_bracket.jsx');
+  const sched = await import('../../admin_schedule_score_editor.jsx');
+  const viewer = await import('../../viewer_match.jsx');
+  AdminShiaijoPage = window.AdminShiaijoPage;
+  AdminPools = window.AdminPools;
+  AdminBracket = window.AdminBracket;
+  AdminScoreEditor = sched.AdminScoreEditor;
+  MatchViewerModal = viewer.MatchViewerModal;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+beforeEach(() => {
+  probe.props = null;
+  window.tournamentMatches = STUBBED_GLOBALS.tournamentMatches;
+  window.filterMatchesByCourt = STUBBED_GLOBALS.filterMatchesByCourt;
+  window.PoolsViewer = STUBBED_GLOBALS.PoolsViewer;
+  window.BracketTree = STUBBED_GLOBALS.BracketTree;
+  window.compMatches = STUBBED_GLOBALS.compMatches;
+});
+
+function runningMatch(overrides = {}) {
+  return {
+    id: 'm1', compId: 'c1', compName: 'Comp', status: 'running',
+    phase: 'pool', poolName: 'Pool 1', court: 'A',
+    sideA: { id: 'p1', name: 'Yamada' },
+    sideB: { id: 'p2', name: 'Tanaka' },
+    ...overrides,
+  };
+}
+
+// ── 1. admin_shiaijo.jsx: inline court console ───────────────────────────────
+
+describe('mount site: admin_shiaijo.jsx (court console)', () => {
+  it('wires Finish+StartNext and after-decision advance; inline, cannot close, NO Prev/Next', async () => {
+    window.tournamentMatches = () => [runningMatch()];
+    await act(async () => {
+      render(
+        <AdminShiaijoPage
+          tournament={{ name: 'T', courts: ['A'], competitions: [] }}
+          court="A"
+          onBack={vi.fn()} onEditScore={vi.fn()} onMoveCourt={vi.fn()}
+          onLogout={vi.fn()} onViewerMode={vi.fn()} password="pw"
+          showToast={vi.fn()} tweaks={{}} onSwitchCourt={vi.fn()}
+        />
+      );
+    });
+    expect(screen.getByTestId('probe-score-editor')).toBeTruthy();
+    expect(wiringOf(probe.props)).toEqual({
+      onSubmit: 'fn',
+      onSubmitAndNext: 'fn',       // Finish + Start Next (court flow)
+      onAfterDecision: 'fn',       // fusenpai/kiken also advances the court
+      onPrev: 'absent',            // court console has no match navigation
+      onNext: 'absent',
+      prevMatch: 'absent',
+      nextMatch: 'absent',
+      onClose: 'fn',               // wired but a no-op: () => {}
+      canClose: false,             // the inline editor IS the page
+      variant: 'inline',
+      password: 'pw',
+      selfReport: 'absent',
+    });
+  });
+});
+
+// ── 2. admin_pools.jsx: pool card modal ──────────────────────────────────────
+
+describe('mount site: admin_pools.jsx (pools tab)', () => {
+  it('wires a bare modal: NO chaining (onSubmitAndNext null) and NO Prev/Next', async () => {
+    const rawPoolMatch = {
+      id: 'Pool 1-1', status: 'scheduled',
+      sideA: { id: 'p1', name: 'Yamada' }, sideB: { id: 'p2', name: 'Tanaka' },
+    };
+    // PoolsViewer probe: expose the surface's onMatchClick as a button.
+    window.PoolsViewer = (props) => (
+      <button data-testid="open-pool-match" onClick={() => props.onMatchClick(rawPoolMatch)}>open</button>
+    );
+    await act(async () => {
+      render(
+        <AdminPools
+          c={{ id: 'c1', name: 'Comp', format: 'mixed', kind: 'individual', status: 'started' }}
+          pools={[{ name: 'Pool 1', players: [] }]}
+          poolMatches={[]}
+          standings={[]}
+          tweaks={{}}
+          onEditScore={vi.fn()}
+          password="pw"
+        />
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open-pool-match'));
+    });
+    expect(screen.getByTestId('probe-score-editor')).toBeTruthy();
+    expect(wiringOf(probe.props)).toEqual({
+      onSubmit: 'fn',
+      onSubmitAndNext: 'null',     // explicitly null: no chaining from pools
+      onAfterDecision: 'absent',
+      onPrev: 'null',              // explicitly null: no navigation
+      onNext: 'null',
+      prevMatch: 'null',
+      nextMatch: 'null',
+      onClose: 'fn',
+      canClose: 'absent',          // default (true): a modal can close
+      variant: 'absent',           // default modal
+      password: 'pw',
+      selfReport: 'absent',
+    });
+  });
+});
+
+// ── 3. admin_competition_bracket.jsx: bracket running panel ──────────────────
+
+describe('mount site: admin_competition_bracket.jsx (bracket panel)', () => {
+  it('wires an inline no-chain editor; close only when the match is complete', async () => {
+    const bm = runningMatch({ id: 'bm1', phase: undefined, poolName: undefined });
+    delete bm.phase;
+    delete bm.poolName;
+    // BracketTree probe: expose the tree's onMatchClick as a button.
+    window.BracketTree = (props) => (
+      <button data-testid="open-bracket-match" onClick={() => props.onMatchClick(bm, 0, 0)}>open</button>
+    );
+    await act(async () => {
+      render(
+        <AdminBracket
+          c={{ id: 'c1', name: 'Comp', engi: false }}
+          t={{ courts: ['A'] }}
+          bracket={{ rounds: [[bm]] }}
+          onMoveCourt={vi.fn()}
+          onEditScore={vi.fn()}
+          tweaks={{}}
+          password="pw"
+        />
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('open-bracket-match'));
+    });
+    expect(screen.getByTestId('probe-score-editor')).toBeTruthy();
+    expect(wiringOf(probe.props)).toEqual({
+      onSubmit: 'fn',
+      onSubmitAndNext: 'null',     // explicitly null: no chaining from the bracket
+      onAfterDecision: 'absent',
+      onPrev: 'absent',
+      onNext: 'absent',
+      prevMatch: 'absent',
+      nextMatch: 'absent',
+      onClose: 'fn',
+      canClose: false,             // running match: nowhere to fall back to
+      variant: 'inline',
+      password: 'pw',
+      selfReport: 'absent',
+    });
+    // The bracket panel stamps phase "bracket" on the editor's match so the
+    // no-draw knockout rule holds (AdminBracket.scoringMatch enrichment).
+    expect(probe.props.match.phase).toBe('bracket');
+  });
+});
+
+// ── 4. admin_schedule_score_editor.jsx: Scores tab ───────────────────────────
+
+describe('mount site: admin_schedule_score_editor.jsx (Scores tab)', () => {
+  it('wires the FULL navigation set: Prev/Next, Finish+StartNext, after-decision', async () => {
+    const m1 = runningMatch();
+    const m2 = runningMatch({ id: 'm2', status: 'scheduled' });
+    window.compMatches = () => [m1, m2];
+    await act(async () => {
+      render(
+        <AdminScoreEditor
+          t={{ competitions: [{ id: 'c1', name: 'Comp' }] }}
+          onEditScore={vi.fn()}
+          onMoveCourt={null}
+          password="pw"
+          showToast={vi.fn()}
+        />
+      );
+    });
+    // Open the first (running) match via its row button.
+    const openBtns = document.querySelectorAll('button.test-score-open');
+    expect(openBtns.length).toBe(2);
+    await act(async () => { fireEvent.click(openBtns[0]); });
+    expect(screen.getByTestId('probe-score-editor')).toBeTruthy();
+    expect(wiringOf(probe.props)).toEqual({
+      onSubmit: 'fn',
+      onSubmitAndNext: 'fn',       // next same-court active match exists (m2)
+      onAfterDecision: 'fn',
+      onPrev: 'fn',
+      onNext: 'fn',
+      prevMatch: 'null',           // m1 is the first match on this court
+      nextMatch: 'object',         // m2: same-shiaijo chain (see pitfall note)
+      onClose: 'fn',
+      canClose: 'absent',          // default (true): modal can close
+      variant: 'absent',           // default modal
+      password: 'pw',
+      selfReport: 'absent',
+    });
+    // Chained navigation must stay on the current match's shiaijo (CLAUDE.md
+    // pitfall): with both fixtures on court A, m2 is the wired next match.
+    expect(probe.props.nextMatch.id).toBe('m2');
+  });
+
+  it('onSubmitAndNext is NULL when no same-court active match remains', async () => {
+    window.compMatches = () => [runningMatch()];
+    await act(async () => {
+      render(
+        <AdminScoreEditor
+          t={{ competitions: [{ id: 'c1', name: 'Comp' }] }}
+          onEditScore={vi.fn()} onMoveCourt={null} password="pw" showToast={vi.fn()}
+        />
+      );
+    });
+    await act(async () => { fireEvent.click(document.querySelector('button.test-score-open')); });
+    expect(wiringOf(probe.props).onSubmitAndNext).toBe('null');
+    expect(wiringOf(probe.props).onAfterDecision).toBe('null');
+  });
+});
+
+// ── 5. viewer_match.jsx: public self-run surface ─────────────────────────────
+
+describe('mount site: viewer_match.jsx (public self-run)', () => {
+  it('wires ONLY submit/close with selfReport:true and empty password — no navigation, no chaining, no decision advance', async () => {
+    // Pinned CURRENT behaviour: the public surface passes neither
+    // onSubmitAndNext nor Prev/Next nor onAfterDecision. Combined with the
+    // dispatch gap (the engi branch drops selfReport entirely: see
+    // score_editor_dispatch.render.test.jsx), the self-run affordance set is
+    // ruled on by mp-yqxn.5.
+    await act(async () => {
+      render(
+        <MatchViewerModal
+          match={runningMatch()}
+          onClose={vi.fn()}
+          tournament={{ mode: 'self-run' }}
+          compId="c1"
+        />
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Report result' }));
+    });
+    expect(screen.getByTestId('probe-score-editor')).toBeTruthy();
+    expect(wiringOf(probe.props)).toEqual({
+      onSubmit: 'fn',
+      onSubmitAndNext: 'absent',
+      onAfterDecision: 'absent',
+      onPrev: 'absent',
+      onNext: 'absent',
+      prevMatch: 'absent',
+      nextMatch: 'absent',
+      onClose: 'fn',
+      canClose: 'absent',          // default (true)
+      variant: 'absent',           // default modal
+      password: '',                // public surface authenticates nothing
+      selfReport: true,
+    });
+  });
+});

--- a/web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx
+++ b/web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx
@@ -51,7 +51,7 @@ function wiringOf(p) {
     onClose: kind(p.onClose),
     canClose: kind(p.canClose),
     variant: kind(p.variant),
-    password: kind(p.password) === 'absent' ? 'absent' : p.password,
+    password: kind(p.password),
     selfReport: kind(p.selfReport),
   };
 }
@@ -324,8 +324,9 @@ describe('mount site: admin_schedule_score_editor.jsx (Scores tab)', () => {
       );
     });
     await act(async () => { fireEvent.click(document.querySelector('button.test-score-open')); });
-    expect(wiringOf(probe.props).onSubmitAndNext).toBe('null');
-    expect(wiringOf(probe.props).onAfterDecision).toBe('null');
+    const w = wiringOf(probe.props);
+    expect(w.onSubmitAndNext).toBe('null');
+    expect(w.onAfterDecision).toBe('null');
   });
 });
 

--- a/web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx
+++ b/web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx
@@ -73,7 +73,6 @@ const STUBBED_GLOBALS = {
   matchScoreStr: () => '',
   // LAZY / render-time
   filterMatchesByCourt: (matches) => matches,
-  filterMatchesByPhase: (matches) => matches,
   tournamentMatches: () => [],
   compMatches: () => [],
   startPatch: () => ({ status: 'running', winner: null }),
@@ -226,7 +225,9 @@ describe('mount site: admin_pools.jsx (pools tab)', () => {
 
 describe('mount site: admin_competition_bracket.jsx (bracket panel)', () => {
   it('wires an inline no-chain editor; close only when the match is complete', async () => {
-    const bm = runningMatch({ id: 'bm1', phase: undefined, poolName: undefined });
+    // Raw bracket.rounds entries carry no phase/pool stamps: strip them so the
+    // panel's own enrichment (phase: "bracket") is what reaches the editor.
+    const bm = runningMatch({ id: 'bm1' });
     delete bm.phase;
     delete bm.poolName;
     // BracketTree probe: expose the tree's onMatchClick as a button.

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -281,11 +281,11 @@ describe('TeamScoreEditorModal kachinuki bout navigation', () => {
         { position: 2, sideA: 'A1', sideB: 'B2', ipponsA: [], ipponsB: [] },
       ],
     });
+    // Exactly one bout row, and it is bout 2: bout 1 is not rendered and no
+    // back affordance exists.
     const rows = container.querySelectorAll('.team-sub-match');
     expect(rows.length).toBe(1);
     expect(rows[0].querySelector('.team-sub-match__pos-num').textContent).toBe('2');
-    // No affordance references bout 1.
-    expect(container.querySelector('.team-sub-match__pos-num').textContent).not.toBe('1');
   });
 
   it('COMPLETED (correction): every fought server bout renders and is editable', async () => {

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -21,11 +21,7 @@
 import React from 'react';
 import { render, act, fireEvent, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
-
-// Expected button-letter sets, built once (compared per cell with Set toEqual).
-const KENDO_SET = new Set(KENDO_LETTERS);
-const NAGINATA_SET = new Set(NAGINATA_LETTERS);
+import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_SET, NAGINATA_SET } from './score_editor_matrix_axes.js';
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -184,20 +180,31 @@ describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => 
   // bracket. Nothing to mount for size<2; recorded here so the cell is
   // visibly excluded rather than forgotten.
 
-  // IMPOSSIBLE_FORMAT_PHASES is the derived complement of FORMAT_PHASES, so a
-  // format added to the axes module automatically extends this block. Pinned:
-  // the team editor trusts a mis-stamped phase outright.
+  // The cell LIST is derived (axes module complement); the EXPECTATIONS are
+  // explicit and independent — the team editor's knockout gate is TWO clauses
+  // (phase === "bracket" OR playoffs/mixed with a non-pool phase,
+  // admin_scoring_team.jsx isKnockoutPhase), so deriving the expected value
+  // from phase alone would silently mis-pin any future cell that exercises the
+  // format clause. A newly-derived cell with no map entry fails loudly here
+  // until its expectation is pinned deliberately. Pinned:
   //   playoffs × pool      → NON-knockout: no in-match daihyosen (a drawn pool
   //                          match must never grow one). Ruled on by mp-yqxn.2.
   //   league|swiss × bracket → the phase clause runs FIRST, so the daihyosen
   //                          affordance renders although the round-robin format
   //                          has no rules for it. Ruled on by mp-yqxn.3
   //                          (league) / mp-yqxn.4 (swiss).
+  const IMPOSSIBLE_EXPECT_DAIHYOSEN = {
+    'playoffs/pool': false,
+    'league/bracket': true,
+    'swiss/bracket': true,
+  };
   it.each(IMPOSSIBLE_FORMAT_PHASES.map(fp => [`${fp.format} × phase "${fp.phase}"`, fp]))(
     '%s: product-impossible; the editor trusts the phase stamp',
     async (_name, fp) => {
+      const key = `${fp.format}/${fp.phase}`;
+      expect(IMPOSSIBLE_EXPECT_DAIHYOSEN, `no pinned expectation for new impossible cell ${key}`).toHaveProperty(key);
       await renderCell({ ...fp, teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
-      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(fp.phase === 'bracket');
+      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(IMPOSSIBLE_EXPECT_DAIHYOSEN[key]);
     }
   );
 });

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -180,13 +180,11 @@ describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => 
   // bracket. Nothing to mount for size<2; recorded here so the cell is
   // visibly excluded rather than forgotten.
 
-  // The cell LIST is derived (axes module complement); the EXPECTATIONS are
-  // explicit and independent — the team editor's knockout gate is TWO clauses
-  // (phase === "bracket" OR playoffs/mixed with a non-pool phase,
-  // admin_scoring_team.jsx isKnockoutPhase), so deriving the expected value
-  // from phase alone would silently mis-pin any future cell that exercises the
-  // format clause. A newly-derived cell with no map entry fails loudly here
-  // until its expectation is pinned deliberately. Pinned:
+  // Expectations are pinned explicitly because the team editor's knockout gate
+  // is TWO clauses (phase === "bracket" OR playoffs/mixed with a non-pool
+  // phase, admin_scoring_team.jsx isKnockoutPhase) — deriving the expected
+  // value from phase alone would silently mis-pin a future cell exercising the
+  // format clause. Pinned:
   //   playoffs × pool      → NON-knockout: no in-match daihyosen (a drawn pool
   //                          match must never grow one). Ruled on by mp-yqxn.2.
   //   league|swiss × bracket → the phase clause runs FIRST, so the daihyosen
@@ -198,13 +196,21 @@ describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => 
     'league/bracket': true,
     'swiss/bracket': true,
   };
+
+  // Both directions at once: a newly-derived cell with no pinned expectation
+  // AND a stale expectation for a cell that became product-possible each fail
+  // this 1:1 check by name.
+  it('expectation map stays 1:1 with the derived impossible-cell list', () => {
+    expect(Object.keys(IMPOSSIBLE_EXPECT_DAIHYOSEN).sort()).toEqual(
+      IMPOSSIBLE_FORMAT_PHASES.map(fp => `${fp.format}/${fp.phase}`).sort()
+    );
+  });
+
   it.each(IMPOSSIBLE_FORMAT_PHASES.map(fp => [`${fp.format} × phase "${fp.phase}"`, fp]))(
     '%s: product-impossible; the editor trusts the phase stamp',
     async (_name, fp) => {
-      const key = `${fp.format}/${fp.phase}`;
-      expect(IMPOSSIBLE_EXPECT_DAIHYOSEN, `no pinned expectation for new impossible cell ${key}`).toHaveProperty(key);
       await renderCell({ ...fp, teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
-      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(IMPOSSIBLE_EXPECT_DAIHYOSEN[key]);
+      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(IMPOSSIBLE_EXPECT_DAIHYOSEN[`${fp.format}/${fp.phase}`]);
     }
   );
 });

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -21,7 +21,7 @@
 import React from 'react';
 import { render, act, fireEvent, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_SET, NAGINATA_SET } from './score_editor_matrix_axes.js';
+import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, cellKey, NAGINATA, MAX_ENCHO, KENDO_SET, NAGINATA_SET } from './score_editor_matrix_axes.js';
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -202,7 +202,7 @@ describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => 
   // this 1:1 check by name.
   it('expectation map stays 1:1 with the derived impossible-cell list', () => {
     expect(Object.keys(IMPOSSIBLE_EXPECT_DAIHYOSEN).sort()).toEqual(
-      IMPOSSIBLE_FORMAT_PHASES.map(fp => `${fp.format}/${fp.phase}`).sort()
+      IMPOSSIBLE_FORMAT_PHASES.map(cellKey).sort()
     );
   });
 
@@ -210,7 +210,7 @@ describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => 
     '%s: product-impossible; the editor trusts the phase stamp',
     async (_name, fp) => {
       await renderCell({ ...fp, teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
-      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(IMPOSSIBLE_EXPECT_DAIHYOSEN[`${fp.format}/${fp.phase}`]);
+      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(IMPOSSIBLE_EXPECT_DAIHYOSEN[cellKey(fp)]);
     }
   );
 });

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -21,6 +21,7 @@
 import React from 'react';
 import { render, act, fireEvent, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -65,18 +66,10 @@ afterAll(() => {
 
 // ── matrix ───────────────────────────────────────────────────────────────────
 
-// Product-possible format+phase pairs (see header comment).
-const FORMAT_PHASES = [
-  { format: 'playoffs', phase: 'bracket' },
-  { format: 'mixed', phase: 'pool' },
-  { format: 'mixed', phase: 'bracket' },
-  { format: 'league', phase: 'pool' },
-  { format: 'swiss', phase: 'pool' },
-];
+// Shared axes + letter tables live in score_editor_matrix_axes.js (kept in
+// lockstep with the individual-editor matrix). Team-only axes stay here.
 const TEAM_SIZES = [3, 5];
 const MATCH_TYPES = ['fixed', 'kachinuki'];
-const NAGINATA = [false, true];
-const MAX_ENCHO = [0, 2];
 
 const CELLS = FORMAT_PHASES.flatMap(fp =>
   TEAM_SIZES.flatMap(teamSize =>
@@ -139,9 +132,6 @@ async function renderCell(cell, matchOverrides = {}, props = {}) {
   });
   return utils;
 }
-
-const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
-const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];
 
 describe('TeamScoreEditorModal config matrix (running match, admin surface)', () => {
   it.each(CELLS.map(c => [cellName(c), c]))('%s', async (_name, cell) => {

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -21,7 +21,11 @@
 import React from 'react';
 import { render, act, fireEvent, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
+import { FORMAT_PHASES, IMPOSSIBLE_FORMAT_PHASES, NAGINATA, MAX_ENCHO, KENDO_LETTERS, NAGINATA_LETTERS } from './score_editor_matrix_axes.js';
+
+// Expected button-letter sets, built once (compared per cell with Set toEqual).
+const KENDO_SET = new Set(KENDO_LETTERS);
+const NAGINATA_SET = new Set(NAGINATA_LETTERS);
 
 const STUBBED_GLOBALS = {
   isHikiwake: (_type) => false,
@@ -149,9 +153,7 @@ describe('TeamScoreEditorModal config matrix (running match, admin surface)', ()
     const letters = new Set(
       [...container.querySelectorAll('.ipt-btn')].map(b => b.textContent)
     );
-    expect([...letters].sort()).toEqual(
-      [...(cell.naginata ? NAGINATA_LETTERS : KENDO_LETTERS)].sort()
-    );
+    expect(letters).toEqual(cell.naginata ? NAGINATA_SET : KENDO_SET);
 
     // Encho affordance: always present, collapsed to the pill while no
     // overtime is active. maxEnchoPeriods only caps the stepper (covered by
@@ -182,24 +184,20 @@ describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => 
   // bracket. Nothing to mount for size<2; recorded here so the cell is
   // visibly excluded rather than forgotten.
 
-  it('playoffs × phase "pool": product-impossible; the editor trusts the stamp and renders NON-knockout', async () => {
-    // Playoffs generates no pool matches, so this shape can only appear via a
-    // mis-stamped match. Pinned: the team editor's isKnockoutPhase excludes
-    // explicit pool phases even in KO-bearing formats (a drawn pool match must
-    // never grow an in-match daihyosen). Ruled on by mp-yqxn.2.
-    await renderCell({ format: 'playoffs', phase: 'pool', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
-    expect(screen.queryByTestId('scoring-modal-daihyosen-button')).toBeNull();
-  });
-
-  it.each([['league'], ['swiss']])(
-    '%s × phase "bracket": product-impossible; the phase clause wins and the daihyosen affordance renders',
-    async (format) => {
-      // League and swiss produce no bracket matches. Pinned: the editor's
-      // phase check runs FIRST, so a mis-stamped bracket match in a
-      // round-robin format would offer an in-match daihyosen the format has
-      // no rules for. Ruled on by mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
-      await renderCell({ format, phase: 'bracket', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
-      expect(screen.queryByTestId('scoring-modal-daihyosen-button')).not.toBeNull();
+  // IMPOSSIBLE_FORMAT_PHASES is the derived complement of FORMAT_PHASES, so a
+  // format added to the axes module automatically extends this block. Pinned:
+  // the team editor trusts a mis-stamped phase outright.
+  //   playoffs × pool      → NON-knockout: no in-match daihyosen (a drawn pool
+  //                          match must never grow one). Ruled on by mp-yqxn.2.
+  //   league|swiss × bracket → the phase clause runs FIRST, so the daihyosen
+  //                          affordance renders although the round-robin format
+  //                          has no rules for it. Ruled on by mp-yqxn.3
+  //                          (league) / mp-yqxn.4 (swiss).
+  it.each(IMPOSSIBLE_FORMAT_PHASES.map(fp => [`${fp.format} × phase "${fp.phase}"`, fp]))(
+    '%s: product-impossible; the editor trusts the phase stamp',
+    async (_name, fp) => {
+      await renderCell({ ...fp, teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
+      expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(fp.phase === 'bracket');
     }
   );
 });

--- a/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx
@@ -1,0 +1,303 @@
+// mp-yqxn.1: TeamScoreEditorModal config matrix.
+//
+// Mounts the REAL team editor (via the ScoreEditorModal dispatch, exactly as
+// every mount site does) across the full config matrix
+//   {format(+phase)} × {teamSize: 3, 5} × {teamMatchType: fixed, kachinuki}
+//   × {naginata: on, off} × {maxEnchoPeriods: 0, 2}
+// and asserts, per cell, WHICH controls render. Config reaches the editor two
+// ways, mirroring production: match-level stamps (compFormat, teamMatchType —
+// stamped by viewer_utils.compMatches) and the async competition fetch
+// (naginata, maxEnchoPeriods — via window.API.fetchCompetitionDetails).
+//
+// Formats map to phases: playoffs has ONLY bracket matches; league and swiss
+// have ONLY pool-shaped matches; mixed has both. Cells outside that mapping
+// are product-impossible and asserted as such in the IMPOSSIBLE CELLS block
+// below, not silently skipped.
+//
+// REGRESSION-PIN ONLY (epic mp-yqxn constraint): DOM assertions prove nothing
+// about rendering, friction, or legibility under time pressure. Judgement
+// calls belong to the browser-review children named in the comments.
+
+import React from 'react';
+import { render, act, fireEvent, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+const STUBBED_GLOBALS = {
+  isHikiwake: (_type) => false,
+  arraysEqual: (a, b) => a.length === b.length && a.every((v, i) => v === b[i]),
+  isKikenDecision: (_kind) => false,
+  isTextEntry: () => false,
+  isInteractiveTarget: () => false,
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  resolveRoundIndex: () => 0,
+  API: {
+    fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
+    recordScore: vi.fn().mockResolvedValue(undefined),
+    recordDaihyosen: vi.fn(),
+    removeDaihyosen: vi.fn(),
+    putMatchLineup: vi.fn(),
+    recordDecision: vi.fn(),
+  },
+  AdminLineupHelpers: { rosterFor: vi.fn().mockReturnValue([]) },
+  compMatches: () => [],
+  Term: ({ children }) => <span>{children}</span>,
+  GlossaryHint: ({ name }) => <span title={name} />,
+};
+
+const originals = {};
+let ScoreEditorModal;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  await import('../../admin_scoring_modal.jsx');
+  ScoreEditorModal = window.ScoreEditorModal;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+// ── matrix ───────────────────────────────────────────────────────────────────
+
+// Product-possible format+phase pairs (see header comment).
+const FORMAT_PHASES = [
+  { format: 'playoffs', phase: 'bracket' },
+  { format: 'mixed', phase: 'pool' },
+  { format: 'mixed', phase: 'bracket' },
+  { format: 'league', phase: 'pool' },
+  { format: 'swiss', phase: 'pool' },
+];
+const TEAM_SIZES = [3, 5];
+const MATCH_TYPES = ['fixed', 'kachinuki'];
+const NAGINATA = [false, true];
+const MAX_ENCHO = [0, 2];
+
+const CELLS = FORMAT_PHASES.flatMap(fp =>
+  TEAM_SIZES.flatMap(teamSize =>
+    MATCH_TYPES.flatMap(tmt =>
+      NAGINATA.flatMap(naginata =>
+        MAX_ENCHO.map(maxEncho => ({ ...fp, teamSize, tmt, naginata, maxEncho }))
+      )
+    )
+  )
+);
+
+function cellName(c) {
+  return `${c.format}/${c.phase} size=${c.teamSize} ${c.tmt} naginata=${c.naginata} maxEncho=${c.maxEncho}`;
+}
+
+function makeTeamMatch(cell, overrides = {}) {
+  return {
+    id: 'm1',
+    compId: 'comp1',
+    status: 'running',
+    phase: cell.phase,
+    court: 'A',
+    compKind: 'team',
+    teamSize: cell.teamSize,
+    compFormat: cell.format,
+    teamMatchType: cell.tmt,
+    ...(cell.phase === 'pool'
+      ? { poolName: 'Pool 1' }
+      : { round: 'Semi-final', matchNumber: 1 }),
+    sideA: { id: 'team-A', name: 'Team A' },
+    sideB: { id: 'team-B', name: 'Team B' },
+    ...overrides,
+  };
+}
+
+// Mock the competition fetch for this cell, mount through the dispatcher, and
+// flush the async compMeta effect inside act() so assertions see settled state.
+async function renderCell(cell, matchOverrides = {}, props = {}) {
+  window.API.fetchCompetitionDetails = vi.fn().mockResolvedValue({
+    id: 'comp1',
+    config: {
+      format: cell.format,
+      teamMatchType: cell.tmt,
+      naginata: cell.naginata,
+      maxEnchoPeriods: cell.maxEncho,
+      players: [],
+    },
+  });
+  let utils;
+  await act(async () => {
+    utils = render(
+      <ScoreEditorModal
+        match={makeTeamMatch(cell, matchOverrides)}
+        onClose={vi.fn()}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+        password=""
+        {...props}
+      />
+    );
+  });
+  return utils;
+}
+
+const KENDO_LETTERS = ['M', 'K', 'D', 'T', 'H'];
+const NAGINATA_LETTERS = ['M', 'K', 'D', 'T', 'S', 'H'];
+
+describe('TeamScoreEditorModal config matrix (running match, admin surface)', () => {
+  it.each(CELLS.map(c => [cellName(c), c]))('%s', async (_name, cell) => {
+    const { container } = await renderCell(cell);
+
+    // Bout rows: fixed renders every position; kachinuki renders ONLY the
+    // current bout (bootstrap: bout 1 on a fresh match) — see
+    // kachinukiVisiblePositions. Whether hiding earlier/later bouts is the
+    // right operator affordance is ruled on by mp-yqxn.2.
+    const rows = container.querySelectorAll('.team-sub-match');
+    expect(rows.length).toBe(cell.tmt === 'kachinuki' ? 1 : cell.teamSize);
+
+    // Sune: the per-bout ippon buttons gain "S" ONLY when the competition is
+    // naginata (admin_scoring_team.jsx getIpponButtons(isNaginataTeam)).
+    const letters = new Set(
+      [...container.querySelectorAll('.ipt-btn')].map(b => b.textContent)
+    );
+    expect([...letters].sort()).toEqual(
+      [...(cell.naginata ? NAGINATA_LETTERS : KENDO_LETTERS)].sort()
+    );
+
+    // Encho affordance: always present, collapsed to the pill while no
+    // overtime is active. maxEnchoPeriods only caps the stepper (covered by
+    // the focused cap tests below).
+    expect(screen.queryByTestId('scoring-modal-encho-pill')).not.toBeNull();
+
+    // Daihyosen affordance is knockout-only (T141): phase "bracket", or the
+    // playoffs/mixed fallback for non-pool phases. Pool matches resolve ties
+    // via standings + the auto-injected pool daihyosen instead.
+    const expectKnockout = cell.phase === 'bracket';
+    expect(!!screen.queryByTestId('scoring-modal-daihyosen-button')).toBe(expectKnockout);
+
+    // Admin decision controls (kiken/fusenpai) render on the admin surface.
+    expect(screen.queryByTestId('scoring-modal-kiken-voluntary-button')).not.toBeNull();
+    expect(screen.queryByTestId('scoring-modal-kiken-injury-button')).not.toBeNull();
+    expect(screen.queryByTestId('scoring-modal-fusenpai-button')).not.toBeNull();
+
+    // Per-bout tie + fusensho affordances scale with the visible rows.
+    expect(screen.queryAllByTestId('scoring-modal-tie-button').length).toBe(rows.length);
+    expect(screen.queryAllByTestId('scoring-modal-fusensho-button').length).toBe(rows.length * 2);
+  });
+});
+
+describe('TeamScoreEditorModal IMPOSSIBLE CELLS (asserted, not skipped)', () => {
+  // kachinuki × teamSize<2 is rejected at create/settings time
+  // (state.ValidateTeamMatchType: "kachinuki requires teamSize >= 2"), so the
+  // matrix's teamSize axis {3,5} already covers every legal kachinuki size
+  // bracket. Nothing to mount for size<2; recorded here so the cell is
+  // visibly excluded rather than forgotten.
+
+  it('playoffs × phase "pool": product-impossible; the editor trusts the stamp and renders NON-knockout', async () => {
+    // Playoffs generates no pool matches, so this shape can only appear via a
+    // mis-stamped match. Pinned: the team editor's isKnockoutPhase excludes
+    // explicit pool phases even in KO-bearing formats (a drawn pool match must
+    // never grow an in-match daihyosen). Ruled on by mp-yqxn.2.
+    await renderCell({ format: 'playoffs', phase: 'pool', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
+    expect(screen.queryByTestId('scoring-modal-daihyosen-button')).toBeNull();
+  });
+
+  it.each([['league'], ['swiss']])(
+    '%s × phase "bracket": product-impossible; the phase clause wins and the daihyosen affordance renders',
+    async (format) => {
+      // League and swiss produce no bracket matches. Pinned: the editor's
+      // phase check runs FIRST, so a mis-stamped bracket match in a
+      // round-robin format would offer an in-match daihyosen the format has
+      // no rules for. Ruled on by mp-yqxn.3 (league) / mp-yqxn.4 (swiss).
+      await renderCell({ format, phase: 'bracket', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
+      expect(screen.queryByTestId('scoring-modal-daihyosen-button')).not.toBeNull();
+    }
+  );
+});
+
+describe('TeamScoreEditorModal selfReport (public self-run surface)', () => {
+  it('selfReport hides the admin decision controls', async () => {
+    await renderCell(
+      { format: 'mixed', phase: 'pool', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 },
+      {},
+      { selfReport: true }
+    );
+    expect(screen.queryByTestId('scoring-modal-kiken-voluntary-button')).toBeNull();
+    expect(screen.queryByTestId('scoring-modal-fusenpai-button')).toBeNull();
+    // Scoring itself stays available.
+    expect(screen.queryAllByTestId('scoring-modal-tie-button').length).toBeGreaterThan(0);
+  });
+});
+
+describe('TeamScoreEditorModal encho cap (maxEnchoPeriods)', () => {
+  async function expandEncho() {
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('scoring-modal-encho-pill'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('scoring-modal-encho-checkbox'));
+    });
+  }
+
+  it('maxEncho=2: the + stepper disables at the cap and the max banner shows', async () => {
+    await renderCell({ format: 'mixed', phase: 'bracket', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 2 });
+    await expandEncho();
+    const inc = screen.getByRole('button', { name: 'Increase overtime period count' });
+    expect(inc.disabled).toBe(false); // ×1 < cap
+    await act(async () => { fireEvent.click(inc); }); // ×2 = cap
+    expect(inc.disabled).toBe(true);
+    expect(screen.getByRole('alert').textContent).toContain('Maximum encho periods reached');
+  });
+
+  it('maxEncho=0 means UNCAPPED: the + stepper never disables', async () => {
+    // canIncrementEncho treats 0 as "no cap". mp-m4bn tracks the fact that no
+    // UI or import path can currently SET maxEnchoPeriods, so 0/uncapped is
+    // the only reachable state in practice.
+    await renderCell({ format: 'mixed', phase: 'bracket', teamSize: 5, tmt: 'fixed', naginata: false, maxEncho: 0 });
+    await expandEncho();
+    const inc = screen.getByRole('button', { name: 'Increase overtime period count' });
+    for (let i = 0; i < 4; i++) {
+      expect(inc.disabled).toBe(false);
+      await act(async () => { fireEvent.click(inc); });
+    }
+    expect(inc.disabled).toBe(false);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});
+
+describe('TeamScoreEditorModal kachinuki bout navigation', () => {
+  const KACHI_CELL = { format: 'playoffs', phase: 'bracket', teamSize: 5, tmt: 'kachinuki', naginata: false, maxEncho: 0 };
+
+  it('RUNNING: only the current bout renders; the operator CANNOT navigate back to a scored earlier bout', async () => {
+    // Server bout log: bout 1 fought (won by A1), bout 2 appended by
+    // engine.AdvanceKachinuki and not yet scored. kachinukiVisiblePositions
+    // shows ONLY the first unscored server bout while running: bout 1 is not
+    // rendered and no back affordance exists. Corrections to an earlier bout
+    // require finishing the match first (correction mode below). Whether the
+    // operator SHOULD be able to step back mid-encounter is ruled on by
+    // mp-yqxn.2.
+    const { container } = await renderCell(KACHI_CELL, {
+      subResults: [
+        { position: 1, sideA: 'A1', sideB: 'B1', ipponsA: ['M', 'K'], ipponsB: [], winner: 'A1' },
+        { position: 2, sideA: 'A1', sideB: 'B2', ipponsA: [], ipponsB: [] },
+      ],
+    });
+    const rows = container.querySelectorAll('.team-sub-match');
+    expect(rows.length).toBe(1);
+    expect(rows[0].querySelector('.team-sub-match__pos-num').textContent).toBe('2');
+    // No affordance references bout 1.
+    expect(container.querySelector('.team-sub-match__pos-num').textContent).not.toBe('1');
+  });
+
+  it('COMPLETED (correction): every fought server bout renders and is editable', async () => {
+    const { container } = await renderCell(KACHI_CELL, {
+      status: 'completed',
+      winner: { id: 'team-A', name: 'Team A' },
+      subResults: [
+        { position: 1, sideA: 'A1', sideB: 'B1', ipponsA: ['M', 'K'], ipponsB: [], winner: 'A1' },
+        { position: 2, sideA: 'A1', sideB: 'B2', ipponsA: ['D'], ipponsB: ['M'], winner: '' },
+      ],
+    });
+    const nums = [...container.querySelectorAll('.team-sub-match__pos-num')].map(n => n.textContent);
+    expect(nums).toEqual(['1', '2']);
+  });
+});


### PR DESCRIPTION
## Summary

- Pins the ScoreEditorModal **dispatch** (engi → team → individual) as render tests, including the real-world failure shape where `compEngi` is missing entirely — the bug class already hit twice (mp-9k3v and its predecessor).
- Pins the **prop-forwarding contract** per dispatch branch: the engi branch drops `password`, `selfReport` AND `onAfterDecision` while the team branch forwards all three. Pinned to CURRENT behaviour with comments naming the review children (mp-yqxn.5/.6) that will rule on whether it is correct.
- Adds an **80-cell team-editor config matrix** ({format+phase} × {teamSize 3,5} × {fixed,kachinuki} × {naginata on/off} × {maxEncho 0,2}) asserting which controls render per cell: bout rows, Sune button, encho affordance, knockout-only daihyosen, admin decision controls, per-bout tie/fusensho counts. Product-impossible cells (playoffs×pool, league/swiss×bracket, engi+team, kachinuki×size<2) are **asserted as impossible, not silently skipped**.
- Adds the **same matrix for the individual editor** (20 cells), pinning that it derives knockout from `m.phase` alone (no compFormat fallback, unlike the team editor).
- Pins **kachinuki navigation**: while running, only the current bout renders (operator cannot step back to a scored earlier bout); completed shows every fought bout for correction. Ruled on by mp-yqxn.2.
- Pins the **five mount surfaces** (shiaijo / pools / bracket / Scores tab / public self-run) as exact prop-kind wiring tables, so any future affordance divergence fails the build.
- Pins that the **engi editor has no ippon buttons and no Sune** affordance (appended to the existing engi render test).

## Why

mp-yqxn.1 is the only child of the mp-yqxn UX-review epic that ships code: it makes the affordance divergence across surfaces VISIBLE and REGRESSION-PROOF so the browser-review children can rule on it without the matrix regressing underneath them. This PR changes **no product code**.

Pin quality was mutation-verified: temporarily forwarding `password` from the engi branch and wiring a non-null `onSubmitAndNext` in admin_pools each turned exactly the right test red (then reverted).

## Files changed

| File | What |
|---|---|
| `web-mobile/js/__tests__/render/score_editor_dispatch.render.test.jsx` | NEW: dispatch routing + per-branch prop forwarding (10 tests) |
| `web-mobile/js/__tests__/render/team_editor_config_matrix.render.test.jsx` | NEW: 80-cell team matrix + impossible cells + selfReport + encho cap + kachinuki navigation (88 tests) |
| `web-mobile/js/__tests__/render/individual_editor_config_matrix.render.test.jsx` | NEW: 20-cell individual matrix + impossible cells + selfReport/hantei pin (24 tests) |
| `web-mobile/js/__tests__/render/score_editor_mount_sites.render.test.jsx` | NEW: exact wiring table per mount surface, probe-recorded (6 tests) |
| `web-mobile/js/__tests__/render/admin_scoring_engi.render.test.jsx` | Appended: engi editor has zero ippon buttons / no Sune (1 test) |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change (139 new/updated render tests; full JS suite: 117 files / 2466 tests green under `make js/test`)
- [x] Manual browser verification: N/A — test-only change, no product code or UI behaviour touched (verified `git status` shows only `__tests__/` files)
- [x] Docs: N/A — no user-facing feature, flag, command, or behaviour changed
- [x] No new console errors or warnings (the render suite setup FAILS any test emitting console.warn/error)

Closes mp-yqxn.1
