### PR TITLE
chore(bc-go66): bump the Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Init project
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Init project
@@ -175,7 +175,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           cache: true
 
       - name: Install LibreOffice headless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 # Build stage
 FROM golang:${GO_VERSION} AS builder

--- a/Dockerfile.mobile
+++ b/Dockerfile.mobile
@@ -1,5 +1,5 @@
 # Build stage
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 # Build stage
 FROM golang:${GO_VERSION} AS builder

--- a/Dockerfile.mobile-pdf
+++ b/Dockerfile.mobile-pdf
@@ -11,7 +11,7 @@
 # libreoffice-nogui). The Go binary's LocateSoffice() probes $PATH first, so no
 # additional env vars are required.
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 # ---------------------------------------------------------------------------
 # Build stage, identical to Dockerfile.mobile

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BIN_NAME := bracket-creator
 GH_REPOSITORY ?= gitrgoliveira/bracket-creator
 IMAGE_NAME := ghcr.io/$(GH_REPOSITORY)
 BIN_PATH := ./bin
-GO_VERSION := 1.26.5
+GO_VERSION := 1.26.6
 GO_SOURCES := $(shell find . -name "*.go" -type f)
 EMBEDDED_ASSETS := $(shell find ./web ./web-mobile -type f 2>/dev/null)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gitrgoliveira/bracket-creator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/gin-gonic/gin v1.12.0


### PR DESCRIPTION
## Summary

- Bumps the Go toolchain from 1.26.5 to **1.26.6** across all eight places it is pinned.
- Clears the six Go standard library CVEs that are currently failing the `validate` job on **every** branch, blocking every open PR.
- `govulncheck ./...` goes from 6 called stdlib vulnerabilities to "No vulnerabilities found".

## Why

The `validate` job began failing on branches that had not changed, so the cause is not any one PR's code.

The proof: commit `9dc849fb` **passed** `validate` on 2026-08-12 and, **re-run unchanged** on 2026-08-14, **failed**. No code differed between those two runs. What changed is the grype vulnerability database, rebuilt as v6.1.9 on 2026-08-14T06:39:10Z. The job's error is `Failed minimum severity level. Found vulnerabilities with level 'medium' or higher`.

`govulncheck` names the culprits. All are Go standard library, all are "found in go1.26.5, fixed in go1.26.6":

| Advisory | Package |
|---|---|
| GO-2026-6218 | `net/url` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6089 | `net/http` |
| GO-2026-6088 | `encoding/xml` |
| GO-2026-5972 | `encoding/asn1` |
| GO-2026-5026 | `net/http` (x/net/idna punycode) |

go1.26.6 is a released, stable version.

All eight pins move together on purpose. A local gate and a CI job that disagree about the toolchain is exactly how this class of problem hides: the failure would then reproduce in one place and not the other.

### One advisory deliberately left alone

`GO-2026-5932` reports that `golang.org/x/crypto/openpgp` is unmaintained. It has **no fixed version** (`Fixed in: N/A`), this code does not call it, and `golang.org/x/crypto@v0.54.0` is unchanged since before the failure, so it was present when `validate` last passed. Nothing in a toolchain bump can address it, and it is not what broke the job.

## Files changed

| File | What |
|---|---|
| `go.mod` | `go 1.26.5` to `go 1.26.6` |
| `Makefile` | `GO_VERSION := 1.26.6` |
| `Dockerfile` | `ARG GO_VERSION=1.26.6` |
| `Dockerfile.mobile` | `ARG GO_VERSION=1.26.6` |
| `Dockerfile.mobile-pdf` | `ARG GO_VERSION=1.26.6` |
| `.github/workflows/validate.yaml` | three `setup-go` steps to `1.26.6` |
| `.github/workflows/release.yaml` | one `setup-go` step to `1.26.6` |

## Screenshots

No UI impact: this changes only the toolchain version pins. No file under `web-mobile/` or `web/` is touched.

## Test plan

- [x] `make go/test` passes (lint + security scan + tests). Exit 0 end to end under 1.26.6, **including the `go/vuln` step that was the failure**. No package with test files below the 85% coverage floor
- [x] New/updated unit tests cover the change. None applicable, and none would be honest: there is no behaviour to pin. The verification that matters is `govulncheck ./...` reporting "No vulnerabilities found" under the new toolchain where it reported 6 called stdlib vulnerabilities under the old one, and CI's own `validate` job going green on this branch
- [x] Manual browser verification (for `web-mobile/` or `web/` changes): not applicable, no frontend file touched
- [x] Screenshots added above. Not applicable, no UI impact
- [x] Docs updated under `docs/` for any new or changed user-facing feature, flag, command, or behavior. Not applicable: the pinned toolchain version is not user-facing and the public site does not state it
- [x] No new console errors or warnings

### Verification performed

```
$ go version                 # in-module, GOTOOLCHAIN=auto
go version go1.26.6 linux/amd64

$ govulncheck ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.

$ make go/test
MAKE go/test EXIT: 0
```

Closes bc-go66
