### PR TITLE
fix(bc-r389): allow unambiguous seeded-participant removal; clear hansoku on reopen

### DIFF
--- a/internal/engine/kachinuki.go
+++ b/internal/engine/kachinuki.go
@@ -1165,6 +1165,8 @@ func reopenPoolMatch(m *state.MatchResult, reason string) {
 	m.WinnerID = ""
 	m.IpponsA = nil
 	m.IpponsB = nil
+	m.HansokuA = 0
+	m.HansokuB = 0
 	m.Decision = ""
 	m.DecisionBy = ""
 	m.DecisionReason = ""
@@ -1186,28 +1188,39 @@ func reopenPoolMatch(m *state.MatchResult, reason string) {
 // Everything cleared below is the discarded verdict ABOUT those bouts, not a
 // record OF them: the encounter winner, the match-level default-win scoreline
 // (the FIK Art. 32 maru fill a kiken/fusenpai writes at match level), the
-// decision, the match-level encho/hantei state describing the bout in progress
-// when the operator ended it, and the provenance stamps for a result that no
-// longer exists (IsOverridden, ResultSource). Leaving those behind produced a
-// match that was running yet still advertised a winner, a scoreline, and a
-// manual-override badge inherited from the result the reopen threw away.
+// match-level hansoku count, the decision, the encho/hantei state describing
+// the bout in progress when the operator ended it, and the provenance stamps
+// for a result that no longer exists (IsOverridden, ResultSource). Leaving
+// those behind produced a match that was running yet still advertised a
+// winner, a scoreline, and a manual-override badge inherited from the result
+// the reopen threw away.
 //
 // This clears the verdict fields RevertMatchToQueue clears (engine/scoring.go)
 // that a kachinuki result can actually carry, MINUS SubResults (which requeue
 // drops and reopen exists to preserve) and CorrectionReason/ReopenPending
-// (which the reopen is itself setting). Two RevertMatchToQueue fields are
-// deliberately NOT mirrored: match-level HansokuA/B and FlagsA/B are never
-// populated on a kachinuki team match (hansoku rides on the sub-bouts, flags
-// are engi-only, and reopen*Match run for kachinuki matches only), and
-// ModifiedAt is left at the completion stamp on purpose — it still fences any
-// stale pre-completion offline write via ApplyByTimestamp and never blocks the
-// re-End. If you add a match-level verdict field a kachinuki result CAN carry,
-// clear it here too.
+// (which the reopen is itself setting). Match-level HansokuA/B ARE mirrored
+// here, even though today's team-editor wire path never sets them on a
+// kachinuki match: NormalizeLegacy (state/legacy_hantei.go) folds a legacy
+// ScoreA/ScoreB string into IpponsA/HansokuA on every bracket read, and
+// MatchResult.HansokuA/B are first-class pool-matches.csv columns any client
+// payload can set (state/pools.go), so a pre-migration file or an
+// out-of-band write can leave a genuine count here. Before bc-bmsc, the old
+// ScoreA = "" clear wiped this count too, because it rode inside the
+// rendered string's "(HN)" suffix; leaving it behind now would let
+// applyHansokuIppons fold a stale count into the H ippons of a scoreline the
+// reopen just cleared. FlagsA/B remain unmirrored: they are engi-only, and
+// engi has no kachinuki, so neither reopen path ever sees them populated.
+// ModifiedAt is left at the completion stamp on purpose — it still
+// fences any stale pre-completion offline write via ApplyByTimestamp and
+// never blocks the re-End. If you add a match-level verdict field a
+// kachinuki result CAN carry, clear it here too.
 func reopenBracketMatch(bm *state.BracketMatch, reason string) {
 	bm.Status = state.MatchStatusRunning
 	bm.Winner = ""
 	bm.IpponsA = nil
 	bm.IpponsB = nil
+	bm.HansokuA = 0
+	bm.HansokuB = 0
 	bm.Decision = ""
 	bm.DecisionBy = ""
 	bm.DecisionReason = ""

--- a/internal/engine/kachinuki_test.go
+++ b/internal/engine/kachinuki_test.go
@@ -1844,6 +1844,7 @@ func TestReopenKachinukiMatch_DiscardsVerdictKeepsBoutLog(t *testing.T) {
 			Status: state.MatchStatusCompleted,
 			Winner: "RedTeam", WinnerID: "red-uuid",
 			IpponsA: []string{"○", "○"}, IpponsB: []string{"M"},
+			HansokuA: 1, HansokuB: 2,
 			Decision: "kiken-voluntary", DecisionBy: "shiro", DecisionReason: "withdrew",
 			Encho:        &state.EnchoMetadata{PeriodCount: 1},
 			ResultSource: "admin", RepPlayerA: "R-2", RepPlayerB: "W-2",
@@ -1868,6 +1869,8 @@ func TestReopenKachinukiMatch_DiscardsVerdictKeepsBoutLog(t *testing.T) {
 		assert.Empty(t, m.WinnerID)
 		assert.Empty(t, m.IpponsA, "the match-level default-win maru belonged to the discarded result")
 		assert.Empty(t, m.IpponsB)
+		assert.Zero(t, m.HansokuA, "the outstanding-foul count belonged to the discarded result, same as the ippons it discharges into")
+		assert.Zero(t, m.HansokuB)
 		assert.Empty(t, m.Decision)
 		assert.Empty(t, m.DecisionBy)
 		assert.Empty(t, m.DecisionReason)
@@ -1888,6 +1891,7 @@ func TestReopenKachinukiMatch_DiscardsVerdictKeepsBoutLog(t *testing.T) {
 					ID: "F0", SideA: "RedTeam", SideB: "WhiteTeam",
 					Status: state.MatchStatusCompleted, Winner: "RedTeam",
 					IpponsA: []string{"○", "○"}, IpponsB: []string{"○"},
+					HansokuA: 1, HansokuB: 2,
 					Decision: "kiken-voluntary", DecisionBy: "shiro", DecisionReason: "withdrew",
 					Encho:        &state.EnchoMetadata{PeriodCount: 1},
 					IsOverridden: true, ResultSource: "admin",
@@ -1909,6 +1913,8 @@ func TestReopenKachinukiMatch_DiscardsVerdictKeepsBoutLog(t *testing.T) {
 		assert.Empty(t, bm.Winner)
 		assert.Empty(t, bm.IpponsA, "the scoreline described the discarded result")
 		assert.Empty(t, bm.IpponsB)
+		assert.Zero(t, bm.HansokuA, "reachable via NormalizeLegacy's score-string fold on a pre-migration file, and must not survive a reopen")
+		assert.Zero(t, bm.HansokuB)
 		assert.Empty(t, bm.Decision)
 		assert.Empty(t, bm.DecisionBy)
 		assert.Empty(t, bm.DecisionReason)

--- a/internal/mobileapp/handlers_participants.go
+++ b/internal/mobileapp/handlers_participants.go
@@ -242,23 +242,36 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			})
 		}
 
-		// Refuse a replace that would orphan an already-seeded participant.
 		// This endpoint carries no seed data of its own (unlike
 		// PUT /competitions/:id, which derives seeds.csv fresh from each
-		// player's Seed field on every save), so it has no way to rewrite a
-		// seed row alongside an identity change the way the single-participant
-		// PUT /participants/:pid path does -- an edit here can only strand the
-		// EXISTING row, never legitimately update it (bc-389 review finding:
+		// player's Seed field on every save), so a seed row whose (name, dojo)
+		// no longer resolves against the new roster needs a rule for what
+		// happened to it. Two readings are indistinguishable from the request
+		// body alone: the participant was RENAMED (their identity moved to a
+		// different row in the same request), or the participant was REMOVED
+		// (their row is simply gone). This is a full replace with no stable
+		// per-request participant id to key a rename off, so the two cannot be
+		// told apart by matching rows -- only by whether the replace ALSO adds
+		// any identity the old roster didn't have: a rename looks structurally
+		// identical to remove-old-add-new, so it can only happen when the
+		// replace is adding something. A replace that adds no identities can
+		// only be removing rows, so any orphaned seed there is unambiguous.
+		//
+		// Ambiguous (orphans a seed AND adds an identity): refuse the whole
+		// write, same as before this rule existed (bc-389 review finding:
 		// correcting a seeded competitor's dojo through this endpoint orphaned
 		// their seeds.csv row, and only generate-draw discovered it later,
-		// minutes or hours after the edit looked like it had succeeded).
-		//
-		// Rather than guess which new row a changed identity corresponds to
-		// (this is a full replace with no stable per-request participant id
-		// to key a rename off), refuse the whole write: the operator keeps
-		// the (name, dojo) pair unchanged, or edits identity through
+		// minutes or hours after the edit looked like it had succeeded). The
+		// operator keeps the (name, dojo) pair unchanged, splits the removal
+		// into a request that adds nothing, or edits identity through
 		// PUT /competitions/:id/participants/:pid (which rewrites the seed
 		// alongside the rename) or the seeding panel directly.
+		//
+		// Unambiguous (orphans a seed, adds nothing): proceed as a removal --
+		// the write below drops the orphaned row(s) from seeds.csv after the
+		// roster save succeeds, matching what PUT /competitions/:id already
+		// does for a removed competitor's seed by deriving seeds.csv fresh on
+		// every save.
 		seeds, serr := store.LoadSeedsRaw(id)
 		if serr != nil {
 			internalError(c, serr, "failed to load seeds")
@@ -294,10 +307,12 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			canonicalPlayers[i].Name = helper.TitleCaseName(canonicalPlayers[i].Name)
 			canonicalPlayers[i].Dojo = strings.TrimSpace(canonicalPlayers[i].Dojo)
 		}
-		if orphaned := seedsOrphanedByRosterReplace(existing, canonicalPlayers, seeds); len(orphaned) > 0 {
+		orphaned, keptSeeds := seedsOrphanedByRosterReplace(existing, canonicalPlayers, seeds)
+		if len(orphaned) > 0 && rosterReplaceAddsIdentities(existing, canonicalPlayers) {
+			labels := formatOrphanedSeedLabels(orphaned)
 			c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf(
-				"this replace would orphan %d already-seeded participant(s): %s; keep their name and dojo unchanged, or update seeds via PUT /competitions/:id/participants/:pid or the seeding panel first",
-				len(orphaned), strings.Join(orphaned, ", "))})
+				"this replace removes or renames %d already-seeded participant(s) (%s), and also adds new participant(s), so a removal can't be told apart from a rename; keep their name and dojo unchanged, do the removal in a request that adds no new participants, or update/clear their seed first via PUT /competitions/:id/participants/:pid or the seeding panel",
+				len(orphaned), strings.Join(labels, ", "))})
 			return
 		}
 
