### PR TITLE
fix(ci): pin golangci-lint to v2.13.1, fix broken /v2 install path, silence gosec false positive

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -54,7 +54,15 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # Pinned, not "latest": a floating pin means CI's linter (and its
+          # bundled gosec ruleset) can change overnight with zero commits in
+          # this repo. That is exactly what broke every open PR's gate on
+          # 2026-08-20 -- v2.13.1 was built the same day this stopped
+          # passing, and it newly flags rand.Shuffle (G404) that v2.12.2
+          # (the Makefile's pin, used by `make go/lint` locally) did not.
+          # Keep this in lockstep with the `go install` version in
+          # Makefile's go/lint target so a local green run predicts CI.
+          version: v2.13.1
 
       #   ____             _
       #  |  _ \  ___   ___| | _____ _ __

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,12 @@ local/deps: hooks/install js/deps ## Install project dependencies
 	go mod tidy
 	go install github.com/spf13/cobra-cli@v1.3.0
 	go install github.com/goreleaser/goreleaser/v2@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.12.2
+	# /v2/ is required in the module path for golangci-lint 2.x (Go module major-
+	# version convention); the path used to omit it and silently resolved anyway
+	# because GOPATH/bin already held an older cached binary (see the note above
+	# go/lint). Keep this version in lockstep with the pin in
+	# .github/workflows/validate.yaml so a local green run predicts CI.
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
 	go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	python3 -m pip install -r docs/requirements.txt

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -59,7 +59,10 @@ func processEntries(entries []string, determined bool, withZekkenName bool) ([]h
 	// already been rejected above.
 	entries = helper.RemoveDuplicates(entries)
 	if !determined {
-		rand.Shuffle(len(entries), func(i, j int) {
+		// math/rand is fine here: this randomizes the ORDER entries are drawn
+		// into a blind pool/bracket, a fairness concern, not a security one.
+		// No auth, token, or crypto material touches this value.
+		rand.Shuffle(len(entries), func(i, j int) { //nolint:gosec // G404: non-cryptographic draw-order shuffle
 			entries[i], entries[j] = entries[j], entries[i]
 		})
 	}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"bufio"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/helper"
@@ -59,16 +60,29 @@ func processEntries(entries []string, determined bool, withZekkenName bool) ([]h
 	// already been rejected above.
 	entries = helper.RemoveDuplicates(entries)
 	if !determined {
-		// math/rand is fine here: this randomizes the ORDER entries are drawn
-		// into a blind pool/bracket, a fairness concern, not a security one.
-		// No auth, token, or crypto material touches this value.
-		rand.Shuffle(len(entries), func(i, j int) { //nolint:gosec // G404: non-cryptographic draw-order shuffle
-			entries[i], entries[j] = entries[j], entries[i]
-		})
+		if err := shuffleStrings(entries); err != nil {
+			return nil, fmt.Errorf("shuffling entries: %w", err)
+		}
 	}
 	players, err := helper.CreatePlayers(entries, withZekkenName)
 	if err != nil {
 		return nil, err
 	}
 	return players, nil
+}
+
+// shuffleStrings randomizes s in place via Fisher-Yates, using crypto/rand
+// rather than math/rand: gosec (G404) flags math/rand and math/rand/v2
+// unconditionally regardless of context, and crypto/rand.Int costs nothing
+// meaningful here (this runs once per CLI invocation over an entry list sized
+// in the tens to low hundreds, not in a hot path).
+func shuffleStrings(s []string) error {
+	for i := len(s) - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return err
+		}
+		s[i], s[int(j.Int64())] = s[int(j.Int64())], s[i]
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Fixes `.github/workflows/validate.yaml`'s `golangci-lint` step, which broke **every** open PR's gate on 2026-08-20 with zero code changes anywhere in this repo, including two docs/config-only PRs.
- Pins `version: latest` → `version: v2.13.1` (was floating; `v2.13.1` was built the same day the gate broke, and its bundled gosec newly flags `cmd/shared.go:62`'s `rand.Shuffle` under G404).
- Replaces the flagged `math/rand.Shuffle` with a real `crypto/rand`-backed Fisher-Yates (`shuffleStrings`), rather than suppressing the finding: `processEntries` already returns an `error`, so `crypto/rand`'s fallible API costs nothing here, and this would otherwise have been the first `nolint` directive in the codebase's production Go (verified: zero prior instances). `crypto/rand` has no built-in `Shuffle`, and gosec's own message also flags `math/rand/v2`, so a real fix meant a small hand-rolled loop, not a suppression or a package swap.
- While pinning the Makefile's local install to the same version, found and fixed an **independent, pre-existing** bug on the same line: golangci-lint 2.x's installable module path is `github.com/golangci/golangci-lint/v2/cmd/golangci-lint` (the `/v2/` Go-module major-version convention) — the unversioned path the Makefile used fails outright with `invalid version: unknown revision` from a clean `GOPATH/bin`. It only ever "worked" because `GOPATH/bin` already held an older cached binary from some prior correctly-pathed install, matching this Makefile's own comment that these tool binaries persist across worktrees by design.

## Why

CI's `golangci-lint` pin floated (`latest`) while the Makefile's local pin was fixed at `v2.12.2`, so a green `make go/test` locally was never a reliable predictor of CI — the two environments could silently diverge, and did. Confirmed with evidence, not assumption:

- `main`'s own `validate` run went from green (2026-08-19) to red (2026-08-20) with no intervening commits to the repo.
- The `v2.13.1` release binary reports a build timestamp of `2026-08-20T14:28:34Z` — the same day.
- Running the actual pinned local version (`v2.12.2`) against the repo: 0 issues. Running `v2.13.1`: exactly the one `G404` hit, nothing else.
- Querying the Go module proxy directly for `github.com/golangci/golangci-lint/cmd/golangci-lint` (no `/v2/`) at any version returns `not found: ... no matching versions`; the `/v2/`-prefixed path resolves and installs cleanly.

Both pins now name `v2.13.1` explicitly and in lockstep, so a green `make go/lint`/`make go/test` locally is a real predictor of CI again, and any future bump is a deliberate, reviewed diff instead of an overnight surprise.

**Not touched, flagged for awareness**: the standalone `securego/gosec@master` SARIF-upload step in the same workflow file also floats on an unpinned ref, but it runs with `-no-fail` and therefore cannot itself block the gate — a lower-priority, differently-shaped risk than the pin that actually broke things, left out of this PR to keep it scoped to the actual failure.

## Files changed

| File | What |
|---|---|
| `.github/workflows/validate.yaml` | `golangci-lint-action`'s `version: latest` → `version: v2.13.1`, with the root-cause comment |
| `Makefile` | `go install`'s golangci-lint path corrected to include `/v2/`, and its version bumped to `v2.13.1` to match CI |
| `cmd/shared.go` | `math/rand.Shuffle` replaced with `shuffleStrings`, a `crypto/rand`/`math/big` Fisher-Yates; `processEntries` propagates its (near-impossible) error |

## Screenshots

No UI impact.

## Test plan

- [x] `make go/test` passes in full (lint + gosec + tests; every package still ≥85% coverage) with the pinned v2.13.1 toolchain installed via the corrected `/v2/` path
- [x] `golangci-lint run ./cmd/... ./internal/... ./tests/... .` at v2.13.1: 0 issues (was 1, the G404 hit, before the fix), with no `nolint` directive anywhere
- [x] Standalone `gosec v2.25.0 ./cmd/... ./internal/... ./tests/... .`: 0 issues
- [x] A probe test confirms `shuffleStrings` preserves the exact input element set (no loss/duplication) and handles 0/1-length slices without panicking
- [x] `go test ./cmd/... -cover`: 86.4% coverage, unchanged, all pre-existing `processEntries`/`create-pools`/`create-playoffs` tests pass
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/validate.yaml'))"` — valid YAML
- [x] N/A: no UI/frontend change
- [x] No new console errors or warnings

No bead: CI-infra fix made directly at the user's request in-conversation, blocking all currently open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

