### PR TITLE
fix(bc-subj): a corrupt cell stops destroying a team encounter, and the operator is told which file is broken

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -393,17 +393,50 @@ so it can never silently drop a legitimate change.
 ### When a file is wrong
 
 Section 1 promises that a wrong cell is repairable by hand, but not what happens when a hand
-edit is itself wrong. The general rule: a malformed cell degrades to its documented default
-and logs the problem, and never fails the row it lives in or the load the row belongs to. A
-team match's sub-bout cell that will not parse as JSON loads as an empty encounter rather
-than aborting the read; a seed row missing its rank or name, or too short to hold them, is
-skipped rather than guessed; a number that will not parse is left at the column's documented
-default. Two cases go further and discard data outright, because there is nothing safe to
-default to: a legacy judges'-decision flag with no attributable winner is dropped rather than
-guessed onto a side, and a hand-edited bracket file carrying both a legacy score string and
-the current ippon arrays keeps the arrays and clears the string. Anyone repairing a file mid
-tournament should read this as: fix the cell, reload, and check the record, rather than
-trusting that a malformed edit would have been rejected.
+edit is itself wrong. Two things can be wrong, and they behave differently: a single cell that
+will not parse, and a whole file that will not parse.
+
+**A wrong cell degrades, and the file keeps loading.** A malformed cell falls back to its
+documented default and never fails the row it lives in or the load the row belongs to. A team
+match's sub-bout cell that will not parse as JSON loads as an empty encounter rather than
+aborting the read; a seed row missing its rank or name, or too short to hold them, is skipped
+rather than guessed; a number that will not parse is left at the column's documented default,
+and a negative count is clamped to zero. One bad cell cannot stop a tournament. Two cases go
+further and discard data outright, because there is nothing safe to default to: a legacy
+judges' decision flag with no attributable winner is dropped rather than guessed onto a side,
+and a hand-edited bracket file carrying both a legacy score string and the current ippon
+arrays keeps the arrays and clears the string.
+
+**A degraded cell is kept, not overwritten.** The results file is rewritten in full every time
+any match in it is scored, so a cell that read as empty would otherwise be written back as
+empty, and the bytes needed to repair it would be gone within seconds of the next bout. A
+sub-bout cell that will not parse is therefore held exactly as it was read and written back
+unchanged for as long as the encounter stays empty. Re-entering the encounter in the app
+replaces it, which is the other way to repair it. While it is unrepaired the operator console
+marks the match and the pool standings it feeds, because an encounter that loads as empty
+contributes no individual victories and no points, and those are the figures a pool tied on
+wins is separated on.
+
+**A wrong file fails the load, and nothing is written to it.** When the damage is structural,
+a bracket file that is not valid JSON or a results file whose rows no longer parse as CSV,
+there is no row left to degrade. The load fails and every write to that file is refused, so
+the competition stops rather than continuing from a half-read record. The file is left exactly
+as it was: refusing the write is what makes a repair possible. The app reports which file
+failed, the line and column, and what the parser found there, so the fault can be found in the
+editor already open.
+
+Repairing the file and reloading is always the option that loses nothing. When that is not
+possible, a competition with a pool stage can reset its knockout stage instead: the unreadable
+file is renamed aside rather than deleted, and the knockout is rebuilt from the pool draw,
+which is held in a different file. That trade is real and the console states it, because the
+knockout results are not recoverable from anywhere else and have to be re-entered from the
+score sheets, and because the rebuilt pairings should be checked against the printed bracket.
+A direct elimination competition cannot do this at all: its bracket file is the only record of
+its draw, so rebuilding would produce a different set of pairings rather than restore the
+original.
+
+Anyone repairing a file mid tournament should read all of this as: fix the cell, reload, and
+check the record, rather than trusting that a malformed edit would have been rejected.
 
 ## 6. How the model maps onto rows
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -403,7 +403,7 @@ aborting the read; a seed row missing its rank or name, or too short to hold the
 rather than guessed; a number that will not parse is left at the column's documented default,
 and a negative count is clamped to zero. One bad cell cannot stop a tournament. Two cases go
 further and discard data outright, because there is nothing safe to default to: a legacy
-judges' decision flag with no attributable winner is dropped rather than guessed onto a side,
+judges'-decision flag with no attributable winner is dropped rather than guessed onto a side,
 and a hand-edited bracket file carrying both a legacy score string and the current ippon
 arrays keeps the arrays and clears the string.
 
@@ -426,14 +426,28 @@ failed, the line and column, and what the parser found there, so the fault can b
 editor already open.
 
 Repairing the file and reloading is always the option that loses nothing. When that is not
-possible, a competition with a pool stage can reset its knockout stage instead: the unreadable
-file is renamed aside rather than deleted, and the knockout is rebuilt from the pool draw,
-which is held in a different file. That trade is real and the console states it, because the
-knockout results are not recoverable from anywhere else and have to be re-entered from the
-score sheets, and because the rebuilt pairings should be checked against the printed bracket.
-A direct elimination competition cannot do this at all: its bracket file is the only record of
-its draw, so rebuilding would produce a different set of pairings rather than restore the
-original.
+possible, what else can be done about an unreadable bracket file depends on where the draw it
+held was written down, which is decided by the competition's format. In every case the file
+itself is renamed aside rather than deleted, keeping the name it had with `.corrupt-` and a
+timestamp appended, so it stays in the competition's folder for a later repair by hand.
+
+**Pools then knockout.** The knockout can be reset. The draw survives in the pool file, so the
+tree is built again from it and every finished pool has its qualifiers seeded back in. That
+trade is real and the console states it: the knockout results are not recorded anywhere else
+and have to be re-entered from the score sheets, and the rebuilt pairings should be checked
+against the printed bracket, because the tree is laid out by the current draw algorithm and the
+one that produced the original died with the file.
+
+**League and Swiss.** Nothing is rebuilt, because neither format draws a knockout bracket at
+all. A bracket file in one of these competitions is left over and unused, so moving it aside is
+the whole repair and no result is affected.
+
+**Direct elimination.** There is no reset. The bracket file is the only record of who was drawn
+against whom, so rebuilding would produce a different set of pairings rather than restore the
+original, and it would then disagree with the bracket already printed. The app refuses it and
+says why. The same refusal covers a competition whose format is missing or unrecognised, which
+a hand edit to the config file can produce: those are drawn as direct elimination, so the file
+is the only record of their draw too.
 
 Anyone repairing a file mid tournament should read all of this as: fix the cell, reload, and
 check the record, rather than trusting that a malformed edit would have been rejected.

--- a/internal/engine/format_draws_bracket_golden_test.go
+++ b/internal/engine/format_draws_bracket_golden_test.go
@@ -24,9 +24,10 @@ import (
 // the console's Create and Start buttons for an allocation the server accepts.
 
 type formatDrawsBracketCase struct {
-	Why          string `json:"why"`
-	Format       string `json:"format"`
-	DrawsBracket bool   `json:"drawsBracket"`
+	Why                  string `json:"why"`
+	Format               string `json:"format"`
+	DrawsBracket         bool   `json:"drawsBracket"`
+	RebuildableFromPools bool   `json:"rebuildableFromPools"`
 }
 
 func loadFormatDrawsBracketTable(t *testing.T) []formatDrawsBracketCase {
@@ -57,6 +58,35 @@ func TestCompetitionDrawsBracket_GoldenTable(t *testing.T) {
 	}
 }
 
+func TestCompetitionRebuildableFromPools_GoldenTable(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range loadFormatDrawsBracketTable(t) {
+		t.Run(tc.Why, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.RebuildableFromPools, CompetitionRebuildableFromPools(tc.Format),
+				"CompetitionRebuildableFromPools(%q); the JS mirror bracketRecoveryKind reads the "+
+					"same table, so a change here has to be made there too", tc.Format)
+		})
+	}
+}
+
+// A format cannot rebuild a bracket its draw never builds, so the table must
+// never claim it can. Without this the two columns could drift into a
+// combination the pipeline has no way to reach, and both mirrors would
+// faithfully implement the impossible state.
+func TestFormatTable_RebuildableImpliesDrawsBracket(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range loadFormatDrawsBracketTable(t) {
+		if tc.RebuildableFromPools {
+			assert.True(t, tc.DrawsBracket,
+				"format %q is marked rebuildableFromPools but not drawsBracket: a format whose "+
+					"draw builds no bracket has none to rebuild", tc.Format)
+		}
+	}
+}
+
 // TestCompetitionDrawsBracket_TableCoversEveryFormat is what stops a new format
 // being added without anyone deciding this question. Without it the table would
 // keep passing while the new format silently took the default branch on the Go
@@ -77,7 +107,8 @@ func TestCompetitionDrawsBracket_TableCoversEveryFormat(t *testing.T) {
 	} {
 		assert.True(t, covered[format],
 			"format %q has no case in testdata/format_draws_bracket.json: add one saying whether "+
-				"its draw builds a bracket, so the operator console is told too", format)
+				"its draw builds a bracket AND whether a lost bracket can be rebuilt from its "+
+				"pools, so the operator console is told too", format)
 	}
 }
 

--- a/internal/engine/pool_write_merge_test.go
+++ b/internal/engine/pool_write_merge_test.go
@@ -616,3 +616,63 @@ func TestPoolWriteRejectsARewrittenParticipantID(t *testing.T) {
 		assert.False(t, applyPoolWrite(stored(), in, matchWriteRestore))
 	})
 }
+
+// The unparsed sub-bout cell is file provenance, not client data. applyPoolWrite
+// is the documented sole owner of what a stored pool match contributes to an
+// incoming one, and its whole-struct overwrite would otherwise drop the retained
+// bytes on ANY write to that match, including one that says nothing about
+// sub-bouts. Pinned against both policies for the same reason as the rest of
+// this file: a field that reaches only one of them is a silent divergence.
+func TestApplyPoolWrite_UnparsedSubResultsCell(t *testing.T) {
+	corruptStored := func() *state.MatchResult {
+		return &state.MatchResult{
+			ID: "P1-1", SideA: "Kyoto", SideB: "Osaka",
+			SubResultsRaw:        `[{"position":1,"sideA":"Tanaka"`,
+			SubResultsUnreadable: true,
+		}
+	}
+
+	t.Run("a write with no sub-bouts keeps the retained bytes under both policies", func(t *testing.T) {
+		// The reachable case is an ordinary match-level edit: a court
+		// reassignment or a correction that never mentions the encounter. Before
+		// this, such a write silently destroyed the organiser's only copy.
+		for _, policy := range []matchWritePolicy{matchWriteForward, matchWriteRestore} {
+			in := &state.MatchResult{ID: "P1-1", SideA: "Kyoto", SideB: "Osaka", Court: "B"}
+			st := corruptStored()
+			require.False(t, applyPoolWrite(st, in, policy), "policy %d", policy)
+			assert.Equal(t, `[{"position":1,"sideA":"Tanaka"`, st.SubResultsRaw, "policy %d", policy)
+			assert.True(t, st.SubResultsUnreadable, "policy %d", policy)
+		}
+	})
+
+	t.Run("a write that carries sub-bouts clears both under both policies", func(t *testing.T) {
+		// Re-entering the encounter IS the repair, and it is the only thing that
+		// supersedes the retained bytes and answers the warning.
+		for _, policy := range []matchWritePolicy{matchWriteForward, matchWriteRestore} {
+			in := &state.MatchResult{
+				ID: "P1-1", SideA: "Kyoto", SideB: "Osaka",
+				SubResults: []state.SubMatchResult{
+					{Position: 1, SideA: "Tanaka", SideB: "Suzuki", Winner: "Tanaka"},
+				},
+			}
+			st := corruptStored()
+			require.False(t, applyPoolWrite(st, in, policy), "policy %d", policy)
+			assert.Empty(t, st.SubResultsRaw, "policy %d", policy)
+			assert.False(t, st.SubResultsUnreadable, "policy %d", policy)
+		}
+	})
+
+	t.Run("a client cannot raise the warning on a match that reads fine", func(t *testing.T) {
+		// Assigned unconditionally from the stored match rather than
+		// set-if-empty, so an echoed or spoofed flag never survives.
+		in := &state.MatchResult{
+			ID: "P1-1", SideA: "Kyoto", SideB: "Osaka",
+			SubResultsUnreadable: true,
+			SubResultsRaw:        `{"not":"the client's business"}`,
+		}
+		st := &state.MatchResult{ID: "P1-1", SideA: "Kyoto", SideB: "Osaka"}
+		require.False(t, applyPoolWrite(st, in, matchWriteForward))
+		assert.False(t, st.SubResultsUnreadable)
+		assert.Empty(t, st.SubResultsRaw)
+	})
+}

--- a/internal/engine/quarantine.go
+++ b/internal/engine/quarantine.go
@@ -1,0 +1,110 @@
+package engine
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// QuarantineResult reports what a quarantine did, so the operator is told
+// whether they are looking at a rebuilt tree or an empty stage.
+type QuarantineResult struct {
+	// QuarantinedAs is the name the broken file was renamed to. It is still in
+	// the competition folder; nothing is deleted.
+	QuarantinedAs string
+	// Rebuilt is false when the competition has no knockout stage to rebuild.
+	Rebuilt bool
+	// ResolvedPools counts the finished pools whose qualifiers were seeded back
+	// into the fresh bracket.
+	ResolvedPools int
+}
+
+// QuarantineCorruptBracket is the operator's way out of a bracket.json that
+// will not parse. It renames the broken file aside (never deletes it) and
+// rebuilds the knockout stage from the records that are still readable.
+//
+// It is the LAST resort, not the first. A corrupt bracket blocks scoring but
+// destroys nothing: every bracket write path aborts on the parse before
+// saving, so the file stays exactly as it was left and repairing it by hand
+// restores the competition completely, results included. This throws the
+// recorded knockout results away. The operator chooses.
+//
+// WHAT A REBUILD CAN AND CANNOT PROMISE. The knockout topology is not stored
+// anywhere else, so a rebuild recomputes it, and ResolveQualifiedPools' own
+// comment records why that is not free: it deliberately reads the placeholder
+// labels PERSISTED at draw time rather than recomputing the template, because
+// an operator who upgrades between a competition's draw and the end of its
+// pool phase (ordinary for a two-day event) would otherwise get qualifiers
+// written into the wrong slots, undetectably. A rebuild IS that recompute, and
+// the original template died with the file. So the tree is only guaranteed to
+// match the one that was drawn when the placement algorithm has not changed
+// since. The caller must say so; the surfaces do.
+//
+// Refused for a standalone playoffs competition, and that refusal is the
+// point: there, bracket.json is the ONLY record of the draw. Rebuilding it
+// from today's roster and seeds would not restore the tournament, it would
+// invent a different one, silently disagreeing with the bracket already
+// printed and posted on the wall. A competition with a pool stage keeps its
+// draw in pools.csv, which is why it can be rebuilt at all.
+func (e *Engine) QuarantineCorruptBracket(id string) (*QuarantineResult, error) {
+	comp, err := e.store.LoadCompetition(id)
+	if err != nil {
+		return nil, err
+	}
+	if comp == nil {
+		return nil, notFoundErrorf("competition %s not found", id)
+	}
+
+	// The guard that keeps this from becoming a general bracket-wipe: it acts
+	// only on a file that genuinely will not parse. A readable bracket is
+	// discarded through DiscardDraw, which has its own status rules.
+	_, loadErr := e.store.LoadBracket(id)
+	if loadErr == nil {
+		return nil, validationErrorf("competition %s has a readable bracket; nothing to quarantine", id)
+	}
+	if _, ok := state.AsCorruptFile(loadErr); !ok {
+		// Anything else (a permissions problem, an I/O failure) is not repaired
+		// by renaming the file, and pretending otherwise would hide it.
+		return nil, loadErr
+	}
+
+	if comp.Format == state.CompFormatPlayoffs || comp.Format == "" {
+		return nil, validationErrorf(
+			"competition %s is a direct-elimination competition, so bracket.json is the only "+
+				"record of its draw: rebuilding it would produce a different set of pairings "+
+				"rather than restoring this one. Repair the file and reload", id)
+	}
+
+	quarantined, err := e.store.QuarantineCompetitionFile(id, "bracket.json")
+	if err != nil {
+		return nil, fmt.Errorf("quarantining bracket.json for %s: %w", id, err)
+	}
+	slog.Warn("engine: bracket.json quarantined after a parse failure",
+		"competition", id, "quarantinedAs", quarantined, "reason", loadErr)
+
+	result := &QuarantineResult{QuarantinedAs: quarantined}
+
+	// League and Swiss have no knockout stage. Their bracket.json is vestigial,
+	// so moving it aside is the whole repair.
+	if comp.Format != state.CompFormatMixed {
+		return result, nil
+	}
+
+	// The pool draw survives in pools.csv, so the knockout structure is
+	// rebuildable from it by the same builder that drew it.
+	if err := e.generatePoolPreviewBracket(comp); err != nil {
+		return nil, fmt.Errorf("rebuilding the bracket for %s: %w", id, err)
+	}
+	result.Rebuilt = true
+
+	// Seed the qualifiers every FINISHED pool has already produced, so the
+	// operator gets back a bracket with real names in it rather than a sheet of
+	// placeholders, and only has to re-enter the knockout bouts themselves.
+	resolved, _, err := e.ResolveQualifiedPools(id)
+	if err != nil {
+		return nil, fmt.Errorf("re-seeding qualifiers for %s: %w", id, err)
+	}
+	result.ResolvedPools = resolved
+	return result, nil
+}