@@ -315,6 +330,27 @@ func RegisterParticipantHandlers(r *gin.RouterGroup, store *state.Store, eng *en
 			}
 			internalError(c, err, "failed to save participants")
 			return
+		}
+
+		// The guard above only refuses the AMBIGUOUS case; reaching here with
+		// orphaned rows means the replace added no new identities, so this is
+		// an unambiguous removal (see the guard comment above). Rewrite
+		// seeds.csv to drop exactly the orphaned rows, matching what
+		// PUT /competitions/:id already does for a removed competitor's seed
+		// by deriving seeds.csv fresh on every save.
+		//
+		// Best-effort, same historical contract as the other seeds.csv writer
+		// that follows a participants write it doesn't want to unwind
+		// (saveCompetitionWithPlayers, handlers_competition.go ~99-107): the
+		// roster save above is the one that matters and has already landed,
+		// and a leftover orphaned row here is exactly the pre-existing-ghost
+		// case seedsOrphanedByRosterReplace already tolerates elsewhere --
+		// not a new failure mode -- so there is nothing worth rolling the
+		// roster write back over.
+		if len(orphaned) > 0 {
+			if err := store.SaveSeeds(id, keptSeeds); err != nil {
+				fmt.Printf("Warning: failed to drop orphaned seed(s) after roster removal: %v\n", err)
+			}
 		}
 
 		// Reload from disk so the response reflects the persisted roster,

