### PR TITLE
chore: onboard pip ecosystem in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,18 @@ updates:
       time: "05:00"
     labels:
       - "dependencies"
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: saturday
+      time: "05:00"
+    labels:
+      - "dependencies"
+    ignore:
+      # Held at 1.2.2 deliberately: see the comment in docs/requirements.txt.
+      # 1.2.3 was published from the ProperDocs fork ecosystem and pulls in
+      # `properdocs` (an MkDocs fork) alongside mkdocs. Any bump here must be
+      # done by hand after re-verifying the release comes from
+      # https://github.com/mkdocs/mkdocs-redirects, not auto-merged.
+      - dependency-name: "mkdocs-redirects"


### PR DESCRIPTION
## Summary

- Onboards the `pip` ecosystem in `.github/dependabot.yml`, pointed at `/docs` (where `requirements.txt` lives), on the same weekly Saturday 05:00 schedule as `gomod`/`github-actions`/`docker`.
- Also enables `dependabot_security_updates` at the repo level (via `PUT /repos/.../automated-security-fixes`), which was disabled — the prerequisite `vulnerability-alerts` were already on.

## Why

PR #390 fixed a pymdown-extensions bump for two open dependabot security alerts (one High: ReDoS, one Medium: path traversal) that had sat open with **no auto-generated fix PR**. Root cause: neither of the two mechanisms that would normally raise one was active for pip:

- `dependabot_security_updates` was disabled repo-wide (now enabled directly via the API — no PR needed for that half, it's an account/repo setting, not a file).
- `.github/dependabot.yml` never had a `pip` entry, so routine version-update PRs (the other path, independent of security alerts) never covered `docs/requirements.txt` either.

This closes the gap for future advisories on the same file, not just the two #390 already fixed.

**One deliberate exception, carried over from `docs/requirements.txt`'s own comment**: `mkdocs-redirects` is pinned at `1.2.2` because `1.2.3` was published from the ProperDocs fork ecosystem and pulls in a different `properdocs` package alongside `mkdocs`. Turning on pip updates without an `ignore` entry would let dependabot open exactly the PR that comment warns against auto-merging, so this config carries the same constraint forward rather than silently reintroducing the risk.

## Files changed

| File | What |
|---|---|
| `.github/dependabot.yml` | New `pip` ecosystem entry (`directory: /docs`), weekly schedule, `dependencies` label; ignores `mkdocs-redirects` |

## Screenshots

No UI impact.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — valid YAML
- [x] Verified via API: `dependabot_security_updates` now reports `{"enabled":true,"paused":false}`
- [x] N/A: no Go/frontend code changed
- [x] No new console errors or warnings (config-only change)
- [x] Docs unaffected: this only edits the dependabot config, not `docs/requirements.txt` itself (that's PR #390)

No bead: repo-config change made directly at the user's request in-conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