--- a/internal/engine/quarantine.go
+++ b/internal/engine/quarantine.go
@@ -41,12 +41,32 @@ type QuarantineResult struct {
 // match the one that was drawn when the placement algorithm has not changed
 // since. The caller must say so; the surfaces do.
 //
-// Refused for a standalone playoffs competition, and that refusal is the
-// point: there, bracket.json is the ONLY record of the draw. Rebuilding it
-// from today's roster and seeds would not restore the tournament, it would
-// invent a different one, silently disagreeing with the bracket already
-// printed and posted on the wall. A competition with a pool stage keeps its
-// draw in pools.csv, which is why it can be rebuilt at all.
+// THREE OUTCOMES, decided by the shared format table (see
+// CompetitionRebuildableFromPools). Mixed is REBUILT, because its draw survives
+// in pools.csv. League and Swiss are moved aside and nothing more, because they
+// never drew a bracket and the file is vestigial; Rebuilt reports false so the
+// caller can say which of the two happened. Everything that draws its bracket
+// DIRECTLY is refused, and that refusal is the point: there, bracket.json is
+// the ONLY record of the draw. Rebuilding it from today's roster and seeds
+// would not restore the tournament, it would invent a different one, silently
+// disagreeing with the bracket already printed and posted on the wall.
+// CompetitionRebuildableFromPools reports whether a competition's knockout
+// bracket can be built again after bracket.json is lost, which is true only
+// when the draw that produced it survives in another file.
+//
+// Mixed is the one format where it does: its knockout is drawn from pools.csv,
+// so the same builder can lay the tree out again and the finished pools can be
+// re-seeded into it. Every other format either draws its bracket directly (so
+// the file IS the draw) or never draws one at all.
+//
+// Pinned with CompetitionDrawsBracket against the shared Go/JS table in
+// testdata/format_draws_bracket.json, whose `_comment` sets out how the two
+// answers combine into rebuild / refuse / discard. Mirrored client-side as
+// bracketRecoveryKind in web-mobile/js/data_integrity.jsx.
+func CompetitionRebuildableFromPools(format string) bool {
+	return format == state.CompFormatMixed
+}
+
 func (e *Engine) QuarantineCorruptBracket(id string) (*QuarantineResult, error) {
 	comp, err := e.store.LoadCompetition(id)
 	if err != nil {
@@ -69,9 +89,17 @@ func (e *Engine) QuarantineCorruptBracket(id string) (*QuarantineResult, error) 
 		return nil, loadErr
 	}
 
-	if comp.Format == state.CompFormatPlayoffs || comp.Format == "" {
+	// Refuse whenever the draw builds a bracket that nothing else records.
+	// Derived from the same pair of questions the draw pipeline answers, rather
+	// than from a hand-written list: this used to read `Format == playoffs ||
+	// Format == ""`, which let every UNRECOGNISED format through -- a typo in a
+	// hand-edited config.md, exactly the class of edit this whole area exists
+	// for. Such a competition takes the pipeline's DEFAULT branch and gets a
+	// standalone playoffs bracket, so bracket.json is the only record of its
+	// draw, and it was being quarantined with nothing rebuilt in its place.
+	if CompetitionDrawsBracket(comp.Format) && !CompetitionRebuildableFromPools(comp.Format) {
 		return nil, validationErrorf(
-			"competition %s is a direct-elimination competition, so bracket.json is the only "+
+			"competition %s draws its bracket directly, so bracket.json is the only "+
 				"record of its draw: rebuilding it would produce a different set of pairings "+
 				"rather than restoring this one. Repair the file and reload", id)
 	}
@@ -86,8 +114,8 @@ func (e *Engine) QuarantineCorruptBracket(id string) (*QuarantineResult, error) 
 	result := &QuarantineResult{QuarantinedAs: quarantined}
 
 	// League and Swiss have no knockout stage. Their bracket.json is vestigial,
-	// so moving it aside is the whole repair.
-	if comp.Format != state.CompFormatMixed {
+	// so moving it aside is the whole repair, and Rebuilt stays false to say so.
+	if !CompetitionRebuildableFromPools(comp.Format) {
 		return result, nil
 	}
 

--- a/internal/engine/quarantine_test.go
+++ b/internal/engine/quarantine_test.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+const brokenBracket = "{\n  \"rounds\": [\n    [{\"id\": \"R1-1\"x}]\n  ]\n}\n"
+
+func quarantineComp(t *testing.T, store *state.Store, eng *Engine, dir, id, format string) string {
+	t.Helper()
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: id, Name: "Q", Kind: "individual", Format: format,
+		PoolSize: 3, PoolSizeMode: "min", PoolWinners: 2,
+		Courts: []string{"A"}, StartTime: "09:00", Status: "setup",
+	}))
+	// Eight, because a mixed (Pools + Knockout) competition needs at least two
+	// pools to have a knockout stage at all.
+	saveTestParticipants(t, store, id, []string{
+		"Alice", "Bob", "Charlie", "Dave", "Erin", "Frank", "Grace", "Heidi",
+	})
+	require.NoError(t, eng.StartCompetition(id))
+	return filepath.Join(dir, "competitions", id, "bracket.json")
+}
+
+func breakBracket(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(brokenBracket), 0600))
+}
+
+// The whole point of the action: the operator's bytes are moved aside, never
+// deleted, because a file that will not parse is the only record of what it
+// described and nothing can say how much that is.
+func TestQuarantineCorruptBracket_KeepsTheBrokenFile(t *testing.T) {
+	eng, store, dir := setupTestEngine(t)
+	path := quarantineComp(t, store, eng, dir, "mixed-q", state.CompFormatMixed)
+	breakBracket(t, path)
+
+	res, err := eng.QuarantineCorruptBracket("mixed-q")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.Rebuilt, "a pool-fed knockout keeps its draw in pools.csv, so it rebuilds")
+	assert.Contains(t, res.QuarantinedAs, "bracket.json.corrupt-")
+
+	kept, err := os.ReadFile(filepath.Join(filepath.Dir(path), res.QuarantinedAs)) // #nosec G304
+	require.NoError(t, err)
+	assert.Equal(t, brokenBracket, string(kept),
+		"the operator's bytes survive verbatim, for a later repair by hand")
+
+	// And the competition is scoreable again.
+	rebuilt, err := store.LoadBracket("mixed-q")
+	require.NoError(t, err, "the fresh bracket parses")
+	assert.NotEmpty(t, rebuilt.Rounds)
+}
+
+// The guard that stops this being a general bracket-wipe.
+func TestQuarantineCorruptBracket_RefusesAReadableBracket(t *testing.T) {
+	eng, store, dir := setupTestEngine(t)
+	path := quarantineComp(t, store, eng, dir, "mixed-ok", state.CompFormatMixed)
+
+	before, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+
+	_, err = eng.QuarantineCorruptBracket("mixed-ok")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "readable bracket")
+
+	after, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "a healthy bracket is untouched")
+}
+
+// For a direct-elimination competition the bracket file IS the draw. Rebuilding
+// it from today's roster would not restore the tournament, it would invent a
+// different one that disagrees with the sheet already printed and on the wall.
+func TestQuarantineCorruptBracket_RefusesPlayoffsRatherThanInventingADraw(t *testing.T) {
+	eng, store, dir := setupTestEngine(t)
+	path := quarantineComp(t, store, eng, dir, "playoffs-q", state.CompFormatPlayoffs)
+	breakBracket(t, path)
+
+	_, err := eng.QuarantineCorruptBracket("playoffs-q")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only record of its draw")
+	assert.Contains(t, err.Error(), "Repair the file")
+
+	after, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	assert.Equal(t, brokenBracket, string(after),
+		"and it refuses BEFORE moving anything, so the file is exactly where the operator left it")
+}
+
+// A league has no knockout stage, so its bracket.json is vestigial: moving it
+// aside is the whole repair and there is nothing to rebuild.
+func TestQuarantineCorruptBracket_LeagueHasNothingToRebuild(t *testing.T) {
+	eng, store, dir := setupTestEngine(t)
+	id := "league-q"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: id, Name: "Q", Kind: "individual", Format: state.CompFormatLeague,
+		Courts: []string{"A"}, StartTime: "09:00", Status: "setup",
+	}))
+	saveTestParticipants(t, store, id, []string{"Alice", "Bob", "Charlie"})
+	require.NoError(t, eng.StartCompetition(id))
+	path := filepath.Join(dir, "competitions", id, "bracket.json")
+	breakBracket(t, path)
+
+	res, err := eng.QuarantineCorruptBracket(id)
+	require.NoError(t, err)
+	assert.False(t, res.Rebuilt)
+	assert.NotEmpty(t, res.QuarantinedAs)
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "the broken file is out of the way")
+}

--- a/internal/engine/quarantine_test.go
+++ b/internal/engine/quarantine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -115,4 +116,53 @@ func TestQuarantineCorruptBracket_LeagueHasNothingToRebuild(t *testing.T) {
 	assert.NotEmpty(t, res.QuarantinedAs)
 	_, statErr := os.Stat(path)
 	assert.True(t, os.IsNotExist(statErr), "the broken file is out of the way")
+}
+
+// The three recovery outcomes, driven through the real entry point for every
+// format the app can hold, rather than restated as an expression that would
+// happily agree with a broken gate.
+//
+// This is the test that would have caught the hole it now guards: the refusal
+// used to be a hand-written `Format == playoffs || Format == ""`, so an
+// UNRECOGNISED format -- a typo in a hand-edited config.md -- passed it,
+// reached the quarantine, and had its bracket moved aside with nothing built to
+// replace it. That format takes the draw pipeline's default branch and gets a
+// standalone playoffs bracket, so the file it lost was the only record of its
+// draw. The table says which formats those are; this says the engine agrees.
+func TestQuarantineCorruptBracket_OutcomeFollowsTheFormatTable(t *testing.T) {
+	for i, tc := range loadFormatDrawsBracketTable(t) {
+		t.Run(tc.Why, func(t *testing.T) {
+			eng, store, dir := setupTestEngine(t)
+			id := fmt.Sprintf("fmt-%d", i)
+			path := quarantineComp(t, store, eng, dir, id, tc.Format)
+			breakBracket(t, path)
+
+			res, err := eng.QuarantineCorruptBracket(id)
+
+			switch {
+			case tc.RebuildableFromPools:
+				require.NoError(t, err, "format %q rebuilds from pools.csv", tc.Format)
+				require.NotNil(t, res)
+				assert.True(t, res.Rebuilt,
+					"format %q rebuilds, so the caller must be able to say so", tc.Format)
+			case !tc.DrawsBracket:
+				require.NoError(t, err,
+					"format %q draws no bracket, so its bracket.json is vestigial and moving it "+
+						"aside is the whole repair", tc.Format)
+				require.NotNil(t, res)
+				assert.False(t, res.Rebuilt,
+					"format %q has no knockout stage, so nothing was rebuilt and Rebuilt must not "+
+						"claim otherwise -- the console words the operator's confirmation from it",
+					tc.Format)
+				assert.Contains(t, res.QuarantinedAs, "bracket.json.corrupt-")
+			default:
+				var validation *ValidationError
+				require.ErrorAs(t, err, &validation,
+					"format %q draws its bracket directly, so quarantining it would discard the "+
+						"only record of the draw and must be refused", tc.Format)
+				assert.Nil(t, res)
+				assert.FileExists(t, path, "a refused quarantine leaves the file exactly where it was")
+			}
+		})
+	}
 }

--- a/internal/engine/scoring.go
+++ b/internal/engine/scoring.go
@@ -600,6 +600,25 @@ func applyPoolWrite(stored, result *state.MatchResult, policy matchWritePolicy) 
 		// tie-break figures.
 		preserveDaihyosenOutcome(stored.SubResults, result)
 	}
+	// The unparsed sub-bout cell is FILE PROVENANCE, not client data: it exists
+	// so a malformed hand edit survives until someone repairs it, and the
+	// whole-struct overwrite below would drop it on any write to this match --
+	// including one that says nothing about sub-bouts at all, such as a court
+	// reassignment. Assigned unconditionally rather than set-if-empty, under
+	// BOTH policies, so a client that echoes the derived flag back cannot
+	// raise it on a match that reads perfectly well.
+	//
+	// A write that CARRIES sub-bouts clears both: the operator has re-entered
+	// the encounter, so the retained bytes are superseded and the warning has
+	// been answered. That is the repair path, and it is the only thing that
+	// takes the flag down.
+	if len(result.SubResults) == 0 {
+		result.SubResultsRaw = stored.SubResultsRaw
+		result.SubResultsUnreadable = stored.SubResultsUnreadable
+	} else {
+		result.SubResultsRaw = ""
+		result.SubResultsUnreadable = false
+	}
 	*stored = *result
 	return false
 }

--- a/internal/engine/testdata/format_draws_bracket.json
+++ b/internal/engine/testdata/format_draws_bracket.json
@@ -25,48 +25,79 @@
     "",
     "COVERAGE IS ENFORCED: the Go half asserts that every state.CompFormat*",
     "constant appears below, so adding a format without deciding this question",
-    "fails the build rather than defaulting quietly."
+    "fails the build rather than defaulting quietly.",
+    "",
+    "SECOND QUESTION, SAME SWITCH: `rebuildableFromPools` asks whether a corrupt",
+    "bracket.json can be REBUILT rather than only moved aside, which is what",
+    "engine.QuarantineCorruptBracket and the console's recovery banner both need.",
+    "It is a different question from drawsBracket and the two together decide all",
+    "three outcomes, so both live here rather than in a second table that could",
+    "disagree with this one:",
+    "",
+    "  drawsBracket && rebuildableFromPools   REBUILD. Only mixed. Its knockout is",
+    "    drawn from pools.csv, which survives, so the tree can be built again by",
+    "    the same builder and the finished pools re-seeded into it.",
+    "  drawsBracket && !rebuildableFromPools  REFUSE. bracket.json is the ONLY",
+    "    record of the draw, so rebuilding would invent a different set of",
+    "    pairings rather than restore this one. Covers playoffs AND every value",
+    "    that reaches the pipeline's default branch, which is the half a",
+    "    hand-written `format == playoffs || format == \"\"` check gets wrong.",
+    "  !drawsBracket                          DISCARD. League and Swiss never draw",
+    "    a bracket, so any bracket.json they have is vestigial and moving it",
+    "    aside is the whole repair. Nothing is rebuilt and nothing is lost.",
+    "",
+    "rebuildableFromPools implies drawsBracket: a format cannot rebuild a bracket",
+    "its draw never builds. The golden test asserts that, so the table cannot",
+    "describe a state the pipeline has no way to reach."
   ],
   "cases": [
     {
       "why": "playoffs is a bracket from the first bout",
       "format": "playoffs",
-      "drawsBracket": true
+      "drawsBracket": true,
+      "rebuildableFromPools": false
     },
     {
       "why": "mixed builds a knockout after its pools, so the rule binds",
       "format": "mixed",
-      "drawsBracket": true
+      "drawsBracket": true,
+      "rebuildableFromPools": true
     },
     {
       "why": "league is a full round-robin: its shiaijo run in parallel with no blocks to merge",
       "format": "league",
-      "drawsBracket": false
+      "drawsBracket": false,
+      "rebuildableFromPools": false
     },
     {
       "why": "swiss pairs each round afresh and never builds a bracket",
       "format": "swiss",
-      "drawsBracket": false
+      "drawsBracket": false,
+      "rebuildableFromPools": false
     },
     {
       "why": "a legacy record with no format at all takes the pipeline's default branch",
       "format": "",
-      "drawsBracket": true
+      "drawsBracket": true,
+      "rebuildableFromPools": false
     },
     {
       "why": "an unrecognised format takes that same default, so it is held to the rule",
       "format": "not-a-format",
-      "drawsBracket": true
+      "drawsBracket": true,
+      "rebuildableFromPools": false
     },
     {
       "why": "the match is exact: a format is not league merely by containing it",
       "format": "league-playoffs",
-      "drawsBracket": true
+      "drawsBracket": true,
+      "rebuildableFromPools": false
     },
     {
       "why": "and it is case-sensitive, matching the stored lowercase wire values",
       "format": "League",
-      "drawsBracket": true
+      "drawsBracket": true,
+      "rebuildableFromPools": false
     }
   ]
 }

--- a/internal/mobileapp/errors.go
+++ b/internal/mobileapp/errors.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
 // internalError logs err (with request method + path for context) and returns a
@@ -21,6 +23,29 @@ import (
 // failures should still return an explicit 4xx with their own message.
 func internalError(c *gin.Context, err error, publicMsg ...string) {
 	log.Printf("mobileapp: %s %s: %v", c.Request.Method, c.Request.URL.Path, err)
+	// A file the operator can repair is the ONE internal failure worth naming.
+	// Everything else here is deliberately opaque, but "internal error" on a
+	// corrupt competition file tells an organiser mid tournament that scoring
+	// has stopped and nothing else -- while the cause, the file and the exact
+	// line sit in a server log they are not reading. The detail is a parser's
+	// description of syntax, never competitor data, so it is safe to return.
+	//
+	// Hooked HERE rather than at each call site on purpose: this function is
+	// the catch-all every handler already funnels its unexpected failures
+	// through, so one branch upgrades all of them, and a future handler that
+	// can reach a corrupt file inherits the message without having to know it
+	// exists.
+	if cf, ok := state.AsCorruptFile(err); ok {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":  "a competition data file could not be read",
+			"code":   "corrupt_file",
+			"file":   cf.File,
+			"line":   cf.Line,
+			"column": cf.Column,
+			"detail": cf.Detail,
+		})
+		return
+	}
 	msg := "internal error"
 	if len(publicMsg) > 0 && publicMsg[0] != "" {
 		msg = publicMsg[0]

--- a/internal/mobileapp/errors_test.go
+++ b/internal/mobileapp/errors_test.go
@@ -2,12 +2,15 @@ package mobileapp
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
 )
 
 // TestInternalError verifies the generic-500 helper: it always returns HTTP 500,
@@ -53,5 +56,49 @@ func TestInternalError(t *testing.T) {
 		internalError(c, sensitive, "")
 
 		assert.Contains(t, w.Body.String(), "internal error")
+	})
+}
+
+// A file the operator can repair is the one internal failure worth naming. The
+// rest of internalError's contract still applies to it: nothing that names a
+// path on disk may reach the client.
+func TestInternalErrorNamesACorruptFile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("a located parse failure is reported with its position", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodPost, "/api/matches/R1-1/score", nil)
+
+		internalError(c, fmt.Errorf("loading bracket: %w", &state.CorruptFileError{
+			File: "bracket.json", Line: 47, Column: 12,
+			Detail: "invalid character 'x' after object key:value pair",
+		}))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		body := w.Body.String()
+		assert.Contains(t, body, "corrupt_file", "the SPA keys on the code, not the prose")
+		assert.Contains(t, body, "bracket.json")
+		assert.Contains(t, body, "47")
+		assert.Contains(t, body, "invalid character")
+		assert.NotContains(t, body, "internal error",
+			"a repairable file must not be reported as an opaque failure")
+	})
+
+	t.Run("an I/O failure is NOT reported as corruption", func(t *testing.T) {
+		// It is not something a text editor fixes, and its message carries the
+		// absolute path this helper exists to withhold. The store only wraps
+		// genuine parse failures, so such an error arrives here unwrapped and
+		// falls through to the generic body.
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/api/competitions/abc", nil)
+
+		internalError(c, errors.New("read /srv/tournament-data/competitions/abc/bracket.json: input/output error"))
+
+		body := w.Body.String()
+		assert.Contains(t, body, "internal error")
+		assert.NotContains(t, body, "corrupt_file")
+		assert.NotContains(t, body, "/srv/tournament-data")
 	})
 }

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -1794,6 +1794,41 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 		c.Status(http.StatusNoContent)
 	})
 