--- a/internal/mobileapp/handlers_participants_test.go
+++ b/internal/mobileapp/handlers_participants_test.go
@@ -471,7 +471,9 @@ func TestBatchPostOrphaningSeedRejected(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusConflict, w.Code,
-		"a bulk replace that would orphan an already-seeded participant must be refused, not silently persisted")
+		"a bulk replace that would orphan an already-seeded participant, while also adding a new identity, must be refused, not silently persisted")
+	assert.Contains(t, w.Body.String(), "adds new participant",
+		"the 409 must explain WHY it can't tell a removal from a rename: this replace also adds a new identity")
 
 	// Neither the roster nor the seed should have changed.
 	players := mustLoad(t, store, compID)
@@ -486,6 +488,63 @@ func TestBatchPostOrphaningSeedRejected(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, seeds, 1)
 	assert.Equal(t, "Wakaba", seeds[0].Dojo, "the existing seed must be untouched by a refused replace")
+}
+
+// TestBatchPostPureRemovalDropsOrphanedSeed is the removal-only companion to
+// TestBatchPostOrphaningSeedRejected: a bulk replace that drops a seeded
+// participant's row WITHOUT adding any new identity is unambiguous (it can
+// only be a removal, never a rename -- see rosterReplaceAddsIdentities), so it
+// must succeed, and the removed competitor's now-orphaned seeds.csv row must
+// be dropped rather than left to strand generate-draw later. A pre-existing
+// ghost row (never resolvable against the old roster either) must survive
+// untouched, since this replace doesn't make that row any more broken than it
+// already was.
+func TestBatchPostPureRemovalDropsOrphanedSeed(t *testing.T) {
+	r, store, _, _, tempDir := setupTestRouter(t)
+	defer os.RemoveAll(tempDir)
+
+	compID := "comp-batch-seed-pure-removal"
+	require.NoError(t, store.SaveCompetition(&state.Competition{
+		ID:     compID,
+		Name:   "Batch Seed Pure Removal Test",
+		Status: state.CompStatusSetup,
+	}))
+	require.NoError(t, store.SaveParticipants(compID, []domain.Player{
+		{Name: "Alice Smith", Dojo: "Wakaba"},
+		{Name: "Bob Jones", Dojo: "Tora"},
+	}))
+	require.NoError(t, store.SaveSeeds(compID, []domain.SeedAssignment{
+		{Name: "Alice Smith", Dojo: "Wakaba", SeedRank: 1},
+		{Name: "Bob Jones", Dojo: "Tora", SeedRank: 2},
+		{Name: "Ghost Competitor", Dojo: "Nowhere", SeedRank: 3}, // pre-existing ghost, never in the roster
+	}))
+
+	// Remove Alice entirely; add nobody. Bob is untouched.
+	body, _ := json.Marshal(map[string]any{"players": []map[string]string{
+		{"name": "Bob Jones", "dojo": "Tora"},
+	}})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/competitions/"+compID+"/participants", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code,
+		"a replace that only removes a seeded participant, adding nothing, is unambiguous and must succeed: %s", w.Body.String())
+
+	players := mustLoad(t, store, compID)
+	require.Len(t, players, 1)
+	assert.Equal(t, "Bob Jones", players[0].Name)
+
+	seeds, err := store.LoadSeedsRaw(compID)
+	require.NoError(t, err)
+	byName := make(map[string]domain.SeedAssignment, len(seeds))
+	for _, s := range seeds {
+		byName[s.Name] = s
+	}
+	assert.NotContains(t, byName, "Alice Smith", "the removed competitor's seed row must be dropped")
+	require.Contains(t, byName, "Bob Jones", "a still-resolving seed row must survive")
+	assert.Equal(t, 2, byName["Bob Jones"].SeedRank)
+	require.Contains(t, byName, "Ghost Competitor", "a pre-existing ghost row must survive untouched")
+	assert.Equal(t, 3, byName["Ghost Competitor"].SeedRank)
 }
 
 // TestBatchPostPreservingSeedIdentityAccepted is the companion case: a bulk

