### PR TITLE
chore(deps): bump pymdown-extensions to 11.0.1 (2 open dependabot alerts)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,6 @@ mkdocs-material==9.7.6
 # https://github.com/mkdocs/mkdocs-redirects
 mkdocs-redirects==1.2.2
 mkdocs-material-extensions==1.3.1
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
 Markdown==3.10.2
 Pygments==2.20.0


### PR DESCRIPTION
## Summary

- Bumps `pymdown-extensions` from `10.21.3` to `11.0.1` in `docs/requirements.txt`, closing two open dependabot security alerts that had no fix PR raised for them.
- Root cause of "no PR": `dependabot_security_updates` is disabled for this repo, and `.github/dependabot.yml` only covers `gomod`/`github-actions`/`docker` (pip was never onboarded), so neither the automated security-fix path nor the version-update path was wired up for `docs/requirements.txt`.

## Why

| Alert | Severity | Advisory | Issue | Vulnerable | Fixed |
|---|---|---|---|---|---|
| #26 | High | GHSA-gm37-52c6-37mw / CVE-2026-67422 | Exponential-backtracking ReDoS in the `caret`/`tilde`/`betterem`/`magiclink` inline processors (default configuration) | ≤ 11.0.0 | 11.0.1 |
| #19 | Medium | GHSA-9xwg-3r6f-jcx2 / CVE-2026-61632 | Path traversal in the `b64` extension: `<img src>` can read files outside `base_path` | ≤ 10.21.3 | 11.0.0 |

Our pin (`10.21.3`) fell inside both vulnerable ranges. `11.0.1` covers both fixes. `mkdocs-material` 9.7.6 only requires `pymdown-extensions>=10.2` (no upper bound), so the bump is unconstrained.

Docs are built from repo-controlled markdown, not untrusted input, so actual exploitability here is low — this is a straightforward hygiene fix, not an incident response.

## Files changed

| File | What |
|---|---|
| `docs/requirements.txt` | `pymdown-extensions==10.21.3` → `==11.0.1` |

## Screenshots

No UI impact.

## Test plan

- [x] `make docs/deps` reinstalls `.venv-docs` and confirms `pymdown-extensions 11.0.1` is installed
- [x] `make docs/build` passes strict
- [x] `docs/check_links.py` still resolves all 2038 internal links/anchors across 36 pages
- [x] N/A: no Go code changed, `make go/test` not applicable to this diff
- [x] No new console errors or warnings (docs-only change)

Closes dependabot alerts #26 and #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