+	// Elevated-gated for the same reason as DELETE /draw above: it discards
+	// recorded results. It does NOT delete the operator's file, but the
+	// knockout results inside it become unreachable through the app, so it is
+	// as consequential as a discard from the console's point of view.
+	r.POST("/competitions/:id/bracket/quarantine", RequireElevatedPassword(elevated), func(c *gin.Context) {
+		id, ok := requireValidCompID(c)
+		if !ok {
+			return
+		}
+		res, err := eng.QuarantineCorruptBracket(id)
+		if err != nil {
+			var notFound *engine.NotFoundError
+			var validation *engine.ValidationError
+			switch {
+			case errors.As(err, &notFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			case errors.As(err, &validation):
+				// Covers both "there is nothing wrong with this bracket" and
+				// the playoffs refusal, whose message explains why rebuilding
+				// would invent a draw rather than restore one. Both are
+				// answerable by the operator, so both are a 400 with the reason.
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			default:
+				internalError(c, err)
+			}
+			return
+		}
+		hub.Broadcast(EventBracketQuarantined, gin.H{"competitionId": id})
+		c.JSON(http.StatusOK, gin.H{
+			"quarantinedAs": res.QuarantinedAs,
+			"rebuilt":       res.Rebuilt,
+			"resolvedPools": res.ResolvedPools,
+		})
+	})
+
 	// Elevated-gated: completing a competition is IRREVERSIBLE (invalidate
 	// rejects a completed comp), like DELETE /competitions/:id and
 	// /invalidate. In file mode without an admin password the gate is a no-op.

--- a/internal/mobileapp/handlers_competition.go
+++ b/internal/mobileapp/handlers_competition.go
@@ -1812,8 +1812,9 @@ func RegisterCompetitionHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 			case errors.As(err, &validation):
 				// Covers both "there is nothing wrong with this bracket" and
-				// the playoffs refusal, whose message explains why rebuilding
-				// would invent a draw rather than restore one. Both are
+				// the refusal for a competition that draws its bracket
+				// directly, whose message explains why rebuilding would invent
+				// a draw rather than restore one. Both are
 				// answerable by the operator, so both are a 400 with the reason.
 				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			default:

--- a/internal/mobileapp/handlers_viewer.go
+++ b/internal/mobileapp/handlers_viewer.go
@@ -225,11 +225,45 @@ func buildViewerCompetitionPayload(store *state.Store, compID, courtFilter strin
 	stripMatchesAudit(poolMatches)
 	stripBracketAudit(bracket)
 
-	return gin.H{
+	payload := gin.H{
 		"config":      comp,
 		"poolMatches": poolMatches,
 		"bracket":     bracket,
 	}
+	// Both loads above already SWALLOW their error into a log and carry on with
+	// whatever they got, which is right -- one unreadable file must not blank a
+	// whole competition view. But it left the operator with a silently
+	// half-empty competition and no way to learn why. Carry the located reason
+	// so the console can say which file is broken and where, and so "the
+	// bracket is missing" and "the bracket file will not parse" stop looking
+	// identical. This is the aggregate the admin SPA renders AdminCompetition
+	// off (see the comment above the participant load), which is why it is the
+	// right place for it despite the endpoint being public: the audience gate
+	// is at render time, and the detail is parser syntax, never competitor data.
+	if issues := dataIssuesFrom(pmErr, brErr); len(issues) > 0 {
+		payload["dataIssues"] = issues
+	}
+	return payload
+}
+
+// dataIssuesFrom collects the located file failures among errs, dropping
+// everything else: a missing file, a permissions problem or a nil is not
+// something an operator repairs with a text editor, so it gets no banner.
+func dataIssuesFrom(errs ...error) []gin.H {
+	var issues []gin.H
+	for _, err := range errs {
+		cf, ok := state.AsCorruptFile(err)
+		if !ok {
+			continue
+		}
+		issues = append(issues, gin.H{
+			"file":   cf.File,
+			"line":   cf.Line,
+			"column": cf.Column,
+			"detail": cf.Detail,
+		})
+	}
+	return issues
 }
 
 func RegisterViewerHandlers(r *gin.RouterGroup, store *state.Store, eng *engine.Engine) {

--- a/internal/mobileapp/handlers_viewer_corrupt_test.go
+++ b/internal/mobileapp/handlers_viewer_corrupt_test.go
@@ -1,0 +1,80 @@
+package mobileapp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gitrgoliveira/bracket-creator/internal/state"
+)
+
+// The aggregate deliberately swallows a per-file load failure and serves what
+// it got, so one unreadable file cannot blank a whole competition view. That
+// left the operator with a silently half-empty competition and no way to learn
+// why: "the bracket is missing" and "the bracket file will not parse" looked
+// identical. These pin the located reason travelling with the payload.
+func TestViewerAggregateReportsACorruptFile(t *testing.T) {
+	r, store, _, _, dir := setupTestRouter(t)
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "kendo", Name: "Kendo", Status: state.CompStatusPools,
+	}))
+
+	broken := "{\n  \"rounds\": [\n    [{\"id\": \"R1-1\"x}]\n  ]\n}\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "competitions", "kendo", "bracket.json"), []byte(broken), 0600))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/viewer/competitions", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code,
+		"one unreadable file must not blank the whole view")
+
+	var payload []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload))
+	require.Len(t, payload, 1)
+
+	issues, ok := payload[0]["dataIssues"].([]any)
+	require.True(t, ok, "the competition carries its data issues, got %#v", payload[0]["dataIssues"])
+	require.Len(t, issues, 1)
+	issue := issues[0].(map[string]any)
+	assert.Equal(t, "bracket.json", issue["file"])
+	assert.EqualValues(t, 3, issue["line"], "the line the operator has to open")
+	assert.NotEmpty(t, issue["detail"])
+}
+
+func TestViewerAggregateHasNoIssuesWhenTheFilesAreFine(t *testing.T) {
+	r, store, _, _, _ := setupTestRouter(t)
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID: "kendo", Name: "Kendo", Status: state.CompStatusPools,
+	}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/viewer/competitions", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var payload []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload))
+	require.Len(t, payload, 1)
+	_, present := payload[0]["dataIssues"]
+	assert.False(t, present, "no banner when there is nothing to repair")
+}
+
+func TestDataIssuesFromKeepsOnlyRepairableFailures(t *testing.T) {
+	// A missing file, a permissions problem or a nil is not something an
+	// operator fixes in a text editor, so it gets no banner.
+	issues := dataIssuesFrom(
+		nil,
+		os.ErrNotExist,
+		&state.CorruptFileError{File: "pool-matches.csv", Line: 9, Column: 4, Detail: "bare \" in field"},
+	)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "pool-matches.csv", issues[0]["file"])
+	assert.Equal(t, 9, issues[0]["line"])
+}

--- a/internal/mobileapp/hub.go
+++ b/internal/mobileapp/hub.go
@@ -39,12 +39,16 @@ const (
 	// and re-show the AuthModal so a logged-in operator notices immediately
 	// instead of waiting for their next write to fail with 401. Viewers
 	// ignore the event, their flow doesn't depend on the admin password.
-	EventPasswordReset  EventType = "password_reset"
-	EventAnnouncement   EventType = "announcement"
-	EventDrawGenerated  EventType = "draw_generated"
-	EventDrawDiscarded  EventType = "draw_discarded"
-	EventLineupUpdated  EventType = "lineup_updated"
-	EventResyncRequired EventType = "resync_required"
+	EventPasswordReset EventType = "password_reset"
+	EventAnnouncement  EventType = "announcement"
+	EventDrawGenerated EventType = "draw_generated"
+	EventDrawDiscarded EventType = "draw_discarded"
+	// EventBracketQuarantined: a bracket.json that would not parse was renamed
+	// aside and the knockout stage rebuilt. Every device is showing a wedged
+	// competition when this happens, so they all need to reload.
+	EventBracketQuarantined EventType = "bracket_quarantined"
+	EventLineupUpdated      EventType = "lineup_updated"
+	EventResyncRequired     EventType = "resync_required"
 )
 
 // AutoCompleteErrorHeader is set on score/start responses when the

--- a/internal/mobileapp/viewer_singleflight.go
+++ b/internal/mobileapp/viewer_singleflight.go
@@ -130,7 +130,11 @@ func (g *viewerSingleFlight) Do(key string, fn func() ([]byte, error)) (v []byte
 // rest.
 func serveSingleFlightJSON(c *gin.Context, data []byte, err error) {
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		// Through the shared helper rather than a hand-rolled 500: this path
+		// used to swallow the cause entirely (no log line at all), and a
+		// corrupt competition file reaching it deserves the same located
+		// message every other handler now gives.
+		internalError(c, err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", data)

--- a/internal/state/bracket.go
+++ b/internal/state/bracket.go
@@ -42,7 +42,12 @@ func parseBracketBytes(raw []byte) (*Bracket, error) {
 	}
 	var b Bracket
 	if err := json.Unmarshal(raw, &b); err != nil {
-		return nil, err
+		// Located, so the operator is told which line and column to look at
+		// rather than being handed a generic failure. Nothing is written on
+		// this path: both bracket write paths abort before saving, so the file
+		// stays exactly as it was left, which is what makes a hand repair the
+		// right advice here.
+		return nil, corruptJSON("bracket.json", raw, err)
 	}
 	// Clamp negative engi flag counts to 0 on load, symmetric with the pool CSV
 	// parser (pools.go parsePoolMatchesRecords): flags are validated

--- a/internal/state/bracket.go
+++ b/internal/state/bracket.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 )
 
@@ -72,11 +73,21 @@ func parseBracketBytes(raw []byte) (*Bracket, error) {
 
 // clampBracketMatchFlags forces negative engi flag counts to 0 (see
 // parseBracketBytes). Non-negative values pass through unchanged.
+//
+// Logged, because a clamp DISCARDS a recorded figure and the next save writes
+// the 0 back, so the original is gone: the same silent-loss shape the sub-bout
+// cell had. The value clamped is nonsense (a negative count of referee flags)
+// so there is nothing recoverable to preserve, but an organiser who typed it
+// deserves to learn that the file no longer says what they wrote.
 func clampBracketMatchFlags(m *BracketMatch) {
 	if m.FlagsA < 0 {
+		slog.Warn("state: bracket match flag count clamped to 0",
+			"matchID", m.ID, "side", "A", "value", m.FlagsA)
 		m.FlagsA = 0
 	}
 	if m.FlagsB < 0 {
+		slog.Warn("state: bracket match flag count clamped to 0",
+			"matchID", m.ID, "side", "B", "value", m.FlagsB)
 		m.FlagsB = 0
 	}
 }

--- a/internal/state/competition.go
+++ b/internal/state/competition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gitrgoliveira/bracket-creator/internal/domain"
 )
@@ -317,6 +318,66 @@ func (s *Store) DeleteCompetitionFile(id, filename string) error {
 	// state just as a write does, so move the version counter here too.
 	s.bumpFileVersion(id, filename)
 	return nil
+}
+
+// QuarantineCompetitionFile renames a competition artifact out of the way,
+// to "<name>.corrupt-<UTC timestamp>", and reports the name it was given.
+//
+// It exists so "reset this broken file" never means "delete the operator's
+// data". A file that will not parse is the only remaining record of whatever
+// it described, and because it will not parse NOTHING can say how much that
+// is: a delete would be asking an organiser mid tournament to discard an
+// unknown amount of their own tournament record, with no way to warn them how
+// much and no way back. Renaming keeps the bytes for a later repair, or for
+// someone who can read them by hand, and still unblocks the competition now.
+//
+// The quarantined copy is deliberately left in the competition directory
+// rather than a hidden folder: the organiser is already looking there, and a
+// file called bracket.json.corrupt-20260822-140301 explains itself.
+//
+// Returns the new base name. A missing source file is an error here, unlike
+// the idempotent delete above: quarantining nothing means the caller's
+// premise (this file is broken) was already false.
+func (s *Store) QuarantineCompetitionFile(id, filename string) (string, error) {
+	if err := ValidateCompetitionID(id); err != nil {
+		return "", fmt.Errorf("invalid competition ID: %w", err)
+	}
+	// Same two-layer guard as DeleteCompetitionFile: this takes a filename, so
+	// it must not become an arbitrary-rename primitive inside the data folder.
+	if filename == "" || filepath.Base(filename) != filename {
+		return "", fmt.Errorf("invalid filename: %q", filename)
+	}
+	if _, ok := allowedDrawFiles[filename]; !ok {
+		return "", fmt.Errorf("QuarantineCompetitionFile: filename %q is not an allowed draw artifact", filename)
+	}
+
+	mu := s.getCompLock(id)
+	mu.Lock()
+	defer mu.Unlock()
+
+	path := s.compPath(id, filename)
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+	// Second granularity is enough to name a file an operator will read, but
+	// two quarantines inside one second must not collide and silently destroy
+	// the first -- the one thing this function exists to prevent. Probe for a
+	// free name rather than overwriting.
+	stamp := time.Now().UTC().Format("20060102-150405")
+	target := filename + ".corrupt-" + stamp
+	for i := 2; ; i++ {
+		if _, err := os.Stat(s.compPath(id, target)); os.IsNotExist(err) {
+			break
+		}
+		target = fmt.Sprintf("%s.corrupt-%s-%d", filename, stamp, i)
+	}
+	if err := os.Rename(path, s.compPath(id, target)); err != nil {
+		return "", err
+	}
+	// The artifact is gone from its name, which changes derived state exactly
+	// as a write or a delete does.
+	s.bumpFileVersion(id, filename)
+	return target, nil
 }
 
 func (s *Store) DeleteCompetition(id string) error {

--- a/internal/state/corrupt_file.go
+++ b/internal/state/corrupt_file.go
@@ -1,0 +1,129 @@
+package state
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// CorruptFileError says that a competition file on disk could not be parsed,
+// and WHERE. It exists because the alternative the operator used to get was a
+// generic HTTP 500: scoring simply stopped, with the cause visible only in the
+// server log of a laptop nobody is watching mid event.
+//
+// The tool's storage is deliberately shaped for people to read and repair
+// (docs/architecture/data-model.md section 1), which only works if a wrong edit
+// says what is wrong and where. Line and Column are 1-based and are 0 when the
+// parser could not place the fault.
+//
+// This is the LOUD class of malformed data, the one that fails the load: a
+// competition whose bracket.json will not parse cannot be scored, and both
+// bracket write paths abort before saving, so the file on disk is left exactly
+// as the operator left it. That is deliberate. The QUIET class -- a single
+// malformed cell that degrades to its documented default -- does not produce
+// this error; it keeps its own per-match channel (MatchResult.SubResultsRaw and
+// SubResultsUnreadable) so one bad cell cannot stop a tournament.
+type CorruptFileError struct {
+	// File is the competition-relative filename, e.g. "bracket.json".
+	File   string
+	Line   int
+	Column int
+	// Detail is the underlying parser's own message, which names the offending
+	// byte ("invalid character 'x' after object key:value pair"). Safe to show
+	// an operator: it describes syntax, not competitor data.
+	Detail string
+	Err    error
+}
+
+func (e *CorruptFileError) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("%s is corrupt at line %d, column %d: %s", e.File, e.Line, e.Column, e.Detail)
+	}
+	return fmt.Sprintf("%s is corrupt: %s", e.File, e.Detail)
+}
+
+func (e *CorruptFileError) Unwrap() error { return e.Err }
+
+// AsCorruptFile reports whether err is (or wraps) a CorruptFileError.
+func AsCorruptFile(err error) (*CorruptFileError, bool) {
+	var c *CorruptFileError
+	if errors.As(err, &c) {
+		return c, true
+	}
+	return nil, false
+}
+
+// corruptJSON converts a json decode failure into a located CorruptFileError.
+// Both error types carry a byte OFFSET rather than a position, so the offset is
+// resolved against the bytes that produced it: a line and column is what an
+// operator can act on in the editor they already have open.
+func corruptJSON(file string, raw []byte, err error) error {
+	if err == nil {
+		return nil
+	}
+	// ONLY a genuine parse failure becomes a CorruptFileError. Anything else --
+	// an I/O failure, a programming error in the destination type -- is not
+	// corruption, must not tell an operator to go and repair their file, and
+	// must not have its message forwarded: Detail is returned to the CLIENT, and
+	// an I/O error's message carries the absolute path that internalError exists
+	// to keep out of a response body.
+	c := &CorruptFileError{File: file, Detail: err.Error(), Err: err}
+	var syn *json.SyntaxError
+	var typ *json.UnmarshalTypeError
+	switch {
+	case errors.As(err, &syn):
+		c.Line, c.Column = offsetToLineColumn(raw, syn.Offset)
+	case errors.As(err, &typ):
+		c.Line, c.Column = offsetToLineColumn(raw, typ.Offset)
+	default:
+		return err
+	}
+	return c
+}
+
+// corruptCSV converts a csv PARSE failure into a located CorruptFileError.
+// encoding/csv already reports a line and column, so there is no offset to
+// resolve. Any other failure is returned untouched.
+func corruptCSV(file string, err error) error {
+	if err == nil {
+		return nil
+	}
+	// Parse failures only, for the reason given on corruptJSON: a read error
+	// mid file is not something a text editor fixes, and its message names the
+	// path on disk.
+	var pe *csv.ParseError
+	if !errors.As(err, &pe) {
+		return err
+	}
+	c := &CorruptFileError{File: file, Line: pe.Line, Column: pe.Column, Detail: err.Error(), Err: err}
+	// pe.Err is the bare reason ("extraneous or missing \" in quoted-field");
+	// pe.Error() prefixes it with the position this struct already carries.
+	if pe.Err != nil {
+		c.Detail = pe.Err.Error()
+	}
+	return c
+}
+
+// offsetToLineColumn resolves a 0-based byte offset into a 1-based line and
+// column. An offset past the end (json reports one for a truncated document,
+// which is what half a hand edit looks like) resolves to the final position
+// rather than to nothing, so a truncation still points somewhere useful.
+func offsetToLineColumn(raw []byte, offset int64) (line, column int) {
+	if offset < 0 {
+		return 0, 0
+	}
+	if offset > int64(len(raw)) {
+		offset = int64(len(raw))
+	}
+	line, column = 1, 1
+	for _, b := range raw[:offset] {
+		if b == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
+}

--- a/internal/state/corrupt_file_test.go
+++ b/internal/state/corrupt_file_test.go
@@ -1,0 +1,111 @@
+package state
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The storage is shaped for an organiser to read and repair, which only works
+// if a wrong edit says WHAT is wrong and WHERE. These pin the located reporting
+// for the loud class: damage that fails the load outright.
+
+func TestOffsetToLineColumn(t *testing.T) {
+	raw := []byte("one\ntwo\nthree")
+	tests := []struct {
+		name      string
+		offset    int64
+		line, col int
+	}{
+		{"start of file", 0, 1, 1},
+		{"within the first line", 2, 1, 3},
+		{"immediately after a newline", 4, 2, 1},
+		{"on the third line", 10, 3, 3},
+		{"past the end resolves to the last position, as a truncated document reports", 999, 3, 6},
+		{"a negative offset reports no position rather than guessing", -1, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line, col := offsetToLineColumn(raw, tt.offset)
+			assert.Equal(t, tt.line, line)
+			assert.Equal(t, tt.col, col)
+		})
+	}
+}
+
+func TestLoadBracketReportsWhereTheFileIsBroken(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, s.SaveCompetition(&Competition{ID: "c", Name: "C"}))
+
+	// A hand edit that breaks the JSON on a known line.
+	broken := "{\n  \"rounds\": [\n    [{\"id\": \"R1-1\"x}]\n  ]\n}\n"
+	require.NoError(t, s.atomicWrite(s.compPath("c", "bracket.json"), []byte(broken), 0600))
+
+	fresh, err := NewStore(dir)
+	require.NoError(t, err)
+	_, err = fresh.LoadBracket("c")
+	require.Error(t, err, "a corrupt bracket must fail the load, not degrade")
+
+	cf, ok := AsCorruptFile(err)
+	require.True(t, ok, "and must arrive as a located CorruptFileError, got %T", err)
+	assert.Equal(t, "bracket.json", cf.File)
+	assert.Equal(t, 3, cf.Line, "the line the operator has to open")
+	assert.Positive(t, cf.Column)
+	assert.Contains(t, cf.Error(), "line 3")
+	assert.NotEmpty(t, cf.Detail)
+}
+
+func TestLoadBracketLeavesTheBrokenFileAlone(t *testing.T) {
+	// The whole reason a hand repair is the right advice: nothing rewrites the
+	// file while it will not parse, so the operator's bytes are still there.
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, s.SaveCompetition(&Competition{ID: "c", Name: "C"}))
+	path := s.compPath("c", "bracket.json")
+	broken := "{\n  \"rounds\": [[{\"id\": \"R1-1\"x}]]\n}\n"
+	require.NoError(t, s.atomicWrite(path, []byte(broken), 0600))
+
+	fresh, err := NewStore(dir)
+	require.NoError(t, err)
+	_, loadErr := fresh.LoadBracket("c")
+	require.Error(t, loadErr)
+
+	// Every bracket write path aborts on the parse before saving.
+	found, err := fresh.UpdateBracketMatchByID("c", "R1-1", func(m *BracketMatch) { m.Winner = "anyone" })
+	assert.False(t, found)
+	require.Error(t, err)
+	_, ok := AsCorruptFile(err)
+	assert.True(t, ok, "the write refuses with the same located reason")
+
+	after, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	assert.Equal(t, broken, string(after), "the operator's bytes are untouched")
+}
+
+func TestLoadPoolMatchesReportsWhereTheRowStructureBroke(t *testing.T) {
+	// CSV-level damage is a different class from a malformed CELL: there is no
+	// row left to degrade, so the load fails and must say where.
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, s.SaveCompetition(&Competition{ID: "c", Name: "C"}))
+
+	// An unclosed quoted field: the shape a half-finished hand edit leaves.
+	broken := "PoolName,MatchIdx,SideA\nPool A,1,\"Kyoto\nPool A,2,Osaka,extra\n"
+	require.NoError(t, s.atomicWrite(s.compPath("c", "pool-matches.csv"), []byte(broken), 0600))
+
+	fresh, err := NewStore(dir)
+	require.NoError(t, err)
+	_, err = fresh.LoadPoolMatches("c")
+	require.Error(t, err)
+	cf, ok := AsCorruptFile(err)
+	require.True(t, ok, "got %T", err)
+	assert.Equal(t, "pool-matches.csv", cf.File)
+	assert.Positive(t, cf.Line)
+	assert.NotEmpty(t, cf.Detail)
+}