--- a/internal/mobileapp/validation.go
+++ b/internal/mobileapp/validation.go
@@ -242,46 +242,89 @@ func seedsOffRoster(players []domain.Player, assignments []domain.SeedAssignment
 		strings.Join(unknown, ", "), verb, remedy)
 }
 
-// seedsOrphanedByRosterReplace reports which of the CURRENTLY resolvable
-// seed assignments would stop resolving if oldPlayers were replaced by
-// newPlayers -- the set POST /competitions/:id/participants (the bulk
-// roster-replace endpoint) would silently strand, since that endpoint
-// carries no seed data of its own and so has no way to rewrite seeds.csv
-// alongside an identity change (bc-389 review finding). Both rosters are
-// resolved via domain.RosterIndex, the same (name, dojo)-with-unique-
-// bare-name-fallback resolver every other seed matcher uses, so "would
-// this still resolve" here means exactly what it means to generate-draw.
+// seedsOrphanedByRosterReplace partitions seeds into KEPT (rows that still
+// resolve against newPlayers, plus pre-existing ghosts already unresolvable
+// against oldPlayers -- see below) and ORPHANED (rows that resolve against
+// oldPlayers but not newPlayers): the set POST /competitions/:id/participants
+// (the bulk roster-replace endpoint) would silently strand if it wrote the
+// new roster as-is, since that endpoint carries no seed data of its own and
+// so has no way to rewrite seeds.csv alongside an identity change (bc-389
+// review finding). Both rosters are resolved via domain.RosterIndex, the
+// same (name, dojo)-with-unique-bare-name-fallback resolver every other seed
+// matcher uses, so "would this still resolve" here means exactly what it
+// means to generate-draw.
+//
+// Whether an orphaned row is refused (an identity change looks structurally
+// identical to remove-old-add-new, so it cannot be told apart from a rename)
+// or treated as an unambiguous removal (dropped from seeds.csv) is the
+// caller's decision, in handlers_participants.go -- this function only
+// reports the partition.
 //
 // A seed row that is ALREADY unresolvable against oldPlayers (a
