### PR TITLE
fix(mp-u37s): derive the viewer schedule bout middle from boutMiddle

### DIFF
--- a/web-mobile/js/__tests__/admin_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/admin_shiaijo.test.jsx
@@ -554,7 +554,7 @@ describe('groupQueueMatches; Upcoming queue grouping', () => {
     expect(groups[1].matches.map((m) => m.id)).toEqual(['b1']);
   });
 
-  it('groups playoff matches by round, keyed by round index', () => {
+  it('groups playoff matches by round name', () => {
     const groups = groupQueueMatches([
       bracket('Semifinals', 0, 's1'), bracket('Semifinals', 0, 's2'), bracket('Final', 1, 'f1'),
     ]);

--- a/web-mobile/js/__tests__/bracket_round_label_agreement.test.jsx
+++ b/web-mobile/js/__tests__/bracket_round_label_agreement.test.jsx
@@ -14,7 +14,7 @@ import { phaseLabel } from '../display_helpers.jsx';
 //
 // bracketRoundLabel is the single primitive both sides now go through.
 
-// The 5-player individual knockout exactly as the engine persists it. Captured
+// The 5-player individual knockout as the engine persists it, trimmed to the fields under test (winner/status/court/scheduledAt/matchNumber dropped). Captured
 // from a live run: TOURNAMENT_DATA_DIR=… mobile-app, 5 participants, start,
 // then competitions/<id>/bracket.json. 3 backend rounds; Alice/Bob sit in
 // backend round 0 but carry displayRound 2 (their winner meets the final).
@@ -34,8 +34,12 @@ const fivePlayerRounds = () => [
   ],
 ];
 
-// Column labels exactly as BracketTreeMeta renders them: one per column, taken
-// from a match in that column through the shared primitive.
+// The column labels BracketTreeMeta is EXPECTED to render: one per column,
+// taken from a match in that column through the shared primitive. This mirrors
+// the component's call rather than reading its output, so it pins the ROW side
+// of the agreement only; that the DOM header really says this is pinned by
+// render/bracket_round_label.render.test.jsx, which mounts BracketTree and
+// reads .bc-round-label.
 const columnLabels = (rounds) => {
   const model = buildDisplayModel(rounds);
   return model.columns.map((col, ci) => bracketRoundLabel(col[0], ci, model.columns.length));

--- a/web-mobile/js/__tests__/bracket_round_label_agreement.test.jsx
+++ b/web-mobile/js/__tests__/bracket_round_label_agreement.test.jsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildDisplayModel, roundLabel, bracketRoundLabel } from '../bracket.jsx';
+import { compMatches } from '../viewer_utils.jsx';
+import { phaseLabel } from '../display_helpers.jsx';
+
+// mp-u37s: a bracket round label must read the SAME on every surface.
+//
+// Two independent renderings of one match existed: the Bracket tab groups
+// matches into EFFECTIVE-round columns (mp-7f2w `displayRound`, which collapses
+// a round that is entirely structural byes), while every row surface (viewer
+// Overview, admin score editor, watchlist, schedule, TV boards) named the round
+// from the match's RAW index in bracket.rounds. In any non-power-of-two draw the
+// two disagree: a match can sit in backend round 0 yet feed the final directly.
+//
+// bracketRoundLabel is the single primitive both sides now go through.
+
+// The 5-player individual knockout exactly as the engine persists it. Captured
+// from a live run: TOURNAMENT_DATA_DIR=… mobile-app, 5 participants, start,
+// then competitions/<id>/bracket.json. 3 backend rounds; Alice/Bob sit in
+// backend round 0 but carry displayRound 2 (their winner meets the final).
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', sideA: 'Alice', sideB: 'Bob', displayRound: 2, feeders: ['', ''] },
+    { id: 'm-r1-1', sideA: '', sideB: '', hidden: true },
+    { id: 'm-r1-2', sideA: 'Carol', sideB: '', hidden: true },
+    { id: 'm-r1-3', sideA: 'Dave', sideB: 'Eve', displayRound: 3, feeders: ['', ''] },
+  ],
+  [
+    { id: 'm-r2-0', sideA: 'Winner of r3-m0', sideB: '', hidden: true },
+    { id: 'm-r2-1', sideA: 'Carol', sideB: 'Winner of r3-m3', displayRound: 2, feeders: ['', 'm-r1-3'] },
+  ],
+  [
+    { id: 'm-r3-0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1', displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'] },
+  ],
+];
+
+// Column labels exactly as BracketTreeMeta renders them: one per column, taken
+// from a match in that column through the shared primitive.
+const columnLabels = (rounds) => {
+  const model = buildDisplayModel(rounds);
+  return model.columns.map((col, ci) => bracketRoundLabel(col[0], ci, model.columns.length));
+};
+
+// matchId → the label of the Bracket tab column the card is drawn in.
+const columnLabelByMatchId = (rounds) => {
+  const model = buildDisplayModel(rounds);
+  const out = {};
+  model.columns.forEach((col, ci) => {
+    const label = bracketRoundLabel(col[0], ci, model.columns.length);
+    col.forEach((m) => { if (!m.isByeSlot) out[m.id] = label; });
+  });
+  return out;
+};
+
+describe('bracketRoundLabel: one round name per match, every surface (mp-u37s)', () => {
+  it('names the effective round, not the raw backend round', () => {
+    // Alice/Bob: backend round 0 of 3 → the raw rule says "Quarterfinals".
+    expect(roundLabel(0, 3)).toBe('Quarterfinals');
+    // …but its winner plays the final, so it IS a semifinal.
+    expect(bracketRoundLabel({ displayRound: 2 }, 0, 3)).toBe('Semifinals');
+  });
+
+  it('falls back to the raw round index for legacy brackets with no metadata', () => {
+    expect(bracketRoundLabel({ id: 'x' }, 0, 3)).toBe(roundLabel(0, 3));
+    expect(bracketRoundLabel(undefined, 1, 3)).toBe(roundLabel(1, 3));
+    // displayRound 0 is the engine's "unset" sentinel, not a real round.
+    expect(bracketRoundLabel({ displayRound: 0 }, 2, 3)).toBe('Final');
+    // -1 is the bronze sentinel; it must not be read as a round either.
+    expect(bracketRoundLabel({ displayRound: -1 }, 2, 3)).toBe('Final');
+  });
+
+  it('labels the collapsed 5-player bracket columns QF / SF / Final', () => {
+    expect(columnLabels(fivePlayerRounds())).toEqual(['Quarterfinals', 'Semifinals', 'Final']);
+  });
+});
+
+describe('row labels agree with bracket columns across a collapsed bye round (mp-u37s)', () => {
+  beforeEach(() => {
+    global.window = global.window || {};
+    // The REAL primitives, exactly as bracket.jsx publishes them at runtime.
+    global.window.roundLabel = roundLabel;
+    global.window.bracketRoundLabel = bracketRoundLabel;
+  });
+
+  const comp = () => ({
+    id: 'c1', name: 'Knockout5', status: 'playoffs', format: 'playoffs',
+    kind: 'individual', teamSize: 0, engi: false,
+    bracket: { rounds: fivePlayerRounds() },
+  });
+
+  it('gives every bracket match the same round on the row surface as in its column', () => {
+    const byColumn = columnLabelByMatchId(fivePlayerRounds());
+    const rows = compMatches(comp()).filter((m) => m.phase === 'bracket');
+    // Only the real (non-phantom) matches carry a column, so pin that we
+    // actually compared all four rather than vacuously passing on zero.
+    const compared = rows.filter((m) => byColumn[m.id]);
+    expect(compared).toHaveLength(4);
+    compared.forEach((m) => {
+      expect(m.round).toBe(byColumn[m.id]);
+      expect(m.phaseName).toBe(byColumn[m.id]);
+    });
+  });
+
+  it('calls the bye-collapsed match a semifinal on the row surface too', () => {
+    const rows = compMatches(comp()).filter((m) => m.phase === 'bracket');
+    const byId = Object.fromEntries(rows.map((m) => [m.id, m]));
+    // THE regression: this row read "Quarterfinals" while the column above the
+    // very same card read "Semifinals".
+    expect(byId['m-r1-0'].round).toBe('Semifinals');
+    expect(byId['m-r1-3'].round).toBe('Quarterfinals'); // genuinely a QF; unchanged
+    expect(byId['m-r2-1'].round).toBe('Semifinals');
+    expect(byId['m-r3-0'].round).toBe('Final');
+  });
+
+  it('agrees on the TV/lobby/scoreboard boards too (phaseLabel)', () => {
+    // Those surfaces flatten c.bracket.rounds themselves and pass the raw
+    // (roundIndex, totalRounds) with no phaseName stamped, so phaseLabel's
+    // bracket branch is the label they show.
+    const rounds = fivePlayerRounds();
+    const byColumn = columnLabelByMatchId(rounds);
+    rounds.forEach((round, ri) => round.forEach((m) => {
+      if (!byColumn[m.id]) return; // phantom: never promoted to a board
+      expect(phaseLabel(m, true, ri, rounds.length, 'playoffs')).toBe(byColumn[m.id]);
+    }));
+    expect(phaseLabel(rounds[0][0], true, 0, 3, 'playoffs')).toBe('Semifinals');
+  });
+
+  it('keeps roundIndex RAW so lineup fetches still key on the backend round', () => {
+    const rows = compMatches(comp()).filter((m) => m.phase === 'bracket');
+    const byId = Object.fromEntries(rows.map((m) => [m.id, m]));
+    // The label moved to the effective round; the index must NOT follow it.
+    expect(byId['m-r1-0'].roundIndex).toBe(0);
+    expect(byId['m-r2-1'].roundIndex).toBe(1);
+    expect(byId['m-r3-0'].roundIndex).toBe(2);
+  });
+});

--- a/web-mobile/js/__tests__/bracket_slot_label.test.jsx
+++ b/web-mobile/js/__tests__/bracket_slot_label.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { slotDisplayName, makeSlotLabeller, bracketSlotLabeller } from '../bracket.jsx';
+import { hasBothSides, isPendingBracketMatch, bracketFullyComplete, compMatchStats } from '../admin_helpers.jsx';
+
+// The engine writes an unresolved bracket feeder as "Winner of r<depth>-m<idx>"
+// (engine.winnerOfPlaceholder). That is a WIRE value: an internal round/index
+// pair that means nothing to a spectator AND does not match the match numbers
+// the bracket prints on its cards ("M1", "M2"), which are ordered by effective
+// round. Printing it pointed readers at the wrong card. slotDisplayName is the
+// one rule for what a human reads in that slot; the wire value is untouched.
+
+// 5-player bracket exactly as the engine persists it (same fixture as
+// bracket_display_model.test.jsx):
+//   QF: Dave/Eve (dr3) · SF: Alice/Bob + Carol (dr2) · Final (dr1)
+//   phantoms: the dead r1-m1, Carol's bye r1-m2, the latent-bye SF r2-m0.
+// Match numbers: m-r1-3 = 1, m-r1-0 = 2, m-r2-1 = 3, m-r3-0 = 4.
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', sideA: 'Alice', sideB: 'Bob', displayRound: 2, feeders: ['', ''] },
+    { id: 'm-r1-1', sideA: '', sideB: '', hidden: true },
+    { id: 'm-r1-2', sideA: 'Carol', sideB: '', hidden: true },
+    { id: 'm-r1-3', sideA: 'Dave', sideB: 'Eve', displayRound: 3, feeders: ['', ''] },
+  ],
+  [
+    { id: 'm-r2-0', sideA: 'Winner of r3-m0', sideB: '', hidden: true },
+    { id: 'm-r2-1', sideA: 'Carol', sideB: 'Winner of r3-m3', displayRound: 2, feeders: ['', 'm-r1-3'] },
+  ],
+  [
+    { id: 'm-r3-0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1', displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'] },
+  ],
+];
+
+describe('slotDisplayName: the one rule for a bracket slot a human reads', () => {
+  it('never returns the raw round/match id, with or without a number', () => {
+    expect(slotDisplayName('Winner of r3-m3', 1)).toBe('Winner of M1');
+    expect(slotDisplayName('Winner of r3-m3', 0)).toBe('TBD');
+    expect(slotDisplayName('Winner of r12-m7')).toBe('TBD');
+    expect(slotDisplayName('Winner of r3-m3', 1)).not.toMatch(/r\d+-m\d+/);
+    expect(slotDisplayName('Winner of r3-m3')).not.toMatch(/r\d+-m\d+/);
+  });
+
+  it('leaves real competitor names untouched, including near-misses', () => {
+    expect(slotDisplayName('Yuki Tanaka', 3)).toBe('Yuki Tanaka');
+    // A legitimate participant whose name merely starts with the same words
+    // must survive: the rule matches the EXACT wire shape, like the filters.
+    expect(slotDisplayName('Winner of the 2025 Cup', 3)).toBe('Winner of the 2025 Cup');
+    expect(slotDisplayName('')).toBe('');
+    expect(slotDisplayName(undefined)).toBe(undefined);
+  });
+
+  it('leaves pool-origin placeholders alone: they are self-describing', () => {
+    // "Pool A-1st" names a pool and a finishing position; a spectator can act on
+    // it. Only the rX-mY feeder is an internal index, so only it is relabelled.
+    expect(slotDisplayName('Pool A-1st', 2)).toBe('Pool A-1st');
+    expect(slotDisplayName('Pool B-2nd')).toBe('Pool B-2nd');
+  });
+});
+
+describe('makeSlotLabeller: resolves a slot to the number the bracket prints', () => {
+  const label = () => bracketSlotLabeller(fivePlayerRounds());
+
+  it('names the feeder by its CARD number, not the id in the slot', () => {
+    // The bug: "Winner of r3-m3" was printed raw, and r3-m3 is not "M3" — it is
+    // the card drawn as M1. Resolved via m-r2-1's feeders entry ['', 'm-r1-3'].
+    expect(label()('Winner of r3-m3', 'm-r1-3')).toBe('Winner of M1');
+    expect(label()('Winner of r2-m1', 'm-r2-1')).toBe('Winner of M3');
+  });
+
+  it('sees through a phantom bye match via the engine feeder graph', () => {
+    // The final's sideA literally reads "Winner of r2-m0", but r2-m0 is a dead
+    // bye match: the winner really arrives from m-r1-0 (card M2). The positional
+    // parse alone can only reach the phantom, which has no number → "TBD".
+    const slot = 'Winner of r2-m0';
+    expect(label()(slot, 'm-r1-0')).toBe('Winner of M2'); // feeder-graph path
+    expect(label()(slot)).toBe('TBD');                    // positional → phantom
+  });
+
+  it('falls back to the positional parse (Go parseWinnerOf) with no feeder id', () => {
+    // roundIndex = rounds.length - depth; "r3-m3" → rounds[0][3] = m-r1-3 = M1.
+    expect(label()('Winner of r3-m3')).toBe('Winner of M1');
+  });
+
+  it('degrades to TBD, never the raw id, when nothing resolves', () => {
+    expect(label()('Winner of r9-m9')).toBe('TBD');               // no such match
+    expect(label()('Winner of r9-m9', 'm-nope')).toBe('TBD');     // neither path resolves
+    expect(makeSlotLabeller(null, null)('Winner of r1-m0')).toBe('TBD'); // no bracket
+    expect(makeSlotLabeller([], {})('Winner of r1-m0')).toBe('TBD');
+  });
+
+  it('falls back to the positional parse when the feeder id is unknown', () => {
+    // A stale/unknown feeder id must not swallow the resolution: the positional
+    // parse still finds m-r1-3 (= M1) for "r3-m3".
+    expect(label()('Winner of r3-m3', 'm-nope')).toBe('Winner of M1');
+  });
+
+  it('uses the server matchNumber when no display model is supplied', () => {
+    // Legacy/no-metadata callers: state.BracketMatch.MatchNumber is
+    // equal-by-contract with matchNumById (engine.assignBracketMatchNumbers).
+    const rounds = [
+      [{ id: 'a0', sideA: 'P1', sideB: 'P2', matchNumber: 7 }],
+      [{ id: 'b0', sideA: 'Winner of r2-m0', sideB: 'P3' }],
+    ];
+    expect(makeSlotLabeller(rounds, null)('Winner of r2-m0')).toBe('Winner of M7');
+  });
+
+  it('is pure: labelling never rewrites the bracket it read', () => {
+    const rounds = fivePlayerRounds();
+    const before = JSON.stringify(rounds);
+    bracketSlotLabeller(rounds)('Winner of r3-m3', 'm-r1-3');
+    expect(JSON.stringify(rounds)).toBe(before);
+  });
+});
+
+// The wire value is load-bearing: helper.reservedWinnerOfRE (Go),
+// admin_helpers.BRACKET_PLACEHOLDER_RE and display_helpers.DISPLAY_PLACEHOLDER_RE
+// all decide playability/schedulability from it. Relabelling is DISPLAY-ONLY, so
+// every one of those classifications must be untouched.
+describe('placeholder filtering is unchanged by the display label', () => {
+  const feederMatch = () => ({
+    id: 'm-r2-1',
+    status: 'scheduled',
+    sideA: { id: '', name: 'Carol' },
+    sideB: { id: '', name: 'Winner of r3-m3' },
+    feeders: ['', 'm-r1-3'],
+  });
+
+  it('a feeder-sided match is still not playable and still "pending"', () => {
+    const m = feederMatch();
+    expect(hasBothSides(m)).toBe(false);         // not actionable / not schedulable
+    expect(isPendingBracketMatch(m)).toBe(true); // still a non-actionable "Later" row
+    // Still not counted as a real match, and still blocks "Complete competition".
+    expect(compMatchStats({ bracket: { rounds: [[m]] } })).toEqual({ total: 0, done: 0, running: 0 });
+    expect(bracketFullyComplete({ rounds: [[{ ...m, status: 'completed' }, m]] })).toBe(false);
+  });
+
+  it('the label does not make a match pass the filters (no side is rewritten)', () => {
+    const m = feederMatch();
+    const label = bracketSlotLabeller(fivePlayerRounds());
+    expect(label(m.sideB.name, m.feeders[1])).toBe('Winner of M1');
+    // The match object still carries the wire value, so the predicates that read
+    // it are byte-for-byte unaffected.
+    expect(m.sideB.name).toBe('Winner of r3-m3');
+    expect(hasBothSides(m)).toBe(false);
+    expect(isPendingBracketMatch(m)).toBe(true);
+  });
+
+  it('a "Winner of M1" name would NOT be mistaken for a wire placeholder', () => {
+    // Defensive: if a relabelled string ever reached a filter it would read as a
+    // real competitor, which is exactly why nothing writes it back into a side.
+    const relabelled = { id: 'x', status: 'scheduled', sideA: { name: 'Carol' }, sideB: { name: 'Winner of M1' } };
+    expect(hasBothSides(relabelled)).toBe(true);
+  });
+});

--- a/web-mobile/js/__tests__/bronze_shiaijo.test.jsx
+++ b/web-mobile/js/__tests__/bronze_shiaijo.test.jsx
@@ -8,6 +8,7 @@ describe('compMatches: bronze (3rd-place) playoff', () => {
   beforeEach(() => {
     global.window = global.window || {};
     global.window.roundLabel = (i, n) => (i === n - 1 ? 'Final' : `Round ${i + 1}`);
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
   });
 
   const comp = () => ({

--- a/web-mobile/js/__tests__/display_phase_round_group.test.jsx
+++ b/web-mobile/js/__tests__/display_phase_round_group.test.jsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { gatherIndividualGroup, phaseProgressOnCourt } from '../display.jsx';
+import { bracketRoundSiblings, phaseLabel } from '../display_helpers.jsx';
+import { bracketRoundLabel } from '../bracket.jsx';
+
+// Kept out of display_white_board.test.jsx deliberately: this suite imports the
+// REAL bracket.jsx so phaseLabel routes through the real bracketRoundLabel, and
+// bracket.jsx's module eval installs window.bracketRoundLabel. That file's
+// phaseLabel suite asserts the NO-helper fallback path ("does NOT derive a
+// pool-like label from a bracket id when bracketRoundLabel is unavailable"), so
+// loading bracket.jsx alongside it would change what its other cases see.
+
+// mp-u37s: the TV phase strip's heading and its match set must name the SAME
+// round.
+//
+// phaseLabel moved to the EFFECTIVE round (mp-7f2w displayRound, which collapses
+// a round whose other match is a structural bye), but phaseProgressOnCourt and
+// gatherIndividualGroup kept building their set from rounds[roundIndex] — the
+// RAW backend round. In any draw where the two differ the board rendered a
+// heading over the wrong bouts: "SEMIFINALS · 0 / 2" counting a quarterfinal,
+// and that quarterfinal listed in the rows beneath the semifinal heading.
+// bracketRoundSiblings is the shared selector that closes both.
+
+// The 5-entrant knockout the engine really persists (same fixture as
+// bracket_round_label_agreement / bracket_display_model), with the court and
+// status the board reads. Backend round 0 holds BOTH m-r1-0 (displayRound 2 →
+// Semifinals; its winner plays the final) and m-r1-3 (displayRound 3 →
+// Quarterfinals). The OTHER semifinal, m-r2-1, sits in backend round 1: one
+// effective round spread over two raw rounds, one raw round holding two
+// effective rounds. Everything is on court A so the court filter can never be
+// what separates them — only the round rule can.
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', sideA: 'Alice', sideB: 'Bob', displayRound: 2, court: 'A', status: 'running', scheduledAt: '10:00' },
+    { id: 'm-r1-1', sideA: '', sideB: '', hidden: true },
+    { id: 'm-r1-2', sideA: 'Carol', sideB: '', hidden: true },
+    { id: 'm-r1-3', sideA: 'Dave', sideB: 'Eve', displayRound: 3, court: 'A', status: 'completed', scheduledAt: '09:30' },
+  ],
+  [
+    { id: 'm-r2-0', sideA: 'Winner of r3-m0', sideB: '', hidden: true },
+    { id: 'm-r2-1', sideA: 'Carol', sideB: 'Eve', displayRound: 2, court: 'A', status: 'scheduled', scheduledAt: '10:05' },
+  ],
+  [
+    { id: 'm-r3-0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1', displayRound: 1, court: 'A', status: 'scheduled' },
+  ],
+];
+
+const compOf = (rounds) => ({ id: 'c1', name: 'Knockout5', kind: 'individual', teamSize: 0, bracket: { rounds } });
+const findMatch = (rounds, id) => rounds.flat().find((m) => m.id === id);
+
+// promoted, exactly as findRunningOnCourt / findUpcomingOnCourt build it:
+// roundIndex is the RAW index in bracket.rounds.
+const promotedFor = (rounds, id) => {
+  const ri = rounds.findIndex((r) => r.some((m) => m.id === id));
+  return { competition: compOf(rounds), match: findMatch(rounds, id), isBracket: true, roundIndex: ri, totalRounds: rounds.length };
+};
+
+describe('bracketRoundSiblings; selects the effective round, not the raw one (mp-u37s)', () => {
+  it('gathers one effective round across two backend rounds', () => {
+    const rounds = fivePlayerRounds();
+    const sibs = bracketRoundSiblings(rounds, findMatch(rounds, 'm-r1-0'), 0);
+    // Both semifinals, from backend rounds 0 AND 1 — and NOT the quarterfinal
+    // that shares backend round 0 with the promoted match.
+    expect(sibs.map((m) => m.id)).toEqual(['m-r1-0', 'm-r2-1']);
+  });
+
+  it('gathers only the quarterfinal for the quarterfinal, though it shares raw round 0', () => {
+    const rounds = fivePlayerRounds();
+    const sibs = bracketRoundSiblings(rounds, findMatch(rounds, 'm-r1-3'), 0);
+    expect(sibs.map((m) => m.id)).toEqual(['m-r1-3']);
+  });
+
+  it('never returns a hidden phantom, even one tagged with the same effective round', () => {
+    const rounds = [
+      [{ id: 'real', displayRound: 2 }, { id: 'phantom', displayRound: 2, hidden: true }],
+    ];
+    expect(bracketRoundSiblings(rounds, rounds[0][0], 0).map((m) => m.id)).toEqual(['real']);
+  });
+
+  it('falls back to the raw round, unchanged, for a legacy bracket with no metadata', () => {
+    // A balanced 4-player bracket as older data (and every power-of-two draw)
+    // stores it: no displayRound anywhere, so roundIndex IS the effective round
+    // and the raw array must be handed back untouched — same identity, so no
+    // caller can be surprised by a filtered copy.
+    const rounds = [
+      [{ id: 'sf-0', court: 'A' }, { id: 'sf-1', court: 'B' }],
+      [{ id: 'final', court: 'A' }],
+    ];
+    expect(bracketRoundSiblings(rounds, rounds[0][0], 0)).toBe(rounds[0]);
+    expect(bracketRoundSiblings(rounds, rounds[1][0], 1)).toBe(rounds[1]);
+  });
+
+  it('treats the engine sentinels (displayRound 0 / -1) as "no effective round"', () => {
+    // 0 is the unset sentinel and -1 marks the bronze bout; neither is a round,
+    // so both take the raw-round fallback (mirrors bracketRoundLabel).
+    const rounds = [[{ id: 'a', displayRound: 0 }, { id: 'b', displayRound: -1 }]];
+    expect(bracketRoundSiblings(rounds, rounds[0][0], 0)).toBe(rounds[0]);
+    expect(bracketRoundSiblings(rounds, rounds[0][1], 0)).toBe(rounds[0]);
+  });
+
+  it('returns an empty group rather than throwing for a missing match or round', () => {
+    expect(bracketRoundSiblings([], undefined, 0)).toEqual([]);
+    expect(bracketRoundSiblings([[{ id: 'a' }]], { id: 'a' }, 7)).toEqual([]);
+    // A hole in a round (seen in hand-edited/partial payloads) must not throw
+    // while scanning for effective-round siblings.
+    const holed = [[{ id: 'a', displayRound: 2 }, null], [undefined]];
+    expect(bracketRoundSiblings(holed, holed[0][0], 0).map((m) => m.id)).toEqual(['a']);
+  });
+});
+
+describe('phaseProgressOnCourt; the denominator matches the heading (mp-u37s)', () => {
+  beforeEach(() => {
+    global.window = global.window || {};
+    global.window.bracketRoundLabel = bracketRoundLabel; // the real primitive
+  });
+
+  it('counts only same-effective-round matches on the court, not the raw round', () => {
+    const rounds = fivePlayerRounds();
+    // Promoted: the bye-collapsed semifinal in backend round 0. The raw round
+    // would drag in the COMPLETED quarterfinal (m-r1-3) — reading "1 / 2" for a
+    // semifinal round in which nothing has been decided yet.
+    expect(phaseProgressOnCourt(promotedFor(rounds, 'm-r1-0'), 'A')).toEqual({ done: 0, total: 2 });
+  });
+
+  it('counts the quarterfinal alone, not the semifinal sharing its backend round', () => {
+    const rounds = fivePlayerRounds();
+    expect(phaseProgressOnCourt(promotedFor(rounds, 'm-r1-3'), 'A')).toEqual({ done: 1, total: 1 });
+  });
+
+  it('every counted match carries the heading the strip renders above it', () => {
+    // The invariant behind both numbers: heading and set name one round.
+    const rounds = fivePlayerRounds();
+    [['m-r1-0', 'Semifinals'], ['m-r1-3', 'Quarterfinals']].forEach(([id, expected]) => {
+      const p = promotedFor(rounds, id);
+      const heading = phaseLabel(p.match, true, p.roundIndex, p.totalRounds, 'playoffs');
+      expect(heading).toBe(expected);
+      const counted = bracketRoundSiblings(rounds, p.match, p.roundIndex);
+      expect(counted.length).toBeGreaterThan(0);
+      counted.forEach((m) => {
+        // Each counted match, labelled on its OWN raw round index, still reads
+        // as the heading. (m-r2-1 lives in raw round 1, whose raw label is
+        // "Semifinals" only because the effective round says so.)
+        const ri = rounds.findIndex((r) => r.includes(m));
+        expect(phaseLabel(m, true, ri, rounds.length, 'playoffs')).toBe(heading);
+      });
+    });
+  });
+
+  it('still counts the raw round for a legacy bracket with no effective-round metadata', () => {
+    const rounds = [
+      [{ id: 'sf-0', court: 'A', status: 'completed', sideA: { name: 'A1' }, sideB: { name: 'A2' } },
+       { id: 'sf-1', court: 'A', status: 'scheduled', sideA: { name: 'A3' }, sideB: { name: 'A4' } },
+       { id: 'sf-2', court: 'B', status: 'completed', sideA: { name: 'B1' }, sideB: { name: 'B2' } }],
+      [{ id: 'final', court: 'A', status: 'scheduled', sideA: { name: 'Winner of r2-m0' }, sideB: { name: 'Winner of r2-m1' } }],
+    ];
+    expect(phaseProgressOnCourt(promotedFor(rounds, 'sf-0'), 'A')).toEqual({ done: 1, total: 2 });
+  });
+});
+
+describe('gatherIndividualGroup; the rows under the heading are that round (mp-u37s)', () => {
+  const saved = {};
+  beforeEach(() => {
+    global.window = global.window || {};
+    saved.label = global.window.bracketRoundLabel;
+    global.window.bracketRoundLabel = bracketRoundLabel;
+  });
+  afterEach(() => { global.window.bracketRoundLabel = saved.label; });
+
+  it('does not list a quarterfinal among the semifinal rows', () => {
+    const rounds = fivePlayerRounds();
+    const p = promotedFor(rounds, 'm-r1-0');
+    expect(phaseLabel(p.match, true, p.roundIndex, p.totalRounds, 'playoffs')).toBe('Semifinals');
+    // Bracket phase shows completed + current only. The other semifinal is
+    // still scheduled, so the running one is alone — and the COMPLETED
+    // quarterfinal from the same backend round must not appear beside it.
+    const rows = gatherIndividualGroup(p, 'A');
+    expect(rows.map((m) => m.id)).toEqual(['m-r1-0']);
+  });
+
+  it('lists the completed semifinal under the semifinal heading once it is played', () => {
+    const rounds = fivePlayerRounds();
+    // m-r2-1 (the other semifinal, backend round 1) finishes; m-r1-0 is running.
+    findMatch(rounds, 'm-r2-1').status = 'completed';
+    const rows = gatherIndividualGroup(promotedFor(rounds, 'm-r1-0'), 'A');
+    expect(rows.map((m) => m.id)).toEqual(['m-r2-1', 'm-r1-0']); // completed first, current last
+  });
+});

--- a/web-mobile/js/__tests__/display_white_board.test.jsx
+++ b/web-mobile/js/__tests__/display_white_board.test.jsx
@@ -866,17 +866,17 @@ describe('phaseLabel: league suppresses the round-robin round number', () => {
     expect(phaseLabel({ id: 'Pool A-TB-0', round: 0 }, false, undefined, undefined, 'mixed')).toBe('Pool A');
   });
 
-  it('does NOT derive a pool-like label from a bracket id when roundLabel is unavailable', () => {
+  it('does NOT derive a pool-like label from a bracket id when bracketRoundLabel is unavailable', () => {
     // poolNameOf matches any "*-<digits>" shape, so a bracket id "m-r1-0" would
     // wrongly yield "m-r1". The !isBracket guard prevents that: a bracket match
-    // with no roundLabel falls through to the numeric round (or "").
-    const saved = window.roundLabel;
-    window.roundLabel = undefined; // simulate roundLabel not loaded
+    // with no round-label helper falls through to the numeric round (or "").
+    const saved = window.bracketRoundLabel;
+    window.bracketRoundLabel = undefined; // simulate bracket.jsx not loaded
     try {
       expect(phaseLabel({ id: 'm-r1-0', round: 0 }, true, 0, 3, 'playoffs')).toBe('0');
       expect(phaseLabel({ id: 'm-r1-0' }, true, 0, 3, 'playoffs')).toBe('');
     } finally {
-      window.roundLabel = saved;
+      window.bracketRoundLabel = saved;
     }
   });
 });

--- a/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
+++ b/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
@@ -39,7 +39,7 @@ const matchClickHandlers = (tree, raw) =>
 
 const STUBBED = [
   'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
-  'BracketTree', 'MatchCard', 'buildBracket', 'roundLabel', 'formatIpponsScore',
+  'BracketTree', 'MatchCard', 'buildBracket', 'roundLabel', 'bracketRoundLabel', 'formatIpponsScore',
   'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
   'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
   'matchStateCell', 'engiPairParts', 'bronzeUnderFinalStyle', 'API', 'LoadingSpinner',
@@ -62,6 +62,7 @@ function installStubs() {
   global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
   global.window.buildBracket = () => [];
   global.window.roundLabel = (i) => `Round ${i + 1}`;
+  global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
   global.window.formatIpponsScore = () => '';
   global.window.teamIVScore = () => null;
   global.window.matchScoreStr = () => '';

--- a/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
+++ b/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
@@ -68,6 +68,12 @@ function installStubs() {
   global.window.matchStateCell = () => '-';
   global.window.ipponsFromScore = () => [];
   global.window.isHikiwake = () => false;
+  // Deliberately the naive check, and safe ONLY because this file asserts
+  // compEngi stamping and never exercises a side-presence filter. Do NOT copy
+  // this harness into a test that does: normalizeMatch substitutes a truthy
+  // {id:"",name:""} for an absent side, so this stub waves byes through and
+  // would give such a test a vacuous pass. Import admin_helpers.jsx for the
+  // real predicate instead, as viewer_competition_bye_results.test.jsx does.
   global.window.hasBothSides = (m) => !!(m && m.sideA && m.sideB);
   global.window.compareDmy = (a, b) => String(a).localeCompare(String(b));
   global.window.queueLabel = () => '';

--- a/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
+++ b/web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx
@@ -70,7 +70,8 @@ function installStubs() {
   global.window.ipponsFromScore = () => [];
   global.window.isHikiwake = () => false;
   // Deliberately the naive check, and safe ONLY because this file asserts
-  // compEngi stamping and never exercises a side-presence filter. Do NOT copy
+  // compEngi stamping: ViewerCompetition does call this stub, but no fixture
+  // here has an absent side and no assertion depends on the verdict. Do NOT copy
   // this harness into a test that does: normalizeMatch substitutes a truthy
   // {id:"",name:""} for an absent side, so this stub waves byes through and
   // would give such a test a vacuous pass. Import admin_helpers.jsx for the

--- a/web-mobile/js/__tests__/mp_turx_knockout.test.jsx
+++ b/web-mobile/js/__tests__/mp_turx_knockout.test.jsx
@@ -68,7 +68,7 @@ describe('ViewerCompetition: merged mixed comp shows no cross-link (mp-turx back
   const savedGlobals = {};
   const STUBBED = [
     'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
-    'BracketTree', 'buildBracket', 'roundLabel', 'formatIpponsScore',
+    'BracketTree', 'buildBracket', 'roundLabel', 'bracketRoundLabel', 'formatIpponsScore',
     'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
     'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
   ];
@@ -114,6 +114,7 @@ describe('ViewerCompetition: merged mixed comp shows no cross-link (mp-turx back
     global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
     global.window.buildBracket = () => runningBracket.rounds;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.formatIpponsScore = () => '';
     global.window.teamIVScore = () => null;
     global.window.matchScoreStr = (m) =>
@@ -228,7 +229,7 @@ describe('AdminCompetition: page-head has no Start-knockout affordance (mp-turx)
     'AdminTopbar', 'AdminParticipants', 'AdminSettings', 'AdminExport',
     'AdminScoreEditor', 'AdminPools', 'AdminCompOverview', 'AdminTeamLineupsList',
     'AdminSwissRounds', 'RunningMatchPanel', 'BracketTree', 'promptAdminPassword',
-    'isValidDate', 'roundLabel', 'hasBothSides',
+    'isValidDate', 'roundLabel', 'bracketRoundLabel', 'hasBothSides',
     'AdminCompetition',
   ];
 
@@ -286,6 +287,7 @@ describe('AdminCompetition: page-head has no Start-knockout affordance (mp-turx)
     global.window.promptAdminPassword = () => 'admin';
     global.window.isValidDate = () => true;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.hasBothSides = (m) => !!(m && m.sideA && m.sideB && m.sideA.id && m.sideB.id);
     global.window.API = {
       startCompetition: vi.fn(() => Promise.resolve({})),
@@ -446,7 +448,7 @@ describe('AdminBracket: per-match playability (mp-turx)', () => {
     'AdminTopbar', 'AdminParticipants', 'AdminSettings', 'AdminExport',
     'AdminScoreEditor', 'AdminPools', 'AdminCompOverview', 'AdminTeamLineupsList',
     'AdminSwissRounds', 'RunningMatchPanel', 'BracketTree', 'promptAdminPassword',
-    'isValidDate', 'roundLabel', 'hasBothSides',
+    'isValidDate', 'roundLabel', 'bracketRoundLabel', 'hasBothSides',
     'AdminCompetition',
   ];
 
@@ -527,6 +529,7 @@ describe('AdminBracket: per-match playability (mp-turx)', () => {
     global.window.promptAdminPassword = () => 'admin';
     global.window.isValidDate = () => true;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.hasBothSides = realHasBothSides;
     global.window.API = {
       startCompetition: vi.fn(() => Promise.resolve({})),

--- a/web-mobile/js/__tests__/render/bracket_bye_slot.render.test.jsx
+++ b/web-mobile/js/__tests__/render/bracket_bye_slot.render.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// A non-power-of-two knockout contains structural byes: an entrant who advances
+// a round with no opponent. BracketTreeMeta draws that as a standalone
+// .bc-bye-slot placeholder in the upstream column. A NAMED slot used to render
+// the competitor's name and nothing else, so a spectator saw an unexplained grey
+// box sitting beside the match cards. These tests pin that the slot always
+// carries the visible BYE marker, and that the marker is printed exactly once in
+// either case (named or nameless).
+//
+// Render project (not the unit one): the marker is DOM the viewer reads off the
+// bracket, so it has to be asserted on a real mount. The unit suite's fake-React
+// stub never produces the slot markup.
+
+let BracketTree;
+
+beforeAll(async () => {
+  // BracketTree measures card geometry for its connectors; jsdom has no
+  // ResizeObserver. Only the slot TEXT matters here.
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  await import('../../bracket.jsx');
+  BracketTree = window.BracketTree;
+});
+
+// 5 entrants, the smallest roster that produces a structural bye. Same fixture
+// shape as bracket_display_model.test.jsx / bracket_feeder_slot.render.test.jsx:
+// Carol is seeded straight into the semi-final, so m-r2-1's sideA feeder is ""
+// and buildDisplayModel inserts a named bye slot for her in the column before.
+const side = (name) => ({ id: name ? `p-${name}` : '', name });
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', court: 'A', status: 'scheduled', sideA: side('Alice'), sideB: side('Bob'), displayRound: 2, feeders: ['', ''] },
+    { id: 'm-r1-1', court: 'A', sideA: side(''), sideB: side(''), hidden: true },
+    { id: 'm-r1-2', court: 'A', sideA: side('Carol'), sideB: side(''), hidden: true },
+    { id: 'm-r1-3', court: 'A', status: 'scheduled', sideA: side('Dave'), sideB: side('Eve'), displayRound: 3, feeders: ['', ''] },
+  ],
+  [
+    { id: 'm-r2-0', court: 'A', sideA: side('Winner of r3-m0'), sideB: side(''), hidden: true },
+    { id: 'm-r2-1', court: 'A', status: 'scheduled', sideA: side('Carol'), sideB: side('Winner of r3-m3'), displayRound: 2, feeders: ['', 'm-r1-3'] },
+  ],
+  [
+    { id: 'm-r3-0', court: 'A', status: 'scheduled', sideA: side('Winner of r2-m0'), sideB: side('Winner of r2-m1'), displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'] },
+  ],
+];
+
+const byeSlots = (container) => Array.from(container.querySelectorAll('.bc-bye-slot'));
+const slotNamed = (container, name) =>
+  byeSlots(container).find((s) => s.querySelector('.bc-bye-slot__name')?.textContent === name);
+
+describe('public bracket: a named bye slot is legible as an unopposed advance', () => {
+  // Alice, Bob and Carol are each seeded past a round in this bracket, so the
+  // fixture draws three named placeholders.
+  it('renders the competitor name AND a visible BYE marker in the same slot', () => {
+    const { container } = render(<BracketTree rounds={fivePlayerRounds()} />);
+    const slot = slotNamed(container, 'Carol');
+    expect(slot).toBeTruthy();
+    const tags = slot.querySelectorAll('.bc-bye-slot__tag');
+    expect(tags).toHaveLength(1); // marker printed exactly once
+    expect(tags[0].textContent).toBe('BYE');
+    // What a spectator actually reads off the box, in order.
+    expect(slot.textContent).toBe('CarolBYE');
+  });
+
+  it('marks every named slot, as visible text and not only in the aria-label', () => {
+    const { container } = render(<BracketTree rounds={fivePlayerRounds()} />);
+    const slots = byeSlots(container);
+    expect(slots).toHaveLength(3);
+    expect(slots.map((s) => s.textContent).sort()).toEqual(['AliceBYE', 'BobBYE', 'CarolBYE']);
+    expect(screen.getAllByText('BYE')).toHaveLength(3);
+  });
+
+  it('prints the marker once, not twice, when the slot has no name', () => {
+    // A bye whose feeding side carries no player: the placeholder is nameless.
+    const rounds = fivePlayerRounds();
+    rounds[1][1].sideA = side('');
+    const { container } = render(<BracketTree rounds={rounds} />);
+    const nameless = byeSlots(container).filter((s) => !s.querySelector('.bc-bye-slot__name'));
+    expect(nameless).toHaveLength(1);
+    expect(nameless[0].querySelectorAll('.bc-bye-slot__tag')).toHaveLength(1);
+    expect(nameless[0].textContent).toBe('BYE');
+  });
+});

--- a/web-mobile/js/__tests__/render/bracket_feeder_slot.render.test.jsx
+++ b/web-mobile/js/__tests__/render/bracket_feeder_slot.render.test.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// The PUBLIC bracket (viewer Bracket tab) and the admin bracket both render
+// through BracketTree → MatchCard → PlayerLine. An unresolved feeder side
+// arrives from the server as the wire value "Winner of r<depth>-m<idx>", which
+// is (a) an internal index a spectator cannot use and (b) NOT the number the
+// same bracket prints on its cards. These tests pin that no raw id reaches the
+// DOM and that the human label names a card that is actually on screen.
+
+let BracketTree, MatchCard;
+
+beforeAll(async () => {
+  // BracketTree measures card geometry to place its connectors; jsdom has no
+  // ResizeObserver, so stub the observe/disconnect surface it uses. The layout
+  // maths is covered by bracket_display_model.test.jsx; here only the TEXT matters.
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  await import('../../bracket.jsx');
+  BracketTree = window.BracketTree;
+  MatchCard = window.MatchCard;
+});
+
+// 5 entrants: the roster that produces exactly this placeholder. Shape verified
+// against the engine's bracket.json (same fixture as bracket_display_model.test.jsx),
+// with sides in the normalized {id, name} form the viewer receives.
+// Card numbers: m-r1-3 = M1, m-r1-0 = M2, m-r2-1 = M3, m-r3-0 = M4.
+const side = (name) => ({ id: name ? `p-${name}` : '', name });
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', court: 'A', status: 'scheduled', sideA: side('Alice'), sideB: side('Bob'), displayRound: 2, feeders: ['', ''] },
+    { id: 'm-r1-1', court: 'A', sideA: side(''), sideB: side(''), hidden: true },
+    { id: 'm-r1-2', court: 'A', sideA: side('Carol'), sideB: side(''), hidden: true },
+    { id: 'm-r1-3', court: 'A', status: 'scheduled', sideA: side('Dave'), sideB: side('Eve'), displayRound: 3, feeders: ['', ''] },
+  ],
+  [
+    { id: 'm-r2-0', court: 'A', sideA: side('Winner of r3-m0'), sideB: side(''), hidden: true },
+    { id: 'm-r2-1', court: 'A', status: 'scheduled', sideA: side('Carol'), sideB: side('Winner of r3-m3'), displayRound: 2, feeders: ['', 'm-r1-3'] },
+  ],
+  [
+    { id: 'm-r3-0', court: 'A', status: 'scheduled', sideA: side('Winner of r2-m0'), sideB: side('Winner of r2-m1'), displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'] },
+  ],
+];
+
+describe('public bracket: an unresolved feeder slot reads as a match number', () => {
+  it('never renders a raw r<N>-m<N> id anywhere in the tree', () => {
+    const { container } = render(<BracketTree rounds={fivePlayerRounds()} />);
+    // The whole rendered subtree, text + attributes (aria-labels included).
+    expect(container.innerHTML).not.toMatch(/r\d+-m\d+/);
+    expect(container.textContent).not.toContain('Winner of r');
+  });
+
+  it('names the feeder after the card the bracket itself prints', () => {
+    render(<BracketTree rounds={fivePlayerRounds()} />);
+    // "Winner of r3-m3" is fed by m-r1-3, the card labelled M1 — NOT "M3", which
+    // is the trap in reading the id as a match number.
+    expect(screen.getByText('Winner of M1')).toBeTruthy();
+    expect(screen.getByText('M1')).toBeTruthy(); // the card it points at is on screen
+  });
+
+  it('resolves a slot that points through a phantom bye match', () => {
+    render(<BracketTree rounds={fivePlayerRounds()} />);
+    // The final's sideA slot says "r2-m0" (a dead bye match); the real feeder is
+    // m-r1-0 = M2. Its sideB slot "r2-m1" → m-r2-1 = M3.
+    expect(screen.getByText('Winner of M2')).toBeTruthy();
+    expect(screen.getByText('Winner of M3')).toBeTruthy();
+  });
+
+  it('leaves real competitor names untouched', () => {
+    render(<BracketTree rounds={fivePlayerRounds()} />);
+    ['Alice', 'Bob', 'Dave', 'Eve'].forEach((n) => expect(screen.getAllByText(n).length).toBeGreaterThan(0));
+  });
+});
+
+describe('MatchCard without a bracket context still cannot leak the id', () => {
+  it('degrades a feeder slot to TBD when no labeller is supplied', () => {
+    const { container } = render(
+      <MatchCard
+        match={{ id: 'm-r3-0', court: 'A', status: 'scheduled', sideA: side('Winner of r2-m0'), sideB: side('Yuki Tanaka') }}
+        variant="1"
+      />
+    );
+    expect(container.innerHTML).not.toMatch(/r\d+-m\d+/);
+    expect(screen.getByText('TBD')).toBeTruthy();
+    expect(screen.getByText('Yuki Tanaka')).toBeTruthy();
+  });
+
+  it('keeps pool-origin placeholders verbatim: they are self-describing', () => {
+    render(
+      <MatchCard
+        match={{ id: 'm-r1-0', court: 'A', status: 'scheduled', sideA: side('Pool A-1st'), sideB: side('Pool B-2nd') }}
+        variant="1"
+      />
+    );
+    expect(screen.getByText('Pool A-1st')).toBeTruthy();
+    expect(screen.getByText('Pool B-2nd')).toBeTruthy();
+  });
+});

--- a/web-mobile/js/__tests__/render/bracket_feeder_slot.render.test.jsx
+++ b/web-mobile/js/__tests__/render/bracket_feeder_slot.render.test.jsx
@@ -6,8 +6,11 @@ import { describe, it, expect, beforeAll } from 'vitest';
 // through BracketTree → MatchCard → PlayerLine. An unresolved feeder side
 // arrives from the server as the wire value "Winner of r<depth>-m<idx>", which
 // is (a) an internal index a spectator cannot use and (b) NOT the number the
-// same bracket prints on its cards. These tests pin that no raw id reaches the
-// DOM and that the human label names a card that is actually on screen.
+// same bracket prints on its cards. These tests pin that no raw SLOT VALUE
+// reaches the DOM, and that the human label names a card that is actually on
+// screen. Note the regex targets the "Winner of r<N>-m<N>" slot shape, not
+// match ids in general: those legitimately appear in data-match-id and in the
+// aria-label fallback, and are not what leaks to a reader.
 
 let BracketTree, MatchCard;
 

--- a/web-mobile/js/__tests__/render/bracket_round_label.render.test.jsx
+++ b/web-mobile/js/__tests__/render/bracket_round_label.render.test.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// mp-u37s: pin the bracket COLUMN header as the DOM actually renders it.
+//
+// bracket_round_label_agreement.test.jsx proves the ROW side of the agreement
+// (compMatches → m.round) against the shared bracketRoundLabel primitive, but
+// its column half is computed by a test-local helper that calls
+// bracketRoundLabel(col[0], ci, len) itself. That mirrors BracketTreeMeta's
+// source line rather than reading it, so it stays green even if the component
+// stops calling the primitive (or prints a literal). This file closes that gap:
+// it MOUNTS BracketTree and reads .bc-round-label out of the rendered tree, so
+// the header text is asserted against the DOM a spectator sees.
+//
+// Also pinned here: the column a card is drawn UNDER carries the same name as
+// that card's own bracketRoundLabel row label. The column side comes from the
+// DOM; the row side comes from the real primitive. Nothing in this file
+// re-spells the roundIdx → name rule.
+
+let BracketTree, bracketRoundLabel, roundLabel;
+
+beforeAll(async () => {
+  // BracketTree measures card geometry to place its connectors; jsdom has no
+  // ResizeObserver. The layout maths is covered by bracket_display_model.test.jsx;
+  // here only the header TEXT and the card-to-column grouping matter.
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  const mod = await import('../../bracket.jsx');
+  BracketTree = window.BracketTree;
+  bracketRoundLabel = mod.bracketRoundLabel;
+  roundLabel = mod.roundLabel;
+});
+
+// The 5-entrant individual knockout as the engine persists it: 3 backend rounds
+// with a bye-collapsed round, so a match's effective round (displayRound) can
+// name a DIFFERENT round from its raw slot in bracket.rounds. Same shape as
+// bracket_round_label_agreement.test.jsx and bracket_display_model.test.jsx,
+// with sides in the normalized {id, name} form the viewer receives (as in
+// bracket_feeder_slot.render.test.jsx).
+const side = (name) => ({ id: name ? `p-${name}` : '', name });
+const fivePlayerRounds = () => [
+  [
+    { id: 'm-r1-0', court: 'A', status: 'scheduled', sideA: side('Alice'), sideB: side('Bob'), displayRound: 2, feeders: ['', ''] },
+    { id: 'm-r1-1', court: 'A', sideA: side(''), sideB: side(''), hidden: true },
+    { id: 'm-r1-2', court: 'A', sideA: side('Carol'), sideB: side(''), hidden: true },
+    { id: 'm-r1-3', court: 'A', status: 'scheduled', sideA: side('Dave'), sideB: side('Eve'), displayRound: 3, feeders: ['', ''] },
+  ],
+  [
+    { id: 'm-r2-0', court: 'A', sideA: side('Winner of r3-m0'), sideB: side(''), hidden: true },
+    { id: 'm-r2-1', court: 'A', status: 'scheduled', sideA: side('Carol'), sideB: side('Winner of r3-m3'), displayRound: 2, feeders: ['', 'm-r1-3'] },
+  ],
+  [
+    { id: 'm-r3-0', court: 'A', status: 'scheduled', sideA: side('Winner of r2-m0'), sideB: side('Winner of r2-m1'), displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'] },
+  ],
+];
+
+// Every rendered column: its header text and the ids of the match cards drawn
+// under it, straight out of the DOM. Bye slots carry no data-match-id (they are
+// a .bc-bye-slot div, not a MatchCard button), so only real matches appear.
+const domColumns = (container) => Array.from(container.querySelectorAll('.bc-round')).map((col) => {
+  const header = col.querySelector('.bc-round-label');
+  return {
+    label: header ? header.textContent : null,
+    matchIds: Array.from(col.querySelectorAll('[data-match-id]')).map((el) => el.getAttribute('data-match-id')),
+  };
+});
+
+// matchId → the raw (roundIndex, totalRounds) pair it occupies on the wire.
+const rawPositions = (rounds) => {
+  const out = {};
+  rounds.forEach((round, ri) => round.forEach((m) => { out[m.id] = { m, ri, total: rounds.length }; }));
+  return out;
+};
+
+describe('bracket column headers as rendered (mp-u37s)', () => {
+  it('prints exactly Quarterfinals / Semifinals / Final for the 5-entrant draw', () => {
+    const { container } = render(<BracketTree rounds={fivePlayerRounds()} />);
+    expect(domColumns(container).map((c) => c.label)).toEqual(['Quarterfinals', 'Semifinals', 'Final']);
+  });
+
+  it('draws each card under a column whose header matches that card own round label', () => {
+    const rounds = fivePlayerRounds();
+    const { container } = render(<BracketTree rounds={rounds} />);
+    const positions = rawPositions(rounds);
+    const columns = domColumns(container);
+
+    const compared = [];
+    columns.forEach(({ label, matchIds }) => {
+      matchIds.forEach((id) => {
+        const pos = positions[id];
+        expect(pos, `card ${id} is on screen but not in the fixture`).toBeTruthy();
+        // Column header: read from the DOM. Row label: the real primitive.
+        expect(label).toBe(bracketRoundLabel(pos.m, pos.ri, pos.total));
+        compared.push(id);
+      });
+    });
+    // Guard against a vacuous pass: all four real matches must have been drawn.
+    expect(compared.sort()).toEqual(['m-r1-0', 'm-r1-3', 'm-r2-1', 'm-r3-0']);
+  });
+
+  it('headers the bye-collapsed match Semifinals, not the raw Quarterfinals', () => {
+    const { container } = render(<BracketTree rounds={fivePlayerRounds()} />);
+    const column = domColumns(container).find((c) => c.matchIds.includes('m-r1-0'));
+    expect(column).toBeTruthy();
+    // THE regression: m-r1-0 sits in backend round 0 of 3, so the raw rule calls
+    // it a quarterfinal, but its winner plays the final. The header a spectator
+    // reads above the card must be the effective round.
+    expect(roundLabel(0, 3)).toBe('Quarterfinals'); // what the raw rule would print
+    expect(column.label).toBe('Semifinals');
+  });
+});

--- a/web-mobile/js/__tests__/render/score_editor_seed_from_score_string.render.test.jsx
+++ b/web-mobile/js/__tests__/render/score_editor_seed_from_score_string.render.test.jsx
@@ -1,0 +1,225 @@
+// Regression: ScoreEditorModal must seed its ippon slots from the scoreA /
+// scoreB STRINGS when the ippon arrays are absent.
+//
+// THE BUG (found in browser UAT, HIGH, silent data loss). The editor seeded
+// only from m.ipponsA / m.ipponsB:
+//
+//   const seedAPts = m.ipponsA?.filter(...) || (m.score?.type === "ippon" && ...);
+//
+// state.MatchResult (pool / league) carries ipponsA / ipponsB on the wire, but
+// state.BracketMatch (knockout) carries ONLY ScoreA / ScoreB strings
+// (internal/state/models.go — no ippon slices on the bracket type). So a
+// KNOCKOUT match re-read from the server arrived with no ippon arrays at all:
+// the editor opened EMPTY on a match that already had points, and the
+// operator's next tap saved over them — a recorded ippon lost mid-match.
+//
+// The fix parses the string as a fallback, which is what every DISPLAY surface
+// already did (admin_shiaijo.jsx, match_scoreboard.jsx, bracket.jsx); the
+// editor was the one surface that did not.
+//
+// Two things this file deliberately pins beyond the headline case:
+//   * the score.type === "ippon" branch must stay REACHABLE as the last
+//     resort. It is guarded by `cleanA.length ? ... : ...` and NOT by `||`,
+//     because an empty array is truthy and `||` would make it dead code.
+//     "seeds from score.ippons" below fails if anyone "simplifies" it back.
+//   * window.ipponsFromScore is the REAL implementation, published as a side
+//     effect of importing bracket.jsx (the idiom of vsched_bout_middle.test.jsx
+//     and how the browser reaches it). Stubbing it would make these assertions
+//     circular — in particular the "MK (H1)" case only passes because the real
+//     helper strips the backend's hansoku suffix before splitting.
+//
+// Render project (real React 18 + jsdom): the seeding runs in the component
+// body and is only observable through the mounted slot buttons, so there is no
+// lighter home that pins the same behaviour. Mirrors the global-stub setup of
+// admin_scoring_modal.render.test.jsx.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+const STUBBED_GLOBALS = {
+  isHikiwake: (_type) => false,
+  arraysEqual: (a, b) => a.length === b.length && a.every((v, i) => v === b[i]),
+  isKikenDecision: (_kind) => false,
+  isTextEntry: () => false,
+  isInteractiveTarget: () => false,
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  resolveRoundIndex: () => 0,
+  API: {
+    fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
+    recordScore: vi.fn(),
+    recordDaihyosen: vi.fn(),
+    removeDaihyosen: vi.fn(),
+    putMatchLineup: vi.fn(),
+    recordDecision: vi.fn(),
+  },
+  AdminLineupHelpers: { rosterFor: vi.fn().mockReturnValue([]) },
+  compMatches: () => [],
+  Term: ({ children }) => <span>{children}</span>,
+  GlossaryHint: ({ name }) => <span title={name} />,
+};
+
+const originals = {};
+let ScoreEditorModal;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  // Side-effect import: publishes the REAL window.ipponsFromScore that the
+  // editor's fallback calls. Not stubbed on purpose (see header).
+  await import('../../bracket.jsx');
+  await import('../../admin_scoring_modal.jsx');
+  ScoreEditorModal = window.ScoreEditorModal;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+const SIDE_A = { id: 'p1', name: 'Yamada' }; // Aka  (right column)
+const SIDE_B = { id: 'p2', name: 'Tanaka' }; // Shiro (left column)
+
+// A knockout match exactly as state.BracketMatch reaches the client: scoreA /
+// scoreB strings, NO ipponsA / ipponsB, still running so there is no winner.
+function knockoutMatch(overrides = {}) {
+  return {
+    id: 'bm1',
+    status: 'running',
+    phase: 'bracket',
+    round: 'Quarter-final',
+    court: 'A',
+    sideA: SIDE_A,
+    sideB: SIDE_B,
+    // No compId → the fetchCompetitionDetails effect returns early.
+    ...overrides,
+  };
+}
+
+// Empty slots render "·" (a middle dot placeholder), filled ones the letter.
+function slotsOf(container, color) {
+  return Array.from(container.querySelectorAll(`.sb-side--${color} .sb-slot`))
+    .map((b) => b.textContent);
+}
+
+// sides[] in admin_scoring_individual.jsx is [b → shiro, a → aka]:
+// sideB is Shiro (left), sideA is Aka (right), matching the app-wide convention.
+const akaSlots = (c) => slotsOf(c, 'aka');
+const shiroSlots = (c) => slotsOf(c, 'shiro');
+
+function renderEditor(match) {
+  return render(
+    <ScoreEditorModal match={match} onClose={vi.fn()} onSubmit={vi.fn()} password="" />
+  );
+}
+
+describe('ScoreEditorModal ippon seeding', () => {
+  it('is a sanity check that the REAL ipponsFromScore is in play', () => {
+    expect(typeof window.ipponsFromScore).toBe('function');
+    expect(window.ipponsFromScore('MK')).toEqual(['M', 'K']);
+    expect(window.ipponsFromScore('MK (H1)')).toEqual(['M', 'K']);
+  });
+
+  // ── THE bug case ──────────────────────────────────────────────────────────
+  it('seeds Aka from scoreA when a knockout match carries no ippon arrays', () => {
+    const { container } = renderEditor(knockoutMatch({ scoreA: 'M' }));
+    // Before the fix these read ['·', '·'] and the next tap overwrote the M.
+    expect(akaSlots(container)).toEqual(['M', '·']);
+    expect(shiroSlots(container)).toEqual(['·', '·']);
+  });
+
+  it('seeds Shiro from scoreB when a knockout match carries no ippon arrays', () => {
+    const { container } = renderEditor(knockoutMatch({ scoreB: 'K' }));
+    expect(shiroSlots(container)).toEqual(['K', '·']);
+    expect(akaSlots(container)).toEqual(['·', '·']);
+  });
+
+  it('seeds both sides from their score strings', () => {
+    const { container } = renderEditor(knockoutMatch({ scoreA: 'M', scoreB: 'K' }));
+    expect(akaSlots(container)).toEqual(['M', '·']);
+    expect(shiroSlots(container)).toEqual(['K', '·']);
+  });
+
+  it('strips the backend hansoku suffix rather than splitting it into slots', () => {
+    // engine/scoring.go formatScore appends " (H1)". A naive split would seed
+    // ["M", " ", "(", "H", "1", ")"]; the real ipponsFromScore strips it.
+    const { container } = renderEditor(knockoutMatch({ scoreA: 'M (H1)' }));
+    expect(akaSlots(container)).toEqual(['M', '·']);
+  });
+
+  // ── no regression on the pool / league shape ──────────────────────────────
+  it('still seeds from ipponsA / ipponsB when the arrays are present', () => {
+    const { container } = renderEditor({
+      id: 'pm1',
+      status: 'running',
+      phase: 'pool',
+      poolName: 'Pool 1',
+      court: 'A',
+      sideA: SIDE_A,
+      sideB: SIDE_B,
+      ipponsA: ['M', 'K'],
+      ipponsB: ['D'],
+    });
+    expect(akaSlots(container)).toEqual(['M', 'K']);
+    expect(shiroSlots(container)).toEqual(['D', '·']);
+  });
+
+  it('prefers the ippon arrays over a disagreeing score string', () => {
+    const { container } = renderEditor(knockoutMatch({
+      ipponsA: ['M', 'K'],
+      scoreA: 'D',
+      ipponsB: [],
+      scoreB: 'T',
+    }));
+    expect(akaSlots(container)).toEqual(['M', 'K']);
+    // An explicitly EMPTY ipponsB still wins over scoreB: the array is the
+    // authoritative source when the wire carries one.
+    expect(shiroSlots(container)).toEqual(['·', '·']);
+  });
+
+  // ── the last-resort branch must stay reachable ────────────────────────────
+  it('seeds from score.ippons when there is neither an array nor a score string', () => {
+    // GUARD against replacing `cleanA.length ? ... : ...` with `cleanA || ...`:
+    // cleanA is [] here, which is TRUTHY, so `||` would return the empty array
+    // and this branch would become dead code — slots would read ['·', '·'].
+    const { container } = renderEditor(knockoutMatch({
+      status: 'completed',
+      winner: SIDE_A,
+      score: { type: 'ippon', ippons: ['M', 'K'] },
+    }));
+    expect(akaSlots(container)).toEqual(['M', 'K']);
+    expect(shiroSlots(container)).toEqual(['·', '·']);
+  });
+
+  it('attributes score.ippons to the winning side only', () => {
+    const { container } = renderEditor(knockoutMatch({
+      status: 'completed',
+      winner: SIDE_B,
+      score: { type: 'ippon', ippons: ['D'] },
+    }));
+    expect(shiroSlots(container)).toEqual(['D', '·']);
+    expect(akaSlots(container)).toEqual(['·', '·']);
+  });
+
+  // ── the "•" placeholder filter applies to BOTH sources ────────────────────
+  it('filters the "•" placeholder out of the ippon arrays', () => {
+    const { container } = renderEditor(knockoutMatch({
+      ipponsA: ['•', 'M'],
+      ipponsB: ['•', '•'],
+    }));
+    expect(akaSlots(container)).toEqual(['M', '·']);
+    expect(shiroSlots(container)).toEqual(['·', '·']);
+  });
+
+  it('filters the "•" placeholder out of a parsed score string', () => {
+    const { container } = renderEditor(knockoutMatch({ scoreA: '•M', scoreB: '•' }));
+    expect(akaSlots(container)).toEqual(['M', '·']);
+    // scoreB parses to ["•"], which filters to empty — and with no winner /
+    // score.ippons to fall back on, Shiro stays empty rather than showing "•".
+    expect(shiroSlots(container)).toEqual(['·', '·']);
+  });
+});

--- a/web-mobile/js/__tests__/shiaijo_queue_round_groups.test.jsx
+++ b/web-mobile/js/__tests__/shiaijo_queue_round_groups.test.jsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { groupQueueMatches } from '../admin_shiaijo.jsx';
+import { bracketRoundLabel } from '../bracket.jsx';
+import { compMatches } from '../viewer_utils.jsx';
+
+// Kept in its own file rather than folded into admin_shiaijo.test.jsx: this
+// suite needs the REAL bracket.jsx (for bracketRoundLabel), whose module eval
+// installs window.teamIVPWScore & friends, and that would silently take over
+// from the hand-rolled window stubs the score-cell suites there rely on.
+
+// mp-u37s: a queue group's HEADING must describe every match under it.
+//
+// Row labels now come from the EFFECTIVE round (bracketRoundLabel / mp-7f2w
+// displayRound), which collapses a round whose other match is a structural bye.
+// groupQueueMatches kept keying on the RAW backend index (m.roundIndex) while
+// taking the heading from the first member's m.round, so the two disagreed in
+// exactly the two ways one raw↔effective mismatch allows:
+//   1. one raw round holding two effective rounds → a QUARTERFINAL rendered
+//      under a "Semifinals" heading;
+//   2. two raw rounds sharing one effective round → TWO groups both headed
+//      "Semifinals", the same round split across two blocks of the queue.
+// Keying on the displayed label closes both.
+describe('groupQueueMatches; the heading describes its members (mp-u37s)', () => {
+  // The 5-entrant knockout the engine really persists (same fixture as
+  // bracket_round_label_agreement / bracket_display_model): backend round 0
+  // holds BOTH m-r1-0 (displayRound 2 → Semifinals, its winner plays the final)
+  // and m-r1-3 (displayRound 3 → Quarterfinals). Backend round 1 holds the
+  // OTHER semifinal. One raw round, two effective rounds — and one effective
+  // round spread over two raw rounds.
+  const fivePlayerRounds = () => [
+    [
+      { id: 'm-r1-0', sideA: 'Alice', sideB: 'Bob', displayRound: 2, feeders: ['', ''], court: 'A', status: 'scheduled' },
+      { id: 'm-r1-1', sideA: '', sideB: '', hidden: true },
+      { id: 'm-r1-2', sideA: 'Carol', sideB: '', hidden: true },
+      { id: 'm-r1-3', sideA: 'Dave', sideB: 'Eve', displayRound: 3, feeders: ['', ''], court: 'A', status: 'scheduled' },
+    ],
+    [
+      { id: 'm-r2-0', sideA: 'Winner of r3-m0', sideB: '', hidden: true },
+      { id: 'm-r2-1', sideA: 'Carol', sideB: 'Winner of r3-m3', displayRound: 2, feeders: ['', 'm-r1-3'], court: 'A', status: 'scheduled' },
+    ],
+    [
+      { id: 'm-r3-0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1', displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'], court: 'A', status: 'scheduled' },
+    ],
+  ];
+
+  // Build the queue rows the way the console really does: through compMatches,
+  // which stamps `round` from window.bracketRoundLabel and keeps `roundIndex`
+  // raw. Phantom (hidden) matches never reach the queue.
+  const queueRows = () => {
+    const comp = {
+      id: 'c1', name: 'Knockout5', status: 'playoffs', format: 'playoffs',
+      kind: 'individual', teamSize: 0, engi: false,
+      bracket: { rounds: fivePlayerRounds() },
+    };
+    return compMatches(comp).filter((m) => m.phase === 'bracket' && !m.hidden);
+  };
+
+  beforeEach(() => {
+    global.window = global.window || {};
+    global.window.bracketRoundLabel = bracketRoundLabel; // the real primitive
+  });
+
+  it('never files a quarterfinal under a "Semifinals" heading', () => {
+    const groups = groupQueueMatches(queueRows());
+    // The invariant, stated directly: every member's own round name equals the
+    // heading it is drawn under. Nothing else about the grouping matters.
+    groups.forEach((g) => g.matches.forEach((m) => {
+      expect(m.round).toBe(g.label);
+    }));
+    // …and pin the specific pairing that regressed, so the invariant above
+    // can't pass vacuously on a fixture that lost its mismatch.
+    const byLabel = Object.fromEntries(groups.map((g) => [g.label, g.matches.map((m) => m.id)]));
+    expect(byLabel['Semifinals']).not.toContain('m-r1-3');
+    expect(byLabel['Quarterfinals']).toEqual(['m-r1-3']);
+  });
+
+  it('puts one effective round in ONE group, not two identically-titled ones', () => {
+    const groups = groupQueueMatches(queueRows());
+    const labels = groups.map((g) => g.label);
+    expect(new Set(labels).size).toBe(labels.length); // no duplicate headings
+    // Both semifinals — from DIFFERENT backend rounds (0 and 1) — under one
+    // "Semifinals" block.
+    const sf = groups.find((g) => g.label === 'Semifinals');
+    expect(sf.matches.map((m) => m.id)).toEqual(['m-r1-0', 'm-r2-1']);
+    expect(sf.matches.map((m) => m.roundIndex)).toEqual([0, 1]); // roundIndex stays raw
+    expect(labels).toEqual(['Semifinals', 'Quarterfinals', 'Final']);
+  });
+
+  it('still groups pool / swiss / league queues by pool, untouched by the round change', () => {
+    // Pool and Swiss key on poolName, league returns null (flat): none of them
+    // reads m.round or m.roundIndex, so the bracket fix must not disturb them.
+    const pools = groupQueueMatches([
+      { phase: 'pool', compFormat: 'mixed', poolName: 'Pool A', id: 'a1' },
+      { phase: 'pool', compFormat: 'mixed', poolName: 'Pool B', id: 'b1' },
+      { phase: 'pool', compFormat: 'mixed', poolName: 'Pool A', id: 'a2' },
+    ]);
+    expect(pools.map((g) => g.label)).toEqual(['Pool A', 'Pool B']);
+    expect(pools[0].matches.map((m) => m.id)).toEqual(['a1', 'a2']);
+
+    const swiss = groupQueueMatches([
+      { phase: 'pool', compFormat: 'swiss', poolName: 'Swiss-R1', id: 's1' },
+      { phase: 'pool', compFormat: 'swiss', poolName: 'Swiss-R2', id: 's2' },
+    ]);
+    expect(swiss.map((g) => g.label)).toEqual(['Round 1', 'Round 2']);
+
+    expect(groupQueueMatches([
+      { phase: 'pool', compFormat: 'league', poolName: 'League table', id: 'l1' },
+    ])).toBeNull();
+  });
+
+  it('keeps the bronze bout in its own group beside the final', () => {
+    // The bronze match is stamped round "3rd Place" (viewer_utils), a label no
+    // bracket round can collide with, so label-keying still isolates it.
+    const groups = groupQueueMatches([
+      ...queueRows(),
+      { phase: 'bracket', compFormat: 'playoffs', round: '3rd Place', roundIndex: 3, id: 'bronze' },
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(['Semifinals', 'Quarterfinals', 'Final', '3rd Place']);
+  });
+});

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1301,7 +1301,7 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
   let runtime;
   let VSchedItemComp;
   const savedGlobals = {};
-  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'roundLabel', 'pluralize', 'queueLabelCompact'];
+  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'boutMiddle', 'roundLabel', 'pluralize', 'queueLabelCompact'];
 
   function findNode(node, pred) {
     if (!node || typeof node !== 'object') return null;
@@ -1334,6 +1334,10 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
     });
     global.window.ipponsFromScore = vi.fn(() => []);
     global.window.matchScoreStr = vi.fn(() => '');
+    // VSchedItem's no-score fallback renders the bout middle from the shared
+    // boutMiddle primitive (bracket.jsx); these fixtures carry no
+    // decision/encho, so the real primitive would return the plain "vs".
+    global.window.boutMiddle = vi.fn(() => 'vs');
     global.window.roundLabel = vi.fn((i) => `Round ${i + 1}`);
     global.window.pluralize = vi.fn((n, s) => `${n} ${s}`);
     global.window.queueLabelCompact = null;

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -1301,7 +1301,7 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
   let runtime;
   let VSchedItemComp;
   const savedGlobals = {};
-  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'boutMiddle', 'roundLabel', 'pluralize', 'queueLabelCompact'];
+  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'roundLabel', 'pluralize', 'queueLabelCompact'];
 
   function findNode(node, pred) {
     if (!node || typeof node !== 'object') return null;
@@ -1334,10 +1334,6 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
     });
     global.window.ipponsFromScore = vi.fn(() => []);
     global.window.matchScoreStr = vi.fn(() => '');
-    // VSchedItem's no-score fallback renders the bout middle from the shared
-    // boutMiddle primitive (bracket.jsx); these fixtures carry no
-    // decision/encho, so the real primitive would return the plain "vs".
-    global.window.boutMiddle = vi.fn(() => 'vs');
     global.window.roundLabel = vi.fn((i) => `Round ${i + 1}`);
     global.window.pluralize = vi.fn((n, s) => `${n} ${s}`);
     global.window.queueLabelCompact = null;

--- a/web-mobile/js/__tests__/viewer.test.jsx
+++ b/web-mobile/js/__tests__/viewer.test.jsx
@@ -354,7 +354,9 @@ describe('Viewer Utils', () => {
     it('threads compKind and teamSize onto bracket matches for team comps', () => {
       global.window = global.window || {};
       const savedRoundLabel = global.window.roundLabel;
+      const savedBracketRoundLabel = global.window.bracketRoundLabel;
       global.window.roundLabel = (i, _total) => `Round ${i + 1}`;
+      global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
       try {
         const c = mkComp({
           kind: 'team',
@@ -369,6 +371,8 @@ describe('Viewer Utils', () => {
       } finally {
         if (savedRoundLabel === undefined) delete global.window.roundLabel;
         else global.window.roundLabel = savedRoundLabel;
+        if (savedBracketRoundLabel === undefined) delete global.window.bracketRoundLabel;
+        else global.window.bracketRoundLabel = savedBracketRoundLabel;
       }
     });
   });
@@ -1014,7 +1018,7 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
   const realReact = global.React;
   let runtime;
   let ViewerOverview;
-  const STUBBED = ['ipponsFromScore', 'formatIpponsScore', 'queueLabel', 'isHikiwake', 'useEscapeToClose', 'hasBothSides', 'StatusBadge', 'formatLabel', 'roundLabel', 'queueLabelCompact', 'pluralize', 'teamIVScore', 'matchScoreStr'];
+  const STUBBED = ['ipponsFromScore', 'formatIpponsScore', 'queueLabel', 'isHikiwake', 'useEscapeToClose', 'hasBothSides', 'StatusBadge', 'formatLabel', 'roundLabel', 'bracketRoundLabel', 'queueLabelCompact', 'pluralize', 'teamIVScore', 'matchScoreStr'];
   const savedGlobals = {};
 
   const mkMatch = (id) => ({
@@ -1056,6 +1060,7 @@ describe('ViewerOverview self-run vs officiated match click (mp-7x4n)', () => {
     global.window.StatusBadge = vi.fn(() => null);
     global.window.formatLabel = vi.fn((x) => x || '');
     global.window.roundLabel = vi.fn((x) => x || '');
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.pluralize = vi.fn((n, s) => `${n} ${s}`);
     vi.resetModules();
     ({ ViewerOverview } = await import('../viewer.jsx'));
@@ -1301,7 +1306,7 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
   let runtime;
   let VSchedItemComp;
   const savedGlobals = {};
-  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'roundLabel', 'pluralize', 'queueLabelCompact'];
+  const STUBBED = ['ipponsFromScore', 'matchScoreStr', 'roundLabel', 'bracketRoundLabel', 'pluralize', 'queueLabelCompact'];
 
   function findNode(node, pred) {
     if (!node || typeof node !== 'object') return null;
@@ -1335,6 +1340,7 @@ describe('VSchedItem live score rendering (mp-42rg)', () => {
     global.window.ipponsFromScore = vi.fn(() => []);
     global.window.matchScoreStr = vi.fn(() => '');
     global.window.roundLabel = vi.fn((i) => `Round ${i + 1}`);
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.pluralize = vi.fn((n, s) => `${n} ${s}`);
     global.window.queueLabelCompact = null;
     vi.resetModules();
@@ -1397,7 +1403,7 @@ describe('ViewerHome empty-state discoverability (mp-og2g)', () => {
   const STUBBED = [
     'StatusBadge', 'formatDate', 'formatLabel', 'formatViewerHeaderEyebrow',
     'pluralize', 'hasBothSides', 'compareDmy', 'queueLabelCompact',
-    'roundLabel', 'matchScoreStr', 'ipponsFromScore', 'EmptyState',
+    'roundLabel', 'bracketRoundLabel', 'matchScoreStr', 'ipponsFromScore', 'EmptyState',
   ];
   const savedGlobals = {};
 
@@ -1458,6 +1464,7 @@ describe('ViewerHome empty-state discoverability (mp-og2g)', () => {
     global.window.compareDmy = () => 0;
     global.window.queueLabelCompact = null;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.matchScoreStr = () => '';
     global.window.ipponsFromScore = () => [];
     vi.resetModules();
@@ -1526,7 +1533,7 @@ describe('ViewerHome globalRunning de-dup (mp-42rg)', () => {
   const STUBBED = [
     'StatusBadge', 'formatDate', 'formatLabel', 'formatViewerHeaderEyebrow',
     'pluralize', 'hasBothSides', 'compareDmy', 'queueLabelCompact',
-    'roundLabel', 'matchScoreStr', 'ipponsFromScore', 'EmptyState',
+    'roundLabel', 'bracketRoundLabel', 'matchScoreStr', 'ipponsFromScore', 'EmptyState',
   ];
   const savedGlobals = {};
 
@@ -1594,6 +1601,7 @@ describe('ViewerHome globalRunning de-dup (mp-42rg)', () => {
     global.window.compareDmy = () => 0;
     global.window.queueLabelCompact = null;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.matchScoreStr = () => '';
     global.window.ipponsFromScore = () => [];
     global.window.EmptyState = function EmptyState(props) { return { type: 'div', props: { className: 'empty', ...props }, children: [props.icon, props.title, props.message, props.cta].filter(Boolean) }; };

--- a/web-mobile/js/__tests__/viewer_bronze_match.test.jsx
+++ b/web-mobile/js/__tests__/viewer_bronze_match.test.jsx
@@ -73,7 +73,7 @@ describe('ViewerCompetition bronze / 3rd-place match rendering (mp-gy6g)', () =>
   // the setup/teardown symmetric and avoids surprise bleed between test suites.
   const STUBBED = [
     'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
-    'BracketTree', 'MatchCard', 'buildBracket', 'roundLabel', 'formatIpponsScore',
+    'BracketTree', 'MatchCard', 'buildBracket', 'roundLabel', 'bracketRoundLabel', 'formatIpponsScore',
     'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
     'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
     'EmptyState', 'bronzeUnderFinalStyle',
@@ -148,6 +148,7 @@ describe('ViewerCompetition bronze / 3rd-place match rendering (mp-gy6g)', () =>
     global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
     global.window.buildBracket = () => [];
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.formatIpponsScore = () => '';
     global.window.teamIVScore = () => null;
     global.window.matchScoreStr = () => '';

--- a/web-mobile/js/__tests__/viewer_competition_bye_results.test.jsx
+++ b/web-mobile/js/__tests__/viewer_competition_bye_results.test.jsx
@@ -9,9 +9,10 @@
 // "TBD vs <name>" under a Final badge, with nothing to say that nobody was
 // ever scheduled. A bye is bracket structure, not a result; it stays
 // discoverable in the Bracket tab, where the entrant renders as an unopposed
-// slot feeding the next round. (Verified in the browser: it is NOT tagged
-// "BYE" there. bracket.jsx gates that tag on score.type === "bye", which the
-// Go side never sets, so it is unreachable from a server payload.)
+// slot tagged BYE feeding the next round (bc-bye-slot__tag in BracketTreeMeta,
+// pinned by render/bracket_bye_slot.render.test.jsx; not the MatchCard's
+// bc-bye-tag, which is gated on score.type === "bye" and unreachable from a
+// server payload).
 //
 // The filter's guard is the shared `hasBothSides` predicate, NOT a hand-rolled
 // `m.sideA && m.sideB`: normalizeMatch (api_serializers.jsx) substitutes a
@@ -83,7 +84,7 @@ describe('ViewerCompetition Recent results excludes byes', () => {
     saved = installStubs();
     vi.resetModules();
     // Side-effect imports: publish the REAL window.hasBothSides (the predicate
-    // under test) and the real window.roundLabel / window.matchScoreStr the
+    // under test) and the real window.bracketRoundLabel / window.matchScoreStr the
     // viewer calls while building and rendering the match lists.
     await import('../admin_helpers.jsx');
     await import('../bracket.jsx');
@@ -99,10 +100,15 @@ describe('ViewerCompetition Recent results excludes byes', () => {
     vi.resetModules();
   });
 
-  // Three entrants → one real first-round match plus one structural bye,
-  // shaped exactly as internal/engine/bracket.go emits it: the bye's empty
-  // side is the JSON empty string "", and it is already completed with the
-  // lone competitor as winner.
+  // Three entrants → one real first-round match plus one structural bye.
+  // Carries the PROPERTIES that matter here exactly as internal/engine/bracket.go
+  // emits them: the absent side is the JSON empty string "" (sideA has no
+  // omitempty, so it really is on the wire) and the match is already completed
+  // with the lone competitor as winner. Deliberately NOT a byte-faithful
+  // capture: the engine's ids are 1-based (m-r1-*) and it also stamps
+  // hidden:true. Both are omitted so the filter is forced to key on the SIDES,
+  // which is the property under test; hidden would be an easier discriminator
+  // and must not be what makes this pass.
   const rawDetail = () => ({
     id: 'c1',
     name: 'Knockout Cup',

--- a/web-mobile/js/__tests__/viewer_competition_bye_results.test.jsx
+++ b/web-mobile/js/__tests__/viewer_competition_bye_results.test.jsx
@@ -1,0 +1,206 @@
+// Regression: a BYE must never appear in the viewer's "Recent results" list.
+//
+// A knockout competition with a non-power-of-two roster carries structural
+// byes: internal/engine/bracket.go auto-resolves them at generation time
+// (`sideA == "" && sideB != ""` → Winner = sideB, Status = completed), so they
+// arrive at the client as COMPLETED matches WITH a winner. The Recent-results
+// filter in viewer_competition.jsx used to test only `status === "completed"
+// && m.winner`, so those byes rendered as finished results reading
+// "TBD vs <name>" under a Final badge, with nothing to say that nobody was
+// ever scheduled. A bye is bracket structure, not a result; it stays
+// discoverable in the Bracket tab, where the entrant renders as an unopposed
+// slot feeding the next round. (Verified in the browser: it is NOT tagged
+// "BYE" there. bracket.jsx gates that tag on score.type === "bye", which the
+// Go side never sets, so it is unreachable from a server payload.)
+//
+// The filter's guard is the shared `hasBothSides` predicate, NOT a hand-rolled
+// `m.sideA && m.sideB`: normalizeMatch (api_serializers.jsx) substitutes a
+// TRUTHY `{id:"",name:""}` for a missing side, which the naive check waves
+// through. This test therefore:
+//   * builds the RAW server payload and runs it through the real
+//     normalizeCompetitionDetail, so the absent side takes the exact shape the
+//     browser sees (asserted below, so a payload drift can't weaken the test);
+//   * uses the REAL window.hasBothSides (admin_helpers.jsx is imported for its
+//     side-effect window publication) rather than a stub that returns true,
+//     which would make the assertion vacuous.
+//
+// ViewerCompetition owns the running/upcoming/recent computation and hands the
+// result to ViewerOverview, which renders the rows. The reactive test runtime
+// does not invoke child function components, so the assertion is made in two
+// stages: mount ViewerCompetition, take the props it built for ViewerOverview,
+// then mount ViewerOverview with them and read the VSchedItem rows actually
+// rendered under the "Recent results" heading.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+import { findAll, findInTree, collectText, hasClass } from './helpers/vdom.js';
+
+// Stubbed purely to keep unrelated child components inert. hasBothSides is
+// deliberately NOT in this list: the test needs the real implementation.
+const STUBBED = [
+  'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
+  'BracketTree', 'MatchCard', 'buildBracket', 'bronzeUnderFinalStyle',
+  'API', 'LoadingSpinner',
+];
+
+function installStubs() {
+  global.window = global.window || {};
+  const saved = {};
+  STUBBED.forEach((k) => {
+    saved[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+      ? { had: true, val: global.window[k] }
+      : { had: false };
+  });
+  global.window.StatusBadge = function StatusBadge() { return null; };
+  global.window.BracketTree = function BracketTree() { return null; };
+  global.window.MatchCard = function MatchCard() { return null; };
+  global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
+  global.window.formatDate = (d) => d || '';
+  global.window.formatLabel = (s) => s || '';
+  global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
+  global.window.buildBracket = () => [];
+  global.window.bronzeUnderFinalStyle = () => ({});
+  global.window.API = { leagueStandings: () => Promise.resolve([]) };
+  global.window.LoadingSpinner = function LoadingSpinner() { return null; };
+  return saved;
+}
+
+function restoreStubs(saved) {
+  STUBBED.forEach((k) => {
+    if (saved[k]?.had) global.window[k] = saved[k].val;
+    else delete global.window[k];
+  });
+}
+
+describe('ViewerCompetition Recent results excludes byes', () => {
+  const realReact = global.React;
+  let runtime;
+  let saved;
+  let ViewerCompetition, ViewerOverview, VSchedItem, normalizeCompetitionDetail;
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    saved = installStubs();
+    vi.resetModules();
+    // Side-effect imports: publish the REAL window.hasBothSides (the predicate
+    // under test) and the real window.roundLabel / window.matchScoreStr the
+    // viewer calls while building and rendering the match lists.
+    await import('../admin_helpers.jsx');
+    await import('../bracket.jsx');
+    ({ ViewerCompetition, ViewerOverview, VSchedItem } = await import('../viewer.jsx'));
+    ({ normalizeCompetitionDetail } = await import('../api_serializers.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    restoreStubs(saved);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  // Three entrants → one real first-round match plus one structural bye,
+  // shaped exactly as internal/engine/bracket.go emits it: the bye's empty
+  // side is the JSON empty string "", and it is already completed with the
+  // lone competitor as winner.
+  const rawDetail = () => ({
+    id: 'c1',
+    name: 'Knockout Cup',
+    kind: 'individual',
+    teamSize: 0,
+    format: 'playoffs',
+    status: 'playoffs',
+    startTime: '09:00',
+    courts: ['A'],
+    config: {
+      players: [
+        { id: 'p1', name: 'Aiko Tanaka', dojo: 'Dojo One' },
+        { id: 'p2', name: 'Bo Nakamura', dojo: 'Dojo Two' },
+        { id: 'p3', name: 'Chie Sato', dojo: 'Dojo Three' },
+      ],
+    },
+    pools: [],
+    poolMatches: [],
+    standings: {},
+    bracket: {
+      preview: false,
+      rounds: [[
+        {
+          id: 'm-r0-0',
+          sideA: 'Aiko Tanaka',
+          sideB: 'Bo Nakamura',
+          winner: 'Aiko Tanaka',
+          status: 'completed',
+          court: 'A',
+          scheduledAt: '09:00',
+          scoreA: 'MK',
+          scoreB: 'D',
+        },
+        {
+          // The bye: no sideA was ever drawn.
+          id: 'm-r0-1',
+          sideA: '',
+          sideB: 'Chie Sato',
+          winner: 'Chie Sato',
+          status: 'completed',
+          court: 'A',
+          scheduledAt: '09:10',
+        },
+      ]],
+    },
+  });
+
+  // Mount ViewerCompetition on the Overview tab and return the props it built
+  // for ViewerOverview (recentMatches among them).
+  function mountCompetition(detail) {
+    const tree = runtime.mount(ViewerCompetition, {
+      tournament: { competitions: [detail], mode: 'public' },
+      competition: detail,
+      pools: detail.pools,
+      poolMatches: detail.poolMatches,
+      standings: detail.standings,
+      bracket: detail.bracket,
+      onBack: () => {},
+      tweaks: {},
+      activeTab: 'overview',
+    });
+    const overview = findInTree(tree, (n) => n.type === ViewerOverview);
+    expect(overview, 'expected the Overview tab to render ViewerOverview').not.toBeNull();
+    return overview.props;
+  }
+
+  // Render ViewerOverview and return the match objects of the VSchedItem rows
+  // sitting under the "Recent results" heading.
+  function recentRows(overviewProps) {
+    const tree = runtime.mount(ViewerOverview, overviewProps);
+    const section = findInTree(tree, (n) => {
+      const kids = [].concat(n.props?.children || []).filter((k) => k && typeof k === 'object');
+      return kids.some((k) => hasClass(k, 'section-title') && collectText(k) === 'Recent results')
+        && kids.some((k) => hasClass(k, 'vsched'));
+    });
+    expect(section, 'expected a "Recent results" section with a match list').not.toBeNull();
+    return findAll(section, (n) => n.type === VSchedItem).map((n) => n.props.m);
+  }
+
+  it('normalizeMatch turns the bye\'s absent side into a TRUTHY {id:"",name:""}', () => {
+    const detail = normalizeCompetitionDetail(rawDetail());
+    const bye = detail.bracket.rounds[0][1];
+    // This is why the filter must use hasBothSides: `m.sideA && m.sideB` is
+    // true here. If this ever fails, the regression test below has stopped
+    // exercising the case that motivated the fix.
+    expect(bye.sideA).toEqual({ id: '', name: '' });
+    expect(!!(bye.sideA && bye.sideB)).toBe(true);
+    expect(window.hasBothSides(bye)).toBe(false);
+    expect(window.hasBothSides(detail.bracket.rounds[0][0])).toBe(true);
+  });
+
+  it('lists the real completed match and omits the auto-completed bye', () => {
+    const detail = normalizeCompetitionDetail(rawDetail());
+    const rows = recentRows(mountCompetition(detail));
+
+    expect(rows.map((m) => m.id)).toEqual(['m-r0-0']);
+    // Named explicitly: the bye's lone competitor must not headline a result.
+    expect(rows.some((m) => m.id === 'm-r0-1')).toBe(false);
+    expect(rows.every((m) => m.sideA?.name && m.sideB?.name)).toBe(true);
+  });
+});

--- a/web-mobile/js/__tests__/viewer_competition_round_labels.test.jsx
+++ b/web-mobile/js/__tests__/viewer_competition_round_labels.test.jsx
@@ -1,0 +1,188 @@
+// mp-u37s: the public competition page's own bracket-row stamping.
+//
+// ViewerCompetition builds its OWN allMatches list (viewer_competition.jsx):
+// a second copy of the "flatten bracket.rounds and stamp round/phaseName" loop,
+// separate from viewer_utils.compMatches. compMatches is pinned by
+// bracket_round_label_agreement.test.jsx; this copy was not, yet the Overview
+// rows it feeds are the exact surface the round-label mismatch was reported on.
+// Reverting this file's window.bracketRoundLabel(...) call to
+// window.roundLabel(ri, …) left the whole suite green.
+//
+// Separate file rather than an addition to viewer_competition_bye_results.jsx:
+// that file pins one specific regression (a structural bye must not appear as a
+// Recent result) around a 3-entrant fixture chosen so the FILTER is forced to
+// key on the sides. This invariant needs a 5-entrant collapsed-bye draw where a
+// match's effective round differs from its raw one, and it asserts labels, not
+// membership. Sharing a fixture would weaken both.
+//
+// Harness follows viewer_competition_bye_results.jsx: mount ViewerCompetition,
+// take the props it hands ViewerOverview. The REAL window.bracketRoundLabel is
+// used (side-effect import of bracket.jsx); it is deliberately NOT stubbed.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+import { findInTree } from './helpers/vdom.js';
+
+// Stubbed purely to keep unrelated child components inert. bracketRoundLabel
+// and hasBothSides are deliberately NOT in this list: the test needs the real
+// implementations (the former is under test, the latter decides which rows
+// reach the Overview lists at all).
+const STUBBED = [
+  'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
+  'BracketTree', 'MatchCard', 'buildBracket', 'bronzeUnderFinalStyle',
+  'API', 'LoadingSpinner',
+];
+
+function installStubs() {
+  global.window = global.window || {};
+  const saved = {};
+  STUBBED.forEach((k) => {
+    saved[k] = Object.prototype.hasOwnProperty.call(global.window, k)
+      ? { had: true, val: global.window[k] }
+      : { had: false };
+  });
+  global.window.StatusBadge = function StatusBadge() { return null; };
+  global.window.BracketTree = function BracketTree() { return null; };
+  global.window.MatchCard = function MatchCard() { return null; };
+  global.window.Term = function Term(props) { return { type: 'span', props, children: props?.children }; };
+  global.window.formatDate = (d) => d || '';
+  global.window.formatLabel = (s) => s || '';
+  global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
+  global.window.buildBracket = () => [];
+  global.window.bronzeUnderFinalStyle = () => ({});
+  global.window.API = { leagueStandings: () => Promise.resolve([]) };
+  global.window.LoadingSpinner = function LoadingSpinner() { return null; };
+  return saved;
+}
+
+function restoreStubs(saved) {
+  STUBBED.forEach((k) => {
+    if (saved[k]?.had) global.window[k] = saved[k].val;
+    else delete global.window[k];
+  });
+}
+
+describe('ViewerCompetition stamps bracket rows with the EFFECTIVE round (mp-u37s)', () => {
+  const realReact = global.React;
+  let runtime;
+  let saved;
+  let ViewerCompetition, ViewerOverview, normalizeCompetitionDetail;
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    saved = installStubs();
+    vi.resetModules();
+    // Side-effect imports: the REAL window.hasBothSides and the REAL
+    // window.roundLabel / window.bracketRoundLabel the viewer calls while
+    // building its match lists.
+    await import('../admin_helpers.jsx');
+    await import('../bracket.jsx');
+    ({ ViewerCompetition, ViewerOverview } = await import('../viewer.jsx'));
+    ({ normalizeCompetitionDetail } = await import('../api_serializers.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    restoreStubs(saved);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  // The 5-entrant individual knockout as the engine persists it: 3 backend
+  // rounds, one of them entirely structural byes, so mp-7f2w collapses it and
+  // stamps an effective round (displayRound, counted from the final) that does
+  // not follow the raw slot in bracket.rounds. Same shape as
+  // bracket_round_label_agreement.test.jsx, in raw server-payload form so
+  // normalizeCompetitionDetail produces exactly what the browser holds.
+  //
+  //   m-r1-0  backend round 0, displayRound 2 → raw "Quarterfinals",
+  //                                             effective "Semifinals"  ← the case
+  //   m-r1-3  backend round 0, displayRound 3 → both say "Quarterfinals" ← control
+  const rawDetail = () => ({
+    id: 'c1',
+    name: 'Knockout5',
+    kind: 'individual',
+    teamSize: 0,
+    format: 'playoffs',
+    status: 'playoffs',
+    startTime: '09:00',
+    courts: ['A'],
+    config: {
+      players: [
+        { id: 'p1', name: 'Alice', dojo: 'Dojo One' },
+        { id: 'p2', name: 'Bob', dojo: 'Dojo Two' },
+        { id: 'p3', name: 'Carol', dojo: 'Dojo Three' },
+        { id: 'p4', name: 'Dave', dojo: 'Dojo Four' },
+        { id: 'p5', name: 'Eve', dojo: 'Dojo Five' },
+      ],
+    },
+    pools: [],
+    poolMatches: [],
+    standings: {},
+    bracket: {
+      preview: false,
+      rounds: [
+        [
+          { id: 'm-r1-0', sideA: 'Alice', sideB: 'Bob', displayRound: 2, feeders: ['', ''], status: 'running', court: 'A', scheduledAt: '09:20' },
+          { id: 'm-r1-1', sideA: '', sideB: '', hidden: true },
+          { id: 'm-r1-2', sideA: 'Carol', sideB: '', hidden: true },
+          { id: 'm-r1-3', sideA: 'Dave', sideB: 'Eve', displayRound: 3, feeders: ['', ''], status: 'completed', winner: 'Dave', court: 'A', scheduledAt: '09:00' },
+        ],
+        [
+          { id: 'm-r2-0', sideA: 'Winner of r3-m0', sideB: '', hidden: true },
+          { id: 'm-r2-1', sideA: 'Carol', sideB: 'Winner of r3-m3', displayRound: 2, feeders: ['', 'm-r1-3'], status: 'scheduled', court: 'A', scheduledAt: '09:40' },
+        ],
+        [
+          { id: 'm-r3-0', sideA: 'Winner of r2-m0', sideB: 'Winner of r2-m1', displayRound: 1, feeders: ['m-r1-0', 'm-r2-1'], status: 'scheduled', court: 'A', scheduledAt: '10:00' },
+        ],
+      ],
+    },
+  });
+
+  // Mount ViewerCompetition on the Overview tab and return the props it built
+  // for ViewerOverview (running/upcoming/recent among them).
+  function overviewProps(detail) {
+    const tree = runtime.mount(ViewerCompetition, {
+      tournament: { competitions: [detail], mode: 'public' },
+      competition: detail,
+      pools: detail.pools,
+      poolMatches: detail.poolMatches,
+      standings: detail.standings,
+      bracket: detail.bracket,
+      onBack: () => {},
+      tweaks: {},
+      activeTab: 'overview',
+    });
+    const overview = findInTree(tree, (n) => n.type === ViewerOverview);
+    expect(overview, 'expected the Overview tab to render ViewerOverview').not.toBeNull();
+    return overview.props;
+  }
+
+  it('calls the bye-collapsed match a Semifinal on the rows it builds', () => {
+    const props = overviewProps(normalizeCompetitionDetail(rawDetail()));
+    const running = props.runningMatches;
+    expect(running.map((m) => m.id)).toEqual(['m-r1-0']);
+    // The raw rule would name backend round 0 of 3 a quarterfinal. Pinned here
+    // so this assertion is provably discriminating: the two labels differ.
+    expect(window.roundLabel(0, 3)).toBe('Quarterfinals');
+    expect(running[0].round).toBe('Semifinals');
+    expect(running[0].phaseName).toBe('Semifinals');
+  });
+
+  it('leaves a match whose effective round matches its raw one alone', () => {
+    const props = overviewProps(normalizeCompetitionDetail(rawDetail()));
+    const recent = props.recentMatches;
+    expect(recent.map((m) => m.id)).toEqual(['m-r1-3']);
+    // Genuinely a quarterfinal (displayRound 3 of 3 rounds), so both rules agree.
+    expect(recent[0].round).toBe('Quarterfinals');
+    expect(recent[0].phaseName).toBe('Quarterfinals');
+  });
+
+  it('keeps roundIndex RAW so lineup fetches still key on the backend round', () => {
+    const props = overviewProps(normalizeCompetitionDetail(rawDetail()));
+    // The label moved to the effective round; the index must NOT follow it.
+    expect(props.runningMatches[0].roundIndex).toBe(0);
+    expect(props.recentMatches[0].roundIndex).toBe(0);
+  });
+});

--- a/web-mobile/js/__tests__/viewer_draw_ready.test.jsx
+++ b/web-mobile/js/__tests__/viewer_draw_ready.test.jsx
@@ -50,7 +50,7 @@ describe('ViewerCompetition draw-ready exposure (mp-rrd)', () => {
   // MUST be set before importing viewer.jsx, plus the lazily-looked-up ones.
   const STUBBED = [
     'StatusBadge', 'formatDate', 'formatLabel', 'pluralize', 'Term',
-    'BracketTree', 'buildBracket', 'roundLabel', 'formatIpponsScore',
+    'BracketTree', 'buildBracket', 'roundLabel', 'bracketRoundLabel', 'formatIpponsScore',
     'ipponsFromScore', 'isHikiwake', 'hasBothSides', 'compareDmy',
     'queueLabel', 'queueLabelCompact', 'teamIVScore', 'matchScoreStr',
     'EmptyState',
@@ -95,6 +95,7 @@ describe('ViewerCompetition draw-ready exposure (mp-rrd)', () => {
     global.window.pluralize = (n, a, b) => `${n} ${n === 1 ? a : b}`;
     global.window.buildBracket = () => sampleBracket.rounds;
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     global.window.formatIpponsScore = () => '';
     global.window.teamIVScore = () => null;
     global.window.matchScoreStr = (m) =>
@@ -267,12 +268,13 @@ describe('draw-ready is not running (mp-rrd)', () => {
     global.window = global.window || {};
     // Save/restore the globals we stub so we don't leak state into other
     // suites if they were already present (delete-only would clobber them).
-    const stubbed = ['hasBothSides', 'roundLabel'];
+    const stubbed = ['hasBothSides', 'roundLabel', 'bracketRoundLabel'];
     const prior = stubbed.map(k => Object.prototype.hasOwnProperty.call(global.window, k)
       ? { k, had: true, val: global.window[k] }
       : { k, had: false });
     global.window.hasBothSides = (m) => !!(m && m.sideA && m.sideB);
     global.window.roundLabel = (i) => `Round ${i + 1}`;
+    global.window.bracketRoundLabel = (_m, i, n) => global.window.roundLabel(i, n);
     try {
       const { tournamentMatches, compMatches } = await import('../viewer.jsx');
       const drawReady = {

--- a/web-mobile/js/__tests__/vsched_bout_middle.test.jsx
+++ b/web-mobile/js/__tests__/vsched_bout_middle.test.jsx
@@ -137,4 +137,31 @@ describe('mp-u37s: VSchedItem bout middle is never a dash', () => {
       expect(mid).not.toContain('-');
     });
   });
+
+  // Degradation: a SCHEDULED row must render without bracket.jsx loaded at all.
+  // This branch renders for scheduled matches, whereas matchScoreStr above is
+  // gated to completed/running, so an unguarded call would have made bracket.jsx
+  // a hard dependency of an up-next list that previously needed no helper. Two
+  // fixtures (viewer.test.jsx, vsched_winner_cue.test.jsx) had to grow a
+  // boutMiddle stub before this guard existed; both are back to their original
+  // form, and this test is what keeps them that way.
+  describe('without bracket.jsx loaded', () => {
+    let saved;
+
+    beforeEach(() => {
+      saved = { boutMiddle: global.window.boutMiddle, matchScoreStr: global.window.matchScoreStr };
+      delete global.window.boutMiddle;
+      delete global.window.matchScoreStr;
+    });
+
+    afterEach(() => {
+      global.window.boutMiddle = saved.boutMiddle;
+      global.window.matchScoreStr = saved.matchScoreStr;
+    });
+
+    it('a scheduled row still renders "vs" instead of throwing', () => {
+      expect(() => centreText({ ...base, status: 'scheduled' })).not.toThrow();
+      expect(centreText({ ...base, status: 'scheduled' })).toBe('vs');
+    });
+  });
 });

--- a/web-mobile/js/__tests__/vsched_bout_middle.test.jsx
+++ b/web-mobile/js/__tests__/vsched_bout_middle.test.jsx
@@ -93,8 +93,12 @@ describe('mp-u37s: VSchedItem bout middle is never a dash', () => {
     expect(centreText({ ...base, status: 'scheduled' })).toBe('vs');
   });
 
-  // Non-plain middles are carried by the score string on this surface; pinned
-  // here so a future refactor of the fallback cannot swallow them either.
+  // Non-plain middles reach this surface INSIDE the score string, not through
+  // the fallback: matchScoreStr already returns "X"/"(E)"/"(DH)" for these
+  // payloads, so scoreStr is truthy and the vsched-item__score span wins. These
+  // cases therefore pin the score-string path (that formatIpponsScore keeps
+  // surfacing the marks), NOT the fallback. The fallback's own handling of the
+  // same marks is pinned separately below.
   it.each([
     ['hikiwake tie', { decision: 'hikiwake' }, 'X'],
     ['encho', { encho: { periodCount: 1 } }, '(E)'],
@@ -103,5 +107,34 @@ describe('mp-u37s: VSchedItem bout middle is never a dash', () => {
     const mid = centreText({ ...base, status: 'completed', ...extra });
     expect(mid).toContain(want);
     expect(mid).not.toContain('-');
+  });
+
+  // Directly pin the FALLBACK branch for the non-"vs" marks. Only
+  // matchScoreStr is stubbed (to the empty string the bye case produces);
+  // boutMiddle stays REAL, so this asserts what the new call actually returns
+  // rather than what a stub was told to say. Without this, every non-"vs"
+  // assertion above would still pass with the fallback entirely broken.
+  describe('fallback branch with an empty score string', () => {
+    let realMatchScoreStr;
+
+    beforeEach(() => {
+      realMatchScoreStr = global.window.matchScoreStr;
+      global.window.matchScoreStr = () => '';
+    });
+
+    afterEach(() => {
+      global.window.matchScoreStr = realMatchScoreStr;
+    });
+
+    it.each([
+      ['hikiwake tie', { decision: 'hikiwake' }, 'X'],
+      ['encho', { encho: { periodCount: 1 } }, '(E)'],
+      ['daihyosen', { decision: 'daihyosen' }, '(DH)'],
+      ['no decision', {}, 'vs'],
+    ])('completed %s falls back to its boutMiddle mark, never a dash', (_label, extra, want) => {
+      const mid = centreText({ ...base, status: 'completed', ...extra });
+      expect(mid).toBe(want);
+      expect(mid).not.toContain('-');
+    });
   });
 });

--- a/web-mobile/js/__tests__/vsched_bout_middle.test.jsx
+++ b/web-mobile/js/__tests__/vsched_bout_middle.test.jsx
@@ -1,0 +1,107 @@
+// Regression (mp-u37s): the VSchedItem bout MIDDLE never renders a dash.
+//
+// Contract (CLAUDE.md § Match Decision Types): the middle slot of a bout may
+// read ONLY "vs" / "X" / "(E)" / "(DH)". A dash is a CELL value, never a
+// middle. The single source is boutMiddle (bracket.jsx).
+//
+// The bug: VSchedItem hand-rolled its no-score fallback as
+//   scoreStr ? <score> : m.status === "completed" ? "-" : "vs"
+// so a COMPLETED match whose score string comes back empty rendered "-" in the
+// middle slot. matchScoreStr/formatIpponsScore return "" whenever both score
+// cells are empty and the match is not a bye/draw/default-win, which is the
+// everyday shape of a match finished with no ippon recorded (and of a match
+// stored with decision "fought" but no cells).
+//
+// These tests mount the real VSchedItem against the REAL window.matchScoreStr
+// and window.boutMiddle (bracket.jsx is imported for its side-effect window.*
+// publication, which is how viewer_match.jsx reaches those helpers in the
+// browser), so the empty-score-string case is produced by production code
+// rather than asserted against a stub.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeReactive } from './helpers/reactive_react.js';
+import { findInTree, hasClass, collectText } from './helpers/vdom.js';
+
+const realReact = global.React;
+
+describe('mp-u37s: VSchedItem bout middle is never a dash', () => {
+  let runtime, VSchedItem;
+
+  beforeEach(async () => {
+    runtime = makeReactive();
+    global.React = runtime.React;
+    global.window = global.window || {};
+    global.window.queueLabelCompact = null;
+    vi.resetModules();
+    // Side-effect import: publishes the real window.matchScoreStr /
+    // window.boutMiddle that viewer_match.jsx calls.
+    await import('../bracket.jsx');
+    ({ VSchedItem } = await import('../viewer_match.jsx'));
+  });
+
+  afterEach(() => {
+    runtime.unmount();
+    global.React = realReact;
+    delete global.window.queueLabelCompact;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  // The centre cell of the players row: either the score string
+  // (vsched-item__score) or the bout middle (vsched-item__vs).
+  const centreText = (m) => {
+    const tree = runtime.mount(VSchedItem, { m, tweaks: {} });
+    const node = findInTree(tree, n =>
+      hasClass(n, 'vsched-item__vs') || hasClass(n, 'vsched-item__score'));
+    expect(node).not.toBeNull();
+    return collectText(node);
+  };
+
+  const base = {
+    id: 'm-1',
+    court: 'A',
+    phase: 'bracket',
+    round: 'Final',
+    sideA: { id: 'a', name: 'Ryu' },
+    sideB: { id: 'b', name: 'Phoenix' },
+  };
+
+  // THE bug case: completed, no score cells → matchScoreStr returns "".
+  it('completed match with no recorded score renders "vs", not "-"', () => {
+    const mid = centreText({ ...base, status: 'completed' });
+    expect(mid).not.toBe('-');
+    expect(mid).not.toContain('-');
+    expect(mid).toBe('vs');
+  });
+
+  it('completed match with a winner but no recorded score renders "vs", not "-"', () => {
+    const mid = centreText({ ...base, status: 'completed', winner: { id: 'a', name: 'Ryu' } });
+    expect(mid).not.toContain('-');
+    expect(mid).toBe('vs');
+  });
+
+  it('completed match decided "fought" with no recorded score renders "vs", not "-"', () => {
+    const mid = centreText({ ...base, status: 'completed', decision: 'fought' });
+    expect(mid).not.toContain('-');
+    expect(mid).toBe('vs');
+  });
+
+  it('running match with no score yet still renders "vs"', () => {
+    expect(centreText({ ...base, status: 'running' })).toBe('vs');
+  });
+
+  it('scheduled match renders "vs"', () => {
+    expect(centreText({ ...base, status: 'scheduled' })).toBe('vs');
+  });
+
+  // Non-plain middles are carried by the score string on this surface; pinned
+  // here so a future refactor of the fallback cannot swallow them either.
+  it.each([
+    ['hikiwake tie', { decision: 'hikiwake' }, 'X'],
+    ['encho', { encho: { periodCount: 1 } }, '(E)'],
+    ['daihyosen', { decision: 'daihyosen' }, '(DH)'],
+  ])('completed %s renders its mark in the centre, never a dash', (_label, extra, want) => {
+    const mid = centreText({ ...base, status: 'completed', ...extra });
+    expect(mid).toContain(want);
+    expect(mid).not.toContain('-');
+  });
+});

--- a/web-mobile/js/__tests__/vsched_winner_cue.test.jsx
+++ b/web-mobile/js/__tests__/vsched_winner_cue.test.jsx
@@ -25,6 +25,10 @@ describe('T5: VSchedItem winner cue - completed team match', () => {
     global.window = global.window || {};
     global.window.ipponsFromScore = vi.fn(() => []);
     global.window.matchScoreStr = vi.fn(() => '');
+    // VSchedItem's no-score fallback renders the bout middle from the shared
+    // boutMiddle primitive (bracket.jsx); these fixtures carry no
+    // decision/encho, so the real primitive would return the plain "vs".
+    global.window.boutMiddle = vi.fn(() => 'vs');
     global.window.queueLabelCompact = null;
     vi.resetModules();
     // Import serializers first (attaches window.normalizeMatch) then viewer_match.
@@ -37,6 +41,7 @@ describe('T5: VSchedItem winner cue - completed team match', () => {
     global.React = realReact;
     delete global.window.ipponsFromScore;
     delete global.window.matchScoreStr;
+    delete global.window.boutMiddle;
     delete global.window.queueLabelCompact;
     vi.restoreAllMocks();
     vi.resetModules();

--- a/web-mobile/js/__tests__/vsched_winner_cue.test.jsx
+++ b/web-mobile/js/__tests__/vsched_winner_cue.test.jsx
@@ -25,10 +25,6 @@ describe('T5: VSchedItem winner cue - completed team match', () => {
     global.window = global.window || {};
     global.window.ipponsFromScore = vi.fn(() => []);
     global.window.matchScoreStr = vi.fn(() => '');
-    // VSchedItem's no-score fallback renders the bout middle from the shared
-    // boutMiddle primitive (bracket.jsx); these fixtures carry no
-    // decision/encho, so the real primitive would return the plain "vs".
-    global.window.boutMiddle = vi.fn(() => 'vs');
     global.window.queueLabelCompact = null;
     vi.resetModules();
     // Import serializers first (attaches window.normalizeMatch) then viewer_match.
@@ -41,7 +37,6 @@ describe('T5: VSchedItem winner cue - completed team match', () => {
     global.React = realReact;
     delete global.window.ipponsFromScore;
     delete global.window.matchScoreStr;
-    delete global.window.boutMiddle;
     delete global.window.queueLabelCompact;
     vi.restoreAllMocks();
     vi.resetModules();

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -221,7 +221,7 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
       matchNum: displayModel.matchNumById ? displayModel.matchNumById[matchId] : null,
       // window.bracketRoundLabel is the one round-naming primitive (mp-u37s), so
       // this panel, the column header beside it and the viewer/board rows for the
-      // same match can never disagree. `ci` is already the DISPLAY column here,
+      // same match can never disagree. `ci` is the DISPLAY column whenever the bracket carries metadata, and the raw index otherwise (where no displayRound exists to disagree with),
       // which is why this surface was correct before; keep it derived from the
       // match anyway rather than holding a second copy of the rule.
       roundName: (ci >= 0 && window.bracketRoundLabel) ? window.bracketRoundLabel(found, ci, cols.length) : null,

--- a/web-mobile/js/admin_competition_bracket.jsx
+++ b/web-mobile/js/admin_competition_bracket.jsx
@@ -212,13 +212,19 @@ function AdminBracket({ c, t, bracket, onMoveCourt, onEditScore, tweaks, passwor
   const matchMeta = (matchId) => {
     if (!matchId || !bracket?.rounds) return { matchNum: null, roundName: null };
     const cols = displayModel.hasMeta ? displayModel.columns : bracket.rounds;
-    let ci = -1;
+    let ci = -1, found = null;
     for (let i = 0; i < cols.length; i++) {
-      if ((cols[i] || []).some((m) => m && m.id === matchId)) { ci = i; break; }
+      const hit = (cols[i] || []).find((m) => m && m.id === matchId);
+      if (hit) { ci = i; found = hit; break; }
     }
     return {
       matchNum: displayModel.matchNumById ? displayModel.matchNumById[matchId] : null,
-      roundName: (ci >= 0 && window.roundLabel) ? window.roundLabel(ci, cols.length) : null,
+      // window.bracketRoundLabel is the one round-naming primitive (mp-u37s), so
+      // this panel, the column header beside it and the viewer/board rows for the
+      // same match can never disagree. `ci` is already the DISPLAY column here,
+      // which is why this surface was correct before; keep it derived from the
+      // match anyway rather than holding a second copy of the rule.
+      roundName: (ci >= 0 && window.bracketRoundLabel) ? window.bracketRoundLabel(found, ci, cols.length) : null,
     };
   };
 

--- a/web-mobile/js/admin_scoring_engi.jsx
+++ b/web-mobile/js/admin_scoring_engi.jsx
@@ -352,6 +352,14 @@ export function EngiScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext
             </div>
           </div>
 
+          {/* Decorative entry-zone divider (aria-hidden), not a result
+              projection: the boutMiddle vs/X/(E)/(DH) contract does not bind
+              it, and the exemption is structural rather than stylistic. Flag
+              totals are constrained to odd values by VALID_TOTALS, so a draw
+              cannot exist here and "X" is unreachable by construction; engi
+              has no ippon, no encho and no daihyosen, so "(E)" and "(DH)"
+              have nothing to report either. There is no tied engi result to
+              confirm or render. */}
           <div className="engi-divider" aria-hidden="true">vs</div>
 
           {/* Aka / Red / sideA */}

--- a/web-mobile/js/admin_scoring_engi.jsx
+++ b/web-mobile/js/admin_scoring_engi.jsx
@@ -352,14 +352,13 @@ export function EngiScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext
             </div>
           </div>
 
-          {/* Decorative entry-zone divider (aria-hidden), not a result
-              projection: the boutMiddle vs/X/(E)/(DH) contract does not bind
-              it, and the exemption is structural rather than stylistic. Flag
-              totals are constrained to odd values by VALID_TOTALS, so a draw
-              cannot exist here and "X" is unreachable by construction; engi
-              has no ippon, no encho and no daihyosen, so "(E)" and "(DH)"
-              have nothing to report either. There is no tied engi result to
-              confirm or render. */}
+          {/* Decorative entry-zone divider (aria-hidden), exempt from the
+              boutMiddle contract per the SCOPE note in bracket.jsx (the
+              master statement; change it there first). Here the exemption is
+              structural, not just stylistic: flag totals are constrained to
+              odd values by VALID_TOTALS, so a draw cannot exist and "X" is
+              unreachable by construction; engi has no ippon, no encho and no
+              daihyosen, so "(E)" and "(DH)" have nothing to report either. */}
           <div className="engi-divider" aria-hidden="true">vs</div>
 
           {/* Aka / Red / sideA */}

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -49,8 +49,26 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
   const isTeam = m.compKind === "team" || m.teamSize > 0;
   const teamSize = m.teamSize || 5;
 
-  const seedAPts = m.ipponsA?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
-  const seedBPts = m.ipponsB?.filter(x => x && x !== "•") || (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
+  // Seed from ipponsA/ipponsB when present, else PARSE the scoreA/scoreB
+  // string. That fallback is load-bearing for knockout: state.MatchResult
+  // carries ipponsA/ipponsB on the wire, but state.BracketMatch carries only
+  // the scoreA/scoreB strings, so a bracket match re-read from the server
+  // (any reload, or opening the editor from the Scores page) arrived with no
+  // ippon arrays at all. The editor then opened EMPTY on a match that already
+  // had points, and the next tap saved over them — the operator silently lost
+  // a recorded ippon mid-match. Every display surface already parses the
+  // string this way (admin_shiaijo.jsx, match_scoreboard.jsx, bracket.jsx);
+  // this editor was the one that did not.
+  // Keep the score.type === "ippon" branch as the LAST resort: it serves the
+  // quick-score paths that set only score.ippons. It must stay reachable when
+  // neither source yields a point, so test emptiness explicitly rather than
+  // relying on ||: an empty array is truthy and would swallow it.
+  const cellsA = m.ipponsA || (window.ipponsFromScore ? window.ipponsFromScore(m.scoreA) : []);
+  const cellsB = m.ipponsB || (window.ipponsFromScore ? window.ipponsFromScore(m.scoreB) : []);
+  const cleanA = (cellsA || []).filter(x => x && x !== "•");
+  const cleanB = (cellsB || []).filter(x => x && x !== "•");
+  const seedAPts = cleanA.length ? cleanA : (m.score?.type === "ippon" && m.winner?.id === m.sideA?.id ? m.score.ippons || [] : []);
+  const seedBPts = cleanB.length ? cleanB : (m.score?.type === "ippon" && m.winner?.id === m.sideB?.id ? m.score.ippons || [] : []);
 
   // Use ?? not || so an explicit 0 isn't treated as "unset".
   // reconcileFoulsAtOpen turns the pre-fix cumulative raw count into the

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -627,7 +627,17 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
                         {/* Middle mark is "VS" only — individual ippons are WAZA
                             LETTERS in the slots, never a numeric count (numbers
                             belong to pool/team summaries or engi). Matches the
-                            team editor's centre and the boutMiddle contract. */}
+                            team editor's centre. This is an entry-zone separator,
+                            not a result projection, so the boutMiddle contract does
+                            not bind it. mp-42g deliberately demoted the vs/X that
+                            used to live here (it was the draw-toggle button itself,
+                            undiscoverable as such) to a plain non-interactive
+                            separator. The special middles get dedicated controls
+                            instead — tie by the draw toggle below (its active state
+                            replaces this VS, seeded from the persisted decision via
+                            initialIsDrawToggled), encho by the "· (E) Overtime ×N"
+                            eyebrow plus the EnchoControl pill, daihyosen by the DH
+                            eyebrow badge. Don't "restore" X/(E)/(DH) here. */}
                         {!isDrawToggled && (
                           <div className="sb-vs">VS</div>
                         )}

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -644,20 +644,17 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
                       <div className="sb-center">
                         {/* Middle mark is "VS" only — individual ippons are WAZA
                             LETTERS in the slots, never a numeric count (numbers
-                            belong to pool/team summaries or engi). Matches the
-                            team editor's centre. This is an entry-zone separator,
-                            not a result projection, so the boutMiddle contract does
-                            not bind it. mp-42g deliberately demoted the vs/X that
-                            used to live here (it was the draw-toggle button itself,
-                            undiscoverable as such) to a plain non-interactive
-                            separator. The special middles get dedicated controls
-                            instead — tie by the draw toggle below (its active state
-                            replaces this VS, seeded from the persisted decision via
-                            initialIsDrawToggled), encho by the "· (E) Overtime ×N"
-                            eyebrow plus the EnchoControl pill, daihyosen by the DH
-                            eyebrow badge. Don't "restore" X/(E)/(DH) here.
-                            The exemption itself is stated once, in bracket.jsx's
-                            SCOPE note above boutMiddle; change it there first. */}
+                            belong to pool/team summaries or engi). Entry-zone
+                            separator, exempt from the boutMiddle contract per the
+                            SCOPE note in bracket.jsx (the master statement; change
+                            it there first). mp-42g demoted the vs/X that used to
+                            live here (it was the draw-toggle button itself,
+                            undiscoverable as such) to a plain separator; the
+                            special middles have dedicated controls — tie via the
+                            draw toggle below (seeded from the persisted decision
+                            via initialIsDrawToggled), encho via the "· (E)
+                            Overtime ×N" eyebrow + EnchoControl pill, daihyosen via
+                            the DH eyebrow badge. Don't "restore" X/(E)/(DH) here. */}
                         {!isDrawToggled && (
                           <div className="sb-vs">VS</div>
                         )}

--- a/web-mobile/js/admin_scoring_individual.jsx
+++ b/web-mobile/js/admin_scoring_individual.jsx
@@ -637,7 +637,9 @@ export function ScoreEditorModal({ match, onClose, onSubmit, onSubmitAndNext, on
                             replaces this VS, seeded from the persisted decision via
                             initialIsDrawToggled), encho by the "· (E) Overtime ×N"
                             eyebrow plus the EnchoControl pill, daihyosen by the DH
-                            eyebrow badge. Don't "restore" X/(E)/(DH) here. */}
+                            eyebrow badge. Don't "restore" X/(E)/(DH) here.
+                            The exemption itself is stated once, in bracket.jsx's
+                            SCOPE note above boutMiddle; change it there first. */}
                         {!isDrawToggled && (
                           <div className="sb-vs">VS</div>
                         )}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -1756,7 +1756,9 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
                         result-projecting surface in this file is the per-bout
                         row, which derives its middle through
                         renderTeamBoutMiddle → boutMiddle. Don't "fix" this one
-                        to match that one; they answer different questions. */}
+                        to match that one; they answer different questions.
+                        The exemption itself is stated once, in bracket.jsx's
+                        SCOPE note above boutMiddle; change it there first. */}
                     <div className="sb-vs">VS</div>
                   </div>
                 )}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -1749,16 +1749,14 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
                 </div>
                 {idx === 0 && (
                   <div className="sb-center">
-                    {/* Encounter-header separator, deliberately a plain "VS":
-                        an entry-zone separator, not a result projection, so the
-                        boutMiddle contract does not bind it — the same mp-42g
-                        exemption as the individual editor's centre. The
+                    {/* Encounter-header separator, deliberately a plain "VS" —
+                        the same mp-42g entry-zone exemption as the individual
+                        editor's centre, per the SCOPE note in bracket.jsx (the
+                        master statement; change it there first). The
                         result-projecting surface in this file is the per-bout
-                        row, which derives its middle through
-                        renderTeamBoutMiddle → boutMiddle. Don't "fix" this one
-                        to match that one; they answer different questions.
-                        The exemption itself is stated once, in bracket.jsx's
-                        SCOPE note above boutMiddle; change it there first. */}
+                        row, which goes through renderTeamBoutMiddle → boutMiddle.
+                        Don't "fix" this one to match that one; they answer
+                        different questions. */}
                     <div className="sb-vs">VS</div>
                   </div>
                 )}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -1749,6 +1749,14 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
                 </div>
                 {idx === 0 && (
                   <div className="sb-center">
+                    {/* Encounter-header separator, deliberately a plain "VS":
+                        an entry-zone separator, not a result projection, so the
+                        boutMiddle contract does not bind it — the same mp-42g
+                        exemption as the individual editor's centre. The
+                        result-projecting surface in this file is the per-bout
+                        row, which derives its middle through
+                        renderTeamBoutMiddle → boutMiddle. Don't "fix" this one
+                        to match that one; they answer different questions. */}
                     <div className="sb-vs">VS</div>
                   </div>
                 )}

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -1530,7 +1530,16 @@ export function groupQueueMatches(matches) {
     for (const m of matches) {
         let key, label;
         if (m.phase === "bracket") {
-            key = "round:" + (m.roundIndex != null ? m.roundIndex : (m.round || ""));
+            // Key on the LABEL, not roundIndex: m.round is the EFFECTIVE round
+            // (bracketRoundLabel), and one backend round can hold two of them
+            // when a bye collapses a round, while two backend rounds can share
+            // one. Keying on roundIndex therefore both put a quarterfinal under
+            // a "Semifinals" heading and split one round name across two
+            // identically-titled groups. Keying on the displayed string keeps
+            // the invariant the operator relies on: the heading describes every
+            // match under it. Same cross-competition behaviour as before, since
+            // a shared roundIndex already merged those.
+            key = "round:" + (m.round || "");
             label = m.round || "Playoffs";
         } else if (m.phase === "pool") {
             key = "pool:" + (m.poolName || "");

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -262,6 +262,15 @@ export function shiaijoScoreCell(m) {
 function ResolveFeedersModal({ match, comp, password, onClose, onResolved, onOptimisticResolve, showToast }) {
     const rounds = (comp && comp.bracket && comp.bracket.rounds) || [];
     const slots = useMemoSh(() => pendingFeederSlots(match, rounds), [match, rounds]);
+    // Slot text comes from the ONE rule in bracket.jsx, so this modal names a
+    // feeder exactly as the bracket card does ("Winner of M3") instead of
+    // stripping the prefix off the wire value and printing "r2-m0".
+    // (Guarded like the window.boutMiddle reads elsewhere: a mount without
+    // bracket.js degrades instead of throwing. index.html loads it first.)
+    const slotLabel = useMemoSh(
+        () => (window.bracketSlotLabeller ? window.bracketSlotLabeller(rounds) : (n) => n),
+        [rounds]
+    );
     const resolvable = slots.filter(s => s.resolvable);
     const blocked = slots.filter(s => !s.resolvable);
     // feeder id → asserted winner name.
@@ -322,7 +331,10 @@ function ResolveFeedersModal({ match, comp, password, onClose, onResolved, onOpt
             </p>
             {resolvable.map((s) => (
                 <div key={s.feeder.id} className="resolve-feeder">
-                    <div className="resolve-feeder__label">Winner of {s.feeder.matchNumber ? `Match ${s.feeder.matchNumber}` : s.placeholder.replace(/^Winner of /, "")}</div>
+                    {/* s.feeder is the match whose winner is being asserted, so
+                        name the slot after IT rather than re-deriving from the
+                        slot string. */}
+                    <div className="resolve-feeder__label">{slotLabel(s.placeholder, s.feeder.id)}</div>
                     <div className="resolve-feeder__opts">
                         {s.options.map((opt) => {
                             const name = _bracketSideName(opt);
@@ -571,6 +583,24 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
         () => courtMatchesRaw.filter(window.isPendingBracketMatch),
         [courtMatchesRaw]
     );
+    // A "Later" row shows the placeholder sides of a bout whose feeders are not
+    // in yet, so its names go through the shared slot rule (bracket.jsx) and read
+    // "Winner of M3" — the number on the bracket card — instead of the internal
+    // "r2-m0". One labeller per competition, memoised with the court feed it is
+    // derived from. NOTE: the labeller is DISPLAY only; the queue is still split
+    // by isPendingBracketMatch / hasBothSides on the RAW sides above, so a
+    // relabelled row stays non-actionable exactly as before.
+    const slotLabelFor = useMemoSh(() => {
+        const cache = new Map();
+        return (compId) => {
+            if (!cache.has(compId)) {
+                const c = courtCompetitions.find((x) => x.id === compId);
+                const rounds = (c && c.bracket && c.bracket.rounds) || [];
+                cache.set(compId, window.bracketSlotLabeller ? window.bracketSlotLabeller(rounds) : (n) => n);
+            }
+            return cache.get(compId);
+        };
+    }, [courtCompetitions]);
     const { sorted, running, scheduled, completed } = useMemoSh(
         () => partitionShiaijoMatches(allMatches),
         [allMatches]
@@ -1206,7 +1236,7 @@ function AdminShiaijoPage({ tournament, court: routeCourt, onBack, onEditScore, 
                                     </div>
                                     <div className="score-editor__list">
                                         {filteredPending.map((m) => (
-                                            <ShiaijoQueueRow key={matchKey(m)} m={m} pending onResolve={setResolveMatch} />
+                                            <ShiaijoQueueRow key={matchKey(m)} m={m} pending onResolve={setResolveMatch} slotLabel={slotLabelFor(m.compId)} />
                                         ))}
                                     </div>
                                 </div>
@@ -1550,8 +1580,15 @@ function ShiaijoQueueGroup({ label, matches, subGroup, scheduled, courts, onMove
     );
 }
 
-export function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCorrect, onCall, callingKey, calledKey, startingKey, pending, onResolve }) {
+export function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onEnterLineup, onPick, onCorrect, onCall, callingKey, calledKey, startingKey, pending, onResolve, slotLabel }) {
     const isComplete = m.status === "completed";
+    // Slot text through the one shared rule (bracket.jsx). Actionable rows never
+    // hold a placeholder (hasBothSides filtered them out), so this only ever
+    // changes the `pending` "Later" rows; the fallbacks keep any other caller
+    // from printing a raw "Winner of rX-mY" if it ever does.
+    const slotName = slotLabel || window.slotDisplayName || ((n) => n);
+    const aName = slotName(m.sideA?.name || "", (m.feeders || [])[0]);
+    const bName = slotName(m.sideB?.name || "", (m.feeders || [])[1]);
     const scoreCell = shiaijoScoreCell(m);
     // Derive position in the full scheduled list to know when to disable ↑/↓.
     // `scheduled` is the court's complete scheduled array (including Up Next);
@@ -1592,14 +1629,14 @@ export function ShiaijoQueueRow({ m, scheduled, courts, onMoveCourt, onMove, onE
                 </span>
             </div>
             <div className="shiaijo-qrow__match">
-                <div className="shiaijo-qrow__side" aria-label={`Shiro: ${m.sideB?.name || ""}`}>
+                <div className="shiaijo-qrow__side" aria-label={`Shiro: ${bName}`}>
                     <span className="se-color-badge se-color-badge--shiro">SHIRO</span>
-                    <span className="shiaijo-qrow__name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{m.sideB?.name}</span>
+                    <span className="shiaijo-qrow__name">{m.sideB?.number ? <span className="num-prefix">{m.sideB.number}</span> : null}{bName}</span>
                 </div>
                 <span className="shiaijo-qrow__vs">vs</span>
-                <div className="shiaijo-qrow__side shiaijo-qrow__side--aka" aria-label={`Aka: ${m.sideA?.name || ""}`}>
+                <div className="shiaijo-qrow__side shiaijo-qrow__side--aka" aria-label={`Aka: ${aName}`}>
                     <span className="se-color-badge se-color-badge--aka">AKA</span>
-                    <span className="shiaijo-qrow__name">{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{m.sideA?.name}</span>
+                    <span className="shiaijo-qrow__name">{m.sideA?.number ? <span className="num-prefix">{m.sideA.number}</span> : null}{aName}</span>
                 </div>
             </div>
             {/* Completed result on its own centred line BELOW the names: the

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -76,7 +76,7 @@ function bracketRoundLabel(m, roundIdx, total) {
 // nothing here rewrites a side, so a slot relabelled for humans is still the
 // same unplayable placeholder to every predicate. The two capture groups are
 // the only addition: they let a DISPLAY surface say which match will fill the
-// slot. Do not use this regex as a filter — use the predicates above.
+// slot. Do not use this regex as a filter — use the predicates named above (they live in admin_helpers.jsx / display_helpers.jsx / Go, not here).
 const FEEDER_SLOT_RE = /^Winner of r(\d+)-m(\d+)$/;
 
 // slotDisplayName: THE single mapping from a bracket SLOT VALUE to the text a
@@ -231,7 +231,7 @@ const defaultWinMaru = (encho) => (enchoOn(encho) ? ["○"] : ["○", "○"]);
 // "(DH)" (rep bout). Nothing else is a valid middle value: a dash never is
 // (operator ruling), and Ht/Kiken/Fus. are side results, never middles.
 // SCOPE: this binds the surfaces that PROJECT A RESULT — viewer, display,
-// scoreboard, match cards, export cells — and every one of them derives its
+// scoreboard, match cards — and every one of them derives its
 // middle from here. It does NOT bind the score editors' live-ENTRY
 // separators (the plain "VS" in the individual/team encounter headers, the
 // engi divider): those sit in the input zone and project no result, so they
@@ -448,9 +448,9 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD,
       </div>
     );
   }
-  // Slot text first, THEN the engi split: an unresolved feeder is never an engi
-  // pair, and labelling after the split would leak the raw id whenever the name
-  // is passed through untouched. `slotLabel` carries this card's bracket (so the
+  // One call, on the whole name, before the engi pair split: a feeder slot has
+  // no " - " so the split is a no-op on it either way, and doing it first keeps
+  // the rule in one place rather than per-half. `slotLabel` carries this card's bracket (so the
   // slot resolves to "Winner of M<n>"); without one, slotDisplayName still
   // guarantees no raw id escapes — it degrades to "TBD".
   const shownName = slotLabel ? slotLabel(player.name, feederId) : slotDisplayName(player.name);
@@ -492,7 +492,9 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
   // type "ippon" or "hikiwake". Kept because it is the ONLY bye cue a MatchCard
   // has (the card builds its per-side scores from ippon arrays and never calls
   // matchScoreStr, so removing this leaves such a card completely unlabelled).
-  // A server-fed structural bye is not drawn as a MatchCard at all: it renders
+  // A server-fed structural bye in a bracket carrying mp-7f2w metadata is not
+  // drawn as a MatchCard at all (a legacy bracket has no metadata, routes to
+  // BracketTreeLegacy, and does draw every rounds[] entry as a card): it renders
   // as the bc-bye-slot placeholder in BracketTreeMeta below.
   const isBye = match.score?.type === "bye";
 
@@ -1095,9 +1097,10 @@ function BracketTreeLegacy({ rounds, slotLabel, variant = 1, showDojo = true, on
           // Round index is a stable key: bracket rounds never reorder.
           // oxlint-disable-next-line react/no-array-index-key
           <div key={ri} className="bc-round" style={{ "--round": ri }}>
-            {/* Legacy (pre-mp-7f2w) brackets only: this renderer runs exactly
-                when NO match carries displayRound, so bracketRoundLabel would
-                degrade to this same call. Raw index is the only round there is. */}
+            {/* Legacy (pre-mp-7f2w) brackets only: this renderer runs when no
+                match carries displayRound AND none is hidden (see hasMeta), so
+                bracketRoundLabel would degrade to this same call. Raw index is
+                the only round there is. */}
             <div className="bc-round-label">{roundLabel(ri, rounds.length)}</div>
             <div className={`bc-round-matches${positioned ? " bc-round-matches--abs" : ""}`}>
               {round.map((m, mi) => {

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -110,7 +110,14 @@ const defaultWinMaru = (encho) => (enchoOn(encho) ? ["○"] : ["○", "○"]);
 // "vs" (plain, including unplayed/pending), "X" (tie), "(E)" (overtime),
 // "(DH)" (rep bout). Nothing else is a valid middle value: a dash never is
 // (operator ruling), and Ht/Kiken/Fus. are side results, never middles.
-// Every surface that renders a bout middle derives it from here.
+// SCOPE: this binds the surfaces that PROJECT A RESULT — viewer, display,
+// scoreboard, match cards, export cells — and every one of them derives its
+// middle from here. It does NOT bind the score editors' live-ENTRY
+// separators (the plain "VS" in the individual/team encounter headers, the
+// engi divider): those sit in the input zone and project no result, so they
+// are exempt by mp-42g and carry their own note at each site. The team
+// editor's per-BOUT rows do project a result, and go through
+// renderTeamBoutMiddle → boutMiddle like every other bound surface.
 function boutMiddle(decision, encho, score) {
   return (isDrawResult(decision, score) ? "X" : middleMark(decision, encho)) || "vs";
 }

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -20,14 +20,51 @@ function TermBC(props) {
 function isHikiwakeBC(v) { return v === "hikiwake"; }
 function isKikenDecisionBC(v) { return v === "kiken" || v === "kiken-voluntary" || v === "kiken-injury"; }
 
-function roundLabel(roundIdx, total) {
-  const fromEnd = total - 1 - roundIdx;
+// roundLabelFromEnd: the ONE mapping from "rounds still to come after this one"
+// to a round NAME. 0 = Final, 1 = Semifinals, 2 = Quarterfinals, then the
+// abbreviated bracket-size form. Every round name on every surface bottoms out
+// here; nothing else may spell these strings.
+function roundLabelFromEnd(fromEnd) {
   if (fromEnd === 0) return "Final";
   if (fromEnd === 1) return "Semifinals";
   if (fromEnd === 2) return "Quarterfinals";
   // mp-13y #8: abbreviated column header: R{N} where N is the bracket size
   // = 2^(fromEnd+1). Keeps column labels tight for wide brackets (R32, R128).
   return `R${2 ** (fromEnd + 1)}`;
+}
+
+function roundLabel(roundIdx, total) {
+  return roundLabelFromEnd(total - 1 - roundIdx);
+}
+
+// bracketRoundLabel: THE single source of truth for what round a bracket MATCH
+// belongs to, on every surface (bracket columns, viewer rows, admin score
+// editor, watchlist, TV/display boards).
+//
+// mp-7f2w gave every real match an EFFECTIVE round (`displayRound`, counted from
+// the final: 1 = Final, 2 = Semifinals, …) computed by walking the real feeder
+// graph, so a structural bye COLLAPSES a round rather than showing an empty
+// card. In a non-power-of-two draw that effective round can be nearer the final
+// than the match's raw position in `bracket.rounds`, and the two disagree:
+//
+//   5-player knockout, backend rounds = 3
+//     m-r1-0 (Alice v Bob)  backend round 0 → "Quarterfinals"
+//                           displayRound 2  → "Semifinals"   ← its winner
+//                                                              goes straight
+//                                                              to the final
+//
+// The effective round is the true one: a match whose winner plays the final IS a
+// semifinal, whatever array slot it occupies. So prefer `displayRound` and fall
+// back to the raw position only for legacy brackets generated before the field
+// existed (and for the pre-meta rendering path), where the two coincide anyway.
+//
+// Do NOT re-derive a round name from a raw round index at a call site: that is
+// exactly the duplication that let the Overview rows say "Quarterfinals" while
+// the bracket column above the same match said "Semifinals" (mp-u37s).
+function bracketRoundLabel(m, roundIdx, total) {
+  const dr = m && m.displayRound;
+  if (typeof dr === "number" && dr > 0) return roundLabelFromEnd(dr - 1);
+  return roundLabel(roundIdx, total);
 }
 
 // sideA = top = Aka (Red), sideB = bottom = Shiro (White)
@@ -788,7 +825,14 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
         // Column index is a stable key: bracket rounds never reorder.
         // oxlint-disable-next-line react/no-array-index-key
         <div key={ci} className="bc-round" style={{ "--round": ci }}>
-          <div className="bc-round-label">{roundLabel(ci, columns.length)}</div>
+          {/* Label the column from a match IN it, through the shared primitive,
+              so a column header and the row/eyebrow labels for the same match can
+              never diverge. Provably the same string as roundLabel(ci, length):
+              columns run displayRound maxDR→1, so ci === maxDR - displayRound.
+              The (ci, length) args are the fallback for an empty column, which
+              buildDisplayModel never produces (the BFS assigns a contiguous
+              1…maxDR, so every column holds at least one real match). */}
+          <div className="bc-round-label">{bracketRoundLabel(col[0], ci, columns.length)}</div>
           <div className={`bc-round-matches${positioned ? " bc-round-matches--abs" : ""}`} style={matchesStyle}>
             {col.map((m, mi) => {
               const top = positioned ? cardTops.tops[m.id] : undefined;
@@ -938,6 +982,9 @@ function BracketTreeLegacy({ rounds, variant = 1, showDojo = true, onMatchClick,
           // Round index is a stable key: bracket rounds never reorder.
           // oxlint-disable-next-line react/no-array-index-key
           <div key={ri} className="bc-round" style={{ "--round": ri }}>
+            {/* Legacy (pre-mp-7f2w) brackets only: this renderer runs exactly
+                when NO match carries displayRound, so bracketRoundLabel would
+                degrade to this same call. Raw index is the only round there is. */}
             <div className="bc-round-label">{roundLabel(ri, rounds.length)}</div>
             <div className={`bc-round-matches${positioned ? " bc-round-matches--abs" : ""}`}>
               {round.map((m, mi) => {
@@ -1030,6 +1077,10 @@ window.BracketTree = BracketTree;
 window.MatchCard = MatchCard;
 window.bronzeUnderFinalStyle = bronzeUnderFinalStyle;
 window.roundLabel = roundLabel;
+// Exposed so every surface that labels a bracket MATCH (viewer rows, admin
+// score editor, TV/display boards) uses the effective-round rule rather than
+// re-deriving a name from the raw round index. See bracketRoundLabel above.
+window.bracketRoundLabel = bracketRoundLabel;
 // Exposed so the bracket winner-picker panel can label a selected match with
 // the SAME number ("M1") and round the tree shows on its cards/columns.
 window.buildDisplayModel = buildDisplayModel;
@@ -1047,4 +1098,4 @@ window.winnerSideLR = winnerSideLR;
 window.sideLabel = sideLabel;
 window.ipponsFromScore = ipponsFromScore;
 
-export { formatIpponsScore, enchoLabel, boutMiddle, defaultWinMaru, matchMiddleMark, winnerSideLR, sideLabel, roundLabel, ipponsFromScore, teamIVScore, teamIVPWScore, engiFlagScore, matchScoreStr, matchStateCell, buildDisplayModel, computeMetaTops, bronzeUnderFinalStyle, PlayerLine };
+export { formatIpponsScore, enchoLabel, boutMiddle, defaultWinMaru, matchMiddleMark, winnerSideLR, sideLabel, roundLabel, bracketRoundLabel, ipponsFromScore, teamIVScore, teamIVPWScore, engiFlagScore, matchScoreStr, matchStateCell, buildDisplayModel, computeMetaTops, bronzeUnderFinalStyle, PlayerLine };

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -485,6 +485,15 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
   const aWin = match.winner && match.sideA && match.winner.id === match.sideA.id;
   const bWin = match.winner && match.sideB && match.winner.id === match.sideB.id;
   const running = match.status === "running";
+  // score.type === "bye" is CLIENT-ONLY: the sole producers are the sample-data
+  // generators in data.jsx (advanceByes / simulateRounds), never a server
+  // payload — Go's BracketMatch/Match carry scoreA/scoreB strings and no `score`
+  // object, and api_serializers.normalizeMatch only ever synthesizes
+  // type "ippon" or "hikiwake". Kept because it is the ONLY bye cue a MatchCard
+  // has (the card builds its per-side scores from ippon arrays and never calls
+  // matchScoreStr, so removing this leaves such a card completely unlabelled).
+  // A server-fed structural bye is not drawn as a MatchCard at all: it renders
+  // as the bc-bye-slot placeholder in BracketTreeMeta below.
   const isBye = match.score?.type === "bye";
 
   const ipponsA = match.ipponsA || ipponsFromScore(match.scoreA);
@@ -936,9 +945,17 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, slotLabel, varian
                   aria-label={`${m.playerName || "Bye"}: advances without an opponent`}
                   ref={(el) => { if (el) refMap.current[m.id] = el; }}
                 >
-                  {m.playerName
-                    ? <span className="bc-bye-slot__name">{m.playerName}</span>
-                    : <span className="bc-bye-slot__tag">BYE</span>}
+                  {/* The BYE tag is unconditional: a named slot without it is
+                      just a grey box with a name in it, which reads as an
+                      unexplained extra card rather than "this entrant advanced
+                      unopposed". Name + tag share one flex row (see
+                      .bc-bye-slot in styles.css): the name takes the free space
+                      and ellipsises, the tag never shrinks, so a long name
+                      truncates instead of pushing the marker out of the
+                      fixed-width column. Rendered once in both cases: the
+                      nameless slot is the tag alone, exactly as before. */}
+                  {m.playerName ? <span className="bc-bye-slot__name">{m.playerName}</span> : null}
+                  <span className="bc-bye-slot__tag">BYE</span>
                 </div>
               ) : (
                 <MatchCard

--- a/web-mobile/js/bracket.jsx
+++ b/web-mobile/js/bracket.jsx
@@ -67,6 +67,89 @@ function bracketRoundLabel(m, roundIdx, total) {
   return roundLabel(roundIdx, total);
 }
 
+// FEEDER_SLOT_RE reads (never writes) the engine's unresolved-feeder slot
+// value, "Winner of r<depth>-m<index>" — the wire shape produced by
+// engine.winnerOfPlaceholder and matched by helper.reservedWinnerOfRE, by
+// admin_helpers.BRACKET_PLACEHOLDER_RE and by display_helpers'
+// DISPLAY_PLACEHOLDER_RE. Those filters decide whether a match is
+// playable/schedulable/announceable and they keep operating on the RAW value:
+// nothing here rewrites a side, so a slot relabelled for humans is still the
+// same unplayable placeholder to every predicate. The two capture groups are
+// the only addition: they let a DISPLAY surface say which match will fill the
+// slot. Do not use this regex as a filter — use the predicates above.
+const FEEDER_SLOT_RE = /^Winner of r(\d+)-m(\d+)$/;
+
+// slotDisplayName: THE single mapping from a bracket SLOT VALUE to the text a
+// human reads in that slot. Every surface that puts a bracket side in front of
+// a person — public bracket, admin bracket, match details, the shiaijo "Later"
+// queue — goes through this; no surface may print a raw slot value.
+//
+// "r3-m3" is a backend round/index pair, meaningless to a spectator AND not the
+// number the bracket prints on its cards ("M1", "M2", … from matchNumById /
+// state.BracketMatch.MatchNumber, which are ordered by effective round, not by
+// the id). Printing it therefore pointed readers at the wrong card. So:
+//   feeder resolved to a numbered match → "Winner of M<n>", which names a card
+//                                         visible on the same screen;
+//   feeder not resolvable (legacy bracket with no numbering, or a hidden
+//   phantom feeder)                     → "TBD", the neutral label the empty
+//                                         side already uses. Never the raw id.
+// Anything that is NOT a feeder slot is returned untouched — in particular the
+// pool-origin placeholders ("Pool A-1st", "Pool B-2nd"): those are already
+// self-describing to a spectator (they name a pool and a finishing position, no
+// internal index), so relabelling them would lose real information.
+function slotDisplayName(name, feederMatchNum) {
+  if (typeof name !== "string" || !FEEDER_SLOT_RE.test(name)) return name;
+  return feederMatchNum > 0 ? `Winner of M${feederMatchNum}` : "TBD";
+}
+
+// makeSlotLabeller binds slotDisplayName to ONE bracket: it returns
+// (slotValue, feederId) => display text, resolving each feeder slot to the
+// match that will fill it.
+//
+// Two resolution paths, in order:
+//  1. `feederId` — the caller's own state.BracketMatch.Feeders entry for that
+//     side (mp-7f2w, [A, B] order). PREFERRED: the engine walked the REAL
+//     feeder graph to build it, so it sees through phantom bye matches. In a
+//     5-entrant draw the final's slot literally reads "Winner of r2-m0", but
+//     r2-m0 is a dead bye match — the winner actually arrives from m-r1-0.
+//  2. Positional parse of the slot itself, mirroring Go parseWinnerOf
+//     (scoring.go): depth is 1-based from the final, so roundIndex =
+//     rounds.length - depth and the index is the 0-based position in that
+//     round. The fallback for brackets saved before the feeder metadata
+//     existed, where there are no phantoms to see through anyway.
+// Either way the NUMBER comes from matchNumById when the caller has a display
+// model (the exact map that stamps "M<n>" on the cards, so the reference always
+// resolves against something on screen), falling back to the server's
+// match.matchNumber, which is equal-by-contract (engine.assignBracketMatchNumbers).
+// An unresolvable feeder yields 0 and slotDisplayName degrades it to "TBD".
+function makeSlotLabeller(rounds, matchNumById) {
+  const rs = Array.isArray(rounds) ? rounds : [];
+  const numOf = (m) => (m ? ((matchNumById && matchNumById[m.id]) || m.matchNumber || 0) : 0);
+  const byId = (id) => {
+    for (const round of rs) {
+      const hit = (round || []).find((m) => m && m.id === id);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  return (name, feederId) => {
+    const mm = typeof name === "string" ? FEEDER_SLOT_RE.exec(name) : null;
+    if (!mm) return name;
+    let num = feederId ? numOf(byId(feederId)) : 0;
+    if (!num) num = numOf((rs[rs.length - Number(mm[1])] || [])[Number(mm[2])]);
+    return slotDisplayName(name, num);
+  };
+}
+
+// bracketSlotLabeller: makeSlotLabeller for callers that hold only the rounds
+// (the match-details modal, the shiaijo queue). It derives the SAME numbering
+// the tree draws by going through buildDisplayModel, so a slot's label and the
+// card it points at can never disagree. BracketTree builds its labeller from
+// the model it already computed instead of calling this (same result, one pass).
+function bracketSlotLabeller(rounds) {
+  return makeSlotLabeller(rounds, buildDisplayModel(rounds).matchNumById);
+}
+
 // sideA = top = Aka (Red), sideB = bottom = Shiro (White)
 function sideLabel(side) {
   return side === "a" ? "AKA" : "SHIRO";
@@ -355,7 +438,7 @@ function teamIVPWScore(m) {
   return iv == null ? null : `IV ${iv}`;
 }
 
-const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD, isEngi }) => {
+const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD, isEngi, slotLabel, feederId }) => {
   const isAka = side === "a";
   if (!player || isTBD) {
     return (
@@ -365,9 +448,15 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD,
       </div>
     );
   }
+  // Slot text first, THEN the engi split: an unresolved feeder is never an engi
+  // pair, and labelling after the split would leak the raw id whenever the name
+  // is passed through untouched. `slotLabel` carries this card's bracket (so the
+  // slot resolves to "Winner of M<n>"); without one, slotDisplayName still
+  // guarantees no raw id escapes — it degrades to "TBD".
+  const shownName = slotLabel ? slotLabel(player.name, feederId) : slotDisplayName(player.name);
   // Engi pair: split the combined name so member 2 stacks under member 1
   // instead of truncating on narrow bracket cards.
-  const [m1, m2] = isEngi && window.engiPairParts ? window.engiPairParts(player.name) : [player.name, ""];
+  const [m1, m2] = isEngi && window.engiPairParts ? window.engiPairParts(shownName) : [shownName, ""];
   return (
     <div className={`bc-side bc-side--${side} ${isWinner ? "bc-side--winner" : ""}`}>
       <span className={`bc-color-badge bc-color-badge--${isAka ? "aka" : "shiro"}`}>{isAka ? "AKA" : "SHIRO"}</span>
@@ -392,7 +481,7 @@ const PlayerLine = React.memo(({ player, isWinner, side, showDojo, score, isTBD,
 });
 PlayerLine.displayName = "PlayerLine";
 
-const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, highlightPlayers, matchNum, isEngi }) => {
+const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, matchRef, highlightPlayers, matchNum, isEngi, slotLabel }) => {
   const aWin = match.winner && match.sideA && match.winner.id === match.sideA.id;
   const bWin = match.winner && match.sideB && match.winner.id === match.sideB.id;
   const running = match.status === "running";
@@ -448,9 +537,11 @@ const MatchCard = React.memo(({ match, variant, showDojo, onClick, highlighted, 
           <span className="bc-decision-chip"><TermBC name="daihyosen">(DH)</TermBC></span>
         ) : null}
       </div>
-      <PlayerLine player={match.sideA} isWinner={aWin} side="a" showDojo={showDojo} score={aScore} isTBD={aTBD} isEngi={isEngi} />
+      {/* feeders is [A, B]: hand each side ITS feeder so an unresolved slot can
+          be named after the match that will actually fill it (see makeSlotLabeller). */}
+      <PlayerLine player={match.sideA} isWinner={aWin} side="a" showDojo={showDojo} score={aScore} isTBD={aTBD} isEngi={isEngi} slotLabel={slotLabel} feederId={(match.feeders || [])[0]} />
       <div className="bc-divider"></div>
-      <PlayerLine player={match.sideB} isWinner={bWin} side="b" showDojo={showDojo} score={bScore} isTBD={bTBD} isEngi={isEngi} />
+      <PlayerLine player={match.sideB} isWinner={bWin} side="b" showDojo={showDojo} score={bScore} isTBD={bTBD} isEngi={isEngi} slotLabel={slotLabel} feederId={(match.feeders || [])[1]} />
     </button>
   );
 });
@@ -733,7 +824,7 @@ function BracketConnectorsMeta({ columns, feedersById, treeRef, refMap, version,
 // (hidden) are dropped. All cards are absolutely positioned at the
 // feeder-graph-derived top so parents sit centred on their feeders
 // (see computeMetaTops).
-function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers, isEngi }) {
+function BracketTreeMeta({ columns, feedersById, matchNumById, slotLabel, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers, isEngi }) {
   const treeRef = useRef(null);
   const refMap = useRef({});
   const [version, setVersion] = useStateBC(0);
@@ -860,6 +951,7 @@ function BracketTreeMeta({ columns, feedersById, matchNumById, variant = 1, show
                   highlightPlayers={highlightPlayers}
                   matchNum={matchNumById[m.id]}
                   isEngi={isEngi}
+                  slotLabel={slotLabel}
                 />
               );
               return (
@@ -882,13 +974,17 @@ function BracketTree(props) {
   // meta renderer's effects key on those: recomputing every render would reset
   // the measured layout in a loop.
   const model = React.useMemo(() => buildDisplayModel(props.rounds), [props.rounds]);
+  // One labeller per bracket, built from the model that numbers the cards, so
+  // "Winner of M3" always names the card drawn as "M3". Memoised alongside the
+  // model: MatchCard is memo(), so a fresh function every render would defeat it.
+  const slotLabel = React.useMemo(() => makeSlotLabeller(props.rounds, model.matchNumById), [props.rounds, model]);
   if (model.hasMeta) {
-    return <BracketTreeMeta {...props} columns={model.columns} feedersById={model.feedersById} matchNumById={model.matchNumById} />;
+    return <BracketTreeMeta {...props} columns={model.columns} feedersById={model.feedersById} matchNumById={model.matchNumById} slotLabel={slotLabel} />;
   }
-  return <BracketTreeLegacy {...props} />;
+  return <BracketTreeLegacy {...props} slotLabel={slotLabel} />;
 }
 
-function BracketTreeLegacy({ rounds, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers, isEngi }) {
+function BracketTreeLegacy({ rounds, slotLabel, variant = 1, showDojo = true, onMatchClick, highlightedMatchId, autoScrollMatchId, scrollContainerRef, highlightPlayers, isEngi }) {
   const treeRef = useRef(null);
   const refMap = useRef({});
   const [version, setVersion] = useStateBC(0);
@@ -1003,6 +1099,7 @@ function BracketTreeLegacy({ rounds, variant = 1, showDojo = true, onMatchClick,
                     onClick={() => onMatchClick && onMatchClick(m, ri, mi, rounds.length)}
                     highlightPlayers={highlightPlayers}
                     isEngi={isEngi}
+                    slotLabel={slotLabel}
                   />
                 </div>
                 );
@@ -1084,6 +1181,13 @@ window.bracketRoundLabel = bracketRoundLabel;
 // Exposed so the bracket winner-picker panel can label a selected match with
 // the SAME number ("M1") and round the tree shows on its cards/columns.
 window.buildDisplayModel = buildDisplayModel;
+// Exposed so every surface that shows a bracket SIDE to a human (match details
+// modal, shiaijo "Later" queue, feeder-resolution modal) renders slot values
+// through the one rule instead of printing the raw "Winner of rX-mY" wire
+// value. slotDisplayName is the no-bracket-context fallback ("TBD");
+// bracketSlotLabeller resolves the slot to the card number the tree prints.
+window.slotDisplayName = slotDisplayName;
+window.bracketSlotLabeller = bracketSlotLabeller;
 window.formatIpponsScore = formatIpponsScore;
 window.teamIVScore = teamIVScore;
 window.teamIVPWScore = teamIVPWScore;
@@ -1098,4 +1202,4 @@ window.winnerSideLR = winnerSideLR;
 window.sideLabel = sideLabel;
 window.ipponsFromScore = ipponsFromScore;
 
-export { formatIpponsScore, enchoLabel, boutMiddle, defaultWinMaru, matchMiddleMark, winnerSideLR, sideLabel, roundLabel, bracketRoundLabel, ipponsFromScore, teamIVScore, teamIVPWScore, engiFlagScore, matchScoreStr, matchStateCell, buildDisplayModel, computeMetaTops, bronzeUnderFinalStyle, PlayerLine };
+export { formatIpponsScore, enchoLabel, boutMiddle, defaultWinMaru, matchMiddleMark, winnerSideLR, sideLabel, roundLabel, bracketRoundLabel, ipponsFromScore, teamIVScore, teamIVPWScore, engiFlagScore, matchScoreStr, matchStateCell, buildDisplayModel, computeMetaTops, bronzeUnderFinalStyle, PlayerLine, slotDisplayName, makeSlotLabeller, bracketSlotLabeller, MatchCard, BracketTree };

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -264,6 +264,22 @@ function phaseLabel(m, isBracket, roundIndex, totalRounds, format) {
 // because the board is per-court; the spectator wants to know how far into the
 // phase this court is, not the venue overall. Returns null when there's no
 // group to count (e.g. promoted / promoted.competition missing).
+// bracketRoundSiblings returns the matches sharing `match`'s EFFECTIVE round
+// (mp-7f2w displayRound) — the same round phaseLabel names. Selecting
+// rounds[roundIndex] instead mixes rounds whenever a bye collapses one: in a
+// 5-entrant draw backend round 0 holds both a semifinal and a quarterfinal, so
+// the board rendered "SEMIFINALS · 0 / 2" over a set containing a quarterfinal
+// and listed that quarterfinal under the semifinal heading. Hidden phantom
+// matches are never real bouts and are excluded. Falls back to the raw round
+// for legacy brackets with no metadata, where roundIndex IS the effective round.
+function bracketRoundSiblings(rounds, match, roundIndex) {
+    const dr = match && match.displayRound;
+    if (typeof dr === "number" && dr > 0) {
+        return rounds.flat().filter((m) => m && !m.hidden && m.displayRound === dr);
+    }
+    return rounds[roundIndex] || [];
+}
+
 function phaseProgressOnCourt(promoted, court) {
     if (!promoted) return null;
     const comp = promoted.competition;
@@ -271,7 +287,7 @@ function phaseProgressOnCourt(promoted, court) {
     let group;
     if (promoted.isBracket) {
         const rounds = (comp.bracket && comp.bracket.rounds) || [];
-        const round = rounds[promoted.roundIndex] || [];
+        const round = bracketRoundSiblings(rounds, promoted.match, promoted.roundIndex);
         // Exclude unresolved placeholders ("Winner of rX-mY" / "Pool X-1st") so
         // the denominator matches the runnable matches the board actually shows
         // (the feed filters them via bracketSidesReady too).
@@ -326,6 +342,7 @@ function StreamingQR({ url, label }) {
 
 export {
     DISPLAY_PLACEHOLDER_RE,
+    bracketRoundSiblings,
     bracketSidesReady,
     findRunningOnCourt,
     findUpcomingOnCourt,

--- a/web-mobile/js/display_helpers.jsx
+++ b/web-mobile/js/display_helpers.jsx
@@ -229,8 +229,13 @@ function phaseLabel(m, isBracket, roundIndex, totalRounds, format) {
     if (format === "league") return "";
     if (m.phaseName) return m.phaseName;
     if (m.poolName) return m.poolName;
-    if (isBracket && typeof roundIndex === "number" && window.roundLabel) {
-        return window.roundLabel(roundIndex, totalRounds);
+    // Bracket matches reach the display surfaces straight off c.bracket.rounds
+    // (no phaseName stamped), so this branch is the label. Route it through
+    // window.bracketRoundLabel: it keys on the match's effective round (mp-7f2w
+    // displayRound) so the board agrees with the bracket column and the viewer
+    // rows for the same match; roundIndex is only the legacy fallback (mp-u37s).
+    if (isBracket && typeof roundIndex === "number" && window.bracketRoundLabel) {
+        return window.bracketRoundLabel(m, roundIndex, totalRounds);
     }
     // Pool matches reach the feed with a pool-shaped id "<PoolName>-<index>"
     // (regular bouts use round === -1 sentinel; DH/TB supplementary bouts are
@@ -238,7 +243,7 @@ function phaseLabel(m, isBracket, roundIndex, totalRounds, format) {
     // never render a bare "-1" or "0": covers regular, daihyosen and tiebreaker
     // bouts alike via poolNameOf. Guard on !isBracket: poolNameOf matches any
     // "*-<digits>" shape, so a bracket id like "m-r1-0" would otherwise yield a
-    // bogus "m-r1" pool-like label when window.roundLabel is unavailable.
+    // bogus "m-r1" pool-like label when window.bracketRoundLabel is unavailable.
     if (!isBracket) {
         const fromId = poolNameOf(m.id);
         if (fromId) return fromId;

--- a/web-mobile/js/display_scoreboard.jsx
+++ b/web-mobile/js/display_scoreboard.jsx
@@ -2,7 +2,7 @@
 // Fullscreen white board shown on Shiaijo-dedicated screens.
 // T061, T062, T063, mp-13y.
 
-import { findRunningOnCourt, findUpcomingOnCourt, countCourtMatches, sideLabel, phaseLabel, TermD, poolNameOf, isSupplementaryBout, phaseProgressOnCourt, StreamingQR } from './display_helpers.jsx';
+import { findRunningOnCourt, findUpcomingOnCourt, countCourtMatches, sideLabel, phaseLabel, TermD, poolNameOf, isSupplementaryBout, phaseProgressOnCourt, bracketRoundSiblings, StreamingQR } from './display_helpers.jsx';
 import { teamMatchTypeFor, DAIHYOSEN_POSITION } from './pool_ids.jsx';
 import { TeamScoreboard, IndividualScore, useTeamLineups, teamIVPW } from './match_scoreboard.jsx';
 
@@ -205,8 +205,10 @@ function gatherIndividualGroup(promoted, court) {
     const matchCourt = court || cur.court || "";
     let group;
     if (promoted.isBracket) {
+        // Effective round, matching the phaseLabel heading above these rows:
+        // the raw round can mix two effective rounds when a bye collapses one.
         const rounds = (comp.bracket && comp.bracket.rounds) || [];
-        group = rounds[promoted.roundIndex] || [];
+        group = bracketRoundSiblings(rounds, cur, promoted.roundIndex);
     } else {
         const pool = poolNameOf(cur.id);
         if (!pool) return []; // non-pool-shaped id → don't collect every other non-pool match

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -151,6 +151,17 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     // server payload). Use
     // hasBothSides, never `m.sideA && m.sideB`: normalizeMatch substitutes a
     // truthy {id:"",name:""} for a missing side.
+    //
+    // SWISS is NOT affected by this filter, despite building a bye in the same
+    // one-real-side shape ({SideA: name, SideB: "", Winner: name, completed} —
+    // engine/swiss.go). Swiss piggybacks on pool-matches.csv but never writes
+    // pools.csv, so the viewer payload carries `pools: []` with the matches in
+    // poolMatches (verified against a live 5-player Swiss round: 3 poolMatches,
+    // pools empty). The loop above walks `pools`, so NO Swiss match reaches
+    // allMatches at all and none of these three lists can contain one. A Swiss
+    // bye therefore does not appear here for a different reason than a knockout
+    // bye, and the operator has ruled that acceptable. Do not add a Swiss case
+    // to this filter expecting it to change anything.
     const recent = allMatches
       .filter((m) => m.status === "completed" && m.winner && hasBothSides(m) && matchInvolvesWatched(m))
       .sort((a, b) => (b.scheduledAt || "00:00").localeCompare(a.scheduledAt || "00:00"))

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -145,9 +145,10 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     // arrived here as finished results reading "TBD vs <name>" with a Final
     // badge and no indication that nobody was ever scheduled. A bye is bracket
     // structure, not a result. It stays discoverable in the Bracket tab, where
-    // the entrant renders as an unopposed slot feeding the next round (NOT as a
-    // "BYE" tag: bracket.jsx gates that on score.type === "bye", which the Go
-    // side never sets, so it is unreachable from a server payload). Use
+    // the entrant renders as an unopposed slot tagged BYE feeding the next
+    // round (that is bc-bye-slot__tag in BracketTreeMeta; not the MatchCard's
+    // bc-bye-tag, which is gated on score.type === "bye" and unreachable from a
+    // server payload). Use
     // hasBothSides, never `m.sideA && m.sideB`: normalizeMatch substitutes a
     // truthy {id:"",name:""} for a missing side.
     const recent = allMatches

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -134,8 +134,19 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     // pool-then-bracket order (not time order), so a bare slice(-N).reverse()
     // produced a jumbled "Recent results" list: sort by scheduledAt desc,
     // then take the most recent N. Missing times sort last (oldest).
+    // hasBothSides here for the same reason as running/upcoming above, and to
+    // keep byes out: a non-power-of-two knockout auto-completes its bye
+    // matches, which have one real competitor and one absent side, so they
+    // arrived here as finished results reading "TBD vs <name>" with a Final
+    // badge and no indication that nobody was ever scheduled. A bye is bracket
+    // structure, not a result. It stays discoverable in the Bracket tab, where
+    // the entrant renders as an unopposed slot feeding the next round (NOT as a
+    // "BYE" tag: bracket.jsx gates that on score.type === "bye", which the Go
+    // side never sets, so it is unreachable from a server payload). Use
+    // hasBothSides, never `m.sideA && m.sideB`: normalizeMatch substitutes a
+    // truthy {id:"",name:""} for a missing side.
     const recent = allMatches
-      .filter((m) => m.status === "completed" && m.winner && matchInvolvesWatched(m))
+      .filter((m) => m.status === "completed" && m.winner && hasBothSides(m) && matchInvolvesWatched(m))
       .sort((a, b) => (b.scheduledAt || "00:00").localeCompare(a.scheduledAt || "00:00"))
       .slice(0, hasActiveFilter ? 20 : 5);
     return { runningMatches: running, upcomingMatches: upcoming, recentMatches: recent };

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -173,6 +173,16 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     return null;
   }, [bracket]);
 
+  // Names an unresolved feeder slot after the card that will fill it
+  // ("Winner of M1"), via the one rule in bracket.jsx. Only the match modal
+  // needs it explicitly: BracketTree builds the same labeller internally from
+  // the rounds it is handed. Without it the modal would still never leak the
+  // raw id, but it would say "TBD" where the card behind it says "Winner of M1".
+  const bracketSlotLabel = useMemo(
+    () => (derivedBracket && window.bracketSlotLabeller ? window.bracketSlotLabeller(derivedBracket.rounds) : null),
+    [derivedBracket]
+  );
+
   // draw-ready is NOT pre-start for the purposes of showing pool/bracket
   // structure: the draw has been generated and the payload already includes
   // pools + bracket data returned unconditionally by handlers_viewer.go.
@@ -421,7 +431,7 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
           {window.VersionFooter && <window.VersionFooter />}
         </div>
       </div>
-      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} compId={c.id} />}
+      {selectedMatch && <MatchViewerModal match={selectedMatch} onClose={() => setSelectedMatch(null)} tournament={tournament} compId={c.id} slotLabel={bracketSlotLabel} />}
     </div>
   );
 }

--- a/web-mobile/js/viewer_competition.jsx
+++ b/web-mobile/js/viewer_competition.jsx
@@ -60,7 +60,12 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
     // renders `bracket`/`derivedBracket` directly and is NOT affected.
     if (bracket && bracket.rounds && !bracket.preview) {
         bracket.rounds.forEach((round, ri) => {
-            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.roundLabel(ri, bracket.rounds.length), phaseName: window.roundLabel(ri, bracket.rounds.length), roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, compEngi: isEngi, teamMatchType: compTMT }));
+            // window.bracketRoundLabel is the ONE round-naming primitive: it keys
+            // on the match's effective round (mp-7f2w displayRound), so an Overview
+            // row and the Bracket tab column above the same match always agree.
+            // roundLabel(ri, …) named a DIFFERENT round whenever a bye collapsed
+            // one (mp-u37s). roundIndex stays RAW: lineup fetches key on it.
+            round.forEach((m) => out.push({ ...m, phase: "bracket", round: window.bracketRoundLabel(m, ri, bracket.rounds.length), phaseName: window.bracketRoundLabel(m, ri, bracket.rounds.length), roundIndex: ri, compId: c.id, compName: c.name, compKind: c.kind, teamSize: c.teamSize, compEngi: isEngi, teamMatchType: compTMT }));
         });
     }
     return out;
@@ -351,7 +356,12 @@ export function ViewerCompetition({ tournament, competition, pools, poolMatches,
                     scrollContainerRef={bracketScrollRef}
                     highlightPlayers={highlightPlayers}
                     onMatchClick={(m, ri, _mi, total) => {
-                      const label = window.roundLabel(ri, total ?? derivedBracket.rounds.length);
+                      // Same primitive as the row surfaces and the column header
+                      // above the card. BracketTree hands back the DISPLAY column
+                      // index here, so this already agreed; going through
+                      // bracketRoundLabel keeps it agreeing if that ever changes,
+                      // and leaves no second copy of the naming rule (mp-u37s).
+                      const label = window.bracketRoundLabel(m, ri, total ?? derivedBracket.rounds.length);
                       // m.roundIndex is the backend round array index, stamped by
                       // buildDisplayModel (meta mode) or the raw rounds[ri] position
                       // (legacy mode where ri equals the backend index). Prefer it

--- a/web-mobile/js/viewer_match.jsx
+++ b/web-mobile/js/viewer_match.jsx
@@ -210,11 +210,21 @@ export const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, hig
             (bracket.jsx): "vs" / "X" / "(E)" / "(DH)" and nothing else. A dash
             is never a valid middle (it is a CELL value only), so both the
             pending and the completed-but-scoreless cases go through the same
-            call rather than being branched by status here. */}
+            call rather than being branched by status here.
+
+            Guarded like the twin call in admin_schedule_score_editor.jsx, and
+            unlike matchScoreStr above, because this branch also renders for
+            SCHEDULED rows: an unguarded call would make bracket.jsx a hard
+            dependency of an up-next list that previously needed no helper at
+            all, so a mount without it would throw instead of degrading. The
+            literal here is the module-missing fallback, NOT a second statement
+            of the display contract; boutMiddle stays the source whenever it is
+            present. Production load order already guarantees it is
+            (index.html tags bracket.js before every viewer module). */}
         {scoreStr ? (
           <span className={`vsched-item__score${isRunning ? " vsched-item__score--live" : ""}`}>{scoreStr}</span>
         ) : (
-          <span className="vsched-item__vs">{window.boutMiddle(m.decision, m.encho, m.score)}</span>
+          <span className="vsched-item__vs">{window.boutMiddle ? window.boutMiddle(m.decision, m.encho, m.score) : "vs"}</span>
         )}
         <div className={`vsched-item__side vsched-item__side--aka ${aWin ? "vsched-item__side--w" : ""}`}>
           <span className="sr-only">Aka:</span>

--- a/web-mobile/js/viewer_match.jsx
+++ b/web-mobile/js/viewer_match.jsx
@@ -76,16 +76,26 @@ export function localQueueLabelCompact(m) {
 // MatchDetailCard
 // ---------------------------------------------------------------------------
 
-export function MatchDetailCard({ match, onClose, escapeToClose = true }) {
+export function MatchDetailCard({ match, onClose, escapeToClose = true, slotLabel }) {
   window.useEscapeToClose(escapeToClose ? onClose : undefined);
   if (!match) return null;
   const isTeam = match.compKind === "team" || match.teamSize > 0;
   const teamSize = match.teamSize || 0;
+  // A card opened from the Bracket tab can still hold an unresolved feeder slot
+  // ("Winner of r3-m3"), so names go through the ONE slot-naming rule
+  // (slotDisplayName / bracketSlotLabeller in bracket.jsx) — never printed raw.
+  // `slotLabel` carries the bracket, so this modal names the same card the tree
+  // does ("Winner of M1"); openers with no bracket to resolve against (the
+  // schedule/home lists, which filter placeholder-sided matches out anyway) fall
+  // back to the context-free rule, which degrades to "TBD". The last fallback is
+  // for a mount without bracket.js; production load order rules it out
+  // (index.html tags bracket.js before every viewer module).
+  const slotName = slotLabel || window.slotDisplayName || ((n) => n);
   // withNumber prepends the assigned competitor number (e.g. "K1") when the
   // competition has numberPrefix; team-level sides have no .number so this
   // degrades to the bare team name.
-  const aName = withNumber(match.sideA);
-  const bName = withNumber(match.sideB);
+  const aName = slotName(withNumber(match.sideA), (match.feeders || [])[0]);
+  const bName = slotName(withNumber(match.sideB), (match.feeders || [])[1]);
   const aWin = match.winner?.id === match.sideA?.id && match.winner?.id;
   const bWin = match.winner?.id === match.sideB?.id && match.winner?.id;
   const isRunning = match.status === "running";
@@ -241,7 +251,7 @@ VSchedItem.displayName = "VSchedItem";
 // MatchViewerModal
 // ---------------------------------------------------------------------------
 
-export function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId }) {
+export function MatchViewerModal({ match, onClose, tournament, compId: defaultCompId, slotLabel }) {
   window.useEscapeToClose(onClose);
   const [scoringMatch, setScoringMatch] = useState(null);
   const triggerRef = useRefV(null);
@@ -281,8 +291,12 @@ export function MatchViewerModal({ match, onClose, tournament, compId: defaultCo
   const isSelfRun = tournament && tournament.mode === "self-run";
   const bothSidesReady = window.hasBothSides ? window.hasBothSides(match) : false;
   const isFinalized = match.status === "completed";
-  const sideAName = match.sideA?.name || (typeof match.sideA === "string" ? match.sideA : "");
-  const sideBName = match.sideB?.name || (typeof match.sideB === "string" ? match.sideB : "");
+  // Same slot-naming rule as the card below (see MatchDetailCard): the
+  // accessible name must read like the visible one, so an unresolved feeder
+  // announces as "Winner of M1"/"TBD" rather than the raw wire value.
+  const slotName = slotLabel || window.slotDisplayName || ((n) => n);
+  const sideAName = slotName(match.sideA?.name || (typeof match.sideA === "string" ? match.sideA : ""), (match.feeders || [])[0]);
+  const sideBName = slotName(match.sideB?.name || (typeof match.sideB === "string" ? match.sideB : ""), (match.feeders || [])[1]);
   const dialogLabel = sideAName && sideBName ? `Match: ${sideBName} vs ${sideAName}` : "Match details";
 
   if (scoringMatch && window.ScoreEditorModal) {
@@ -320,7 +334,7 @@ export function MatchViewerModal({ match, onClose, tournament, compId: defaultCo
         {/* Reuse the canonical MatchDetailCard so the modal and the inline
             card render identically (DRY): same header, colour badges and
             BoutSubRow team grid. The modal adds only the self-run scoring. */}
-        <MatchDetailCard match={match} onClose={onClose} escapeToClose={false} />
+        <MatchDetailCard match={match} onClose={onClose} escapeToClose={false} slotLabel={slotLabel} />
         {isSelfRun && bothSidesReady && (
           <div className="card" style={{ marginTop: 12, padding: 16 }}>
             {isFinalized ? (

--- a/web-mobile/js/viewer_match.jsx
+++ b/web-mobile/js/viewer_match.jsx
@@ -205,12 +205,16 @@ export const VSchedItem = React.memo(({ m, tweaks, showCompetition, onClick, hig
           <span className="n">{withNumber(m.sideB)}</span>
           {tweaks.showDojo && m.sideB?.dojo ? <span className="d">{m.sideB.dojo}</span> : null}
         </div>
+        {/* No score string (pending, or completed with no recorded cells) →
+            the bout MIDDLE, derived from the single source boutMiddle
+            (bracket.jsx): "vs" / "X" / "(E)" / "(DH)" and nothing else. A dash
+            is never a valid middle (it is a CELL value only), so both the
+            pending and the completed-but-scoreless cases go through the same
+            call rather than being branched by status here. */}
         {scoreStr ? (
           <span className={`vsched-item__score${isRunning ? " vsched-item__score--live" : ""}`}>{scoreStr}</span>
-        ) : m.status === "completed" ? (
-          <span className="vsched-item__vs">-</span>
         ) : (
-          <span className="vsched-item__vs">vs</span>
+          <span className="vsched-item__vs">{window.boutMiddle(m.decision, m.encho, m.score)}</span>
         )}
         <div className={`vsched-item__side vsched-item__side--aka ${aWin ? "vsched-item__side--w" : ""}`}>
           <span className="sr-only">Aka:</span>

--- a/web-mobile/js/viewer_schedule.jsx
+++ b/web-mobile/js/viewer_schedule.jsx
@@ -266,7 +266,13 @@ export function TWMatch({ m, highlight, onClick }) {
       </div>
       <div style={{ textAlign: "right", fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: 13 }}>
         {m.status === "completed" && scoreStr}
-        {m.status === "completed" && m.score?.type === "bye" && <span style={{ fontSize: 10, color: "var(--ink-3)" }}>BYE</span>}
+        {/* No separate "BYE" span here. Two independent reasons: this list is
+            filtered through hasBothSides (see ScheduleViewer.allMatches), which
+            rejects a match with an absent side, and a bye is exactly that; and
+            score.type === "bye" is client-only sample data (data.jsx) that no
+            live surface produces. Were one to arrive anyway, scoreStr above
+            already reads "BYE" (matchScoreStr → formatIpponsScore), so the span
+            only ever risked printing the word twice. */}
         {/* No centre "●" dot: a running match is signalled by the row's
             .tw-match--running highlight (accent ring). The labelled "● NOW"
             badge elsewhere is a separate status affordance. */}

--- a/web-mobile/js/viewer_utils.jsx
+++ b/web-mobile/js/viewer_utils.jsx
@@ -87,11 +87,16 @@ export function compMatches(c) {
   // any code path that bypasses the aggregator.
   const isPreviewBracket = !!(c.bracket && c.bracket.preview);
   const rounds = (!isPreviewBracket && c.bracket && c.bracket.rounds) ? c.bracket.rounds : (!isPreviewBracket ? (c.bracket || []) : []);
+  // window.bracketRoundLabel (bracket.jsx) is the ONE place the round name is
+  // decided: it prefers the match's effective round (mp-7f2w displayRound, which
+  // collapses bye-only rounds) so these rows agree with the bracket column drawn
+  // above the very same match. Do not substitute roundLabel(ri, …) here — the raw
+  // index is a DIFFERENT round in any non-power-of-two draw (mp-u37s).
   rounds.forEach((round, ri) => round.forEach((m) => out.push({
     ...m,
     phase: "bracket",
-    round: window.roundLabel(ri, rounds.length),
-    phaseName: window.roundLabel(ri, rounds.length),
+    round: window.bracketRoundLabel(m, ri, rounds.length),
+    phaseName: window.bracketRoundLabel(m, ri, rounds.length),
     // Raw 0-based round index alongside the display label so consumers
     // (useTeamLineups) need not parse the label: now a bracket-size string
     // ("Round 16") that a "Round N"→N-1 parse would misread as round 15.


### PR DESCRIPTION
## Summary

- **The viewer schedule rendered a forbidden dash in the bout middle.** `VSchedItem` hand-rolled its no-score fallback as `scoreStr ? <score> : status === "completed" ? "-" : "vs"`, so a completed match whose score string came back empty showed `-` between the two competitors. The display contract permits only `vs` / `X` / `(E)` / `(DH)` in a middle; a dash is a CELL value and is never a valid middle.
- **This was reachable on a public page through an ordinary flow, not a theoretical edge case.** A knockout competition with a non-power-of-two roster auto-completes its bye matches, and those land in the viewer's Recent Results as completed rows with no score. Confirmed in the browser (screenshot below).
- Both fallback branches now collapse into a single call to `boutMiddle`, the single source, so the dash disappears by construction.
- **Scopes the contract comments** so the next audit does not repeat the one that produced this bead: `boutMiddle` binds surfaces that PROJECT A RESULT, not the score editors' live-ENTRY separators. Each exempt separator now documents why at its own site.

## Why

Root cause: a call site duplicated logic that the shared `boutMiddle` primitive already owns, and the duplicate drifted. `matchScoreStr` returns `""` whenever both score cells are empty and the match is not a bye/draw/default-win, which is exactly the shape of an auto-completed bye. The hand-rolled branch mapped that empty string plus `status === "completed"` onto a dash.

The bead that raised this originally concluded the score editors had drifted from the contract. They had not. Verification showed the editors' centre `VS` elements are deliberately exempt live-entry separators, and that "fixing" them would have regressed the closed decision in mp-42g (PR #144), which demoted an undiscoverable `vs`/`X` toggle button to a plain separator and moved draw state to a dedicated control. The bead's description and title were corrected first; the real bug it had missed is what this PR fixes.

`matchStateCell` is deliberately NOT reused here despite being the shared primitive for this shape: it gates the score on `status === "completed"`, while `VSchedItem` intentionally shows a LIVE score for running matches too. A straight swap would have silently killed the live score on the viewer schedule. Both the code comment and a browser check pin this.

## Files changed

| File | What |
|---|---|
| `web-mobile/js/viewer_match.jsx` | Fix: `VSchedItem`'s no-score fallback derives the middle from `window.boutMiddle` instead of branching on status to a dash. Guarded like the twin call in `admin_schedule_score_editor.jsx`, since this branch also renders for scheduled rows |
| `web-mobile/js/__tests__/vsched_bout_middle.test.jsx` | New regression suite (13 tests): mounts the real `VSchedItem` against the real `boutMiddle`/`matchScoreStr` and pins that a completed scoreless match renders `vs`, never `-`. A second block stubs only `matchScoreStr` to the empty string a bye produces, leaving `boutMiddle` real, so the fallback branch itself is pinned for `X`/`(E)`/`(DH)` |
| `web-mobile/js/bracket.jsx` | Comment only: scopes the `boutMiddle` contract to result-projecting surfaces, naming the entry-separator exemption |
| `web-mobile/js/admin_scoring_individual.jsx` | Comment only: replaces the inaccurate "and the boutMiddle contract" clause with the real reason and cites mp-42g |
| `web-mobile/js/admin_scoring_team.jsx` | Comment only: documents the encounter-header `VS` exemption and distinguishes it from `renderTeamBoutMiddle`, which does follow the contract |
| `web-mobile/js/admin_scoring_engi.jsx` | Comment only: documents the structural exemption (odd flag totals make a draw impossible; no ippon/encho/daihyosen in engi) |


| `web-mobile/js/viewer_competition.jsx` | Byes: the public "Recent results" list now filters through `hasBothSides(m)`, as `running`/`upcoming` in the same `useMemo` already did |
| `web-mobile/js/__tests__/viewer_competition_bye_results.test.jsx` | New regression suite (2 tests): builds the raw wire payload, normalizes it with production code, and pins that a bye is excluded while a real result is kept |
| `web-mobile/js/__tests__/engi_comp_engi_stamp.test.jsx` | Comment only: flags its naive `hasBothSides` stub as a tripwire (safe there, vacuous if copied into a filter test) |

| `web-mobile/js/bracket.jsx` | Adds two display primitives: `bracketRoundLabel` (effective-round naming) and `slotDisplayName`/`makeSlotLabeller` (feeder slots as `Winner of M<n>`) |
| `web-mobile/js/viewer_utils.jsx`, `display_helpers.jsx`, `admin_competition_bracket.jsx` | Route round naming through the one primitive |
| `web-mobile/js/admin_shiaijo.jsx` | Feeder slot labels in the Later queue and the resolve-feeders modal |
| `web-mobile/js/__tests__/bracket_round_label_agreement.test.jsx`, `bracket_slot_label.test.jsx`, `render/bracket_feeder_slot.render.test.jsx` | New suites for both pre-existing fixes, including a DOM assertion that no raw `rN-mN` renders |

| `web-mobile/js/viewer_schedule.jsx` | Removes a dead (and latently double-printing) `BYE` span in `TWMatch` |
| `web-mobile/js/__tests__/render/bracket_bye_slot.render.test.jsx` | New render suite: a named bye slot shows the competitor AND the visible marker |

| `web-mobile/js/admin_shiaijo.jsx` | Queue groups key on the displayed round label, so a heading always describes its members |
| `web-mobile/js/display_helpers.jsx`, `display_scoreboard.jsx` | Shared `bracketRoundSiblings`: the TV phase strip counts and lists the round its heading names |

| `web-mobile/js/admin_scoring_individual.jsx` | Seeds ippon slots from the scoreA/scoreB string when the arrays are absent, so a knockout match no longer opens empty and lose points |

## Screenshots

**The bug case, fixed:** an auto-completed bye on the public competition page. `Final` badge, no score, middle reads `vs`. Pre-fix this expression yields `-`.

![Completed scoreless bye row showing vs](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/mp-u37s-viewer-bye-completed-scoreless-vs.png)

**No regression, running + pending:** the NOW row keeps its LIVE score (`D vs –`) while running, and pending rows read `vs`. This is the case that would have broken had the fix reused `matchStateCell`.

![Viewer home with live running score and pending vs rows](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/mp-u37s-viewer-home-live-and-pending.png)

**No regression, completed + scored:** Recent Results renders the score string unchanged (`– vs MK`, waza letters, dash only as a cell value).

![Viewer competition page with scored completed row and pending rows](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/mp-u37s-viewer-competition-completed-and-pending.png)


### Byes in Recent results

An auto-completed bye used to appear as a finished result reading `TBD vs <name>` under a `Final` badge. It is now excluded; real results are untouched.

**After start, no bye in Recent results** (the section does not render at all when it would hold only byes):

![Public competition page after start, no bye row](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/a-public-after-start-no-bye.png)

**Real results still list, with score strings intact:**

![Recent results with two real scored matches and no bye](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/g-public-two-results-no-bye.png)

**The bye stays discoverable in the Bracket tab** as an unopposed slot feeding the next round (Alice Smith / Bob Jones / Carol White in Quarterfinals):

![Public bracket tab showing unopposed bye entrants](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/c-bracket-anon-bye-visible.png)


### Two pre-existing issues found during this PR's UAT

Both were surfaced by the same 5-player knockout and are fixed here at the user's request.

**Round labels disagreed between surfaces.** The same match read "Quarterfinals" on the Overview row and "Semifinals" in the Bracket column, because three producers derived the label from the raw backend round index while the bracket columns key on the mp-7f2w effective round (which collapses a round whose only other match is a latent bye). All now route through one primitive. Overview below now reads Semifinals for M2, agreeing with the column:

![Overview rows with corrected round labels](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/roundlabel-overview-after.png)

**Internal match ids leaked to spectators.** Unresolved feeder slots rendered the raw `Winner of r3-m3`, an internal index that does not even match the card numbering the same bracket prints, so following the reference misled the reader. Slots now name the card visible on the same screen:

![Public bracket with Winner of M1 / M2 / M3 slot labels](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/public-bracket-winner-of-M.png)

**Bye slots were unlabelled.** A named bye slot rendered the competitor's name alone, so a spectator saw an unexplained grey box beside the match cards with no way to tell the entrant advanced unopposed. The marker is now unconditional. No CSS was needed: `.bc-bye-slot` was already a name+tag flex pair, so only the JSX was out of step.

The bracket below shows all four display fixes at once: correct round columns, `Winner of M<n>` feeder slots, and labelled bye slots. The long name truncates rather than pushing the marker out of the fixed-width column:

![Public bracket with labelled bye slots](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/mp-u37s/bracket-all-fixes.png)

This is display-only: no side is written back, so every placeholder filter is untouched.


### Post-review hardening

A three-lens review (correctness / comment accuracy / test quality) of the accumulated diff found two regressions the round-label change had introduced, both fixed here and pinned by mutation-verified tests:

- **Shiaijo Upcoming queue** grouped by raw round index but titled from the effective round, so a quarterfinal could sit under a "Semifinals" heading, and one round name could split across two identically-titled groups.
- **TV phase strip** named the effective round but counted and listed `rounds[roundIndex]`, rendering `SEMIFINALS · 0 / 2` over a set containing a quarterfinal.

The test-quality lens also proved two coverage gaps by mutation: the bracket column header was asserted against a test-local reimplementation rather than the DOM (replacing it with a literal left the whole suite green), and `viewer_competition`'s own row-stamping had no test despite being the surface the original bug was reported on. Both closed.

Comment corrections from the same pass; the worst was self-inflicted, two comments claiming a bye is not tagged BYE that a later commit in this PR falsified.


### Browser UAT + a data-loss bug it caught

Full UAT across every surface this PR touches, on a 5-entrant knockout (the draw that triggers all of it), a 9-entrant knockout, and a 6-player league: **12 of 12 checks pass**, zero console errors. Byes excluded from Recent results, real results and live running scores intact, no dash in any bout middle, bye slots tagged, feeder slots reading `Winner of M<n>` with `/r\d+-m\d+/` matching nothing in the DOM on any page, round labels agreeing across viewer Overview, Bracket, shiaijo, score editor and the TV board, and both regression fixes confirmed on their own surfaces.

The pass also surfaced a **pre-existing data-loss bug**, fixed here: the individual score editor seeded its ippon slots only from `ipponsA`/`ipponsB`. `state.MatchResult` carries those arrays, but `state.BracketMatch` carries only the `scoreA`/`scoreB` strings, so a knockout match re-read from the server opened the editor EMPTY on a match that already had points, and the operator's next tap saved over them. Pools and league never reproduced it, which is how it survived. Every display surface already parsed the string; this editor was the sole holdout.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests) — 134 JS test files / 2606 tests pass; all Go packages at or above the 85% coverage gate
- [x] New/updated unit tests cover the change - **verified RED before the fix**: reverting only `viewer_match.jsx` and rerunning turns all 7 fallback assertions red, failing on the dash exactly as intended. Green with the fix restored. The existing `boutMiddle` suite in `score_display.test.jsx` passes unchanged
- [x] Manual browser verification: built the binary, served a throwaway data dir, and drove the ADMIN UI to create a tournament, an 8-player knockout, and a 5-player knockout. Verified on the PUBLIC viewer surfaces (`/` and `/competition/:id`) that pending rows show `vs`, a scored completed row shows its score string unchanged, a running row still shows its live score, and the auto-completed bye row shows `vs` instead of `-`. Also probed the operator paths that are BLOCKED from producing a scoreless completed match (Finish + Start Next disabled at 0-0, Save correction disabled with both ippons removed, Mark draw disabled at 0-0; hantei/kiken/fusenpai all produce a non-empty string)
- [x] Manual browser verification (byes): 5-player knockout, public competition page. Verified the auto-completed bye is absent from Recent results, a real scored match still lists with its score string, the bye is still visible in the Bracket tab as an unopposed slot, and up next / running are unchanged. Checked signed out as an anonymous spectator as well as as admin
- [x] Manual browser verification (pre-existing fixes): 5-player knockout. Round labels now agree across viewer Overview, Bracket, admin shiaijo, score editor and the TV board. Feeder slots read `Winner of M<n>` on the public bracket, public match modal, admin bracket and shiaijo; `/r\d+-m\d+/` matches nothing in the DOM on any of them. Confirmed placeholder-sided matches are still non-playable (Scores page lists only the 2 real matches; Later rows stay WAITING with no Start)
- [x] Manual browser verification (bye slot): public Bracket tab at desktop and 390px, plus a 35-char name forced into a slot to check truncation. Slot height and connector anchors unchanged; the marker never leaves the column
- [x] Manual browser UAT (full): 12/12 checks across public viewer, admin shiaijo/score editor/bracket, and TV display, on 5-entrant + 9-entrant knockouts and a league. Zero console errors. Caught the score-editor data-loss bug fixed in this PR
- [x] Screenshots added above
- [x] Docs updated under `docs/` — not applicable: no user-facing feature, flag, command or behaviour is added or changed; this restores the documented display contract on one surface
- [x] No new console errors or warnings

## Review

Ran a three-lens adversarial review (simplify / correctness / security) with per-finding verification over the diff. The simplify and security lenses returned no findings; I confirmed from the run journal that this was a genuine empty result and not a crashed agent. One low-severity correctness finding was confirmed and is fixed in `e0ca0583`:

The three non-plain-middle cases (hikiwake, encho, daihyosen) never reached the fallback branch this PR changes. `matchScoreStr` already returns `X`/`(E)`/`(DH)` for those payloads, so `scoreStr` is truthy and the score span wins, meaning those cases were pinning `formatIpponsScore` rather than `boutMiddle`. Demonstrated by patching `boutMiddle` to throw: all three passed regardless. The adjacent comment claimed they were pinned "so a future refactor of the fallback cannot swallow them either", which was precisely the overclaim, and now states what they actually cover.

The fix adds a block that stubs only `matchScoreStr`, leaving `boutMiddle` real, so the assertions test what the new call returns rather than what a stub was told to say. Re-running the broken-`boutMiddle` experiment now takes the failures from 5 to 9; the 3 that still pass are the score-string cases, which correctly do not depend on it.

Closes mp-u37s