--- a/internal/state/models.go
+++ b/internal/state/models.go
@@ -990,8 +990,37 @@ type MatchResult struct {
 	Round          int              `json:"round" yaml:"round"`
 	ScheduledAt    string           `json:"scheduledAt"`
 	SubResults     []SubMatchResult `json:"subResults,omitempty"`
-	Encho          *EnchoMetadata   `json:"encho,omitempty" yaml:"encho,omitempty"`
-	QueuePosition  int              `json:"queuePosition,omitempty" yaml:"-"`
+	// SubResultsRaw holds the sub-bout cell EXACTLY as it was read, and only
+	// when it failed to parse as JSON. It is the repair copy. The reader
+	// degrades a malformed cell to an empty encounter rather than failing the
+	// row (docs/architecture/data-model.md, "When a file is wrong") and the
+	// writer rewrites the WHOLE file on every match write, so without this the
+	// first score entered on any OTHER match in the competition overwrote the
+	// organiser's broken cell with an empty one and destroyed the bouts it
+	// described -- along with every IV/PW figure they fed. The SubResults
+	// column's put writes it back verbatim while the encounter is still empty,
+	// which is what makes the documented remedy (fix the cell, reload)
+	// reachable at all. It has no column of its own because it IS the
+	// SubResults column, unparsed.
+	SubResultsRaw string `json:"-" yaml:"-"`
+	// SubResultsUnreadable is the wire companion to SubResultsRaw, derived on
+	// read from the same parse failure. MatchResult marshals straight to the
+	// SPA, so the operator-facing warning needs a field rather than a method;
+	// QueuePosition below is the precedent for a derived field that is
+	// deliberately not a CSV column.
+	//
+	// It is deliberately NOT stripped in public_projection.go, unlike the audit
+	// free-text there. The admin console reads the same PUBLIC aggregate
+	// (handlers_viewer.go, whose comment records that AdminCompetition renders
+	// off it) and the same public SSE stream, so the server cannot tell the two
+	// audiences apart on this path: stripping would blank the flag for the
+	// operator too, and make it vanish again on the next broadcast. The
+	// audience gate is therefore at RENDER time -- the admin callers of
+	// PoolsViewer opt in, the viewer does not -- which is sound because the
+	// field carries no competitor detail, only "this cell would not parse".
+	SubResultsUnreadable bool           `json:"subResultsUnreadable,omitempty" yaml:"-"`
+	Encho                *EnchoMetadata `json:"encho,omitempty" yaml:"encho,omitempty"`
+	QueuePosition        int            `json:"queuePosition,omitempty" yaml:"-"`
 	// DecidedByHantei is a LEGACY READ-ONLY channel, exactly as on
 	// SubMatchResult (see there and legacy_hantei.go): the verdict is the
 	// domain.HanteiMark entry in the winner's IpponsA/IpponsB. A hantei on a

--- a/internal/state/pool_roundtrip_test.go
+++ b/internal/state/pool_roundtrip_test.go
@@ -39,6 +39,16 @@ var notPersistedInPoolCSV = map[string]string{
 		"(DeriveQueuePositions), never authored, so persisting it would create a " +
 		"second source of truth that could disagree with the schedule.",
 	"WinnerSide": "derived: the winner name compared against SideA/SideB.",
+	"SubResultsRaw": "the SubResults cell's UNPARSED bytes, retained only when " +
+		"that cell failed to parse so the whole-file rewrite cannot destroy an " +
+		"organiser's malformed edit. It has no column of its own because it IS " +
+		"the SubResults column: the put writes it back into that cell while the " +
+		"encounter is empty. A round trip of a VALID fixture therefore never " +
+		"carries it, which is the point.",
+	"SubResultsUnreadable": "derived on read from the same parse failure that " +
+		"fills SubResultsRaw, and carried to the SPA so the operator sees which " +
+		"match lost its bouts. Derived state, not a column, exactly like " +
+		"QueuePosition and WinnerSide.",
 	"DecidedByHantei": "LEGACY READ-ONLY compatibility channel (models.go doc " +
 		"comment above the field): the verdict is the domain.HanteiMark entry " +
 		"in the winner's IpponsA/IpponsB, and writers must never set this flag. " +

--- a/internal/state/pool_subresults_corrupt_test.go
+++ b/internal/state/pool_subresults_corrupt_test.go
@@ -1,0 +1,155 @@
+package state
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A team encounter's five bouts live in ONE cell of pool-matches.csv, and the
+// file is the one the tool invites an organiser to hand-edit. These guards
+// cover what happens when that edit is wrong: the cell must degrade to an empty
+// encounter (the documented contract), must SAY SO, and must not be destroyed
+// by the whole-file rewrite that every subsequent match write performs.
+
+// corruptCompetition writes a two-match competition where the first match holds
+// a team encounter and returns the on-disk path of pool-matches.csv.
+func corruptCompetition(t *testing.T) (*Store, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	require.NoError(t, err)
+	require.NoError(t, s.SaveCompetition(&Competition{ID: "c", Name: "C"}))
+
+	team := MatchResult{ID: "Pool A-1", SideA: "Kenshikan", SideB: "Sanshukan", Winner: "Kenshikan", SubResults: []SubMatchResult{
+		{Position: 1, SideA: "Tanaka", SideB: "Suzuki", IpponsA: []string{"M"}, Winner: "Tanaka"},
+		{Position: 2, SideA: "Ito", SideB: "Sato", IpponsA: []string{"K", "M"}, Winner: "Ito"},
+	}}
+	other := MatchResult{ID: "Pool A-2", SideA: "Kenshikan", SideB: "Meirinkan"}
+	require.NoError(t, s.SavePoolMatches("c", []MatchResult{team, other}))
+	return s, dir, s.compPath("c", "pool-matches.csv")
+}
+
+// mangleCell rewrites the sub-bout JSON so it no longer parses while leaving the
+// CSV quoting untouched, which is what a hand edit inside the cell looks like.
+func mangleCell(t *testing.T, path, from, to string) {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	mangled := strings.Replace(string(raw), from, to, 1)
+	require.NotEqual(t, string(raw), mangled, "the mangle pattern must actually match")
+	require.NoError(t, os.WriteFile(path, []byte(mangled), 0600))
+}
+
+// TestCorruptSubResultsSurvivesAWriteToAnotherMatch is the regression guard for
+// bc-subj. Scoring an UNRELATED match rewrites the whole file, so before the
+// fix the organiser's malformed cell came back as empty and the encounter's
+// bouts were gone for good -- destroying the very bytes the documented remedy
+// ("fix the cell, reload") depends on, seconds into a live tournament.
+func TestCorruptSubResultsSurvivesAWriteToAnotherMatch(t *testing.T) {
+	_, dir, path := corruptCompetition(t)
+	mangleCell(t, path, `""position"":2`, `""position"":2x`)
+
+	// Cold reload, as after a restart.
+	fresh, err := NewStore(dir)
+	require.NoError(t, err)
+	loaded, err := fresh.LoadPoolMatches("c")
+	require.NoError(t, err, "a corrupt cell must never fail the load")
+	require.Len(t, loaded, 2)
+	assert.Empty(t, loaded[0].SubResults, "the encounter degrades to empty")
+	assert.True(t, loaded[0].SubResultsUnreadable, "and says so")
+
+	// Score a DIFFERENT match. This rewrites every row in the file.
+	found, err := fresh.UpdatePoolMatchByID("c", "Pool A-2", func(m *MatchResult) {
+		m.Status = MatchStatusCompleted
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	after, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	assert.Contains(t, string(after), "Tanaka",
+		"the malformed cell must survive a write to another match, or the organiser "+
+			"has nothing left to repair")
+	assert.Contains(t, string(after), `""position"":2x`,
+		"and must survive VERBATIM, not partially rewritten")
+
+	// It still reads back as an unreadable, empty encounter.
+	again, err := NewStore(dir)
+	require.NoError(t, err)
+	reloaded, err := again.LoadPoolMatches("c")
+	require.NoError(t, err)
+	assert.Empty(t, reloaded[0].SubResults)
+	assert.True(t, reloaded[0].SubResultsUnreadable, "the warning outlives the write too")
+}
+
+// TestCorruptSubResultsTypeErrorDoesNotNormaliseDamageOntoDisk covers the other
+// half of "malformed". encoding/json rejects a SYNTAX error before decoding
+// anything, but a TYPE error (valid JSON, wrong value type, e.g. quoting a
+// number) decodes as far as it got and returns the error at the end, leaving a
+// partially built slice whose failed entries are silently zeroed. Loading that
+// slice would make the documented "loads as an empty encounter" contract false,
+// and re-marshalling it would replace the organiser's cell with a
+// valid-LOOKING one holding nameless bouts.
+func TestCorruptSubResultsTypeErrorDoesNotNormaliseDamageOntoDisk(t *testing.T) {
+	_, dir, path := corruptCompetition(t)
+	mangleCell(t, path, `""position"":2,`, `""position"":""two"",`)
+
+	fresh, err := NewStore(dir)
+	require.NoError(t, err)
+	loaded, err := fresh.LoadPoolMatches("c")
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.Empty(t, loaded[0].SubResults,
+		"a type error must degrade to EMPTY, not to a half-decoded encounter")
+	assert.True(t, loaded[0].SubResultsUnreadable)
+
+	found, err := fresh.UpdatePoolMatchByID("c", "Pool A-2", func(m *MatchResult) {
+		m.Status = MatchStatusCompleted
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	after, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	assert.Contains(t, string(after), `""position"":""two""`,
+		"the operator's bytes stay as they are")
+	assert.Contains(t, string(after), "Tanaka",
+		"including the bout that DID decode, which a re-marshal would have kept "+
+			"while silently dropping its neighbour")
+}
+
+// TestRepairingTheCellClearsTheWarning: re-entering the encounter through a
+// normal write is the repair path, and it is the only thing that takes the
+// retained bytes and the warning down.
+func TestRepairingTheCellClearsTheWarning(t *testing.T) {
+	_, dir, path := corruptCompetition(t)
+	mangleCell(t, path, `""position"":2`, `""position"":2x`)
+
+	fresh, err := NewStore(dir)
+	require.NoError(t, err)
+	found, err := fresh.UpdatePoolMatchByID("c", "Pool A-1", func(m *MatchResult) {
+		require.True(t, m.SubResultsUnreadable, "the mutate sees the flagged match")
+		m.SubResults = []SubMatchResult{
+			{Position: 1, SideA: "Tanaka", SideB: "Suzuki", IpponsA: []string{"M"}, Winner: "Tanaka"},
+		}
+		m.SubResultsRaw = ""
+		m.SubResultsUnreadable = false
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	after, err := os.ReadFile(path) // #nosec G304
+	require.NoError(t, err)
+	assert.NotContains(t, string(after), "2x", "the malformed bytes are gone once repaired")
+
+	again, err := NewStore(dir)
+	require.NoError(t, err)
+	reloaded, err := again.LoadPoolMatches("c")
+	require.NoError(t, err)
+	assert.Len(t, reloaded[0].SubResults, 1)
+	assert.False(t, reloaded[0].SubResultsUnreadable, "and the warning is answered")
+}

--- a/internal/state/pools.go
+++ b/internal/state/pools.go
@@ -41,7 +41,9 @@ func parsePoolsFile(path string) (any, error) {
 
 	records, err := csv.NewReader(f).ReadAll()
 	if err != nil {
-		return nil, err
+		// Located for the same reason as the results file below: pools.csv is
+		// equally hand-editable and equally able to stop a competition.
+		return nil, corruptCSV("pools.csv", err)
 	}
 
 	// poolIdx maps pool name → index into pools so we can append players in-place
@@ -284,7 +286,12 @@ func parsePoolMatchesFile(path string) (any, error) {
 
 	records, err := csv.NewReader(f).ReadAll()
 	if err != nil {
-		return nil, err
+		// CSV-level damage is the LOUD class: the row structure itself is
+		// broken, so there is no row to degrade and the load fails. Located so
+		// the operator can find it. (A single malformed CELL inside an
+		// otherwise-valid row is the quiet class and never reaches here; see
+		// the SubResults column.)
+		return nil, corruptCSV("pool-matches.csv", err)
 	}
 	return parsePoolMatchesRecords(records), nil
 }
@@ -299,7 +306,9 @@ func parsePoolMatchesBytes(raw []byte) ([]MatchResult, error) {
 	}
 	records, err := csv.NewReader(bytes.NewReader(raw)).ReadAll()
 	if err != nil {
-		return nil, err
+		// Same located failure as parsePoolMatchesFile: this path reads
+		// WAL-staged bytes for the same file, so it must report it the same way.
+		return nil, corruptCSV("pool-matches.csv", err)
 	}
 	return parsePoolMatchesRecords(records), nil
 }

--- a/internal/state/pools.go
+++ b/internal/state/pools.go
@@ -456,7 +456,14 @@ var poolMatchColumns = []poolMatchColumn{
 	{name: "SubResults",
 		put: func(r *MatchResult) string {
 			if len(r.SubResults) == 0 {
-				return ""
+				// An encounter with nothing in it writes back whatever it was
+				// READ from, which is empty for every ordinary match and the
+				// unparsed bytes for one whose cell was corrupt. Without this
+				// the whole-file rewrite that every match write performs
+				// destroyed a malformed cell as soon as any OTHER match in the
+				// competition was scored, taking the only copy of that team
+				// encounter's bouts with it. See MatchResult.SubResultsRaw.
+				return r.SubResultsRaw
 			}
 			b, err := json.Marshal(r.SubResults)
 			if err != nil {
@@ -483,6 +490,25 @@ var poolMatchColumns = []poolMatchColumn{
 				// empty team encounter with no trace of the data loss.
 				slog.Error("state: pool match SubResults cell corrupt; loading as empty",
 					"matchID", m.ID, "error", err)
+				// Discard whatever decoded before the error. Unmarshal only
+				// leaves the destination untouched for a SYNTAX error, which
+				// it rejects before decoding anything; a TYPE error (valid
+				// JSON, wrong value type, e.g. "position":"2" from a hand
+				// edit) decodes as far as it got and returns the error at the
+				// end, leaving a partially built slice whose failed entries
+				// are silently zeroed. Without this reset that slice is
+				// non-empty, so the put below re-marshals the zeroed bouts and
+				// normalises the damage onto disk as a valid-looking cell,
+				// which is worse than the blanking this whole branch exists to
+				// stop. It is also what the documented contract already claims
+				// happens: "loads as an empty encounter".
+				m.SubResults = nil
+				// Retain the bytes so the next write cannot destroy them, and
+				// raise the operator-facing flag from the same branch, so the
+				// warning and the repair copy can never disagree about whether
+				// this cell parsed.
+				m.SubResultsRaw = cell
+				m.SubResultsUnreadable = true
 			}
 		}},
 	strCol("ScheduledAt", func(m *MatchResult) *string { return &m.ScheduledAt }),

--- a/internal/state/pools.go
+++ b/internal/state/pools.go
@@ -420,8 +420,20 @@ func clampedIntCol(name string, field func(m *MatchResult) *int) poolMatchColumn
 		name: name,
 		put:  func(r *MatchResult) string { return strconv.Itoa(*field(r)) },
 		take: func(m *MatchResult, cell string) {
-			if v, err := strconv.Atoi(cell); err == nil && v > 0 {
+			v, err := strconv.Atoi(cell)
+			if err == nil && v > 0 {
 				*field(m) = v
+				return
+			}
+			// A NEGATIVE count is real data being discarded, unlike an empty or
+			// non-numeric cell, which is simply absent. It was clamped in total
+			// silence, which is the same failure mode the SubResults cell had:
+			// a hand edit quietly changing a recorded figure with no trace
+			// anywhere. Say so. (Still clamped rather than rejected: one bad
+			// number must not stop a tournament.)
+			if err == nil && v < 0 {
+				slog.Warn("state: pool match column clamped a negative value to 0",
+					"matchID", m.ID, "column", name, "value", v)
 			}
 		},
 	}

--- a/internal/state/quarantine_test.go
+++ b/internal/state/quarantine_test.go
@@ -1,0 +1,83 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuarantineCompetitionFile(t *testing.T) {
+	newComp := func(t *testing.T) (*Store, string) {
+		t.Helper()
+		dir := t.TempDir()
+		s, err := NewStore(dir)
+		require.NoError(t, err)
+		require.NoError(t, s.SaveCompetition(&Competition{ID: "c", Name: "C"}))
+		require.NoError(t, s.atomicWrite(s.compPath("c", "bracket.json"), []byte("broken{"), 0600))
+		return s, dir
+	}
+
+	t.Run("renames rather than deletes, and the bytes survive", func(t *testing.T) {
+		s, dir := newComp(t)
+		name, err := s.QuarantineCompetitionFile("c", "bracket.json")
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(name, "bracket.json.corrupt-"), "got %q", name)
+
+		_, statErr := os.Stat(s.compPath("c", "bracket.json"))
+		assert.True(t, os.IsNotExist(statErr), "the original name is free again")
+
+		kept, err := os.ReadFile(filepath.Join(dir, "competitions", "c", name)) // #nosec G304
+		require.NoError(t, err)
+		assert.Equal(t, "broken{", string(kept))
+	})
+
+	t.Run("a second quarantine in the same second does not overwrite the first", func(t *testing.T) {
+		// The one thing this function exists to prevent. Second granularity
+		// reads well to an operator but collides trivially, so the probe for a
+		// free name is load-bearing rather than defensive.
+		s, dir := newComp(t)
+		first, err := s.QuarantineCompetitionFile("c", "bracket.json")
+		require.NoError(t, err)
+		require.NoError(t, s.atomicWrite(s.compPath("c", "bracket.json"), []byte("broken again{"), 0600))
+		second, err := s.QuarantineCompetitionFile("c", "bracket.json")
+		require.NoError(t, err)
+		require.NotEqual(t, first, second)
+
+		a, err := os.ReadFile(filepath.Join(dir, "competitions", "c", first)) // #nosec G304
+		require.NoError(t, err)
+		b, err := os.ReadFile(filepath.Join(dir, "competitions", "c", second)) // #nosec G304
+		require.NoError(t, err)
+		assert.Equal(t, "broken{", string(a), "the first copy is still intact")
+		assert.Equal(t, "broken again{", string(b))
+	})
+
+	t.Run("only allowed artifacts, and no path traversal", func(t *testing.T) {
+		s, _ := newComp(t)
+		for _, name := range []string{"", "tournament.md", "../tournament.md", "competitions/c/bracket.json"} {
+			_, err := s.QuarantineCompetitionFile("c", name)
+			assert.Error(t, err, "filename %q must be refused", name)
+		}
+	})
+
+	t.Run("a missing file is an error, not a silent success", func(t *testing.T) {
+		// Unlike the idempotent delete: quarantining nothing means the caller's
+		// premise (this file is broken) was already false.
+		s, _ := newComp(t)
+		_, err := s.QuarantineCompetitionFile("c", "pools.csv")
+		require.Error(t, err)
+		assert.True(t, os.IsNotExist(err), "got %v", err)
+	})
+
+	t.Run("moves the file version on, so derived caches invalidate", func(t *testing.T) {
+		s, _ := newComp(t)
+		before := s.FileVersion("c", "bracket.json")
+		_, err := s.QuarantineCompetitionFile("c", "bracket.json")
+		require.NoError(t, err)
+		assert.Greater(t, s.FileVersion("c", "bracket.json"), before,
+			"losing an artifact changes derived state exactly as a write does")
+	})
+}

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6221,6 +6221,44 @@ button.pool-match-row {
   color: var(--warn-ink);
 }
 
+/* Data-integrity notices (data_integrity.jsx). They ride on the shared .alert
+   --warn family rather than inventing a colour: this is a caution an operator
+   must act on, which is exactly what that family already means, and amber stays
+   clear of red (Aka/danger) per DESIGN.md Principle 3.
+   The two additions are layout only: the leading glyph sits beside the text
+   rather than wrapping under it. */
+.data-issue {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  line-height: 1.4;
+}
+
+/* The per-match variant sits directly beneath the match row it describes, so it
+   is inset to read as belonging to that row and tightened so a pool with a
+   couple of unreadable encounters does not push the standings off screen. */
+.data-issue--inline {
+  margin: 2px 0 6px 20px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+/* The competition-level banner stacks several paragraphs and a button, so it
+   needs room the inline variant does not. */
+.data-issue--banner {
+  margin-bottom: 12px;
+}
+
+.data-issue__list {
+  margin: 6px 0;
+  padding-left: 18px;
+}
+
+.data-issue__list code {
+  font-size: 12px;
+  word-break: break-word;
+}
+
 .alert--success {
   background: var(--ok-soft);
   border-color: #86efac; /* green-300: alert border is stronger than the hairline ok-border token */

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6243,6 +6243,16 @@ button.pool-match-row {
   font-size: 12px;
 }
 
+/* The editor variant sits between the head and the scoring controls, in both
+   the wide overlay and the narrow shiaijo inline panel (one shared `inner`
+   renders both, so they cannot diverge). Tighter than the banner: it must not
+   push the bout rows off a landscape tablet. */
+.data-issue--editor {
+  margin: 0 0 10px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
 /* The competition-level banner stacks several paragraphs and a button, so it
    needs room the inline variant does not. */
 .data-issue--banner {

--- a/web-mobile/css/styles.css
+++ b/web-mobile/css/styles.css
@@ -6238,7 +6238,7 @@ button.pool-match-row {
    is inset to read as belonging to that row and tightened so a pool with a
    couple of unreadable encounters does not push the standings off screen. */
 .data-issue--inline {
-  margin: 2px 0 6px 20px;
+  margin: 4px 0 6px 20px;
   padding: 6px 10px;
   font-size: 12px;
 }
@@ -6261,7 +6261,7 @@ button.pool-match-row {
 
 .data-issue__list {
   margin: 6px 0;
-  padding-left: 18px;
+  padding-left: 20px;
 }
 
 .data-issue__list code {

--- a/web-mobile/js/__tests__/data_integrity.test.jsx
+++ b/web-mobile/js/__tests__/data_integrity.test.jsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  matchDataUnreadable,
+  unreadableMatches,
+  dataIssueText,
+  bracketIssue,
+  canRebuildBracket,
+} from '../data_integrity.jsx';
+
+// data_integrity.jsx is the ONE owner of what the operator is told when a file
+// does not say what the app expects. These pin the two rules that cannot be
+// re-derived at a call site without drifting: which state counts as a problem,
+// and which audience is allowed to see it.
+
+describe('matchDataUnreadable: the one test for a lost encounter', () => {
+  it('is true only when the server says the cell would not parse', () => {
+    expect(matchDataUnreadable({ subResultsUnreadable: true })).toBe(true);
+    expect(matchDataUnreadable({ subResultsUnreadable: false })).toBe(false);
+    // An ordinary team match with no sub-bouts recorded yet is NOT a problem.
+    expect(matchDataUnreadable({ subResults: [] })).toBe(false);
+    expect(matchDataUnreadable(null)).toBe(false);
+    expect(matchDataUnreadable(undefined)).toBe(false);
+  });
+
+  it('counts only the affected matches in a list', () => {
+    const matches = [
+      { id: 'a' },
+      { id: 'b', subResultsUnreadable: true },
+      { id: 'c', subResultsUnreadable: true },
+    ];
+    expect(unreadableMatches(matches).map(m => m.id)).toEqual(['b', 'c']);
+    expect(unreadableMatches(null)).toEqual([]);
+  });
+});
+
+describe('dataIssueText: a line an operator can act on', () => {
+  it('names the file, the position and the parser reason', () => {
+    expect(dataIssueText({ file: 'bracket.json', line: 47, column: 12, detail: "invalid character 'x'" }))
+      .toBe("bracket.json, line 47, column 12: invalid character 'x'");
+  });
+
+  it('omits the position when the parser could not place the fault', () => {
+    // Rather than printing "line 0", which reads as a real location.
+    expect(dataIssueText({ file: 'pools.csv', line: 0, column: 0, detail: 'unexpected end of file' }))
+      .toBe('pools.csv: unexpected end of file');
+  });
+
+  it('is empty for nothing', () => {
+    expect(dataIssueText(null)).toBe('');
+    expect(dataIssueText({})).toBe('');
+  });
+});
+
+describe('canRebuildBracket: where a rebuild would invent a draw', () => {
+  // A pool-fed competition keeps its draw in pools.csv. A direct-elimination
+  // competition keeps it ONLY in bracket.json, so rebuilding from today's
+  // roster produces different pairings rather than restoring these.
+  it('allows the formats whose draw survives elsewhere', () => {
+    expect(canRebuildBracket({ format: 'mixed' })).toBe(true);
+    expect(canRebuildBracket({ format: 'league' })).toBe(true);
+    expect(canRebuildBracket({ format: 'swiss' })).toBe(true);
+  });
+
+  it('refuses direct elimination, where the file IS the draw', () => {
+    expect(canRebuildBracket({ format: 'playoffs' })).toBe(false);
+    expect(canRebuildBracket({})).toBe(false);
+    expect(canRebuildBracket(null)).toBe(false);
+  });
+
+  it('finds the bracket among several issues', () => {
+    const issues = [{ file: 'pools.csv' }, { file: 'bracket.json', line: 3 }];
+    expect(bracketIssue(issues).line).toBe(3);
+    expect(bracketIssue([{ file: 'pools.csv' }])).toBeNull();
+    expect(bracketIssue(null)).toBeNull();
+  });
+});

--- a/web-mobile/js/__tests__/data_integrity.test.jsx
+++ b/web-mobile/js/__tests__/data_integrity.test.jsx
@@ -4,7 +4,12 @@ import {
   unreadableMatches,
   dataIssueText,
   bracketIssue,
-  canRebuildBracket,
+  bracketRecoveryKind,
+  bracketResetPrompt,
+  bracketResetToast,
+  BRACKET_RECOVERY_REBUILD,
+  BRACKET_RECOVERY_DISCARD,
+  BRACKET_RECOVERY_NONE,
 } from '../data_integrity.jsx';
 
 // data_integrity.jsx is the ONE owner of what the operator is told when a file
@@ -51,20 +56,57 @@ describe('dataIssueText: a line an operator can act on', () => {
   });
 });
 
-describe('canRebuildBracket: where a rebuild would invent a draw', () => {
-  // A pool-fed competition keeps its draw in pools.csv. A direct-elimination
-  // competition keeps it ONLY in bracket.json, so rebuilding from today's
-  // roster produces different pairings rather than restoring these.
-  it('allows the formats whose draw survives elsewhere', () => {
-    expect(canRebuildBracket({ format: 'mixed' })).toBe(true);
-    expect(canRebuildBracket({ format: 'league' })).toBe(true);
-    expect(canRebuildBracket({ format: 'swiss' })).toBe(true);
+describe('bracketRecoveryKind: what a lost bracket can be recovered with', () => {
+  // The three outcomes are pinned format-by-format against the shared Go/JS
+  // table in format_draws_bracket.test.jsx. These cover the shape of the
+  // answer and the inputs that table cannot carry.
+  it('rebuilds only where the draw survives in another file', () => {
+    expect(bracketRecoveryKind({ format: 'mixed' })).toBe(BRACKET_RECOVERY_REBUILD);
   });
 
-  it('refuses direct elimination, where the file IS the draw', () => {
-    expect(canRebuildBracket({ format: 'playoffs' })).toBe(false);
-    expect(canRebuildBracket({})).toBe(false);
-    expect(canRebuildBracket(null)).toBe(false);
+  it('discards a vestigial bracket for the formats that never draw one', () => {
+    expect(bracketRecoveryKind({ format: 'league' })).toBe(BRACKET_RECOVERY_DISCARD);
+    expect(bracketRecoveryKind({ format: 'swiss' })).toBe(BRACKET_RECOVERY_DISCARD);
+  });
+
+  it('offers nothing where the file IS the draw, including an unknown format', () => {
+    expect(bracketRecoveryKind({ format: 'playoffs' })).toBe(BRACKET_RECOVERY_NONE);
+    // A typo in a hand-edited config.md takes the draw pipeline's default
+    // branch and gets a standalone playoffs bracket, so it must be refused for
+    // the same reason playoffs is. The first version of this predicate offered
+    // it a rebuild.
+    expect(bracketRecoveryKind({ format: 'not-a-format' })).toBe(BRACKET_RECOVERY_NONE);
+    expect(bracketRecoveryKind({})).toBe(BRACKET_RECOVERY_NONE);
+    expect(bracketRecoveryKind(null)).toBe(BRACKET_RECOVERY_NONE);
+  });
+});
+
+describe('the words that go with each recovery kind', () => {
+  it('never asks a competition without a knockout stage to reset one', () => {
+    const p = bracketResetPrompt(BRACKET_RECOVERY_DISCARD, 'Kanto League');
+    expect(p.message).toContain('Kanto League');
+    expect(p.message).toContain('no knockout stage');
+    expect(p.message).not.toMatch(/reset the knockout/i);
+    expect(p.confirmLabel).not.toMatch(/knockout/i);
+  });
+
+  it('names the knockout stage where there is one', () => {
+    const p = bracketResetPrompt(BRACKET_RECOVERY_REBUILD, 'Open Cup');
+    expect(p.message).toMatch(/knockout stage/i);
+    expect(p.confirmLabel).toBe('Reset knockout stage');
+  });
+
+  // The toast reports what the SERVER did, not what the client predicted, so a
+  // false `rebuilt` can never be dressed up as a rebuild.
+  it('does not claim a rebuild the server did not do', () => {
+    const said = bracketResetToast('bracket.json.corrupt-20260823-101500', false);
+    expect(said).toContain('bracket.json.corrupt-20260823-101500');
+    expect(said).toContain('Nothing was rebuilt');
+    expect(said).not.toMatch(/knockout stage reset/i);
+  });
+
+  it('says so when the server did rebuild', () => {
+    expect(bracketResetToast('x', true)).toMatch(/knockout stage reset/i);
   });
 
   it('finds the bracket among several issues', () => {

--- a/web-mobile/js/__tests__/format_draws_bracket.test.jsx
+++ b/web-mobile/js/__tests__/format_draws_bracket.test.jsx
@@ -6,6 +6,12 @@ import {
   shiaijoCountErrorFor,
   shiaijoCountHintFor,
 } from '../admin_helpers.jsx';
+import {
+  bracketRecoveryKind,
+  BRACKET_RECOVERY_REBUILD,
+  BRACKET_RECOVERY_DISCARD,
+  BRACKET_RECOVERY_NONE,
+} from '../data_integrity.jsx';
 
 // JS half of the shared Go/JS golden table for "does this format draw a
 // bracket?": see the `_comment` in format_draws_bracket.json for why the table
@@ -31,6 +37,30 @@ describe('formatDrawsBracket Go/JS mirror', () => {
 
   it.each(table.cases)('$why', ({ format, drawsBracket }) => {
     expect(formatDrawsBracket(format)).toBe(drawsBracket);
+  });
+
+  // SECOND QUESTION, same table: which formats can have a lost bracket.json
+  // REBUILT rather than only moved aside. Go half:
+  // TestCompetitionRebuildableFromPools_GoldenTable and
+  // TestQuarantineCorruptBracket_OutcomeFollowsTheFormatTable.
+  //
+  // This exists because the console's first version of this predicate was a
+  // hand-written `mixed || league || swiss`, which offered a rebuild to every
+  // UNRECOGNISED format -- the half that a hand-written list gets wrong, and
+  // the exact failure this table was built to stop.
+  describe('bracketRecoveryKind reads the same table', () => {
+    it.each(table.cases)('$why (recovery kind)', ({ format, drawsBracket, rebuildableFromPools }) => {
+      const expected = rebuildableFromPools
+        ? BRACKET_RECOVERY_REBUILD
+        : (drawsBracket ? BRACKET_RECOVERY_NONE : BRACKET_RECOVERY_DISCARD);
+      expect(bracketRecoveryKind({ format })).toBe(expected);
+    });
+
+    // The table must not describe a state the draw pipeline cannot reach: a
+    // format whose draw builds no bracket has none to rebuild.
+    it.each(table.cases)('$why (rebuildable implies drawsBracket)', ({ drawsBracket, rebuildableFromPools }) => {
+      if (rebuildableFromPools) expect(drawsBracket).toBe(true);
+    });
   });
 
   // The scope is only worth pinning because of what it gates. These are the two

--- a/web-mobile/js/__tests__/render/data_integrity.render.test.jsx
+++ b/web-mobile/js/__tests__/render/data_integrity.render.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DataIssueBanner } from '../../data_integrity.jsx';
+
+// The banner is the LOUD-class surface: a whole file will not parse, every
+// write to it is refused, and the operator has to choose between repairing it
+// and resetting. Mounted for real, because what matters is which of those two
+// options it actually offers.
+
+describe('DataIssueBanner', () => {
+  const bracketBroken = [{ file: 'bracket.json', line: 47, column: 12, detail: "invalid character 'x'" }];
+
+  it('renders nothing when there is nothing to repair', () => {
+    const { container } = render(<DataIssueBanner issues={[]} competition={{ format: 'mixed' }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('names the file and position, and says the file is untouched', () => {
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'mixed' }} />);
+    expect(screen.getByRole('alert').textContent).toContain('bracket.json, line 47, column 12');
+    // The reassurance is the whole reason repair is the recommended option.
+    expect(screen.getByRole('alert').textContent).toMatch(/still exactly as it was last saved/);
+  });
+
+  it('offers the reset for a pool-fed competition, and states what it costs', () => {
+    const onReset = vi.fn();
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'mixed' }} onReset={onReset} />);
+    const text = screen.getByRole('alert').textContent;
+    // The four facts an operator needs before choosing.
+    expect(text).toMatch(/never deleted/);
+    expect(text).toMatch(/Pools, participants and pool results are untouched/);
+    expect(text).toMatch(/re-entered from the score sheets/);
+    expect(text).toMatch(/Check the rebuilt pairings against your printed bracket/);
+    screen.getByRole('button', { name: /Reset the knockout stage/ }).click();
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it('does NOT offer the reset for direct elimination, and explains why', () => {
+    // An action that can only fail is worse than an explanation: the server
+    // refuses this case, so the button must not be offered at all.
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'playoffs' }} onReset={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /Reset the knockout stage/ })).toBeNull();
+    expect(screen.getByRole('alert').textContent)
+      .toMatch(/only record of who was drawn against whom/);
+  });
+
+  it('does not offer a reset when the bracket is fine and another file is not', () => {
+    render(<DataIssueBanner issues={[{ file: 'pools.csv', line: 2, column: 1, detail: 'bare quote' }]}
+      competition={{ format: 'mixed' }} onReset={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /Reset the knockout stage/ })).toBeNull();
+    expect(screen.getByRole('alert').textContent).toContain('pools.csv, line 2, column 1');
+  });
+
+  it('disables the reset while it is running', () => {
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'mixed' }} onReset={vi.fn()} resetting />);
+    expect(screen.getByRole('button', { name: /Resetting/ }).disabled).toBe(true);
+  });
+});

--- a/web-mobile/js/__tests__/render/data_integrity.render.test.jsx
+++ b/web-mobile/js/__tests__/render/data_integrity.render.test.jsx
@@ -36,6 +36,31 @@ describe('DataIssueBanner', () => {
     expect(onReset).toHaveBeenCalled();
   });
 
+  it('offers a plain move-aside for a league, and promises no rebuild', () => {
+    // A league has no knockout stage, so every word about resetting one, about
+    // bouts to re-enter and about pairings to check against a printed bracket
+    // would be false. The button is still offered: the file blocks the load and
+    // moving it aside costs nothing.
+    const onReset = vi.fn();
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'league' }} onReset={onReset} />);
+    const text = screen.getByRole('alert').textContent;
+    expect(text).toMatch(/no knockout stage/);
+    expect(text).toMatch(/Nothing is rebuilt/);
+    expect(text).not.toMatch(/re-entered from the score sheets/);
+    expect(text).not.toMatch(/printed bracket/);
+    expect(screen.queryByRole('button', { name: /Reset the knockout stage/ })).toBeNull();
+    screen.getByRole('button', { name: /Move the file aside/ }).click();
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it('offers nothing for an unrecognised format, which is drawn as direct elimination', () => {
+    // A typo in a hand-edited config.md. It takes the draw pipeline's default
+    // branch, so the file IS its draw and a rebuild would invent a new one.
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'not-a-format' }} onReset={vi.fn()} />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByRole('alert').textContent).toMatch(/only record of who was drawn against whom/);
+  });
+
   it('does NOT offer the reset for direct elimination, and explains why', () => {
     // An action that can only fail is worse than an explanation: the server
     // refuses this case, so the button must not be offered at all.
@@ -52,8 +77,15 @@ describe('DataIssueBanner', () => {
     expect(screen.getByRole('alert').textContent).toContain('pools.csv, line 2, column 1');
   });
 
-  it('disables the reset while it is running', () => {
+  it('disables the reset while it is running, and says what it is doing', () => {
     render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'mixed' }} onReset={vi.fn()} resetting />);
     expect(screen.getByRole('button', { name: /Resetting/ }).disabled).toBe(true);
+  });
+
+  it('does not say "resetting" while moving a league file aside', () => {
+    // Nothing is being reset there, so the busy label follows the action too.
+    render(<DataIssueBanner issues={bracketBroken} competition={{ format: 'league' }} onReset={vi.fn()} resetting />);
+    expect(screen.queryByRole('button', { name: /Resetting/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /Moving/ }).disabled).toBe(true);
   });
 });

--- a/web-mobile/js/__tests__/render/pools_data_issues.render.test.jsx
+++ b/web-mobile/js/__tests__/render/pools_data_issues.render.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { PoolsViewer } from '../../viewer_standings.jsx';
+
+// THE AUDIENCE GATE.
+//
+// The admin console and the public viewer render this SAME component off the
+// SAME public payload, so the server cannot tell the two apart: the flag it
+// reveals travels on a payload the console itself reads, and stripping it
+// server-side would blank it for the operator too (and make it vanish again on
+// the next SSE broadcast). The whole gate is therefore the showDataIssues prop,
+// which only the admin callers pass. If that stops working, a data-integrity
+// warning appears on a spectator's phone at a live event.
+
+beforeAll(async () => {
+  // bracket.jsx publishes window.matchStateCell, which every match row calls.
+  await import('../../bracket.jsx');
+});
+
+const pools = [{
+  poolName: 'Pool A',
+  players: [{ id: 'p1', name: 'Kenshikan' }, { id: 'p2', name: 'Sanshukan' }],
+}];
+const poolMatches = [{
+  id: 'Pool A-1',
+  sideA: { id: 'p1', name: 'Kenshikan' },
+  sideB: { id: 'p2', name: 'Sanshukan' },
+  status: 'completed',
+  winner: { id: 'p1', name: 'Kenshikan' },
+  // The server flagged this encounter: its sub-bout cell would not parse.
+  subResultsUnreadable: true,
+}];
+const competition = { id: 'c', name: 'C', format: 'mixed', kind: 'team', teamSize: 3 };
+const standings = { 'Pool A': [] };
+
+const NOTICE = /individual bouts could not be read/;
+const POOL_NOTICE = /IV and PW columns below are incomplete/;
+
+describe('PoolsViewer data-integrity notices', () => {
+  it('shows them on an operator surface, which opts in', () => {
+    render(<PoolsViewer pools={pools} standings={standings} poolMatches={poolMatches}
+      competition={competition} tweaks={{}} highlightPlayers={[]} showDataIssues />);
+    expect(screen.getByText(NOTICE)).toBeTruthy();
+    expect(screen.getByText(POOL_NOTICE)).toBeTruthy();
+  });
+
+  it('shows NOTHING on the public viewer, which does not', () => {
+    render(<PoolsViewer pools={pools} standings={standings} poolMatches={poolMatches}
+      competition={competition} tweaks={{}} highlightPlayers={[]} />);
+    expect(screen.queryByText(NOTICE)).toBeNull();
+    expect(screen.queryByText(POOL_NOTICE)).toBeNull();
+    // The match itself still renders: the encounter is not hidden, only the
+    // operator-facing explanation of what is missing from it.
+    expect(screen.getAllByText("Kenshikan").length).toBeGreaterThan(0);
+  });
+
+  it('shows nothing when every cell parsed, even on the operator surface', () => {
+    const clean = [{ ...poolMatches[0], subResultsUnreadable: false }];
+    render(<PoolsViewer pools={pools} standings={standings} poolMatches={clean}
+      competition={competition} tweaks={{}} highlightPlayers={[]} showDataIssues />);
+    expect(screen.queryByText(NOTICE)).toBeNull();
+    expect(screen.queryByText(POOL_NOTICE)).toBeNull();
+  });
+});

--- a/web-mobile/js/__tests__/render/team_editor_data_issue.render.test.jsx
+++ b/web-mobile/js/__tests__/render/team_editor_data_issue.render.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+// The operator most likely to notice a lost encounter is the one who opens it
+// to score it and finds the bout rows empty. This is the surface that answers
+// their actual question ("did this never get scored?") and names the repair.
+//
+// It is placed inside the team editor's shared `inner`, which renders BOTH the
+// wide overlay and the narrow shiaijo inline panel, so both variants are
+// asserted here: a placement that reached only one of them has happened before.
+
+const STUBBED_GLOBALS = {
+  isHikiwake: () => false,
+  arraysEqual: (a, b) => a.length === b.length && a.every((v, i) => v === b[i]),
+  isKikenDecision: () => false,
+  isTextEntry: () => false,
+  isInteractiveTarget: () => false,
+  confirmDialog: vi.fn().mockResolvedValue(true),
+  resolveRoundIndex: () => 0,
+  API: {
+    fetchCompetitionDetails: vi.fn().mockResolvedValue(null),
+    recordScore: vi.fn(),
+    recordDaihyosen: vi.fn(),
+    removeDaihyosen: vi.fn(),
+    putMatchLineup: vi.fn(),
+    recordDecision: vi.fn(),
+  },
+  AdminLineupHelpers: { rosterFor: vi.fn().mockReturnValue([]) },
+  compMatches: () => [],
+  Term: ({ children }) => <span>{children}</span>,
+  GlossaryHint: ({ name }) => <span title={name} />,
+};
+
+const originals = {};
+let ScoreEditorModal;
+
+beforeAll(async () => {
+  for (const [k, v] of Object.entries(STUBBED_GLOBALS)) {
+    originals[k] = { had: k in window, value: window[k] };
+    window[k] = v;
+  }
+  await import('../../admin_scoring_modal.jsx');
+  ScoreEditorModal = window.ScoreEditorModal;
+});
+
+afterAll(() => {
+  for (const [k, orig] of Object.entries(originals)) {
+    if (orig.had) window[k] = orig.value;
+    else delete window[k];
+  }
+});
+
+function teamMatch(overrides = {}) {
+  return {
+    id: 'm2',
+    status: 'scheduled',
+    phase: 'pool',
+    poolName: 'Pool 1',
+    court: 'A',
+    compKind: 'team',
+    teamSize: 3,
+    sideA: { id: 'team-A', name: 'Kenshikan' },
+    sideB: { id: 'team-B', name: 'Sanshukan' },
+    ...overrides,
+  };
+}
+
+const NOTE = /could not be read from the results\s+file/;
+
+function renderEditor(match, variant) {
+  return render(
+    <ScoreEditorModal match={match} onClose={vi.fn()} onSubmit={vi.fn()} password="" variant={variant} />
+  );
+}
+
+describe('team score editor: unreadable sub-bout cell', () => {
+  it('tells the operator why the bout rows are empty, in the overlay', () => {
+    renderEditor(teamMatch({ subResultsUnreadable: true }), 'modal');
+    const note = screen.getByText(NOTE);
+    expect(note).toBeTruthy();
+    // It must promise the right thing: the text is still on disk, and saving
+    // from here is the repair. An operator told only "unreadable" would
+    // reasonably assume the bouts are gone.
+    expect(note.textContent).toMatch(/still in the file/);
+    expect(note.textContent).toMatch(/Entering the bouts here replaces it/);
+  });
+
+  it('shows it in the narrow shiaijo inline panel too', () => {
+    // Same `inner`, so this cannot diverge from the overlay by construction.
+    // Asserted anyway: that shared-inner property is what the placement relies
+    // on, and a future refactor that splits them would break it silently.
+    renderEditor(teamMatch({ subResultsUnreadable: true }), 'inline');
+    expect(screen.getByText(NOTE)).toBeTruthy();
+  });
+
+  it('says nothing when the encounter read fine', () => {
+    renderEditor(teamMatch(), 'modal');
+    expect(screen.queryByText(NOTE)).toBeNull();
+  });
+
+  it('says nothing for an encounter that simply has no bouts yet', () => {
+    // An unscored team match also shows empty rows. The notice must describe a
+    // PARSE failure only, never the ordinary pre-match state.
+    renderEditor(teamMatch({ status: 'running', subResults: [] }), 'modal');
+    expect(screen.queryByText(NOTE)).toBeNull();
+  });
+});

--- a/web-mobile/js/admin_competition.jsx
+++ b/web-mobile/js/admin_competition.jsx
@@ -477,7 +477,7 @@ function AdminCompetition({ tournament, competition, pools, poolMatches, standin
             </div>
           </div>
           <div>
-            {section === "overview" && <AdminCompOverview c={c} tournament={t} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} password={password} />}
+            {section === "overview" && <AdminCompOverview c={c} tournament={t} pools={pools} poolMatches={poolMatches} bracket={bracket} onSection={onSection} password={password} showToast={showToast} onRefreshCompetition={onRefreshCompetition} />}
             {section === "participants" && <AdminParticipants c={c} tournament={t} onUpdate={onUpdate} password={password} showToast={showToast} onSection={onSection} onBack={onBack} />}
             {section === "lineups" && window.AdminTeamLineupsList && <window.AdminTeamLineupsList comp={c} password={password} showToast={showToast} />}
             {section === "settings" && <AdminSettings c={c} tournament={t} onUpdate={onUpdate} onBack={onBack} password={password} showToast={showToast} onStatusChange={setLocalStatus} />}

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -10,6 +10,9 @@ import { EstimateHeadline } from './admin_schedule_utils.jsx';
 // settings preview so this stat, the checklist and the preview cannot
 // disagree about what counts as seeded.
 import { seededRanks } from './admin_helpers.jsx';
+// One owner for what the operator is told when a file on disk does not say what
+// the app expects; shared with the pool surfaces so the wording cannot drift.
+import { DataIssueBanner } from './data_integrity.jsx';
 
 const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
 
@@ -224,7 +227,34 @@ function overviewResultsSection(format, hasBracket) {
 // ---------------------------------------------------------------------------
 // AdminCompOverview: status-aware overview component
 // ---------------------------------------------------------------------------
-function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSection, password }) {
+function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSection, password, showToast, onRefreshCompetition }) {
+  // Recovery from a competition file that will not parse. Held here rather than
+  // in the banner because the banner owns the WORDING (shared with the other
+  // data-integrity surfaces) and this page owns the network call and the
+  // refresh, exactly like discardDraw in admin_competition.jsx.
+  const [quarantining, setQuarantining] = useStateA(false);
+  const quarantineBracket = async () => {
+    const ok = await window.confirmDialog({
+      message: `Reset the knockout stage for "${c.name}"? The unreadable file is kept, renamed aside, `
+        + `but the knockout results inside it will no longer be used and must be re-entered.`,
+      confirmLabel: "Reset knockout stage",
+      danger: true,
+    });
+    if (!ok) return;
+    const admin = await window.promptAdminPassword();
+    if (admin === null) return;
+    setQuarantining(true);
+    try {
+      const res = await window.API.quarantineBracket(c.id, password, admin);
+      showToast?.(`Knockout stage reset. The unreadable file is kept as ${res.quarantinedAs}`);
+      onRefreshCompetition?.();
+    } catch (e) {
+      console.error("Quarantine bracket failed:", e);
+      showToast?.(e.message, "error");
+    } finally {
+      setQuarantining(false);
+    }
+  };
   // Prefer the props passed from the detail fetch, but fall back to whatever
   // is already on `c` when the detail hasn't loaded yet (or errored). Using ??
   // avoids overwriting non-null fields on `c` with undefined prop values.
@@ -695,6 +725,15 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
 
   return (
     <div>
+      {/* First, above everything: a file that will not parse blocks scoring,
+          and every other number on this page is describing whatever survived
+          the failed load. */}
+      <DataIssueBanner
+        issues={c.dataIssues}
+        competition={c}
+        onReset={quarantineBracket}
+        resetting={quarantining}
+      />
       {renderStatsStrip()}
       {renderPrimaryContent()}
       {renderEstimateFooter()}

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -725,9 +725,18 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
 
   return (
     <div>
-      {/* First, above everything: a file that will not parse blocks scoring,
-          and every other number on this page is describing whatever survived
-          the failed load. */}
+      {/* First in the overview COLUMN: a file that will not parse blocks
+          scoring, and every other number on this page is describing whatever
+          survived the failed load.
+          Not first on the PAGE below 720px, though. There `.comp-rail` stops
+          being a left column and stacks above this one, so the banner lands
+          about 650px down, under the section nav and off a phone's first
+          screen (measured at 375x812). Putting it genuinely first would mean
+          hoisting it into the page shell above the rail, which is a change to
+          a surface this bead does not otherwise touch. Left here because the
+          admin console is a tablet-and-up surface in practice (DESIGN.md
+          Principle 4) and 768px still renders the rail beside this column,
+          with the banner above the fold. */}
       <DataIssueBanner
         issues={c.dataIssues}
         competition={c}

--- a/web-mobile/js/admin_competition_overview.jsx
+++ b/web-mobile/js/admin_competition_overview.jsx
@@ -12,7 +12,12 @@ import { EstimateHeadline } from './admin_schedule_utils.jsx';
 import { seededRanks } from './admin_helpers.jsx';
 // One owner for what the operator is told when a file on disk does not say what
 // the app expects; shared with the pool surfaces so the wording cannot drift.
-import { DataIssueBanner } from './data_integrity.jsx';
+import {
+  DataIssueBanner,
+  bracketRecoveryKind,
+  bracketResetPrompt,
+  bracketResetToast,
+} from './data_integrity.jsx';
 
 const { useState: useStateA, useEffect: useEffectA, useRef: useRefA } = React;
 
@@ -234,10 +239,13 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
   // refresh, exactly like discardDraw in admin_competition.jsx.
   const [quarantining, setQuarantining] = useStateA(false);
   const quarantineBracket = async () => {
+    // The words come from data_integrity.jsx, which owns every one the operator
+    // reads about unreadable data. A league has no knockout stage, so it must
+    // not be asked to confirm resetting one.
+    const prompt = bracketResetPrompt(bracketRecoveryKind(c), c.name);
     const ok = await window.confirmDialog({
-      message: `Reset the knockout stage for "${c.name}"? The unreadable file is kept, renamed aside, `
-        + `but the knockout results inside it will no longer be used and must be re-entered.`,
-      confirmLabel: "Reset knockout stage",
+      message: prompt.message,
+      confirmLabel: prompt.confirmLabel,
       danger: true,
     });
     if (!ok) return;
@@ -246,7 +254,10 @@ function AdminCompOverview({ c, tournament, pools, poolMatches, bracket, onSecti
     setQuarantining(true);
     try {
       const res = await window.API.quarantineBracket(c.id, password, admin);
-      showToast?.(`Knockout stage reset. The unreadable file is kept as ${res.quarantinedAs}`);
+      // res.rebuilt is the SERVER's answer, not the kind we predicted above: it
+      // is what actually happened, and a toast that guessed would one day tell
+      // an operator a stage was rebuilt when nothing was.
+      showToast?.(bracketResetToast(res.quarantinedAs, res.rebuilt));
       onRefreshCompetition?.();
     } catch (e) {
       console.error("Quarantine bracket failed:", e);

--- a/web-mobile/js/admin_pools.jsx
+++ b/web-mobile/js/admin_pools.jsx
@@ -524,12 +524,17 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
           admin_shiaijo.jsx's ShiaijoContext. */}
       {isLeague ? (
         LeagueStandingsViewer ? (
+          // showDataIssues on both branches: this is an operator surface, and
+          // the same components render for spectators from viewer_competition
+          // WITHOUT it. That prop is the whole audience gate, because the flags
+          // it reveals travel on the public payload the admin console reads.
           <LeagueStandingsViewer
             competition={c}
             poolMatches={poolMatches}
             tweaks={tweaks}
             onMatchClick={(m) => setScoreOpenId(m.id)}
             highlightPlayers={[]}
+            showDataIssues
           />
         ) : null
       ) : (
@@ -542,6 +547,7 @@ function AdminPools({ c, pools, poolMatches, standings, tweaks, onEditScore, pas
             tweaks={tweaks}
             onMatchClick={(m) => setScoreOpenId(m.id)}
             highlightPlayers={[]}
+            showDataIssues
           />
         ) : null
       )}

--- a/web-mobile/js/admin_scoring_team.jsx
+++ b/web-mobile/js/admin_scoring_team.jsx
@@ -115,6 +115,9 @@ export function preserveStoredDaihyosenVerdict({ armed, pickedSide, tied, existi
 // re-exports them onward) continue to work.
 import { resolveMatchLineup, resolveLineupTeamId, resolveBoutSideName, POS_KEYS_5, POS_LABELS_5 } from './lineup_resolver.jsx';
 import { DAIHYOSEN_POSITION } from './pool_ids.jsx';
+// The shared owner of what an operator is told about unreadable data; the
+// editor gets the repair-oriented wording, the pool surfaces get theirs.
+import { matchDataUnreadable, UnreadableEditorNote } from './data_integrity.jsx';
 
 // Position keys are generated inline in TeamScoreEditorModal (numbered "1".."N")
 // from teamSize and any persisted kachinuki bouts; the upper bound everywhere is
@@ -2014,6 +2017,9 @@ export function TeamScoreEditorModal({ match, teamSize, onClose, onSubmit, onSub
         </div>
 
         <div className="editor-modal__body">
+          {/* Inside `inner`, so the wide overlay and the narrow shiaijo inline
+              panel get it from ONE placement and cannot diverge. */}
+          {matchDataUnreadable(m) ? <UnreadableEditorNote /> : null}
           {/* Team header */}
           <div className="sb-match" style={{ marginBottom: teamSize === 5 && (lineupIncompleteB || lineupIncompleteA) ? 4 : 16 }}>
             {teamSides.map((s, idx) => (

--- a/web-mobile/js/admin_shiaijo.jsx
+++ b/web-mobile/js/admin_shiaijo.jsx
@@ -1880,6 +1880,7 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
                                         tweaks={tweaks || { showDojo: true }}
                                         onMatchClick={null}
                                         highlightPlayers={[]}
+                                        showDataIssues
                                     />
                                 </div>
                             ) : standingsLoader
@@ -1900,6 +1901,7 @@ function ShiaijoContext({ match, competitions, court, nextPoolName, tweaks, open
                                             tweaks={tweaks || { showDojo: true }}
                                             onMatchClick={null}
                                             highlightPlayers={[]}
+                                            showDataIssues
                                         />
                                     </div>
                                 ) : (

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -88,6 +88,11 @@ function normalizeViewerCompItem(item) {
         ...c,
         poolMatches: item.poolMatches,
         bracket: item.bracket,
+        // Located file failures for this competition, a SIBLING of config on
+        // the wire because they are about the files, not about the record
+        // inside one of them. Hoisted like poolMatches so the console can
+        // render the notice off the flattened competition it already has.
+        dataIssues: item.dataIssues,
         players: (c.players || []).map(normalizePlayer),
     });
 }
@@ -1171,6 +1176,27 @@ const API = {
             const err = await res.json().catch(() => ({}));
             throw new Error(err.error || "Failed to discard draw");
         }
+    },
+    // quarantineBracket: POST /competitions/:id/bracket/quarantine. The way out
+    // of a bracket.json that will not parse, which otherwise blocks every score
+    // write for that competition. Renames the broken file aside (it is NEVER
+    // deleted: it is the only record of the knockout results it holds, and
+    // because it does not parse nothing can count them) and rebuilds the
+    // knockout stage from pools.csv. 400 when the bracket reads fine, and 400
+    // with a reason for a direct-elimination competition, where the file is the
+    // only record of the DRAW and rebuilding would invent different pairings
+    // rather than restore these. Elevated-gated like discardDraw: it discards
+    // recorded results.
+    async quarantineBracket(id, password, adminPassword) {
+        const res = await fetch(`/api/competitions/${id}/bracket/quarantine`, {
+            method: 'POST',
+            headers: { 'X-Tournament-Password': password, ...adminHdr(adminPassword) }
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(body.error || "Failed to quarantine the bracket file");
+        }
+        return body;
     },
     // completeCompetition: POST /competitions/:id/complete. The only trigger
     // for a bracket-based competition (playoffs, or mixed once its knockout is

--- a/web-mobile/js/api_client.jsx
+++ b/web-mobile/js/api_client.jsx
@@ -1181,10 +1181,13 @@ const API = {
     // of a bracket.json that will not parse, which otherwise blocks every score
     // write for that competition. Renames the broken file aside (it is NEVER
     // deleted: it is the only record of the knockout results it holds, and
-    // because it does not parse nothing can count them) and rebuilds the
-    // knockout stage from pools.csv. 400 when the bracket reads fine, and 400
-    // with a reason for a direct-elimination competition, where the file is the
-    // only record of the DRAW and rebuilding would invent different pairings
+    // because it does not parse nothing can count them). What happens next
+    // depends on the format, and the response says which: `rebuilt` is true when
+    // the knockout was rebuilt from pools.csv (mixed), false when there was no
+    // knockout stage to rebuild and moving the file aside was the whole repair
+    // (league, Swiss). 400 when the bracket reads fine, and 400 with a reason
+    // for any competition that draws its bracket DIRECTLY, where the file is the
+    // only record of the draw and rebuilding would invent different pairings
     // rather than restore these. Elevated-gated like discardDraw: it discards
     // recorded results.
     async quarantineBracket(id, password, adminPassword) {

--- a/web-mobile/js/data_integrity.jsx
+++ b/web-mobile/js/data_integrity.jsx
@@ -67,6 +67,29 @@ export function UnreadableBoutsNote() {
   );
 }
 
+// UnreadableEditorNote: the same fact, said to the one person who can act on
+// it immediately.
+//
+// The other notices explain a consequence to someone reading standings. This
+// one is read by an operator who has just opened the encounter and is looking
+// at empty bout rows, so it answers their actual question ("did this never get
+// scored?") and names the repair they are already one step away from. Saving
+// from here writes real sub-bouts, which supersedes the retained cell and
+// clears the warning everywhere.
+export function UnreadableEditorNote() {
+  return (
+    <div className="alert alert--warn data-issue data-issue--editor" role="status">
+      <span aria-hidden="true">⚠</span>
+      <span>
+        The bouts recorded for this encounter could not be read from the results
+        file, so the rows below start empty. They are not lost: the unreadable
+        text is still in the file. Entering the bouts here replaces it and clears
+        this warning.
+      </span>
+    </div>
+  );
+}
+
 // UnreadablePoolNote: the per-pool line, shown above the standings the missing
 // bouts distort. Named for the consequence rather than the cause, because the
 // consequence is what an operator has to decide about: these are the figures a

--- a/web-mobile/js/data_integrity.jsx
+++ b/web-mobile/js/data_integrity.jsx
@@ -1,0 +1,175 @@
+// data_integrity.jsx: what the operator is told when a file on disk does not
+// say what the app expects, and where that text is decided.
+//
+// The tool invites an organiser to open its files in a spreadsheet or a text
+// editor and correct a wrong cell. Two things can go wrong with that, and they
+// are NOT the same failure, so they get separate words here:
+//
+//   QUIET  a single cell will not parse. The row still loads, the cell degrades
+//          to its documented default, and the competition keeps running. Only
+//          a team encounter's sub-bout cell carries enough to be worth naming:
+//          losing it zeroes that encounter's individual victories and points,
+//          which is what decides a tied pool. Per match, via
+//          `subResultsUnreadable` on the match.
+//
+//   LOUD   the file will not parse at all. The load fails, every write to it is
+//          refused, and the competition is stuck until it is repaired or moved
+//          aside. Per competition, via `dataIssues` on the aggregate.
+//
+// One module because the two share an audience and a voice, and because the
+// three surfaces that show them (the pool match list, the pool standings, the
+// competition overview) must not each invent their own wording for the same
+// state -- the way to keep a display rule consistent here is to give it one
+// owner, not to repeat a literal in three files.
+//
+// NOTE ON AUDIENCE. Both flags travel on the PUBLIC wire, because the admin
+// console reads the same aggregate and the same SSE stream the viewer does, so
+// the server cannot tell the two apart on that path. The gate is here instead:
+// every consumer takes an explicit opt-in, and only the admin surfaces pass it.
+// A spectator has nothing to do with a parse error, so they are never shown one.
+
+// matchDataUnreadable: the ONE test for "this match lost its bouts to a cell
+// that would not parse". Everything else asks this rather than reading the
+// field, so a rename or a change of shape lands in one place.
+export function matchDataUnreadable(m) {
+  return !!(m && m.subResultsUnreadable);
+}
+
+// unreadableMatches filters a match list to the affected ones, for the
+// pool-level and competition-level summaries.
+export function unreadableMatches(matches) {
+  return (matches || []).filter(matchDataUnreadable);
+}
+
+// dataIssueText renders one located file failure as a single line an operator
+// can act on: which file, which line, and the parser's own description of what
+// it found. Position is omitted when the parser could not place the fault
+// rather than being printed as "line 0".
+export function dataIssueText(issue) {
+  if (!issue || !issue.file) return "";
+  const where = issue.line > 0 ? `line ${issue.line}, column ${issue.column}` : "";
+  return [issue.file, where].filter(Boolean).join(", ") + (issue.detail ? `: ${issue.detail}` : "");
+}
+
+// UnreadableBoutsNote: the per-match line. Deliberately says what was lost and
+// what it affects, not just that something is wrong -- "could not be read" on
+// its own does not tell an operator that their standings have moved.
+export function UnreadableBoutsNote() {
+  return (
+    <div className="alert alert--warn data-issue data-issue--inline" role="status">
+      <span aria-hidden="true">⚠</span>
+      <span>
+        This encounter's individual bouts could not be read from the results file, so
+        it counts zero individual victories and zero points. Repair the cell, or
+        re-enter the bouts here.
+      </span>
+    </div>
+  );
+}
+
+// UnreadablePoolNote: the per-pool line, shown above the standings the missing
+// bouts distort. Named for the consequence rather than the cause, because the
+// consequence is what an operator has to decide about: these are the figures a
+// tied pool is separated on.
+export function UnreadablePoolNote({ count }) {
+  return (
+    <div className="alert alert--warn data-issue" role="status">
+      <span aria-hidden="true">⚠</span>
+      <span>
+        {count === 1
+          ? "One encounter in this pool is missing its individual bouts"
+          : `${count} encounters in this pool are missing their individual bouts`}
+        , so the IV and PW columns below are incomplete. A pool tied on wins is
+        separated on exactly those figures.
+      </span>
+    </div>
+  );
+}
+
+// bracketIssue: the located failure for bracket.json, if that is one of them.
+// The recovery action only exists for the bracket, so the banner asks this
+// rather than assuming the first issue is the interesting one.
+export function bracketIssue(issues) {
+  return (issues || []).find((i) => i && i.file === "bracket.json") || null;
+}
+
+// canRebuildBracket: whether a corrupt bracket can be rebuilt at all.
+//
+// A pool-fed competition keeps its DRAW in pools.csv, so the knockout structure
+// can be derived again from a file that is still readable. A direct-elimination
+// competition does not: there, bracket.json IS the draw, and rebuilding it from
+// today's roster would not restore the tournament, it would invent a different
+// one that disagrees with the bracket already printed and posted on the wall.
+// The server refuses that case; this keeps the button from being offered at all,
+// because an action that can only fail is worse than an explanation.
+export function canRebuildBracket(competition) {
+  const format = competition && competition.format;
+  return format === "mixed" || format === "league" || format === "swiss";
+}
+
+// DataIssueBanner: the competition-level notice for the LOUD class, where a
+// whole file will not parse and every write to it is refused.
+//
+// It states the consequences in the banner rather than hiding them behind the
+// confirm dialog, because they are what the operator is choosing between and
+// the dialog is a last gate, not a briefing.
+export function DataIssueBanner({ issues, competition, onReset, resetting }) {
+  const list = issues || [];
+  if (list.length === 0) return null;
+  const bracket = bracketIssue(list);
+  const rebuildable = bracket && canRebuildBracket(competition);
+
+  return (
+    <div className="alert alert--error data-issue data-issue--banner" role="alert">
+      <span aria-hidden="true">⚠</span>
+      <div>
+        <strong>A file for this competition could not be read.</strong>
+        <ul className="data-issue__list">
+          {list.map((i) => (
+            <li key={i.file}><code>{dataIssueText(i)}</code></li>
+          ))}
+        </ul>
+        <p>
+          Scoring is blocked for whatever that file holds. Nothing has been
+          overwritten: every write to a file that will not parse is refused, so
+          it is still exactly as it was last saved.
+        </p>
+        <p><strong>Repair it, and this clears on its own.</strong> Open the file, fix the
+          position above, and reload this page. Everything recorded in it comes back,
+          results included. This is the option that loses nothing.</p>
+        {bracket && !rebuildable ? (
+          <p>
+            There is no reset for this competition: it is a direct-elimination
+            draw, so this file is the only record of who was drawn against whom.
+            Rebuilding it would produce a different set of pairings rather than
+            restoring these, and it would then disagree with the bracket you have
+            printed. Repair the file.
+          </p>
+        ) : null}
+        {rebuildable ? (
+          <>
+            <p><strong>Or reset the knockout stage</strong>, if the file cannot be repaired:</p>
+            <ul className="data-issue__list">
+              <li>The unreadable file is kept, renamed aside. It is never deleted.</li>
+              <li>Pools, participants and pool results are untouched.</li>
+              <li>Every knockout bout already fought must be re-entered from the score sheets.</li>
+              <li>
+                Check the rebuilt pairings against your printed bracket. The tree is
+                rebuilt with the current draw algorithm, and the original one was
+                inside the file that will not parse.
+              </li>
+            </ul>
+            <button
+              type="button"
+              className="btn btn--danger"
+              onClick={onReset}
+              disabled={!!resetting}
+            >
+              {resetting ? "Resetting…" : "Reset the knockout stage"}
+            </button>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web-mobile/js/data_integrity.jsx
+++ b/web-mobile/js/data_integrity.jsx
@@ -27,6 +27,16 @@
 // the server cannot tell the two apart on that path. The gate is here instead:
 // every consumer takes an explicit opt-in, and only the admin surfaces pass it.
 // A spectator has nothing to do with a parse error, so they are never shown one.
+//
+// NOTE ON ARIA. The three notices carry no live-region role. They describe a
+// condition that PERSISTS until someone repairs a file, and they sit in reading
+// order beside the rows they are about. Every other `role="status"` in this app
+// is on TRANSIENT state -- the pending-write banner, the reconnect pill, the
+// loading page -- which is what the role is for; and a row-level note announced
+// away from its row ("this encounter's bouts could not be read") names no
+// encounter, so it tells a screen-reader user less than silence does. The
+// competition banner below is the one exception and keeps `role="alert"`: it
+// appears to say scoring is blocked, which is worth interrupting for.
 
 // matchDataUnreadable: the ONE test for "this match lost its bouts to a cell
 // that would not parse". Everything else asks this rather than reading the
@@ -56,7 +66,7 @@ export function dataIssueText(issue) {
 // its own does not tell an operator that their standings have moved.
 export function UnreadableBoutsNote() {
   return (
-    <div className="alert alert--warn data-issue data-issue--inline" role="status">
+    <div className="alert alert--warn data-issue data-issue--inline">
       <span aria-hidden="true">⚠</span>
       <span>
         This encounter's individual bouts could not be read from the results file, so
@@ -78,7 +88,7 @@ export function UnreadableBoutsNote() {
 // clears the warning everywhere.
 export function UnreadableEditorNote() {
   return (
-    <div className="alert alert--warn data-issue data-issue--editor" role="status">
+    <div className="alert alert--warn data-issue data-issue--editor">
       <span aria-hidden="true">⚠</span>
       <span>
         The bouts recorded for this encounter could not be read from the results
@@ -96,7 +106,7 @@ export function UnreadableEditorNote() {
 // tied pool is separated on.
 export function UnreadablePoolNote({ count }) {
   return (
-    <div className="alert alert--warn data-issue" role="status">
+    <div className="alert alert--warn data-issue">
       <span aria-hidden="true">⚠</span>
       <span>
         {count === 1

--- a/web-mobile/js/data_integrity.jsx
+++ b/web-mobile/js/data_integrity.jsx
@@ -126,18 +126,80 @@ export function bracketIssue(issues) {
   return (issues || []).find((i) => i && i.file === "bracket.json") || null;
 }
 
-// canRebuildBracket: whether a corrupt bracket can be rebuilt at all.
+// bracketRecoveryKind: what a corrupt bracket.json can actually be recovered
+// with, which is not one question but two, and the answer decides every word
+// below as well as whether a button is offered.
 //
-// A pool-fed competition keeps its DRAW in pools.csv, so the knockout structure
-// can be derived again from a file that is still readable. A direct-elimination
-// competition does not: there, bracket.json IS the draw, and rebuilding it from
-// today's roster would not restore the tournament, it would invent a different
-// one that disagrees with the bracket already printed and posted on the wall.
-// The server refuses that case; this keeps the button from being offered at all,
-// because an action that can only fail is worse than an explanation.
-export function canRebuildBracket(competition) {
-  const format = competition && competition.format;
-  return format === "mixed" || format === "league" || format === "swiss";
+//   "rebuild"  MIXED only. Its knockout is drawn from pools.csv, which is still
+//              readable, so the tree can be laid out again by the same builder
+//              and the finished pools re-seeded into it.
+//   "discard"  LEAGUE and SWISS. They never draw a bracket, so any bracket.json
+//              they hold is left over and unused. Moving it aside unblocks the
+//              competition and costs nothing, because nothing was in it.
+//   "none"     Everything else, INCLUDING an unrecognised or missing format.
+//              Those take the draw pipeline's default branch and get a
+//              standalone playoffs bracket, so the file IS the draw. Rebuilding
+//              it from today's roster would not restore the tournament, it would
+//              invent a different one that disagrees with the bracket already
+//              printed and posted on the wall. The server refuses this; the
+//              console does not offer it, because an action that can only fail
+//              is worse than an explanation.
+//
+// Mirrors engine.CompetitionDrawsBracket + engine.CompetitionRebuildableFromPools
+// and is pinned against the same shared table they are,
+// internal/engine/testdata/format_draws_bracket.json, so a new format cannot be
+// added without answering this here too. Do NOT hand-extend the list: the
+// unrecognised-format case is exactly the half a hand-written check gets wrong,
+// and it cost this function its first version.
+export const BRACKET_RECOVERY_REBUILD = "rebuild";
+export const BRACKET_RECOVERY_DISCARD = "discard";
+export const BRACKET_RECOVERY_NONE = "none";
+
+export function bracketRecoveryKind(competition) {
+  const format = (competition && competition.format) || "";
+  if (format === "mixed") return BRACKET_RECOVERY_REBUILD;
+  if (format === "league" || format === "swiss") return BRACKET_RECOVERY_DISCARD;
+  return BRACKET_RECOVERY_NONE;
+}
+
+// The banner button, the confirm dialog and the success toast are the same voice
+// as the banner and answer to the same two questions, so they are written here
+// rather than at the call site.
+//
+// buttonLabel and confirmLabel are deliberately NOT the same string. The banner
+// CTA names the whole action because it stands alone on the page; the dialog's
+// label sits under a sentence that has just named it, where repeating the
+// article reads clumsily. Sharing one string collapsed the banner CTA to the
+// dialog's register.
+//
+// The toast takes the server's own `rebuilt`, not the kind we predicted: the
+// server decides, and a message that guessed would eventually tell an operator a
+// stage was rebuilt when it was not.
+export function bracketResetPrompt(kind, name) {
+  if (kind === BRACKET_RECOVERY_DISCARD) {
+    return {
+      message: `Move the unreadable bracket file for "${name}" aside? This competition has no `
+        + `knockout stage, so the file is left over and unused. It is kept, renamed aside, and `
+        + `no results are affected.`,
+      buttonLabel: "Move the file aside",
+      busyLabel: "Moving…",
+      confirmLabel: "Move the file aside",
+    };
+  }
+  return {
+    message: `Reset the knockout stage for "${name}"? The unreadable file is kept, renamed aside, `
+      + `but the knockout results inside it will no longer be used and must be re-entered.`,
+    buttonLabel: "Reset the knockout stage",
+    busyLabel: "Resetting…",
+    confirmLabel: "Reset knockout stage",
+  };
+}
+
+export function bracketResetToast(quarantinedAs, rebuilt) {
+  return rebuilt
+    ? `Knockout stage reset. The unreadable file is kept as ${quarantinedAs}`
+    : `The unreadable file is kept as ${quarantinedAs}. Nothing was rebuilt: this competition `
+      + `has no knockout stage.`;
 }
 
 // DataIssueBanner: the competition-level notice for the LOUD class, where a
@@ -150,7 +212,9 @@ export function DataIssueBanner({ issues, competition, onReset, resetting }) {
   const list = issues || [];
   if (list.length === 0) return null;
   const bracket = bracketIssue(list);
-  const rebuildable = bracket && canRebuildBracket(competition);
+  // Only ask the format question when the bracket is the broken file: a corrupt
+  // pool-matches.csv has no reset, whatever the format.
+  const kind = bracket ? bracketRecoveryKind(competition) : BRACKET_RECOVERY_NONE;
 
   return (
     <div className="alert alert--error data-issue data-issue--banner" role="alert">
@@ -170,16 +234,29 @@ export function DataIssueBanner({ issues, competition, onReset, resetting }) {
         <p><strong>Repair it, and this clears on its own.</strong> Open the file, fix the
           position above, and reload this page. Everything recorded in it comes back,
           results included. This is the option that loses nothing.</p>
-        {bracket && !rebuildable ? (
+        {bracket && kind === BRACKET_RECOVERY_NONE ? (
           <p>
-            There is no reset for this competition: it is a direct-elimination
-            draw, so this file is the only record of who was drawn against whom.
-            Rebuilding it would produce a different set of pairings rather than
-            restoring these, and it would then disagree with the bracket you have
-            printed. Repair the file.
+            There is no reset for this competition: its bracket was drawn
+            directly, so this file is the only record of who was drawn against
+            whom. Rebuilding it would produce a different set of pairings rather
+            than restoring these, and it would then disagree with the bracket you
+            have printed. Repair the file.
           </p>
         ) : null}
-        {rebuildable ? (
+        {kind === BRACKET_RECOVERY_DISCARD ? (
+          <>
+            <p>
+              <strong>Or move the file aside</strong>, if it cannot be repaired. This
+              competition has no knockout stage, so this file is left over and unused:
+            </p>
+            <ul className="data-issue__list">
+              <li>The unreadable file is kept, renamed aside. It is never deleted.</li>
+              <li>Nothing is rebuilt, because there is no knockout stage to rebuild.</li>
+              <li>Participants, standings and every result you have recorded are untouched.</li>
+            </ul>
+          </>
+        ) : null}
+        {kind === BRACKET_RECOVERY_REBUILD ? (
           <>
             <p><strong>Or reset the knockout stage</strong>, if the file cannot be repaired:</p>
             <ul className="data-issue__list">
@@ -192,15 +269,20 @@ export function DataIssueBanner({ issues, competition, onReset, resetting }) {
                 inside the file that will not parse.
               </li>
             </ul>
-            <button
-              type="button"
-              className="btn btn--danger"
-              onClick={onReset}
-              disabled={!!resetting}
-            >
-              {resetting ? "Resetting…" : "Reset the knockout stage"}
-            </button>
           </>
+        ) : null}
+        {/* One button for both recoverable kinds: they run the same endpoint and
+            differ only in what it will find to do, so the label follows the kind
+            rather than each branch growing its own copy of the control. */}
+        {kind !== BRACKET_RECOVERY_NONE ? (
+          <button
+            type="button"
+            className="btn btn--danger"
+            onClick={onReset}
+            disabled={!!resetting}
+          >
+            {resetting ? bracketResetPrompt(kind).busyLabel : bracketResetPrompt(kind).buttonLabel}
+          </button>
         ) : null}
       </div>
     </div>

--- a/web-mobile/js/viewer_standings.jsx
+++ b/web-mobile/js/viewer_standings.jsx
@@ -16,6 +16,9 @@
 import { withNumber } from './match_scoreboard.jsx';
 import { matchParticipantIds, matchParticipantNames, isPlayerWatched } from './viewer_watchlist_core.jsx';
 import { poolNameOf, isSupplementaryBout, isPoolDaihyosenBout, teamMatchTypeFor } from './pool_ids.jsx';
+// Data-integrity notices: one owner for what the operator is told when a file
+// does not say what the app expects, and for the admin-only gate on showing it.
+import { matchDataUnreadable, unreadableMatches, UnreadableBoutsNote, UnreadablePoolNote } from './data_integrity.jsx';
 import { realIppons } from './result_slot.jsx';
 
 const { useState, useMemo } = React;
@@ -220,7 +223,10 @@ export function SwissStandingsViewer({ competition, poolMatches, tweaks }) {
   );
 }
 
-export function LeagueStandingsViewer({ competition, poolMatches, tweaks, onMatchClick, highlightPlayers }) {
+// showDataIssues: see PoolsViewer below. A league is a single round-robin pool
+// and its team encounters carry the same sub-bouts, so it needs the same
+// notices and the same admin-only gate.
+export function LeagueStandingsViewer({ competition, poolMatches, tweaks, onMatchClick, highlightPlayers, showDataIssues }) {
   const c = competition;
   const [standings, setStandings] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -293,6 +299,9 @@ export function LeagueStandingsViewer({ competition, poolMatches, tweaks, onMatc
           <div className="pool__name">{isCompleted ? "Final standings" : "Standings"}</div>
           <div className="pool__match-count">{completed}/{total} matches</div>
         </div>
+        {showDataIssues && unreadableMatches(poolMatches).length > 0 ? (
+          <UnreadablePoolNote count={unreadableMatches(poolMatches).length} />
+        ) : null}
         <table className={`pool__table${isTeam ? " pool__table--team" : ""}`}>
           <caption className="pool__table-caption">Ranked by standings</caption>
           <thead>
@@ -357,23 +366,27 @@ export function LeagueStandingsViewer({ competition, poolMatches, tweaks, onMatc
                   const isRepBout = isSupplementaryBout(m.id || "");
                   const enriched = { ...m, phase: "pool", poolName: m.poolName || "", phaseName: m.poolName || "", compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isRepBout ? "" : competition.kind, teamSize: isRepBout ? 0 : competition.teamSize, compEngi: isRepBout ? false : isEngi, teamMatchType: isRepBout ? "" : compTMT };
                   return (
-                    <PoolNumberedMatchRow
-                      key={m.id}
-                      m={m}
-                      num={idx + 1}
-                      onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
-                    />
+                    <React.Fragment key={m.id}>
+                      <PoolNumberedMatchRow
+                        m={m}
+                        num={idx + 1}
+                        onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
+                      />
+                      {showDataIssues && matchDataUnreadable(m) ? <UnreadableBoutsNote /> : null}
+                    </React.Fragment>
                   );
                 } else {
                   const enriched = { ...m, phase: "pool", poolName: m.poolName || "", phaseName: m.poolName || "", compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0, compEngi: isEngi };
                   return (
-                    <PoolNumberedMatchRow
-                      key={m.id}
-                      m={m}
-                      num={idx + 1}
-                      isEngi={isEngi}
-                      onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
-                    />
+                    <React.Fragment key={m.id}>
+                      <PoolNumberedMatchRow
+                        m={m}
+                        num={idx + 1}
+                        isEngi={isEngi}
+                        onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
+                      />
+                      {showDataIssues && matchDataUnreadable(m) ? <UnreadableBoutsNote /> : null}
+                    </React.Fragment>
                   );
                 }
               })}
@@ -720,7 +733,11 @@ export function qualifiersForPool(competition, pool) {
   return base;
 }
 
-export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMatchClick, highlightPlayers }) {
+// showDataIssues: opt-in for the operator-only data-integrity notices (see
+// data_integrity.jsx). The admin console and the viewer render this SAME
+// component off the SAME public payload, so the audience gate cannot live on
+// the server; it lives here, and only the admin callers pass it.
+export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition, onMatchClick, highlightPlayers, showDataIssues }) {
   const isTeam = competition && (competition.kind === "team" || competition.teamSize > 0);
   // Engi-Kyogi (kata competition): flag-count scoring. Standings show
   // Victories (V) and total Flags columns only.
@@ -806,6 +823,13 @@ export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition
                 {matches.filter(m => m.status === "completed").length}/{matches.length} matches
               </div>
             </div>
+
+            {/* Above the table, not below it: these are the figures the
+                missing bouts distort, and an operator reading a tied pool has
+                to know the numbers are incomplete BEFORE they act on them. */}
+            {showDataIssues && unreadableMatches(matches).length > 0 ? (
+              <UnreadablePoolNote count={unreadableMatches(matches).length} />
+            ) : null}
 
             {/* Standings table. PoolsViewer is pool-only: rows always iterate
                 in draw order with rank surfaced via a badge. Leagues render
@@ -899,24 +923,32 @@ export function PoolsViewer({ pools, standings, poolMatches, tweaks, competition
                       const isRepBout = isSupplementaryBout(m.id || "");
                       const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: isRepBout ? "" : competition.kind, teamSize: isRepBout ? 0 : competition.teamSize, compEngi: isRepBout ? false : isEngi, teamMatchType: isRepBout ? "" : compTMT };
                       return (
-                        <PoolNumberedMatchRow
-                          key={m.id}
-                          m={m}
-                          num={idx + 1}
-                          onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
-                        />
+                        <React.Fragment key={m.id}>
+                          <PoolNumberedMatchRow
+                            m={m}
+                            num={idx + 1}
+                            onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
+                          />
+                          {/* Its own line rather than a glyph in the row: the row
+                              is a four-column grid whose centre cell is the
+                              match's middle mark, a closed set that must never
+                              gain a fifth value. */}
+                          {showDataIssues && matchDataUnreadable(m) ? <UnreadableBoutsNote /> : null}
+                        </React.Fragment>
                       );
                     } else {
                       // Individual or engi: delegates name/pair rendering to PoolNumberedMatchRow (isEngi passed through for name stacking)
                       const enriched = { ...m, phase: "pool", poolName: pool.poolName, phaseName: pool.poolName, compFormat: competition.format, compId: competition.id, compName: competition.name, compKind: "", teamSize: 0, compEngi: isEngi };
                       return (
-                        <PoolNumberedMatchRow
-                          key={m.id}
-                          m={m}
-                          num={idx + 1}
-                          isEngi={isEngi}
-                          onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
-                        />
+                        <React.Fragment key={m.id}>
+                          <PoolNumberedMatchRow
+                            m={m}
+                            num={idx + 1}
+                            isEngi={isEngi}
+                            onMatchClick={onMatchClick ? () => onMatchClick(enriched) : null}
+                          />
+                          {showDataIssues && matchDataUnreadable(m) ? <UnreadableBoutsNote /> : null}
+                        </React.Fragment>
                       );
                     }
                   })}


### PR DESCRIPTION
## Summary

- **A corrupt sub-bout cell no longer destroys the encounter it describes.** A team encounter's individual bouts live in ONE cell of `pool-matches.csv`, the file the tool invites an organiser to hand-edit. A malformed edit there degraded to an empty encounter and logged it, which is the documented contract, but the results file is rewritten in full on every match write, so the first score entered on **any other match in the competition** wrote the empty cell back over the organiser's bytes and destroyed the bouts for good. At a running event that window is one score entry wide.
- **The loss was not cosmetic.** Team standings accrue IV/IL/IT/PW/PL by looping `SubResults` (`accrueTeamSubResults`), so an emptied encounter contributes zero individual victories and zero points while still showing its winner. Teams tied on W/L/T is the normal case in a three-team pool, which is exactly when those tie-breaks decide who advances. See the first two screenshots: same competition, IV/PW all zeros while corrupt, `IV 1-2 / PW 2-3` after repair.
- **The operator is now told.** The affected match row, the pool standings it distorts, the competition overview, and the score editor itself all say what is unreadable and what it costs.
- **A file that will not parse now reports where.** `bracket.json`, `pool-matches.csv` and `pools.csv` produce a located error (file, line, column, parser reason) instead of a generic HTTP 500.
- **A wedged bracket has a way out.** `POST /competitions/:id/bracket/quarantine` renames the unreadable file aside (never deletes it). What happens next follows the format, and the response says which: a mixed competition has its knockout rebuilt from `pools.csv`; a league or Swiss competition has no knockout stage, so moving the vestigial file aside is the whole repair; anything that draws its bracket directly is refused, because there the file is the only record of the draw.

## Why

Two root causes, both in the same branch of `internal/state/pools.go`.

**1. The whole-file rewrite.** `updatePoolMatchByIDLocked` parses the entire file, mutates one match, and rewrites the entire file. A cell that read as empty was written back as empty. The documented remedy in `docs/architecture/data-model.md` ("fix the cell, reload, and check the record") was therefore unreachable in practice. Fixed by retaining the unparsed cell on `MatchResult` and writing it back verbatim while the encounter is still empty. `applyPoolWrite` owns the preserve across its whole-struct overwrite, as it does for every other field that must survive it; a write that CARRIES sub-bouts clears it, because re-entering the encounter is the repair.

**2. Partial decode.** `encoding/json` rejects a SYNTAX error before decoding anything, but a TYPE error (valid JSON, wrong value type, e.g. `"position":"2"` from a hand edit) decodes as far as it got and returns the error at the end, leaving a partially built slice whose failed entries are silently zeroed. That slice is non-empty, so the writer re-marshalled it and normalised the damage onto disk as a **valid-looking** cell holding nameless bouts, which is worse than the blanking because nothing afterwards looks wrong.

**Why the bracket store needed different treatment.** `bracket.json` cannot exhibit this: its parse failure REFUSES the write (`updateBracketLocked`, `updateBracketMatchByIDLocked` both return before saving), so the bytes on disk are already safe. It needed the diagnosis and the recovery path instead, not the preserve.

## Files changed

| File | What |
|---|---|
| `internal/state/models.go` | `MatchResult.SubResultsRaw` (the unparsed cell, retained only on failure) + `SubResultsUnreadable` (derived, wire-only) |
| `internal/state/pools.go` | SubResults column writes the raw back while empty; resets a partially decoded slice; locates CSV parse failures; logs the negative-flag clamp |
| `internal/state/corrupt_file.go` | New. `CorruptFileError{File,Line,Column,Detail}`, json byte-offset to line/column, csv position passthrough |
| `internal/state/bracket.go` | Locates bracket parse failures; logs the previously silent flag clamp |
| `internal/state/competition.go` | `QuarantineCompetitionFile`: rename aside, allowlisted, collision-safe, bumps the file version |
| `internal/engine/scoring.go` | `applyPoolWrite` carries the retained cell across `*stored = *result`, clears it on a real sub-bout write |
| `internal/engine/quarantine.go` | New. `QuarantineCorruptBracket`: refuses a readable bracket; rebuild / discard / refuse decided by the shared format table, not a hand-written list |
| `internal/engine/testdata/format_draws_bracket.json` | Carries the second question, `rebuildableFromPools`, so a new format cannot skip it in either language |
| `internal/mobileapp/errors.go` | One branch in `internalError` upgrades all 99 call sites to the located message |
| `internal/mobileapp/handlers_viewer.go` | Aggregate carries `dataIssues` instead of swallowing the load failure into a log |
| `internal/mobileapp/viewer_singleflight.go` | Route the 500 through `internalError` (this path logged nothing at all) |
| `internal/mobileapp/handlers_competition.go` | `POST /competitions/:id/bracket/quarantine`, elevated-gated |
| `internal/mobileapp/hub.go` | `bracket_quarantined` SSE event |
| `web-mobile/js/data_integrity.jsx` | New. One owner for every word the operator reads about unreadable data, and for `bracketRecoveryKind` (rebuild / discard / refuse) |
| `web-mobile/js/viewer_standings.jsx` | Per-match and per-pool notices in `PoolsViewer` and `LeagueStandingsViewer`, behind `showDataIssues` |
| `web-mobile/js/admin_pools.jsx`, `admin_shiaijo.jsx` | Opt in (4 call sites) |
| `web-mobile/js/admin_competition_overview.jsx` | Renders the banner and owns the reset call |
| `web-mobile/js/admin_scoring_team.jsx` | The editor notice, inside the shared `inner` so the overlay and the inline panel cannot diverge |
| `web-mobile/js/admin_competition.jsx` | Passes `showToast` / `onRefreshCompetition` through |
| `web-mobile/js/api_client.jsx` | `quarantineBracket`; hoists `dataIssues` onto the flattened competition |
| `web-mobile/css/styles.css` | Layout-only additions on the shared `.alert--warn` family |
| `docs/architecture/data-model.md` | "When a file is wrong" now distinguishes a wrong CELL from a wrong FILE, and documents the retention and the quarantine |
| tests (14 files) | See the test plan |

## Screenshots

**The bug, and the fix, on the same competition.** Left: a hand edit broke one cell of the sub-bout JSON. The encounter still shows its winner, but Kenshikan reads W=1 with **IV=0 and PW=0**, because every individual bout it recorded is gone. Right: the same competition after repairing that cell, showing what the standings should have said all along, **IV 1-2 / PW 2-3**.

| Cell unreadable | After repairing the cell |
|---|---|
| ![pool standings with the warning and zeroed IV/PW](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/pools-unreadable.png) | ![the same standings repaired](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/pools-repaired.png) |

**The same corrupt data on the public viewer: no notices.** The audience gate is a render-time prop, not a server-side strip, because the admin console reads the same public aggregate and the same SSE stream.

![public pools view with no data-integrity notices](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/pools-public-clean.png)

**Inside the score editor.** The operator who opens the encounter to score it is the one most likely to notice, and what they see is every bout row blank with the summary reading DRAW / IV 0 / PW 0. Nothing there separates "never fought" from "fought, and the file no longer says so". The wording aims at what they can do: the text is still in the file, and entering the bouts here replaces it.

| Wide overlay | Narrow shiaijo inline panel |
|---|---|
| ![team score editor overlay with the notice](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/editor-overlay.png) | ![the same notice in the shiaijo inline scorer](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/editor-inline.png) |

**A bracket file that will not parse.** The banner names the file, the line and the column, says plainly that nothing has been overwritten, and puts repair first because it is the option that loses nothing.

![competition overview with the corrupt-file banner](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/overview-banner.png)

**The same file on a league, which has no knockout stage.** Every word changes: the offer is to *move the file aside*, not to reset a stage that does not exist, and the bullets promise no rebuild rather than knockout bouts to re-enter and pairings to check against a printed bracket. The button follows. This is the case the first version of this PR got wrong, and the recovery kind now comes from the shared Go/JS format table rather than a hand-written list.

![league overview offering to move the unreadable file aside](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/league-move-aside.png)

**The same banner on a direct-elimination competition: no reset button.** There the file is the only record of the draw, so rebuilding would invent different pairings rather than restore these. The server refuses it too, so offering a button that can only fail would be worse than the explanation.

![playoffs overview with no reset offered](https://raw.githubusercontent.com/gitrgoliveira/bracket-creator/pr-assets/pr-assets/399/playoffs-no-reset.png)


## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change
- [x] Manual browser verification (see below)
- [x] Screenshots added above
- [x] Docs updated under `docs/` (`make docs/build` passes)
- [x] No new console errors or warnings

**Regression guards verified RED without their fix**, not just green with it:

| Test | Reverted | Result |
|---|---|---|
| `TestCorruptSubResultsSurvivesAWriteToAnotherMatch` | put no longer writes the raw back | FAIL |
| `TestCorruptSubResultsTypeErrorDoesNotNormaliseDamageOntoDisk` | put revert, then separately the slice reset | FAIL for each, independently |
| `TestApplyPoolWrite_UnparsedSubResultsCell` | the `applyPoolWrite` preserve | FAIL |
| `pools_data_issues.render.test.jsx` | the `showDataIssues` gate | FAIL (notice reached the public viewer) |
| `team_editor_data_issue.render.test.jsx` | the editor notice placement | FAIL in BOTH the overlay and the inline panel |
| `TestQuarantineCorruptBracket_OutcomeFollowsTheFormatTable` | the derived refusal, back to `Format == playoffs \|\| Format == ""` | FAIL on `not-a-format`, `league-playoffs`, `League`; the 5 already-correct formats stay green |
| `format_draws_bracket.test.jsx` (recovery kind) | the derived JS predicate, back to the hand-written list | FAIL on `league` and `swiss` |

**Manual browser verification** (real tournament seeded through the API, then a hand edit on disk, exercised in Chromium at 1180x900):

1. Scored a 3-bout team encounter in a mixed competition, then broke its `SubResults` cell the way a hand edit does (`"position":2` to `"position":2x`, CSV quoting intact).
2. Admin Pools: per-match notice and per-pool notice both render; standings show W=1 with IV=0 and PW=0, the actual data loss.
3. Public viewer, same competition, same corrupt data: neither notice appears. This is the audience gate, and it cannot live on the server because the admin console reads the same public aggregate and SSE stream.
4. Repaired the cell by hand and reloaded: notices gone, `IV 1-2 / PW 2-3` restored. Nothing was lost, which is the whole point of the fix.
5. Broke `bracket.json` on a known line: banner names `bracket.json, line 12, column 10` with the parser's reason; a score write returns the structured `corrupt_file` body rather than "internal error".
6. Ran the reset: confirm dialog, then the broken file kept verbatim as `bracket.json.corrupt-20260822-231416`, a fresh parseable bracket, Kenshikan already re-seeded from the finished pool and `Pool B-1st` still a placeholder, `pools.csv` and `pool-matches.csv` untouched.
7. Opened the corrupt encounter in the score editor: notice renders in the wide overlay AND in the narrow shiaijo inline panel at 1180x820 (measured 602px inside a 663px panel, no overflow). Entered a bout and saved from the inline panel: the flag cleared, and the malformed text was gone from disk, replaced by the operator's entry. The notice promises exactly that, so it was verified rather than assumed.
8. Playoffs competition with a broken bracket: no reset button, and the banner explains that the file is the only record of the draw there. The server refuses it too (HTTP 400).
9. Banner at 375x812 and 768x1024 as well as desktop: no horizontal overflow, the located error wraps, the button fits. This is what surfaced the placement limit now recorded beside it in `admin_competition_overview.jsx`: below 720px `.comp-rail` stops being a left column and stacks above this one, so the banner sits about 650px down rather than first on the page. Unchanged, and the tablet widths operators use are unaffected.
10. **League with an unreadable vestigial `bracket.json`** (the case this PR previously got wrong): banner reads *"Or move the file aside"* with *"Nothing is rebuilt"*, and none of the knockout, re-entry or printed-bracket text appears. Ran it through the confirm dialog and the admin-password gate; the file was kept verbatim as `bracket.json.corrupt-20260823-090354` and the wire said `rebuilt:false`. Mixed still returns `rebuilt:true`.
11. **A competition whose `config.md` was hand-edited to `format: mixxed`**: refused (HTTP 400), with `bracket.json` still exactly where it was. Before this PR's last commit it was quarantined and nothing rebuilt, because an unrecognised format draws a standalone playoffs bracket and the file was its only record.

Coverage on touched packages: `state` 90.0%, `engine` 87.1%, `mobileapp` 86.1%.

Closes bc-subj