-// pre-existing ghost, e.g. seeds entered before the roster) is not
-// reported: this replace does not make that row any less broken than it
-// already was, and refusing on its account would block an unrelated
-// roster edit for a problem the operator did not just create.
+// pre-existing ghost, e.g. seeds entered before the roster) is reported as
+// KEPT, not orphaned: this replace does not make that row any less broken
+// than it already was, so it is neither grounds to refuse the write nor a
+// row this replace should drop.
 //
-// Returned as ready-to-display "name (dojo) rank N" labels rather than raw
-// domain.SeedAssignment values; callers needing the structured form should
-// re-derive it rather than parse this slice.
-func seedsOrphanedByRosterReplace(oldPlayers, newPlayers []domain.Player, seeds []domain.SeedAssignment) []string {
+// Returns the two partitions as domain.SeedAssignment slices (not
+// ready-to-display labels) so the caller has the exact structured set it
+// needs both to format an error message and to rewrite seeds.csv --
+// previously this returned display labels and told callers needing the
+// structured form to re-derive it, which is exactly the kind of drift this
+// function exists to prevent.
+func seedsOrphanedByRosterReplace(oldPlayers, newPlayers []domain.Player, seeds []domain.SeedAssignment) (orphaned, kept []domain.SeedAssignment) {
 	if len(seeds) == 0 {
-		return nil
+		return nil, nil
 	}
 	oldRoster := domain.NewRosterIndex(oldPlayers)
 	newRoster := domain.NewRosterIndex(newPlayers)
-	var orphaned []string
 	for _, a := range seeds {
 		if _, ok := oldRoster.Lookup(a.Name, a.Dojo); !ok {
-			continue // already unresolvable; this replace doesn't make it worse
+			kept = append(kept, a) // pre-existing ghost; this replace doesn't make it worse
+			continue
 		}
 		if _, ok := newRoster.Lookup(a.Name, a.Dojo); ok {
-			continue // still resolves after the replace
+			kept = append(kept, a) // still resolves after the replace
+			continue
 		}
+		orphaned = append(orphaned, a)
+	}
+	return orphaned, kept
+}
+
+// rosterReplaceAddsIdentities reports whether newPlayers contains any
+// (name, dojo) identity that does not resolve against oldPlayers. A rename
+// is only reachable through POST /competitions/:id/participants by removing
+// the old identity and adding a new one in the same request (this endpoint
+// has no stable per-request participant id to key a rename off), so when
+// this is true, an orphaned seed row (see seedsOrphanedByRosterReplace)
+// cannot be told apart from a rename and the caller must refuse the write.
+// When it is false, every identity in newPlayers was already present in
+// oldPlayers, so any orphaned row is an unambiguous removal.
+func rosterReplaceAddsIdentities(oldPlayers, newPlayers []domain.Player) bool {
+	oldRoster := domain.NewRosterIndex(oldPlayers)
+	for i := range newPlayers {
+		if _, ok := oldRoster.Lookup(newPlayers[i].Name, newPlayers[i].Dojo); !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// formatOrphanedSeedLabels renders orphaned seed rows as ready-to-display
+// "name (dojo) rank N" strings for the 409 error message. Kept separate from
+// seedsOrphanedByRosterReplace so that function can return the structured
+// form every caller needs, with display formatting only where it's consumed.
+func formatOrphanedSeedLabels(orphaned []domain.SeedAssignment) []string {
+	labels := make([]string, 0, len(orphaned))
+	for _, a := range orphaned {
 		label := a.Name
 		if a.Dojo != "" {
 			label = fmt.Sprintf("%s (%s)", a.Name, a.Dojo)
 		}
-		orphaned = append(orphaned, fmt.Sprintf("%s rank %d", label, a.SeedRank))
+		labels = append(labels, fmt.Sprintf("%s rank %d", label, a.SeedRank))
 	}
-	return orphaned
+	return labels
 }
 
 // validateHTTPURL returns a ValidationError when val is non-empty and does not

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1431,7 +1431,12 @@ paths:
                     $ref: '#/components/schemas/ParticipantInput'
       responses:
         '200':
-          description: Participants successfully updated.
+          description: >
+            Participants successfully updated. If the replacement roster
+            dropped an already-seeded participant without adding any new
+            participant, that removal is unambiguous (see the 409 case below)
+            and their now-orphaned row in `seeds.csv` is dropped as part of
+            this save.
           content:
             application/json:
               schema:
@@ -1447,10 +1452,15 @@ paths:
             Conflict. The draw is pending or the competition has already
             started; the request repeats a (name, dojo) pair; the write layer
             found an existing participant with that pair; or the replacement
-            roster would orphan an already-seeded participant (their name or
-            dojo changed, and this endpoint carries no seed data to rewrite
-            `seeds.csv` alongside). The error message names the affected
-            competitors and how to proceed.
+            roster orphans an already-seeded participant's row AND also adds
+            one or more new participants. This endpoint carries no seed data
+            of its own and has no stable per-request participant id, so in
+            that combination it cannot tell a rename (remove old identity, add
+            new identity) apart from an unrelated removal plus addition, and
+            refuses the write rather than guess. A replacement that only
+            removes seeded participants, adding nobody, is unambiguous and
+            succeeds instead (see the 200 response). The error message names
+            the affected competitors and how to proceed.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary

- **Withdrawing a seeded competitor via the batch roster replace now works.** `POST /api/competitions/:id/participants` (batch mode) refused *any* replace that orphaned a seed row — including a plain removal — with an error that only described the rename case, so withdrawal through this endpoint was impossible. The guard now refuses only the genuinely ambiguous case (the replace also **adds** an identity, so a removal cannot be told apart from a rename); an addition-free replace is an unambiguous removal: it saves and drops exactly the removed competitors' `seeds.csv` rows, matching what `PUT /competitions/:id` already does by deriving seeds fresh on every save. Pre-existing ghost rows are untouched.
- **The kachinuki reopen twins no longer leak a stale match-level hansoku count.** `reopenPoolMatch`/`reopenBracketMatch` cleared the verdict but not `HansokuA`/`HansokuB`, which the pre-bc-bmsc `ScoreA = ""` wipe used to clear via the rendered `(HN)` suffix. The doc comment's "never populated on a kachinuki team match" claim only held for the forward team-editor path: `NormalizeLegacy` folds legacy score strings into the ints on every bracket read, and the pool fields are first-class wire/CSV columns. A leftover count would be folded into `H` ippons by `applyHansokuIppons` on the scoreline the reopen had just cleared. Both twins now zero the counts.

## Why

Both are post-merge `/code-review` findings on PR #389 (merge 21f565f5). The reopen finding is wider than reviewed: the review flagged the bracket twin (legacy-fold reachability); verification showed the pool twin has the same hole through an even more direct route (first-class wire fields, no fold needed), so both are fixed.

## Files changed

| File | What |
|---|---|
| `internal/mobileapp/validation.go` | `seedsOrphanedByRosterReplace` now returns the structured orphaned/kept partition (was display labels + "re-derive" instruction); new `rosterReplaceAddsIdentities` (same `RosterIndex` resolver, so the two predicates cannot drift) and `formatOrphanedSeedLabels` |
| `internal/mobileapp/handlers_participants.go` | Guard refuses only orphans-plus-additions; addition-free removal proceeds and rewrites `seeds.csv` without the orphaned rows (best-effort, mirroring the `saveCompetitionWithPlayers` contract); guard comment rewritten for the rename-vs-removal rule |
| `internal/mobileapp/handlers_participants_test.go` | 409 test now requires the adds-new-participants explanation; new `TestBatchPostPureRemovalDropsOrphanedSeed` (removal succeeds, orphaned row dropped, still-resolving row and ghost row survive) |
| `internal/engine/kachinuki.go` | Both reopen twins zero `HansokuA`/`HansokuB`; doc comment corrected (reachability via legacy fold + pool wire/CSV; `FlagsA/B` stay unmirrored as engi-only) |
| `internal/engine/kachinuki_test.go` | Reopen subtests seed asymmetric `HansokuA: 1, HansokuB: 2` and assert both are zeroed, per twin |
| `specs/openapi.yaml` | Batch-POST 409 description now states the adds-participants condition; 200 description documents the seed-row drop on pure removal |

## Test plan

- [x] `make go/test` passes (lint + security scan + tests)
- [x] New/updated unit tests cover the change — both directions revert-checked: with the guard's discriminator neutered, `TestBatchPostPureRemovalDropsOrphanedSeed` fails on the 409; with the two hansoku-clearing lines reverted, both reopen subtests fail with `was 1`/`was 2`
- [x] Manual browser verification: N/A — no `web-mobile/` or `web/` change (the SPA uses this endpoint's single-add mode and the `PUT /competitions/:id` roster path, both unchanged)
- [x] Screenshots: N/A — no UI impact (section removed)
- [x] Docs: no `docs/` page describes this endpoint's seed behavior (checked); the API contract update is in `specs/openapi.yaml`
- [x] No new console errors or warnings: N/A — server-side only

Closes bc-r389
